### PR TITLE
Add an originClassPath for SyntaxElementInfo

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -52,6 +52,7 @@ import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 
 import ch.njol.skript.lang.Trigger;
+import ch.njol.skript.lang.util.SimpleEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -1044,7 +1045,8 @@ public final class Skript extends JavaPlugin implements Listener {
 	 */
 	public static <E extends Condition> void registerCondition(final Class<E> condition, final String... patterns) throws IllegalArgumentException {
 		checkAcceptRegistrations();
-		final SyntaxElementInfo<E> info = new SyntaxElementInfo<>(patterns, condition);
+		String originClassPath = Thread.currentThread().getStackTrace()[2].getClassName();
+		final SyntaxElementInfo<E> info = new SyntaxElementInfo<>(patterns, condition, originClassPath);
 		conditions.add(info);
 		statements.add(info);
 	}
@@ -1057,7 +1059,8 @@ public final class Skript extends JavaPlugin implements Listener {
 	 */
 	public static <E extends Effect> void registerEffect(final Class<E> effect, final String... patterns) throws IllegalArgumentException {
 		checkAcceptRegistrations();
-		final SyntaxElementInfo<E> info = new SyntaxElementInfo<>(patterns, effect);
+		String originClassPath = Thread.currentThread().getStackTrace()[2].getClassName();
+		final SyntaxElementInfo<E> info = new SyntaxElementInfo<>(patterns, effect, originClassPath);
 		effects.add(info);
 		statements.add(info);
 	}
@@ -1093,7 +1096,8 @@ public final class Skript extends JavaPlugin implements Listener {
 		checkAcceptRegistrations();
 		if (returnType.isAnnotation() || returnType.isArray() || returnType.isPrimitive())
 			throw new IllegalArgumentException("returnType must be a normal type");
-		final ExpressionInfo<E, T> info = new ExpressionInfo<>(patterns, returnType, c);
+		String originClassPath = Thread.currentThread().getStackTrace()[2].getClassName();
+		final ExpressionInfo<E, T> info = new ExpressionInfo<>(patterns, returnType, c, originClassPath);
 		for (int i = type.ordinal() + 1; i < ExpressionType.values().length; i++) {
 			expressionTypesStartIndices[i]++;
 		}
@@ -1138,10 +1142,12 @@ public final class Skript extends JavaPlugin implements Listener {
 	@SuppressWarnings({"unchecked"})
 	public static <E extends SkriptEvent> SkriptEventInfo<E> registerEvent(final String name, final Class<E> c, final Class<? extends Event> event, final String... patterns) {
 		checkAcceptRegistrations();
-		final SkriptEventInfo<E> r = new SkriptEventInfo<>(name, patterns, c, CollectionUtils.array(event));
+		String originClassPath = Thread.currentThread().getStackTrace()[2].getClassName();
+		final SkriptEventInfo<E> r = new SkriptEventInfo<>(name, patterns, c, originClassPath, CollectionUtils.array(event));
 		events.add(r);
 		return r;
 	}
+
 	
 	/**
 	 * Registers an event.
@@ -1154,7 +1160,8 @@ public final class Skript extends JavaPlugin implements Listener {
 	 */
 	public static <E extends SkriptEvent> SkriptEventInfo<E> registerEvent(final String name, final Class<E> c, final Class<? extends Event>[] events, final String... patterns) {
 		checkAcceptRegistrations();
-		final SkriptEventInfo<E> r = new SkriptEventInfo<>(name, patterns, c, events);
+		String originClassPath = Thread.currentThread().getStackTrace()[2].getClassName();
+		final SkriptEventInfo<E> r = new SkriptEventInfo<>(name, patterns, c, originClassPath, events);
 		Skript.events.add(r);
 		return r;
 	}

--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -52,7 +52,6 @@ import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 
 import ch.njol.skript.lang.Trigger;
-import ch.njol.skript.lang.util.SimpleEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -1147,7 +1146,6 @@ public final class Skript extends JavaPlugin implements Listener {
 		events.add(r);
 		return r;
 	}
-
 	
 	/**
 	 * Registers an event.

--- a/src/main/java/ch/njol/skript/entity/EntityData.java
+++ b/src/main/java/ch/njol/skript/entity/EntityData.java
@@ -189,7 +189,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		final Noun[] names;
 		
 		public EntityDataInfo(final Class<T> dataClass, final String codeName, final String[] codeNames, final int defaultName, final Class<? extends Entity> entityClass) throws IllegalArgumentException {
-			super(new String[codeNames.length], dataClass);
+			super(new String[codeNames.length], dataClass, dataClass.getName());
 			assert codeName != null && entityClass != null && codeNames.length > 0;
 			this.codeName = codeName;
 			this.codeNames = codeNames;

--- a/src/main/java/ch/njol/skript/lang/ExpressionInfo.java
+++ b/src/main/java/ch/njol/skript/lang/ExpressionInfo.java
@@ -23,8 +23,8 @@ public class ExpressionInfo<E extends Expression<T>, T> extends SyntaxElementInf
 	
 	public Class<T> returnType;
 	
-	public ExpressionInfo(final String[] patterns, final Class<T> returnType, final Class<E> c) throws IllegalArgumentException {
-		super(patterns, c);
+	public ExpressionInfo(final String[] patterns, final Class<T> returnType, final Class<E> c, final String originClassPath) throws IllegalArgumentException {
+		super(patterns, c, originClassPath);
 		this.returnType = returnType;
 	}
 	

--- a/src/main/java/ch/njol/skript/lang/SkriptEvent.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptEvent.java
@@ -19,12 +19,11 @@
  */
 package ch.njol.skript.lang;
 
-import org.bukkit.event.Event;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.events.EvtClick;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
 
 /**
  * A SkriptEvent is like a condition. It is called when any of the registered events occurs.

--- a/src/main/java/ch/njol/skript/lang/SkriptEventInfo.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptEventInfo.java
@@ -49,13 +49,15 @@ public final class SkriptEventInfo<E extends SkriptEvent> extends SyntaxElementI
 	 * @param name Capitalised name of the event without leading "On" which is added automatically (Start the name with an asterisk to prevent this).
 	 * @param patterns
 	 * @param c The SkriptEvent's class
+	 * @param originClassPath The class path for the origin of this event.
 	 * @param events The Bukkit-Events this SkriptEvent listens to
 	 */
-	public SkriptEventInfo(String name, final String[] patterns, final Class<E> c, final Class<? extends Event>[] events) {
-		super(patterns, c);
+	public SkriptEventInfo(String name, final String[] patterns, final Class<E> c, final String originClassPath, final Class<? extends Event>[] events) {
+		super(patterns, c, originClassPath);
 		assert name != null;
 		assert patterns != null && patterns.length > 0;
 		assert c != null;
+		assert originClassPath != null;
 		assert events != null && events.length > 0;
 		
 		for (int i = 0; i < events.length; i++) {
@@ -150,6 +152,7 @@ public final class SkriptEventInfo<E extends SkriptEvent> extends SyntaxElementI
 		this.requiredPlugins = pluginNames;
 		return this;
 	}
+
 	
 	public String getId() {
 		return id;

--- a/src/main/java/ch/njol/skript/lang/SyntaxElementInfo.java
+++ b/src/main/java/ch/njol/skript/lang/SyntaxElementInfo.java
@@ -27,10 +27,12 @@ public class SyntaxElementInfo<E extends SyntaxElement> {
 	
 	public final Class<E> c;
 	public final String[] patterns;
+	public final String originClassPath;
 	
-	public SyntaxElementInfo(final String[] patterns, final Class<E> c) throws IllegalArgumentException {
+	public SyntaxElementInfo(final String[] patterns, final Class<E> c, final String originClassPath) throws IllegalArgumentException {
 		this.patterns = patterns;
 		this.c = c;
+		this.originClassPath = originClassPath;
 		try {
 			c.getConstructor();
 //			if (!c.getDeclaredConstructor().isAccessible())

--- a/src/main/java/ch/njol/skript/util/VisualEffect.java
+++ b/src/main/java/ch/njol/skript/util/VisualEffect.java
@@ -34,6 +34,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.material.MaterialData;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
@@ -296,9 +297,19 @@ public final class VisualEffect implements SyntaxElement, YggdrasilSerializable 
 				}
 				final String[] ps = patterns.toArray(new String[patterns.size()]);
 				assert ps != null;
-				info = new SyntaxElementInfo<>(ps, VisualEffect.class);
+
+				info = new SyntaxElementInfo<>(ps, VisualEffect.class, getOriginPath(VisualEffect.class));
 			}
 		});
+	}
+
+	@NonNull
+	private static String getOriginPath(Class c){
+		String path = c.getName();
+		if (path != null){
+			return path;
+		}
+		return "<null>";
 	}
 	
 	private Type type;


### PR DESCRIPTION
Target Minecraft versions: Any
Requirements: None
Related issues: N/A

Description:

In the previous system calling: 
```kotlin
class.`package`.name
``` 
in kotlin for a SimpleEvent or SimpleExpression would result in 
```
ch.njol.skript.lang.util
```
being returned regardless of if an addon was the origin of the SimpleEvent or SimpleExpression. The addition of the originClassPath allows for a proper class path to the original plugin. This is very useful for documentation generation tools as it prevents other addons SimpleEvents and SimpleExpressions from getting mixed up with Skripts.