### PR TITLE
Fix documentation links

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
@@ -536,7 +536,7 @@ public class SkriptClasses {
 		Classes.registerClass(new ClassInfo<>(Date.class, "date")
 				.user("dates?")
 				.name("Date")
-				.description("A date is a certain point in the real world's time which can currently only be obtained with <a href='../expressions/#ExprNow'>now</a>.",
+				.description("A date is a certain point in the real world's time which can currently only be obtained with <a href='../expressions.html#ExprNow'>now</a>.",
 						"See <a href='#time'>time</a> and <a href='#timespan'>timespan</a> for the other time types of Skript.")
 				.usage("")
 				.examples("set {_yesterday} to now",
@@ -592,7 +592,7 @@ public class SkriptClasses {
 				.description("A direction, e.g. north, east, behind, 5 south east, 1.3 meters to the right, etc.",
 						"<a href='#location'>Locations</a> and some <a href='#block'>blocks</a> also have a direction, but without a length.",
 						"Please note that directions have changed extensively in the betas and might not work perfectly. They can also not be used as command arguments.")
-				.usage("see <a href='../expressions/#ExprDirection'>direction (expression)</a>")
+				.usage("see <a href='../expressions.html#ExprDirection'>direction (expression)</a>")
 				.examples("set the block below the victim to a chest",
 						"loop blocks from the block infront of the player to the block 10 below the player:",
 						"	set the block behind the loop-block to water")
@@ -639,11 +639,11 @@ public class SkriptClasses {
 				.user("(inventory )?slots?")
 				.name("Inventory Slot")
 				.description("Represents a single slot of an <a href='#inventory'>inventory</a>. " +
-						"Notable slots are the <a href='../expressions/#ExprArmorSlot'>armour slots</a> and <a href='../expressions/#ExprFurnaceSlot'>furnace slots</a>. ",
+						"Notable slots are the <a href='../expressions.html#ExprArmorSlot'>armour slots</a> and <a href='../expressions/#ExprFurnaceSlot'>furnace slots</a>. ",
 						"The most important property that distinguishes a slot from an <a href='#itemstack'>item</a> is its ability to be changed, e.g. it can be set, deleted, enchanted, etc. " +
 								"(Some item expressions can be changed as well, e.g. items stored in variables. " +
 								"For that matter: slots are never saved to variables, only the items they represent at the time when the variable is set).",
-						"Please note that <a href='../expressions/#ExprTool'>tool</a> can be regarded a slot, but it can actually change it's position, i.e. doesn't represent always the same slot.")
+						"Please note that <a href='../expressions.html#ExprTool'>tool</a> can be regarded a slot, but it can actually change it's position, i.e. doesn't represent always the same slot.")
 				.usage("")
 				.examples("set tool of player to dirt",
 						"delete helmet of the victim",
@@ -753,7 +753,7 @@ public class SkriptClasses {
 		Classes.registerClass(new ClassInfo<>(StructureType.class, "structuretype")
 				.user("tree ?types?", "trees?")
 				.name("Tree Type")
-				.description("A tree type represents a tree species or a huge mushroom species. These can be generated in a world with the <a href='../effects/#EffTree'>generate tree</a> effect.")
+				.description("A tree type represents a tree species or a huge mushroom species. These can be generated in a world with the <a href='../effects.html#EffTree'>generate tree</a> effect.")
 				.usage("<code>[any] &lt;general tree/mushroom type&gt;</code>, e.g. tree/any jungle tree/etc.", "<code>&lt;specific tree/mushroom species&gt;</code>, e.g. red mushroom/small jungle tree/big regular tree/etc.")
 				.examples("grow any regular tree at the block",
 						"grow a huge red mushroom above the block")
@@ -835,7 +835,7 @@ public class SkriptClasses {
 		Classes.registerClass(new ClassInfo<>(Experience.class, "experience")
 				.name("Experience")
 				.description("Experience points. Please note that Bukkit only allows to give XP, but not remove XP from players. " +
-						"You can however change a player's <a href='../expressions/#ExprLevel'>level</a> and <a href='../expressions/#ExprLevelProgress'>level progress</a> freely.")
+						"You can however change a player's <a href='../expressions.html#ExprLevel'>level</a> and <a href='../expressions/#ExprLevelProgress'>level progress</a> freely.")
 				.usage("<code>[&lt;number&gt;] ([e]xp|experience [point[s]])</code>")
 				.examples("give 10 xp to the player")
 				.since("2.0")

--- a/src/main/java/ch/njol/skript/doc/Documentation.java
+++ b/src/main/java/ch/njol/skript/doc/Documentation.java
@@ -189,7 +189,7 @@ public class Documentation {
 					final NonNullPair<String, Boolean> p = Utils.getEnglishPlural(c);
 					final ClassInfo<?> ci = Classes.getClassInfoNoError(p.getFirst());
 					if (ci != null && ci.getDocName() != null && ci.getDocName() != ClassInfo.NO_DOC) {
-						b.append("<a href='../classes/#").append(p.getFirst()).append("'>").append(ci.getName().toString(p.getSecond())).append("</a>");
+						b.append("<a href='../classes.html#").append(p.getFirst()).append("'>").append(ci.getName().toString(p.getSecond())).append("</a>");
 					} else {
 						b.append(c);
 						if (ci != null && ci.getDocName() != ClassInfo.NO_DOC)

--- a/src/main/java/ch/njol/skript/effects/EffReplace.java
+++ b/src/main/java/ch/njol/skript/effects/EffReplace.java
@@ -48,7 +48,7 @@ import ch.njol.util.StringUtils;
  * @author Peter Güttinger
  */
 @Name("Replace")
-@Description({"Replaces all occurrences of a given text with another text. Please note that you can only change variables and a few expressions, e.g. a <a href='../expressions/#ExprMessage'>message</a> or a line of a sign.",
+@Description({"Replaces all occurrences of a given text with another text. Please note that you can only change variables and a few expressions, e.g. a <a href='../expressions.html#ExprMessage'>message</a> or a line of a sign.",
 		"Starting with 2.2-dev24, you can replace items in a inventory too."})
 @Examples({"replace \"<item>\" in {textvar} with \"%item%\"",
 		"replace every \"&\" with \"§\" in line 1",

--- a/src/main/java/ch/njol/skript/effects/EffVisualEffect.java
+++ b/src/main/java/ch/njol/skript/effects/EffVisualEffect.java
@@ -42,7 +42,7 @@ import ch.njol.util.Kleenean;
  * @author Peter Güttinger
  */
 @Name("Play Effect")
-@Description({"Plays a <a href='../classes/#visualeffect'>visual effect</a> at a given location or on a given entity.",
+@Description({"Plays a <a href='../classes.html#visualeffect'>visual effect</a> at a given location or on a given entity.",
 		"Please note that some effects can only be played on entities, e..g wolf hearts or the hurt effect, and that these are always visible to all players."})
 @Examples({"play wolf hearts on the clicked wolf",
 		"show mob spawner flames at the targeted block to the player"})

--- a/src/main/java/ch/njol/skript/events/EvtAtTime.java
+++ b/src/main/java/ch/njol/skript/events/EvtAtTime.java
@@ -49,7 +49,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class EvtAtTime extends SelfRegisteringSkriptEvent implements Comparable<EvtAtTime> {
 	static {
 		Skript.registerEvent("*At Time", EvtAtTime.class, ScheduledEvent.class, "at %time% [in %worlds%]")
-				.description("An event that occurs at a given <a href='../classes/#time'>minecraft time</a> in every world or only in specific worlds.")
+				.description("An event that occurs at a given <a href='../classes.html#time'>minecraft time</a> in every world or only in specific worlds.")
 				.examples("at 18:00", "at 7am in \"world\"")
 				.since("1.3.4");
 	}

--- a/src/main/java/ch/njol/skript/events/EvtGameMode.java
+++ b/src/main/java/ch/njol/skript/events/EvtGameMode.java
@@ -36,7 +36,7 @@ import ch.njol.util.Checker;
 public final class EvtGameMode extends SkriptEvent {
 	static {
 		Skript.registerEvent("Gamemode Change", EvtGameMode.class, PlayerGameModeChangeEvent.class, "game[ ]mode change [to %gamemode%]")
-				.description("Called when a player's <a href='../classes/#gamemode'>gamemode</a> changes.")
+				.description("Called when a player's <a href='../classes.html#gamemode'>gamemode</a> changes.")
 				.examples("on gamemode change", "on gamemode change to adventure")
 				.since("1.0");
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprAmountOfItems.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAmountOfItems.java
@@ -40,7 +40,7 @@ import ch.njol.util.Kleenean;
  * @author Peter Güttinger
  */
 @Name("Amount of Items")
-@Description("Counts how many of a particular <a href='../classes/#itemtype'>item type</a> are in a given inventory.")
+@Description("Counts how many of a particular <a href='../classes.html#itemtype'>item type</a> are in a given inventory.")
 @Examples("message \"You have %number of ores in the player's inventory% ores in your inventory.\"")
 @Since("2.0")
 public class ExprAmountOfItems extends SimpleExpression<Integer> {

--- a/src/main/java/ch/njol/skript/expressions/ExprChunk.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprChunk.java
@@ -42,7 +42,7 @@ import ch.njol.util.Kleenean;
  * @author Peter Güttinger
  */
 @Name("Chunk")
-@Description("The <a href='../classes/#chunk'>chunk</a> a block, location or entity is in")
+@Description("The <a href='../classes.html#chunk'>chunk</a> a block, location or entity is in")
 @Examples("add the chunk at the player to {protected chunks::*}")
 @Since("2.0")
 public class ExprChunk extends PropertyExpression<Location, Chunk> {

--- a/src/main/java/ch/njol/skript/expressions/ExprColorOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprColorOf.java
@@ -42,7 +42,7 @@ import ch.njol.util.coll.CollectionUtils;
  * @author Peter Güttinger
  */
 @Name("Colour of")
-@Description("The <a href='../classes/#color'>colour</a> of an item, can also be used to colour chat messages with \"&lt;%colour of ...%&gt;this text is coloured!\".")
+@Description("The <a href='../classes.html#color'>colour</a> of an item, can also be used to colour chat messages with \"&lt;%colour of ...%&gt;this text is coloured!\".")
 @Examples({"on click on wool:",
 		"	message \"This wool block is <%colour of block%>%colour of block%<reset>!\"",
 		"	set the colour of the block to black"})

--- a/src/main/java/ch/njol/skript/expressions/ExprCommandSender.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCommandSender.java
@@ -36,7 +36,7 @@ import ch.njol.skript.lang.ExpressionType;
  * @author Peter Güttinger
  */
 @Name("Command Sender")
-@Description("The player or the console who sent a command. Mostly useful in <a href='../commands/'>commands</a> and <a href='../events/#command'>command events</a>.")
+@Description("The player or the console who sent a command. Mostly useful in <a href='../commands/'>commands</a> and <a href='../events.html#command'>command events</a>.")
 @Examples({"make the command sender execute \"/say hi!\"",
 		"on command:",
 		"	log \"%executor% used command /%command% %arguments%\" to \"commands.log\""})

--- a/src/main/java/ch/njol/skript/expressions/ExprDamageCause.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDamageCause.java
@@ -35,7 +35,7 @@ import ch.njol.skript.lang.ExpressionType;
  * @author Peter Güttinger
  */
 @Name("Damage Cause")
-@Description("The <a href='../classes/#damagecause'>damage cause</a> of a damage event. Please click on the link for more information.")
+@Description("The <a href='../classes.html#damagecause'>damage cause</a> of a damage event. Please click on the link for more information.")
 @Examples("damage cause is lava, fire or burning")
 @Since("2.0")
 public class ExprDamageCause extends EventValueExpression<DamageCause> {

--- a/src/main/java/ch/njol/skript/expressions/ExprDifference.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDifference.java
@@ -47,7 +47,7 @@ import ch.njol.util.Kleenean;
  * @author Peter Güttinger
  */
 @Name("Difference")
-@Description("The difference between two values, e.g. <a href='../classes/#number'>numbers</a>, <a href='../classes/#date'>dates</a> or <a href='../classes/#time'>times</a>.")
+@Description("The difference between two values, e.g. <a href='../classes.html#number'>numbers</a>, <a href='../classes/#date'>dates</a> or <a href='../classes/#time'>times</a>.")
 @Examples({"difference between {command.%player%.lastuse} and now is smaller than a minute:",
 		"  message \"You have to wait a minute before using this command again!\"",
 		"  stop"})

--- a/src/main/java/ch/njol/skript/expressions/ExprExperience.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprExperience.java
@@ -42,7 +42,7 @@ import ch.njol.util.Kleenean;
  * @author Peter Güttinger
  */
 @Name("Experience")
-@Description("How much experience was spawned in an <a href='../events/#experience_spawn'>experience spawn</a> event. Can be changed.")
+@Description("How much experience was spawned in an <a href='../events.html#experience_spawn'>experience spawn</a> event. Can be changed.")
 @Examples({"on experience spawn:",
 		"	add 5 to the spawned experience"})
 @Since("2.1")

--- a/src/main/java/ch/njol/skript/expressions/ExprInventoryAction.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprInventoryAction.java
@@ -33,7 +33,7 @@ import ch.njol.skript.expressions.base.EventValueExpression;
 import ch.njol.skript.lang.ExpressionType;
 
 @Name("Inventory Action")
-@Description("The <a href='../classes/#inventoryaction'>inventory action</a> of an inventory event. Please click on the link for more information.")
+@Description("The <a href='../classes.html#inventoryaction'>inventory action</a> of an inventory event. Please click on the link for more information.")
 @Examples("inventory action is pickup all")
 @Since("2.2-dev16")
 public class ExprInventoryAction extends EventValueExpression<InventoryAction> {

--- a/src/main/java/ch/njol/skript/expressions/ExprLastSpawnedEntity.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLastSpawnedEntity.java
@@ -47,7 +47,7 @@ import ch.njol.util.Kleenean;
  * @author Peter Güttinger
  */
 @Name("Last Spawned Entity")
-@Description("Holds the entity that was spawned most recently with the <a href='../effects/#EffSpawn'>spawn effect</a>, drop with the <a href='../effects/#EffDrop'>drop effect</a> or shot with the <a href='../effects/#EffShoot'>shoot effect</a>. " +
+@Description("Holds the entity that was spawned most recently with the <a href='../effects.html#EffSpawn'>spawn effect</a>, drop with the <a href='../effects/#EffDrop'>drop effect</a> or shot with the <a href='../effects/#EffShoot'>shoot effect</a>. " +
 		"Please note that even though you can spawn multiple mobs simultaneously (e.g. with 'spawn 5 creepers'), only the last spawned mob is saved and can be used. " +
 		"If you spawn an entity, shoot a projectile and drop a item you can however access all them together.")
 @Examples({"spawn a priest",

--- a/src/main/java/ch/njol/skript/expressions/ExprLocationAt.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLocationAt.java
@@ -41,7 +41,7 @@ import ch.njol.util.Kleenean;
  * @author Peter Güttinger
  */
 @Name("Location At")
-@Description("Allows to create a <a href='../classes/#location'>location</a> from three coordinates and a world.")
+@Description("Allows to create a <a href='../classes.html#location'>location</a> from three coordinates and a world.")
 @Examples({"set {_loc} to the location at arg-1, arg-2, arg-3 of the world arg-4",
 		"distance between the player and the location (0, 0, 0) is less than 200"})
 @Since("2.0")

--- a/src/main/java/ch/njol/skript/expressions/ExprTeleportCause.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTeleportCause.java
@@ -33,7 +33,7 @@ import ch.njol.skript.expressions.base.EventValueExpression;
 import ch.njol.skript.lang.ExpressionType;
 
 @Name("Teleport Cause")
-@Description("The <a href='../classes/#teleportcause'>teleport cause</a> within a player teleport event.")
+@Description("The <a href='../classes.html#teleportcause'>teleport cause</a> within a player teleport event.")
 @Examples("teleport cause is nether portal, end portal or end gateway")
 @Since("2.2-dev35")
 public class ExprTeleportCause extends EventValueExpression<TeleportCause> {

--- a/src/main/java/ch/njol/skript/expressions/ExprTimeState.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTimeState.java
@@ -38,7 +38,7 @@ import ch.njol.util.Kleenean;
  * @author Peter Güttinger
  */
 @Name("Former/Future State")
-@Description({"Represents the value of an expression before an event happened or the value it will have directly after the event, e.g. the old or new level respectively in a <a href='../events/#level_change'>level change event</a>.",
+@Description({"Represents the value of an expression before an event happened or the value it will have directly after the event, e.g. the old or new level respectively in a <a href='../events.html#level_change'>level change event</a>.",
 		"Note: The past, future and present states of an expression are sometimes called 'time states' of an expression.",
 		"Note 2: If you don't specify whether to use the past or future state of an expression that has different values, its default value will be used which is usually the value after the event."})
 @Examples({"on teleport:",

--- a/src/main/java/ch/njol/skript/hooks/regions/conditions/CondCanBuild.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/conditions/CondCanBuild.java
@@ -42,7 +42,7 @@ import ch.njol.util.Kleenean;
  */
 @Name("Can Build")
 @Description({"Tests whether a player is allowed to build at a certain location.",
-		"This condition requires a supported <a href='../classes/#region'>regions</a> plugin to be installed."})
+		"This condition requires a supported <a href='../classes.html#region'>regions</a> plugin to be installed."})
 @Examples({"command /setblock <material>:",
 		"	description: set the block at your crosshair to a different type",
 		"	trigger:",

--- a/src/main/java/ch/njol/skript/hooks/regions/conditions/CondRegionContains.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/conditions/CondRegionContains.java
@@ -40,7 +40,7 @@ import ch.njol.util.Kleenean;
  * @author Peter Güttinger
  */
 @Name("Region Contains")
-@Description({"Checks whether a location is contained in a particular <a href='../classes/#region'>region</a>.",
+@Description({"Checks whether a location is contained in a particular <a href='../classes.html#region'>region</a>.",
 		"This condition requires a supported regions plugin to be installed."})
 @Examples({"player is in the region {regions::3}",
 		"on region enter:",

--- a/src/main/java/ch/njol/skript/hooks/regions/events/EvtRegionBorder.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/events/EvtRegionBorder.java
@@ -55,7 +55,7 @@ public class EvtRegionBorder extends SelfRegisteringSkriptEvent {
 		Skript.registerEvent("Region Enter/Leave", EvtRegionBorder.class, RegionBorderEvent.class,
 				"(0¦enter[ing]|1¦leav(e|ing)|1¦exit[ing]) [of] ([a] region|[[the] region] %-regions%)",
 				"region (0¦enter[ing]|1¦leav(e|ing)|1¦exit[ing])")
-				.description("Called when a player enters or leaves a <a href='../classes/#region'>region</a>.",
+				.description("Called when a player enters or leaves a <a href='../classes.html#region'>region</a>.",
 						"This event requires a supported regions plugin to be installed.")
 				.examples("on region exit:",
 						"	message \"Leaving %region%.\"")

--- a/src/main/java/ch/njol/skript/hooks/regions/expressions/ExprBlocksInRegion.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/expressions/ExprBlocksInRegion.java
@@ -46,7 +46,7 @@ import ch.njol.util.coll.iterator.EmptyIterator;
  * @author Peter Güttinger
  */
 @Name("Blocks in Region")
-@Description({"All blocks in a <a href='../classes/#region'>region</a>.",
+@Description({"All blocks in a <a href='../classes.html#region'>region</a>.",
 		"This expression requires a supported regions plugin to be installed."})
 @Examples({"loop all blocks in the region {arena.%{faction.%player%}%}:",
 		"	clear the loop-block"})

--- a/src/main/java/ch/njol/skript/hooks/regions/expressions/ExprMembersOfRegion.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/expressions/ExprMembersOfRegion.java
@@ -42,7 +42,7 @@ import ch.njol.util.Kleenean;
  * @author Peter Güttinger
  */
 @Name("Region Members & Owners")
-@Description({"A list of members or owners of a <a href='../classes/#region'>region</a>.",
+@Description({"A list of members or owners of a <a href='../classes.html#region'>region</a>.",
 		"This expression requires a supported regions plugin to be installed."})
 @Examples({"on entering of a region:",
 		"	message \"You're entering %region% whose owners are %owners of region%\"."})

--- a/src/main/java/ch/njol/skript/hooks/regions/expressions/ExprRegionsAt.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/expressions/ExprRegionsAt.java
@@ -43,7 +43,7 @@ import ch.njol.util.Kleenean;
  * @author Peter Güttinger
  */
 @Name("Regions At")
-@Description({"All <a href='../classes/#region'>regions</a> at a particular <a href='../classes/#location'>location</a>.",
+@Description({"All <a href='../classes.html#region'>regions</a> at a particular <a href='../classes/#location'>location</a>.",
 		"This expression requires a supported regions plugin to be installed."})
 @Examples({"On click on a sign:",
 		"	line 1 of the clicked block is \"[region info]\"",


### PR DESCRIPTION
This pull request fixes many links in the docs, probably they are wrong because they were used in Njol's docs.

**For example:**
The `direction type` link in [ExprDirection](https://skriptlang.github.io/Skript/expressions.html#ExprDirection) is correct
but the `item type` link in [ExprAmountOfItems](https://skriptlang.github.io/Skript/expressions.html#ExprAmountOfItems) is wrong,

The fix is:
```diff
- https://skriptlang.github.io/classes/#itemtype
+ https://skriptlang.github.io/classes.html#itemtype
```

I also changed this, probably should be changed already but still i will note:
https://github.com/SkriptLang/Skript/pull/1438/files#diff-c2d9fabc5bac072b3b2469ae4342cda3
([Documentation.java, line 192](https://github.com/SkriptLang/Skript/blob/master/src/main/java/ch/njol/skript/doc/Documentation.java#L192))