### PR TITLE
Add SingleConditions

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/base/AbilityCondition.java
+++ b/src/main/java/ch/njol/skript/conditions/base/AbilityCondition.java
@@ -1,0 +1,46 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.conditions.base;
+
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.Condition;
+
+public abstract class AbilityCondition<T> extends SingleCondition<T> {
+	
+	/**
+	 * @param c
+	 * @param property
+	 * @param type must be plural
+	 */
+	public static void register(final Class<? extends Condition> c, final String property, final String type) {
+		Skript.registerCondition(c,
+				"%" + type + "% can " + property,
+				"%" + type + "% (can't|cannot|can not) " + property);
+	}
+	
+	@Override
+	public String toString(final @Nullable Event e, final boolean debug) {
+		return expr.toString(e, debug) + (isNegated() ? " can't " : " can ") + getPropertyName();
+	}
+	
+}

--- a/src/main/java/ch/njol/skript/conditions/base/PossessionCondition.java
+++ b/src/main/java/ch/njol/skript/conditions/base/PossessionCondition.java
@@ -1,0 +1,49 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.conditions.base;
+
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.Condition;
+
+public abstract class PossessionCondition<T> extends SingleCondition<T> {
+	
+	/**
+	 * @param c
+	 * @param property
+	 * @param type must be plural
+	 */
+	public static void register(final Class<? extends Condition> c, final String property, final String type) {
+		Skript.registerCondition(c,
+				"%" + type + "% (has|have) " + property,
+				"%" + type + "% (doesn't|does not|do not|don't) have " + property);
+	}
+	
+	@Override
+	public String toString(final @Nullable Event e, final boolean debug) {
+		if (expr.isSingle())
+			return expr.toString(e, debug) + (isNegated() ? " doesn't have " : " has ") + getPropertyName();
+		else
+			return expr.toString(e, debug) + (isNegated() ? " don't have " : " have ") + getPropertyName();
+	}
+	
+}

--- a/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
+++ b/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
@@ -24,18 +24,8 @@ import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Condition;
-import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.util.Checker;
-import ch.njol.util.Kleenean;
 
-/**
- * @author Peter Güttinger
- */
-public abstract class PropertyCondition<T> extends Condition implements Checker<T> {
-	
-	@SuppressWarnings("null")
-	private Expression<? extends T> expr;
+public abstract class PropertyCondition<T> extends SingleCondition<T> {
 	
 	/**
 	 * @param c
@@ -43,26 +33,10 @@ public abstract class PropertyCondition<T> extends Condition implements Checker<
 	 * @param type must be plural
 	 */
 	public static void register(final Class<? extends Condition> c, final String property, final String type) {
-		Skript.registerCondition(c, "%" + type + "% (is|are) " + property, "%" + type + "% (isn't|is not|aren't|are not) " + property);
+		Skript.registerCondition(c,
+				"%" + type + "% (is|are) " + property,
+				"%" + type + "% (isn't|is not|aren't|are not) " + property);
 	}
-	
-	@SuppressWarnings({"unchecked", "null"})
-	@Override
-	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
-		expr = (Expression<? extends T>) exprs[0];
-		setNegated(matchedPattern == 1);
-		return true;
-	}
-	
-	@Override
-	public final boolean check(final Event e) {
-		return expr.check(e, this, isNegated());
-	}
-	
-	@Override
-	public abstract boolean check(T t);
-	
-	protected abstract String getPropertyName();
 	
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {

--- a/src/main/java/ch/njol/skript/conditions/base/SingleCondition.java
+++ b/src/main/java/ch/njol/skript/conditions/base/SingleCondition.java
@@ -50,9 +50,4 @@ public abstract class SingleCondition<T> extends Condition implements Checker<T>
 	public abstract boolean check(T t);
 	
 	protected abstract String getPropertyName();
-	
-	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return expr.toString(e, debug) + (expr.isSingle() ? " is " : " are ") + (isNegated() ? "not " : "") + getPropertyName();
-	}
 }

--- a/src/main/java/ch/njol/skript/conditions/base/SingleCondition.java
+++ b/src/main/java/ch/njol/skript/conditions/base/SingleCondition.java
@@ -1,0 +1,58 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.conditions.base;
+
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.lang.Condition;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Checker;
+import ch.njol.util.Kleenean;
+
+public abstract class SingleCondition<T> extends Condition implements Checker<T> {
+	
+	@SuppressWarnings("null")
+	protected Expression<? extends T> expr;
+	
+	@SuppressWarnings({"unchecked", "null"})
+	@Override
+	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final SkriptParser.ParseResult parseResult) {
+		expr = (Expression<? extends T>) exprs[0];
+		setNegated(matchedPattern == 1);
+		return true;
+	}
+	
+	@Override
+	public final boolean check(final Event e) {
+		return expr.check(e, this, isNegated());
+	}
+	
+	@Override
+	public abstract boolean check(T t);
+	
+	protected abstract String getPropertyName();
+	
+	@Override
+	public String toString(final @Nullable Event e, final boolean debug) {
+		return expr.toString(e, debug) + (expr.isSingle() ? " is " : " are ") + (isNegated() ? "not " : "") + getPropertyName();
+	}
+}


### PR DESCRIPTION
A different implementation of the idea in #1497

PossessionCondition example:
```java
public class CondHasClientWeather extends PossessionCondition<Player> {

	static {
		register(CondHasClientWeather.class, "[a] (client|custom) weather [set]", "players");
	}
	
	@Override
	public boolean check(Player player) {
		return player.getPlayerWeather() != null;
	}
	
	@Override
	protected String getPropertyName() {
		return "custom weather set";
	}
	
}
```
AbilityCondition example:
```java
public class CondCanFly extends AbilityCondition<Player> {
	
	static {
		register(CondCanFly.class, "fly", "players");
	}
	
	@Override
	public boolean check(Player player) {
		return player.getAllowFlight();
	}
	
	@Override
	protected String getPropertyName() {
		return "fly";
	}
	
}
```