### PR TITLE
Add connect effect

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffConnect.java
+++ b/src/main/java/ch/njol/skript/effects/EffConnect.java
@@ -65,12 +65,12 @@ public class EffConnect extends Effect {
 		Utils.sendPluginMessage(BUNGEE_CHANNEL, r -> GET_SERVERS_CHANNEL.equals(r.readUTF()), GET_SERVERS_CHANNEL)
 			.thenAccept(response ->
 				Stream.of(response.readUTF().split(", "))
-						.filter(s -> s.equalsIgnoreCase(server))
-						.findFirst()
-						.ifPresent(s -> {
-							for (Player player : players)
-								Utils.sendPluginMessage(player, BUNGEE_CHANNEL, CONNECT_CHANNEL, s);
-						})
+					.filter(s -> s.equalsIgnoreCase(server))
+					.findFirst()
+					.ifPresent(s -> {
+						for (Player player : players)
+							Utils.sendPluginMessage(player, BUNGEE_CHANNEL, CONNECT_CHANNEL, s);
+					})
 			);
 	}
 

--- a/src/main/java/ch/njol/skript/effects/EffConnect.java
+++ b/src/main/java/ch/njol/skript/effects/EffConnect.java
@@ -1,0 +1,88 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.effects;
+
+import java.util.stream.Stream;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.util.Utils;
+import ch.njol.util.Kleenean;
+
+public class EffConnect extends Effect {
+
+	public static final String BUNGEE_CHANNEL = "BungeeCord";
+	public static final String GET_SERVERS_CHANNEL = "GetServers";
+	public static final String CONNECT_CHANNEL = "Connect";
+
+	static {
+		Skript.registerEffect(EffConnect.class,
+				"connect %players% to [server] %string%",
+				"send %players% to server %string%"
+		);
+	}
+
+	@SuppressWarnings("null")
+	private Expression<Player> players;
+
+	@SuppressWarnings("null")
+	private Expression<String> server;
+
+	@Override
+	protected void execute(Event e) {
+		String server = this.server.getSingle(e);
+		if (server == null)
+			return;
+
+		Player[] players = this.players.getArray(e);
+		if (players == null || players.length == 0)
+			return;
+
+		// the message channel is case sensitive so let's fix that
+		Utils.sendPluginMessage(BUNGEE_CHANNEL, r -> GET_SERVERS_CHANNEL.equals(r.readUTF()), GET_SERVERS_CHANNEL)
+			.thenAccept(response ->
+				Stream.of(response.readUTF().split(", "))
+						.filter(s -> s.equalsIgnoreCase(server))
+						.findFirst()
+						.ifPresent(s -> {
+							for (Player player : players)
+								Utils.sendPluginMessage(player, BUNGEE_CHANNEL, CONNECT_CHANNEL, s);
+						})
+			);
+	}
+
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		return "connect " + players.toString(e, debug) + " to " + server.toString(e, debug);
+	}
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		players = (Expression<Player>) exprs[0];
+		server = (Expression<String>) exprs[1];
+		return true;
+	}
+}

--- a/src/main/java/ch/njol/skript/effects/EffConnect.java
+++ b/src/main/java/ch/njol/skript/effects/EffConnect.java
@@ -19,19 +19,25 @@
  */
 package ch.njol.skript.effects;
 
-import java.util.stream.Stream;
-
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.util.Utils;
 import ch.njol.util.Kleenean;
 
+@Name("Connect")
+@Description("Connects a player to another bungeecord server")
+@Examples("connect all players to \"hub\"")
+@Since("INSERT VERSION")
 public class EffConnect extends Effect {
 
 	public static final String BUNGEE_CHANNEL = "BungeeCord";
@@ -57,21 +63,18 @@ public class EffConnect extends Effect {
 		if (server == null)
 			return;
 
-		Player[] players = this.players.getArray(e);
-		if (players == null || players.length == 0)
-			return;
-
 		// the message channel is case sensitive so let's fix that
 		Utils.sendPluginMessage(BUNGEE_CHANNEL, r -> GET_SERVERS_CHANNEL.equals(r.readUTF()), GET_SERVERS_CHANNEL)
-			.thenAccept(response ->
-				Stream.of(response.readUTF().split(", "))
-					.filter(s -> s.equalsIgnoreCase(server))
-					.findFirst()
-					.ifPresent(s -> {
-						for (Player player : players)
-							Utils.sendPluginMessage(player, BUNGEE_CHANNEL, CONNECT_CHANNEL, s);
-					})
-			);
+			.thenAccept(response -> {
+				// for loop isn't as pretty a stream, but will be faster with tons of servers
+				for (String validServer : response.readUTF().split(", ")) {
+					if (validServer.equalsIgnoreCase(server)) {
+						for (Player player : players.getArray(e))
+							Utils.sendPluginMessage(player, BUNGEE_CHANNEL, CONNECT_CHANNEL, validServer);
+						break;
+					}
+				}
+			});
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/util/Utils.java
+++ b/src/main/java/ch/njol/skript/util/Utils.java
@@ -23,17 +23,28 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Creature;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.messaging.PluginMessageListener;
 import org.bukkit.util.Vector;
 import org.eclipse.jdt.annotation.Nullable;
 
+import com.google.common.collect.Iterables;
+import com.google.common.io.ByteArrayDataInput;
+import com.google.common.io.ByteArrayDataOutput;
+import com.google.common.io.ByteStreams;
+import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.effects.EffTeleport;
 import ch.njol.skript.entity.EntityData;
@@ -366,6 +377,105 @@ public abstract class Utils {
 			default:
 				return 1;
 		}
+	}
+
+	/**
+	 * Sends a plugin message using the first player from {@link Bukkit#getOnlinePlayers()}.
+	 *
+	 * The next plugin message to be received through {@code channel} will be assumed to be
+	 * the response.
+	 *
+	 * @param channel the channel for this plugin message
+	 * @param data the data to add to the outgoing message
+	 * @return a completable future for the message of the responding plugin message, if there is one.
+	 * this completable future will complete exceptionally if no players are online.
+	 */
+	public static CompletableFuture<ByteArrayDataInput> sendPluginMessage(String channel, String... data) {
+		return sendPluginMessage(channel, r -> true, data);
+	}
+
+	/**
+	 * Sends a plugin message using the from {@code player}.
+	 *
+	 * The next plugin message to be received through {@code channel} will be assumed to be
+	 * the response.
+	 *
+	 * @param player the player to send the plugin message through
+	 * @param channel the channel for this plugin message
+	 * @param data the data to add to the outgoing message
+	 * @return a completable future for the message of the responding plugin message, if there is one.
+	 * this completable future will complete exceptionally if no players are online.
+	 */
+	public static CompletableFuture<ByteArrayDataInput> sendPluginMessage(Player player, String channel, String... data) {
+		return sendPluginMessage(player, channel, r -> true, data);
+	}
+
+	/**
+	 * Sends a plugin message using the first player from {@link Bukkit#getOnlinePlayers()}.
+	 *
+	 * @param channel the channel for this plugin message
+	 * @param messageVerifier verifies that a plugin message is the response to the sent message
+	 * @param data the data to add to the outgoing message
+	 * @return a completable future for the message of the responding plugin message, if there is one.
+	 * this completable future will complete exceptionally if the player is null.
+	 */
+	public static CompletableFuture<ByteArrayDataInput> sendPluginMessage(String channel,
+			Predicate<ByteArrayDataInput> messageVerifier, String... data) {
+		Player firstPlayer = Iterables.getFirst(Bukkit.getOnlinePlayers(), null);
+		return sendPluginMessage(firstPlayer, channel, messageVerifier, data);
+	}
+
+	/**
+	 * Sends a plugin message.
+	 *
+	 * Example usage using the "GetServers" bungee plugin message channel via an overload:
+	 * <code>
+	 *     Utils.sendPluginMessage("BungeeCord", r -> "GetServers".equals(r.readUTF()), "GetServers")
+	 *     			.thenAccept(response -> Bukkit.broadcastMessage(response.readUTF()) // comma delimited server broadcast
+	 *     			.exceptionally(ex -> {
+	 *     			 	Skript.warning("Failed to get servers because there are no players online");
+	 *     			 	return null;
+	 *     			});
+	 * </code>
+	 *
+	 * @param player the player to send the plugin message through
+	 * @param channel the channel for this plugin message
+	 * @param messageVerifier verifies that a plugin message is the response to the sent message
+	 * @param data the data to add to the outgoing message
+	 * @return a completable future for the message of the responding plugin message, if there is one.
+	 * this completable future will complete exceptionally if the player is null.
+	 */
+	public static CompletableFuture<ByteArrayDataInput> sendPluginMessage(Player player, String channel,
+			Predicate<ByteArrayDataInput> messageVerifier, String... data) {
+		CompletableFuture<ByteArrayDataInput> completableFuture = new CompletableFuture<>();
+
+		if (player == null) {
+			completableFuture.completeExceptionally(new IllegalStateException("Can't send plugin messages from a null player"));
+			return completableFuture;
+		}
+
+		Bukkit.getMessenger().registerOutgoingPluginChannel(Skript.getInstance(), channel);
+
+		Bukkit.getMessenger().registerIncomingPluginChannel(Skript.getInstance(), channel, new PluginMessageListener() {
+
+			@Override
+			public void onPluginMessageReceived(@Nullable String sendingChannel, @Nullable Player sendingPlayer,
+					@Nullable byte[] message) {
+				ByteArrayDataInput input = ByteStreams.newDataInput(message);
+				if (channel.equals(sendingChannel) && sendingPlayer == player && !completableFuture.isDone()
+						&& messageVerifier.test(input)) {
+					completableFuture.complete(input);
+					Bukkit.getMessenger().unregisterIncomingPluginChannel(Skript.getInstance(), channel, this);
+				}
+			}
+
+		});
+
+		ByteArrayDataOutput out = ByteStreams.newDataOutput();
+		Stream.of(data).forEach(out::writeUTF);
+		player.sendPluginMessage(Skript.getInstance(), channel, out.toByteArray());
+
+		return completableFuture;
 	}
 	
 	final static ChatColor[] styles = {ChatColor.BOLD, ChatColor.ITALIC, ChatColor.STRIKETHROUGH, ChatColor.UNDERLINE, ChatColor.MAGIC, ChatColor.RESET};


### PR DESCRIPTION
Target Minecraft versions: Any
Requirements: Bungeecord
Related issues: N/A

Description:
This PR adds an effect that allows scripters to send players to a bungeecord server via plugin messages, like so: `send all players to server "hub"`

This is a PR because I'd like to get @bensku's opinion on the use of `CompletableFuture`s as opposed to spigot's convoluted standard approach.