### PR TITLE
Add Make Say effect

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffMakeSay.java
+++ b/src/main/java/ch/njol/skript/effects/EffMakeSay.java
@@ -1,0 +1,74 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+@Name("Make Say")
+@Description("Forces a player to send a message to the chat. If the message starts with a slash it will force the player to use command.")
+@Examples({"make the player say \"Hello.\"", "force all players to send the message \"I love this server\""})
+@Since("INSERT VERSION")
+public class EffMakeSay extends Effect {
+
+	static {
+		Skript.registerEffect(EffMakeSay.class,
+				"make %players% (say|send [the] message[s]) %strings%",
+				"force %players% to (say|send [the] message[s]) %strings%");
+	}
+
+	@SuppressWarnings("null")
+	private Expression<Player> players;
+
+	@SuppressWarnings("null")
+	private Expression<String> messages;
+
+	@SuppressWarnings({"unchecked", "null"})
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		players = (Expression<Player>) exprs[0];
+		messages = (Expression<String>) exprs[1];
+		return true;
+	}
+
+	@Override
+	protected void execute(Event e) {
+		for (Player player : players.getArray(e)) {
+			for (String message : messages.getArray(e)) {
+				player.chat(message);
+			}
+		}
+	}
+
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		return "make " + players.toString(e, debug) + " say " + messages.toString(e, debug);
+	}
+}


### PR DESCRIPTION
Target Minecraft versions: Any
Requirements: No
Related issues: https://github.com/SkriptLang/Skript/issues/1291

Description:
Adds an effect that forces players to say messages in the chat.