### PR TITLE
Update README to use JitPack for addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ More clear code style guidelines are probably coming in future.
 If you use Skript as (soft) dependency for your plugin, and use maven or Gradle,
 this is for you.
 
-First, you need to add the jitpack repository at the **END** of all your repositories. Skript is not available in Maven Central.
+First, you need to add the JitPack repository at the **END** of all your repositories. Skript is not available in Maven Central.
 ```gradle
 allprojects {
     repositories {

--- a/README.md
+++ b/README.md
@@ -99,37 +99,65 @@ More clear code style guidelines are probably coming in future.
 If you use Skript as (soft) dependency for your plugin, and use maven or Gradle,
 this is for you.
 
-First, you need the repository. Skript is not available in Maven Central.
-```
-maven {
-    url 'https://raw.githubusercontent.com/bensku/mvn-repo/master'
+First, you need to add the jitpack repository at the **END** of all your repositories. Skript is not available in Maven Central.
+```gradle
+allprojects {
+    repositories {
+        jcenter()
+        ...
+        maven { 
+            url 'https://jitpack.io' 
+        }
+    }
 }
 ```
 
 Or, if you use Maven:
+```maven
+<repositories>
+    <repository>
+        <id>jitpack.io</id>
+        <url>https://jitpack.io</url>
+    </repository>
+</repositories>
 ```
+
+For versions of Skript after dev37 you might need to add the paper-api repository to prevent build issues.
+
+```gradle
+maven { 
+    url 'https://repo.destroystokyo.com/repository/maven-public/' 
+}
+```
+
+Or, if you use Maven:
+```maven
 <repository>
-    <id>bensku-repo</id>
-    <url>https://raw.githubusercontent.com/bensku/mvn-repo/master</url>
+    <id>destroystokyo-repo</id>
+    <url>https://repo.destroystokyo.com/content/repositories/snapshots/</url>
 </repository>
 ```
 
 Then you will also need to add Skript as a dependency.
+```gradle
+dependencies {
+    implementation 'com.github.SkriptLang:Skript:[versionTag]'
+}
 ```
-implementation 'ch.njol:skript:2.2-RELEASE_TAG'
-```
-Note: If Gradle isn't able to resolve Skript's dependencies, just [disable the resolution of transitive dependencies](https://docs.gradle.org/current/userguide/managing_transitive_dependencies.html#sub:disabling_resolution_transitive_dependencies) for Skript in your project.
+An example of the version tag would be ```dev37c```.
+
+> Note: If Gradle isn't able to resolve Skript's dependencies, just [disable the resolution of transitive dependencies](https://docs.gradle.org/current/userguide/managing_transitive_dependencies.html#sub:disabling_resolution_transitive_dependencies) for Skript in your project.
 
 Or, if you use Maven:
 ```
 <dependency>
-    <groupId>ch.njol</groupId>
-    <artifactId>skript</artifactId>
-    <version>2.2-RELEASE_TAG</version>
+    <groupId>com.github.SkriptLang</groupId>
+    <artifactId>Skript</artifactId>
+    <version>[versionTag]</version>
 </dependency>
 ```
 
-Note that these repositories are provided as-is, for now. I cannot currently spend time to add nice, but not mandatory, features like Javadoc.
+> Note that these repositories are provided as-is, for now. I cannot currently spend time to add nice, but not mandatory, features like Javadoc.
 
 ## Relevant Links
 * [SkUnity Forums](https://forums.skunity.com/)

--- a/README.md
+++ b/README.md
@@ -101,13 +101,11 @@ this is for you.
 
 First, you need to add the JitPack repository at the **END** of all your repositories. Skript is not available in Maven Central.
 ```gradle
-allprojects {
-    repositories {
-        jcenter()
-        ...
-        maven { 
-            url 'https://jitpack.io' 
-        }
+repositories {
+    jcenter()
+    ...
+    maven { 
+        url 'https://jitpack.io' 
     }
 }
 ```


### PR DESCRIPTION
Target Minecraft versions: N/A
Requirements: N/A
Related issues: N/A

Description:
This is an update to the README in order to move addon developers away from using the [GitHub Maven repo](https://github.com/bensku/mvn-repo) and to instead use JitPack. Right now the GitHub Maven repo requires manual updates and doesn't have dev37. Changing to JitPack will remove the need for manual updates and will instead automatically update.
