### PR TITLE
Support looping of inventories

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprInventory.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprInventory.java
@@ -62,7 +62,7 @@ public class ExprInventory extends SimpleExpression<Object> {
 	}
 
 	@Override
-	@SuppressWarnings({"unchecked", "null"})
+	@SuppressWarnings("unchecked")
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
 		// if we're dealing with a loop of just this expression
 		Node n = SkriptLogger.getNode();

--- a/src/main/java/ch/njol/skript/expressions/ExprInventory.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprInventory.java
@@ -112,7 +112,7 @@ public class ExprInventory extends SimpleExpression<Object> {
 							return true;
 						}
 					}
-			}, 0, Kleenean.FALSE,  new SkriptParser.ParseResult(new SkriptParser(""), ""));
+			}, 0, Kleenean.FALSE, null);
 			return expr.get(e);
 		}
 		return invArray;

--- a/src/main/java/ch/njol/skript/expressions/ExprItemsIn.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprItemsIn.java
@@ -62,7 +62,11 @@ public class ExprItemsIn extends SimpleExpression<Slot> {
 	
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
-	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
+	/*
+	 * the parse result will be null if it is used via the ExprInventory expression, however the expression will never
+	 * be a variable when used with that expression (it is always a anonymous SimpleExpression)
+	 */
+	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, @Nullable final ParseResult parseResult) {
 		invis = (Expression<Inventory>) exprs[0];
 		if (invis instanceof Variable && !invis.isSingle() && parseResult.mark != 1)
 			Skript.warning("'items in {variable::*}' does not actually represent the items stored in the variable. Use either '{variable::*}' (e.g. 'loop {variable::*}') if the variable contains items, or 'items in inventories {variable::*}' if the variable contains inventories.");


### PR DESCRIPTION
Target Minecraft versions: Any
Requirements: None
Related issues: Beginners everywhere wondering why an inventory is a single value

Description:
In it's current form, if you try to loop an inventory like this:
```
on click:
  loop inventory of player:
    broadcast "woah man!"
```
you will get an error saying that an inventory is only a single value and thus cannot be looped. This PR changes the inventory expression to return the items (actually the slots) of an inventory when used in a loop, but maintains the old behavior otherwise.
Example:
```
on click:
  loop inventory of player:
    broadcast "%loop-slot%"
```