### PR TITLE
'%number% times' improvements

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprNumbers.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNumbers.java
@@ -46,16 +46,14 @@ import ch.njol.util.Kleenean;
 @Name("Numbers")
 @Description({"All numbers between two given numbers, useful for looping.",
 		"Use 'numbers' if your start is not an integer and you want to keep the fractional part of the start number constant, or use 'integers' if you only want to loop integers.",
-		"An integer loop from 1 to a number x can also be written as 'loop x times'."})
-@Examples({"loop 5 times: # loops 1, 2, 3, 4, 5",
-		"loop numbers from 2.5 to 5.5: # loops 2.5, 3.5, 4.5, 5.5",
+		"You may want to use the 'times' expression instead, for instance 'loop 5 times:'"})
+@Examples({"loop numbers from 2.5 to 5.5: # loops 2.5, 3.5, 4.5, 5.5",
 		"loop integers from 2.9 to 5.1: # same as '3 to 5', i.e. loops 3, 4, 5"})
 @Since("1.4.6")
 public class ExprNumbers extends SimpleExpression<Number> {
 	static {
 		Skript.registerExpression(ExprNumbers.class, Number.class, ExpressionType.COMBINED,
-				"[(all [[of] the]|the)] (numbers|1¦integers) (between|from) %number% (and|to) %number%",
-				"%number% times");
+				"[(all [[of] the]|the)] (numbers|1¦integers) (between|from) %number% (and|to) %number%");
 	}
 	
 	@SuppressWarnings("null")
@@ -65,9 +63,9 @@ public class ExprNumbers extends SimpleExpression<Number> {
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
 	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
-		start = matchedPattern == 0 ? (Expression<Number>) exprs[0] : new SimpleLiteral<>(1, false);
-		end = (Expression<Number>) exprs[1 - matchedPattern];
-		integer = parseResult.mark == 1 || matchedPattern == 1;
+		start = (Expression<Number>) exprs[0];
+		end = (Expression<Number>) exprs[1];
+		integer = parseResult.mark == 1;
 		return true;
 	}
 	
@@ -88,12 +86,12 @@ public class ExprNumbers extends SimpleExpression<Number> {
 		final double low = integer ? Math.ceil(s.doubleValue()) : s.doubleValue();
 		for (int i = 0; i < amount; i++) {
 			if (integer)
-				list.add(Long.valueOf((long) low + i));
+				list.add((long) low + i);
 			else
-				list.add(Double.valueOf(low + i));
+				list.add(low + i);
 		}
 		if (reverse) Collections.reverse(list);
-		return list.toArray(new Number[list.size()]);
+		return list.toArray(new Number[0]);
 	}
 	
 	@Override
@@ -123,14 +121,9 @@ public class ExprNumbers extends SimpleExpression<Number> {
 				if (!hasNext())
 					throw new NoSuchElementException();
 				if (integer)
-					return Long.valueOf((long) (reverse ? max-- : i++));
+					return (long) (reverse ? max-- : i++);
 				else
-					return Double.valueOf(reverse ? max-- : i++);
-			}
-			
-			@Override
-			public void remove() {
-				throw new UnsupportedOperationException();
+					return reverse ? max-- : i++;
 			}
 		};
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprTimes.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTimes.java
@@ -26,6 +26,7 @@ import java.util.stream.IntStream;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
+import com.google.common.collect.Iterators;
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.NoDoc;
 import ch.njol.skript.lang.Expression;
@@ -68,38 +69,21 @@ public class ExprTimes extends SimpleExpression<Number> {
 	@Nullable
 	@Override
 	protected Number[] get(final Event e) {
-		Number end = this.end.getSingle(e);
-		if (end == null) {
+		Iterator<? extends Integer> iter = iterator(e);
+		if (iter == null) {
 			return null;
 		}
-		// empty if the second param is lesser than 1
-		return IntStream.range(1, end.intValue() + 1).boxed().toArray(Integer[]::new);
+		return Iterators.toArray(iter, Integer.class);
 	}
 
 	@Nullable
 	@Override
-	public Iterator<? extends Number> iterator(final Event e) {
+	public Iterator<? extends Integer> iterator(final Event e) {
 		Number end = this.end.getSingle(e);
 		if (end == null) {
 			return null;
 		}
-		int endInt = end.intValue(); // this whole method is all about performance, so..
-		return new Iterator<Number>() {
-			int current = 0;
-
-			@Override
-			public boolean hasNext() {
-				return current < endInt;
-			}
-
-			@Override
-			public Number next() {
-				if (!hasNext()) {
-					throw new NoSuchElementException();
-				}
-				return ++current;
-			}
-		};
+		return IntStream.range(1, end.intValue() + 1).iterator();
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprTimes.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTimes.java
@@ -1,0 +1,119 @@
+/**
+ * This file is part of Skript.
+ *
+ * Skript is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Skript is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.expressions;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.stream.IntStream;
+
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.NoDoc;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.Literal;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.skript.lang.util.SimpleLiteral;
+import ch.njol.util.Kleenean;
+
+@NoDoc
+public class ExprTimes extends SimpleExpression<Number> {
+
+	static {
+		Skript.registerExpression(ExprTimes.class, Number.class, ExpressionType.SIMPLE,
+				"%number% time[s]", "once", "twice");
+	}
+
+	@SuppressWarnings("null")
+	private Expression<Number> end;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
+		end = matchedPattern == 0 ? (Expression<Number>) exprs[0] : new SimpleLiteral<>(matchedPattern, false);
+		if (end instanceof Literal) {
+			int amount = ((Literal<Number>) end).getSingle().intValue();
+			if (amount == 0) {
+				Skript.warning("Looping zero times makes the code inside of the loop useless");
+			} else if (amount == 1) {
+				Skript.warning("Since you're looping exactly one time, you could simply remove the loop instead");
+			} else if (amount < 0) {
+				Skript.error("Looping a negative amount of times is impossible");
+				return false;
+			}
+		}
+		return true;
+	}
+
+	@Nullable
+	@Override
+	protected Number[] get(final Event e) {
+		Number end = this.end.getSingle(e);
+		if (end == null) {
+			return null;
+		}
+		// empty if the second param is lesser than 1
+		return IntStream.range(1, end.intValue() + 1).boxed().toArray(Integer[]::new);
+	}
+
+	@Nullable
+	@Override
+	public Iterator<? extends Number> iterator(final Event e) {
+		Number end = this.end.getSingle(e);
+		if (end == null) {
+			return null;
+		}
+		int endInt = end.intValue(); // this whole method is all about performance, so..
+		return new Iterator<Number>() {
+			int current = 0;
+
+			@Override
+			public boolean hasNext() {
+				return current < endInt;
+			}
+
+			@Override
+			public Number next() {
+				if (!hasNext()) {
+					throw new NoSuchElementException();
+				}
+				return ++current;
+			}
+		};
+	}
+
+	@Override
+	public boolean isSingle() {
+		return false;
+	}
+
+	@Override
+	public Class<? extends Number> getReturnType() {
+		return Number.class;
+	}
+
+	@Override
+	public String toString(final @Nullable Event e, final boolean debug) {
+		return end.toString(e, debug) + " times";
+	}
+}


### PR DESCRIPTION
- Move `%number% times` into a separate expression
- Warn when a hardcoded 'loop 1 time' or 'loop 0 times' is met.
- Error when a hardcoded 'loop <0 times' is met.
- Do nothing when a non-hardcoded 'loop <1 times' is met.

Originally the code allowed for the expression to [only be used in loops](https://gist.github.com/Nicofisi/cb9acaa666576b2c57f601c03ad7850b), but I removed that restriction since @Snow-Pyon mentioned that other addons depend on this syntax (how?)

The only issue that I see now is that every error & warning message mentions the `loop` but it actually can be used outside of loops. I'm very open to any suggestions about these messages.

I used `Number`s instead of `Integer`s since @Pikachu920 mentioned that there are some known bugs related to an Integer return type / `%integer%` in syntaxes

It's `@NoDoc` since @Blueyescat and @Pikachu920 suggested to make it so. 

Related issue: #1356 