### PR TITLE
Add player language stuff

### DIFF
--- a/src/main/java/ch/njol/skript/events/SimpleEvents.java
+++ b/src/main/java/ch/njol/skript/events/SimpleEvents.java
@@ -425,11 +425,13 @@ public class SimpleEvents {
 						"	if {game::%player%::playing} exists:",
 						"		cancel event")
 				.since("INSERT VERSION");
-		Skript.registerEvent("Language Change", SimpleEvent.class, PlayerLocaleChangeEvent.class, "[player] (language|locale) chang(e|ing)", "[player] chang(e|ing) (language|locale)")
-				.description("Called when a player changes their language in the game settings. You can use the <a href='expressions.html#ExprLanguage'>language</a> expression to get the current language of the player.")
-				.examples("on language change:",
-						"	if player's language starts with \"en\":",
-						"		send \"Hello!\"")
-				.since("INSERT VERSION");
+		if (Skript.classExists("org.bukkit.event.player.PlayerLocaleChangeEvent")) {
+			Skript.registerEvent("Language Change", SimpleEvent.class, PlayerLocaleChangeEvent.class, "[player] (language|locale) chang(e|ing)", "[player] chang(e|ing) (language|locale)")
+					.description("Called when a player changes their language in the game settings. You can use the <a href='expressions.html#ExprLanguage'>language</a> expression to get the current language of the player.")
+					.examples("on language change:",
+							"	if player's language starts with \"en\":",
+							"		send \"Hello!\"")
+					.since("INSERT VERSION");
+		}
 	}
 }

--- a/src/main/java/ch/njol/skript/events/SimpleEvents.java
+++ b/src/main/java/ch/njol/skript/events/SimpleEvents.java
@@ -427,7 +427,8 @@ public class SimpleEvents {
 				.since("INSERT VERSION");
 		if (Skript.classExists("org.bukkit.event.player.PlayerLocaleChangeEvent")) {
 			Skript.registerEvent("Language Change", SimpleEvent.class, PlayerLocaleChangeEvent.class, "[player] (language|locale) chang(e|ing)", "[player] chang(e|ing) (language|locale)")
-					.description("Called when a player changes their language in the game settings. You can use the <a href='expressions.html#ExprLanguage'>language</a> expression to get the current language of the player.")
+					.description("Called after a player changed their language in the game settings. You can use the <a href='expressions.html#ExprLanguage'>language</a> expression to get the current language of the player.",
+						"This event requires Minecraft 1.12+.")
 					.examples("on language change:",
 							"	if player's language starts with \"en\":",
 							"		send \"Hello!\"")

--- a/src/main/java/ch/njol/skript/events/SimpleEvents.java
+++ b/src/main/java/ch/njol/skript/events/SimpleEvents.java
@@ -64,6 +64,7 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerKickEvent;
 import org.bukkit.event.player.PlayerLevelChangeEvent;
 import org.bukkit.event.player.PlayerLoginEvent;
+import org.bukkit.event.player.PlayerLocaleChangeEvent;
 import org.bukkit.event.player.PlayerPortalEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
@@ -423,6 +424,12 @@ public class SimpleEvents {
 				.examples("on flight toggle:",
 						"	if {game::%player%::playing} exists:",
 						"		cancel event")
+				.since("INSERT VERSION");
+		Skript.registerEvent("Language Change", SimpleEvent.class, PlayerLocaleChangeEvent.class, "[player] (language|locale) chang(e|ing)", "[player] chang(e|ing) (language|locale)")
+				.description("Called when a player changes their language in the game settings. You can use the <a href='expressions.html#ExprLanguage'>language</a> expression to get the current language of the player.")
+				.examples("on language change:",
+						"	if player's language starts with \"en\":",
+						"		send \"Hello!\"")
 				.since("INSERT VERSION");
 	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprLanguage.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLanguage.java
@@ -20,8 +20,8 @@
 package ch.njol.skript.expressions;
 
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Player.Spigot;
 import org.eclipse.jdt.annotation.Nullable;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -31,15 +31,16 @@ import ch.njol.skript.expressions.base.SimplePropertyExpression;
 
 @Name("Language")
 @Description({"Currently selected game language of a player. The value of the language is not defined properly.",
-			"The vanilla Minecraft client will use lowercase language / country pairs separated by an underscore, but custom resource packs may use any format they wish.",
-			"This expression is Minecraft 1.12+."})
-@Examples({"message \"%player's current hotbar slot%\"",
-            "set player's selected hotbar slot to slot 4 of player"})
+			"The vanilla Minecraft client will use lowercase language / country pairs separated by an underscore, but custom resource packs may use any format they wish."})
+@Examples({"message player's current language"})
 @Since("INSERT VERSION")
 public class ExprLanguage extends SimplePropertyExpression<Player, String> {
 
+	private static final boolean PLAYER_METHOD = Skript.methodExists(Player.class, "getLocale");
+	private static final boolean PLAYER_SPIGOT_METHOD = Skript.methodExists(Player.Spigot.class, "getLocale");
+	
 	static {
-		if (Skript.methodExists(Player.class, "getLocale")) {
+		if (PLAYER_METHOD || PLAYER_SPIGOT_METHOD) {
 			register(ExprLanguage.class, String.class, "[([currently] selected|current)] [game] (language|locale) [setting]", "players");
 		}
 	}
@@ -47,7 +48,12 @@ public class ExprLanguage extends SimplePropertyExpression<Player, String> {
 	@Override
 	@Nullable
 	public String convert(Player p) {
-		return p.getLocale();
+		if (PLAYER_METHOD) {
+			return p.getLocale();
+		} else if (PLAYER_SPIGOT_METHOD) {
+			return p.spigot().getLocale();
+		}
+		return null;
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprLanguage.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLanguage.java
@@ -1,0 +1,60 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.expressions;
+
+import org.bukkit.entity.Player;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+
+@Name("Language")
+@Description({"Currently selected game language of a player. The value of the language is not defined properly.",
+			"The vanilla Minecraft client will use lowercase language / country pairs separated by an underscore, but custom resource packs may use any format they wish."})
+@Examples({"message \"%player's current hotbar slot%\"",
+            "set player's selected hotbar slot to slot 4 of player"})
+@Since("INSERT VERSION")
+public class ExprLanguage extends SimplePropertyExpression<Player, String> {
+
+	static {
+		register(ExprLanguage.class, String.class, "[([currently] selected|current)] [game] (language|locale) [setting]", "players");
+	}
+	
+	@Override
+	@Nullable
+	public String convert(Player p) {
+		return p.getLocale();
+	}
+	
+	@Override
+	protected String getPropertyName() {
+		return "language";
+	}
+	
+	@Override
+	public Class<? extends String> getReturnType() {
+		return String.class;
+	}
+	
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprLanguage.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLanguage.java
@@ -31,14 +31,17 @@ import ch.njol.skript.expressions.base.SimplePropertyExpression;
 
 @Name("Language")
 @Description({"Currently selected game language of a player. The value of the language is not defined properly.",
-			"The vanilla Minecraft client will use lowercase language / country pairs separated by an underscore, but custom resource packs may use any format they wish."})
+			"The vanilla Minecraft client will use lowercase language / country pairs separated by an underscore, but custom resource packs may use any format they wish.",
+			"This expression is Minecraft 1.12+."})
 @Examples({"message \"%player's current hotbar slot%\"",
             "set player's selected hotbar slot to slot 4 of player"})
 @Since("INSERT VERSION")
 public class ExprLanguage extends SimplePropertyExpression<Player, String> {
 
 	static {
-		register(ExprLanguage.class, String.class, "[([currently] selected|current)] [game] (language|locale) [setting]", "players");
+		if (Skript.methodExists(Player.class, "getLocale")) {
+			register(ExprLanguage.class, String.class, "[([currently] selected|current)] [game] (language|locale) [setting]", "players");
+		}
 	}
 	
 	@Override


### PR DESCRIPTION
**Target Minecraft versions / Requirements:** 1.8+
- The language expression supports Spigot or PaperSpigot 1.8+.
- The language change event supports PaperSpigot 1.8, Spigot 1.12 and PaperSpigot 1.12.

**Related issues:** https://github.com/SkriptLang/Skript/issues/1291

**Description:**
Adds player language expression and language change event. I couldn't add a way to get the old language in the event because the event is called after language is changed.