### PR TITLE
Remove unused repositories from build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,21 +15,9 @@ repositories {
 		url = 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/'
 	}
 
-//	maven {
-//		url 'https://oss.sonatype.org/content/groups/public/'
-//	}
-
 	maven {
 		url 'http://maven.sk89q.com/repo'
 	}
-
-	maven {
-		url 'https://mvn.yawk.at'
-	}
-
-//	maven {
-//		url 'http://nexus.theyeticave.net/content/repositories/pub_releases'
-//	}
 
 	maven {
 		url 'https://repo.destroystokyo.com/repository/maven-public/'
@@ -42,11 +30,6 @@ repositories {
 	maven {
 		url 'http://nexus.hc.to/content/repositories/pub_releases'
 	}
-
-//	maven {
-//		url 'http://maven.elmakers.com/repository/'
-//	}
-
 
 	maven {
 		url 'https://jitpack.io'


### PR DESCRIPTION
Removes 3 commented unneeded maven repos, and one uncommented although it was unneeded too. I'm creating this PR since the uncommented one went down today, making Skript impossible to bulid - https://travis-ci.com/Nicofisi/Skript/builds/78580876 https://i.imgur.com/eRdlFue.png

It'd be best if this was merged ASAP, today