### PR TITLE
Make Skript work in IntelliJ and be compilable with javac

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
-    id "com.github.hierynomus.license" version "0.14.0"
+	id "com.github.hierynomus.license" version "0.14.0"
 }
 
 apply plugin: 'java'
@@ -58,7 +58,7 @@ configurations.all {
 
 processResources {
 	filter ReplaceTokens, tokens: [
-		"version" :System.getenv('SKRIPT_VERSION') == null ? project.property("version") : System.getenv('SKRIPT_VERSION')
+			"version" :System.getenv('SKRIPT_VERSION') == null ? project.property("version") : System.getenv('SKRIPT_VERSION')
 	]
 }
 
@@ -72,10 +72,10 @@ jar {
 }
 
 license {
-    header file('licenseheader.txt')
-    exclude('**/Metrics.java') // Not under GPLv3
-    exclude('**/*.sk') // Sample scripts and maybe aliases
-    exclude('**/*.lang') // Language files
+	header file('licenseheader.txt')
+	exclude('**/Metrics.java') // Not under GPLv3
+	exclude('**/*.sk') // Sample scripts and maybe aliases
+	exclude('**/*.lang') // Language files
 }
 
 configurations {
@@ -98,7 +98,7 @@ compileJava {
 }
 
 task sourceJar(type: Jar) {
-    from sourceSets.main.allJava
+	from sourceSets.main.allJava
 }
 
 publishing {
@@ -111,7 +111,7 @@ publishing {
 			from components.java
 
 			artifact sourceJar {
-    			classifier "sources"
+				classifier "sources"
 			}
 		}
 	}

--- a/src/main/java/ch/njol/skript/registrations/EventValues.java
+++ b/src/main/java/ch/njol/skript/registrations/EventValues.java
@@ -43,18 +43,18 @@ public class EventValues {
 		public final Class<T> c;
 		public final Getter<T, E> getter;
 		@Nullable
-		public final Class<? extends E>[] exculdes;
+		public final Class<? extends E>[] excludes;
 		@Nullable
 		public final String excludeErrorMessage;
 		
-		public EventValueInfo(final Class<E> event, final Class<T> c, final Getter<T, E> getter, final @Nullable String excludeErrorMessage, final @Nullable Class<? extends E>[] exculdes) {
+		public EventValueInfo(final Class<E> event, final Class<T> c, final Getter<T, E> getter, final @Nullable String excludeErrorMessage, final @Nullable Class<? extends E>[] excludes) {
 			assert event != null;
 			assert c != null;
 			assert getter != null;
 			this.event = event;
 			this.c = c;
 			this.getter = getter;
-			this.exculdes = exculdes;
+			this.excludes = excludes;
 			this.excludeErrorMessage = excludeErrorMessage;
 		}
 	}
@@ -212,8 +212,9 @@ public class EventValues {
 		return null;
 	}
 	
+	@SuppressWarnings("unchecked")
 	private static boolean checkExcludes(final EventValueInfo<?, ?> ev, final Class<? extends Event> e) {
-		final Class<? extends Event>[] excl = ev.exculdes;
+		final Class<? extends Event>[] excl = (Class<? extends Event>[]) ev.excludes;
 		if (excl == null)
 			return true;
 		for (final Class<? extends Event> ex : excl) {

--- a/src/main/java/ch/njol/skript/variables/Variables.java
+++ b/src/main/java/ch/njol/skript/variables/Variables.java
@@ -84,7 +84,7 @@ public abstract class Variables {
 			@SuppressWarnings("unchecked")
 			private final void init() {
 				// used by asserts
-				info = (ClassInfo<? extends ConfigurationSerializable>) Classes.getExactClassInfo(Object.class);
+				info = (ClassInfo<? extends ConfigurationSerializable>) (ClassInfo<?>) Classes.getExactClassInfo(Object.class);
 			}
 			
 			@SuppressWarnings({"unchecked"})

--- a/src/main/java/ch/njol/util/coll/BidiHashMap.java
+++ b/src/main/java/ch/njol/util/coll/BidiHashMap.java
@@ -150,7 +150,6 @@ public class BidiHashMap<T1, T2> extends HashMap<T1, T2> implements BidiMap<T1, 
 	
 	@Override
 	public BidiHashMap<T1, T2> clone() {
-		return new BidiHashMap<>(this);
+		return new BidiHashMap<T1, T2>(this);
 	}
-	
 }

--- a/src/main/java/ch/njol/yggdrasil/PseudoEnum.java
+++ b/src/main/java/ch/njol/yggdrasil/PseudoEnum.java
@@ -137,8 +137,8 @@ public abstract class PseudoEnum<T extends PseudoEnum<T>> {
 	 * @see Enum#getDeclaringClass()
 	 */
 	@SuppressWarnings({"unchecked", "null"})
-	public final Class<T> getDeclaringClass() {
-		return getDeclaringClass(getClass());
+	public final Class<? super T> getDeclaringClass() {
+		return getDeclaringClass((Class<T>) getClass());
 	}
 	
 	/**
@@ -164,7 +164,7 @@ public abstract class PseudoEnum<T extends PseudoEnum<T>> {
 	 * @return All constants registered so far.
 	 * @see Enum#valueOf(Class, String)
 	 */
-	public final List<T> values() {
+	public final List<? super T> values() {
 		return values(getDeclaringClass(), info);
 	}
 	
@@ -183,8 +183,8 @@ public abstract class PseudoEnum<T extends PseudoEnum<T>> {
 			throw new IllegalArgumentException(c + " != " + getDeclaringClass(c));
 		return values(c, getInfo(c));
 	}
-	
-	private static <T extends PseudoEnum<T>> List<T> values(final Class<T> c, final Info<T> info) {
+
+	private static <T extends PseudoEnum<T>> List<T> values(final Class<? super T> c, final Info<T> info) {
 		info.readLock.lock();
 		try {
 			return new ArrayList<>(info.values);


### PR DESCRIPTION
Before this commit if you opened for example `EventValues.java` or `BidiHashMap.java` in IntelliJ it would keep showing an error with no option to hide it as far as I'm aware of. Anyway, `javac` treats this as an error too - the code does make sense though and I guess it's a point for ECJ that it accepts it. But anyway, this PR fixes both the IntelliJ and the javac problem. 

The `build.gradle` change was unintentional but I didn't rebase the commit since it fixes indentation so it should be good.

If you wish to compile Skript with javac, apply the following changes to the build.gradle:
```diff
Index: build.gradle
===================================================================
--- build.gradle	(revision 1d32f0f334a0f00ec2933ebcbea5ca3568fbb3cb)
+++ build.gradle	(date 1531668581301)
@@ -78,23 +78,9 @@
 	exclude('**/*.lang') // Language files
 }
 
-configurations {
-	ecj
-}
-
-dependencies {
-	ecj 'org.eclipse.jdt:ecj:3.13.100'
-}
-
 sourceCompatibility = 1.8
 compileJava {
-	options.fork = true
 	options.encoding = 'UTF-8'
-	options.compilerArgs = ['-properties', '.settings/org.eclipse.jdt.core.prefs', '-encoding', 'UTF-8']
-	options.forkOptions.with {
-		executable = 'java'
-		jvmArgs = ['-classpath', project.configurations.ecj.asPath, 'org.eclipse.jdt.internal.compiler.batch.Main']
-	}
 }
 
 task sourceJar(type: Jar) {
```

Keep in mind though that my main intention was to fix the IntelliJ errors