### PR TITLE
Add various property condition types

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
+++ b/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
@@ -114,7 +114,7 @@ public abstract class PropertyCondition<T> extends Condition implements Checker<
 					return expr.toString(e, debug) + (isNegated() ? " don't have " : " have ") + getPropertyName();
 			default:
 				assert false;
-				throw new IllegalStateException();
+				throw new AssertionError();
 		}
 	}
 }

--- a/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
+++ b/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
@@ -143,18 +143,31 @@ public abstract class PropertyCondition<T> extends Condition implements Checker<
 		return PropertyType.BE;
 	}
 	
+	/**
+	 * Sets the expression this condition checks a property of. No reference to the expression should be kept.
+	 *
+	 * @param expr
+	 */
+	protected final void setExpr(final Expression<? extends T> expr) {
+		this.expr = expr;
+	}
+	
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
-		switch (getPropertyType()) {
+		return toString(this, getPropertyType(), e, debug, expr, getPropertyName());
+	}
+	
+	public static String toString(Condition condition, PropertyType propertyType, Event e, boolean debug, Expression<?> expr, String property) {
+		switch (propertyType) {
 			case BE:
-				return expr.toString(e, debug) + (expr.isSingle() ? " is " : " are ") + (isNegated() ? "not " : "") + getPropertyName();
+				return expr.toString(e, debug) + (expr.isSingle() ? " is " : " are ") + (condition.isNegated() ? "not " : "") + property;
 			case CAN:
-				return expr.toString(e, debug) + (isNegated() ? " can't " : " can ") + getPropertyName();
+				return expr.toString(e, debug) + (condition.isNegated() ? " can't " : " can ") + property;
 			case HAVE:
 				if (expr.isSingle())
-					return expr.toString(e, debug) + (isNegated() ? " doesn't have " : " has ") + getPropertyName();
+					return expr.toString(e, debug) + (condition.isNegated() ? " doesn't have " : " has ") + property;
 				else
-					return expr.toString(e, debug) + (isNegated() ? " don't have " : " have ") + getPropertyName();
+					return expr.toString(e, debug) + (condition.isNegated() ? " don't have " : " have ") + property;
 			default:
 				assert false;
 				throw new AssertionError();

--- a/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
+++ b/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
@@ -114,7 +114,7 @@ public abstract class PropertyCondition<T> extends Condition implements Checker<
 					return expr.toString(e, debug) + (isNegated() ? " don't have " : " have ") + getPropertyName();
 			default:
 				assert false;
-				return null;
+				throw new IllegalStateException();
 		}
 	}
 }

--- a/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
+++ b/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
@@ -157,7 +157,8 @@ public abstract class PropertyCondition<T> extends Condition implements Checker<
 		return toString(this, getPropertyType(), e, debug, expr, getPropertyName());
 	}
 	
-	public static String toString(Condition condition, PropertyType propertyType, Event e, boolean debug, Expression<?> expr, String property) {
+	public static String toString(Condition condition, PropertyType propertyType, @Nullable Event e,
+								  boolean debug, Expression<?> expr, String property) {
 		switch (propertyType) {
 			case BE:
 				return expr.toString(e, debug) + (expr.isSingle() ? " is " : " are ") + (condition.isNegated() ? "not " : "") + property;


### PR DESCRIPTION
*The branch is named incorrectly, meant to be property-conditions as they are something completely different, my bad*

Target Minecraft versions: N/A
Requirements: N/A
Related issues: N/A

Description:
With this little change more conditions can be `PropertyCondition`s, which is good because classes like [CondCanFly](https://github.com/SkriptLang/Skript/blob/47af5a699571b3bdc0c112a675daff24cae8bbb1/src/main/java/ch/njol/skript/conditions/CondCanFly.java) could simply be written as:
```java
public class CondCanFly extends PropertyCondition<Player> {
	
	static {
		register(CondCanFly.class, PropertyType.CAN, "fly", "players");
	}
	
	@Override
	public boolean check(Player player) {
		return player.getAllowFlight();
	}
	
	@Override
	protected String getPropertyName() {
		return "fly";
	}
	
	@Override
	public PropertyType getPropertyType() {
		return PropertyType.CAN;
	}
	
}
```

If you don't like this implementation of the idea, another one would be to simply copy the PropertyCondition class to other two ones with different names (what names?) and change the toStrings there, without touching the original PropertyCondition class, but in my opinion that would create too much unneeded code for the little profit of never having to override the `getPropertyType()` method. 

Or maybe they could extend the PropertyCondition class and just override the `toString` and `register` methods - but still, what would the class names be?

I'm open to any opinions :)