### PR TITLE
Add Swap Hand Items and Jump (simple-)events

### DIFF
--- a/src/main/java/ch/njol/skript/events/SimpleEvents.java
+++ b/src/main/java/ch/njol/skript/events/SimpleEvents.java
@@ -443,7 +443,7 @@ public class SimpleEvents {
 					.examples("on jump:",
 							"	event-player does not have permission \"jump\"",
 							"	cancel event")
-					.since("2.2-dev38");
+					.since("INSERT VERSION");
 		}
 		if (Skript.classExists("org.bukkit.event.player.PlayerSwapHandItemsEvent")) {
 			Skript.registerEvent("Hand Item Swap", SimpleEvent.class, PlayerSwapHandItemsEvent.class, "swap[ping of] [(hand|held)] item[s]")
@@ -452,7 +452,7 @@ public class SimpleEvents {
 					.examples("on swap hand items:",
 							"	event-player's tool is a diamond sword",
 							"	cancel event")
-					.since("2.2-dev38");
+					.since("INSERT VERSION");
 		}
 	}
 }

--- a/src/main/java/ch/njol/skript/events/SimpleEvents.java
+++ b/src/main/java/ch/njol/skript/events/SimpleEvents.java
@@ -68,6 +68,7 @@ import org.bukkit.event.player.PlayerLocaleChangeEvent;
 import org.bukkit.event.player.PlayerPortalEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
+import org.bukkit.event.player.PlayerSwapHandItemsEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.player.PlayerToggleFlightEvent;
 import org.bukkit.event.player.PlayerToggleSneakEvent;
@@ -89,6 +90,7 @@ import org.bukkit.event.world.WorldSaveEvent;
 import org.bukkit.event.world.WorldUnloadEvent;
 import org.spigotmc.event.entity.EntityDismountEvent;
 import org.spigotmc.event.entity.EntityMountEvent;
+import com.destroystokyo.paper.event.player.PlayerJumpEvent;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptEventHandler;
@@ -433,6 +435,24 @@ public class SimpleEvents {
 							"	if player's language starts with \"en\":",
 							"		send \"Hello!\"")
 					.since("2.2-dev37");
+		}
+		if (Skript.classExists("com.destroystokyo.paper.event.player.PlayerJumpEvent")) {
+			Skript.registerEvent("Jump", SimpleEvent.class, PlayerJumpEvent.class, "[player] jump[ing]")
+					.description("Called whenever a player jumps",
+							"This event requires PaperSpigot")
+					.examples("on jump:",
+							"	event-player does not have permission \"jump\"",
+							"	cancel event")
+					.since("2.2-dev38");
+		}
+		if (Skript.classExists("org.bukkit.event.player.PlayerSwapHandItemsEvent")) {
+			Skript.registerEvent("Hand Item Swap", SimpleEvent.class, PlayerSwapHandItemsEvent.class, "swap[ping of] [(hand|held)] item[s]")
+					.description("Called whenever a player swaps the items in their",
+							"main- and offhand slots. Does not require any items to be held.")
+					.examples("on swap hand items:",
+							"	event-player's tool is a diamond sword",
+							"	cancel event")
+					.since("2.2-dev38");
 		}
 	}
 }

--- a/src/main/java/ch/njol/skript/events/SimpleEvents.java
+++ b/src/main/java/ch/njol/skript/events/SimpleEvents.java
@@ -447,8 +447,12 @@ public class SimpleEvents {
 		}
 		if (Skript.classExists("org.bukkit.event.player.PlayerSwapHandItemsEvent")) {
 			Skript.registerEvent("Hand Item Swap", SimpleEvent.class, PlayerSwapHandItemsEvent.class, "swap[ping of] [(hand|held)] item[s]")
-					.description("Called whenever a player swaps the items in their",
-							"main- and offhand slots. Does not require any items to be held.")
+					.description("Called whenever a player swaps the items in their main- and offhand slots.",
+						     "Works also when one or both of the slots are empty.",
+						     "The event is called before the items are actually swapped,",
+						     "so when you use the player's tool or player's offtool expressions,",
+						     "they will return the values before the swap -",
+						     "this enables you to cancel the event before anything happens.")
 					.examples("on swap hand items:",
 							"	event-player's tool is a diamond sword",
 							"	cancel event")


### PR DESCRIPTION
Props to Nicofisi helping me understand how to make pull requests <3

Target Minecraft versions: any
Requirements: The jump event requires paper
Related issues: /

Description:
SwapHandItems event is used for when the player is using the dedicated key (default F) to swap their main and offhand items. It only fires while not viewing an inventory.

The PlayerJumpEvent event differs from spigot's PlayerMoveEvent and is less resource straining.

Related issues:
https://github.com/SkriptLang/Skript/issues/1445
https://github.com/SkriptLang/Skript/issues/444