### PR TITLE
Add tropical fish support

### DIFF
--- a/src/main/java/ch/njol/skript/entity/TropicalFishData.java
+++ b/src/main/java/ch/njol/skript/entity/TropicalFishData.java
@@ -29,7 +29,7 @@ import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Literal;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.Color;
 
 public class TropicalFishData extends EntityData<TropicalFish> {
@@ -47,7 +47,9 @@ public class TropicalFishData extends EntityData<TropicalFish> {
 		}
 	}
 
-	public TropicalFishData() {}
+	public TropicalFishData() {
+		this(0);
+	}
 
 	public TropicalFishData(int pattern) {
 		this.pattern = pattern;
@@ -60,15 +62,20 @@ public class TropicalFishData extends EntityData<TropicalFish> {
 	private int pattern = -1;
 
 	@Override
-	protected boolean init(Literal<?>[] exprs, int matchedPattern, SkriptParser.ParseResult parseResult) {
+	protected boolean init(Literal<?>[] exprs, int matchedPattern, ParseResult parseResult) {
 		if (matchedPattern != 0)
 			pattern = matchedPattern - 1;
-
-		bodyColor = exprs.length > 0 ? ((Literal<Color>) exprs[0]).getSingle().getWoolColor() : null;
-		if (parseResult.mark == 2)
+		
+		if (exprs[2] != null) {
+			bodyColor = ((Literal<Color>) exprs[2]).getSingle().getWoolColor();
 			patternColor = bodyColor;
-		else
-			patternColor = exprs.length > 1 ? ((Literal<Color>) exprs[1]).getSingle().getWoolColor() : null;
+		}
+
+		if (exprs[0] != null)
+			bodyColor = ((Literal<Color>) exprs[0]).getSingle().getWoolColor();
+		if (exprs[1] != null)
+			patternColor = ((Literal<Color>) exprs[1]).getSingle().getWoolColor();
+
 		return true;
 	}
 

--- a/src/main/java/ch/njol/skript/entity/TropicalFishData.java
+++ b/src/main/java/ch/njol/skript/entity/TropicalFishData.java
@@ -51,21 +51,21 @@ public class TropicalFishData extends EntityData<TropicalFish> {
 		this(0);
 	}
 
-	public TropicalFishData(int pattern) {
-		this.pattern = pattern;
+	public TropicalFishData(Pattern pattern) {
+		matchedPattern = pattern.ordinal() + 1;
+	}
+
+	private TropicalFishData(int pattern) {
+		matchedPattern = pattern;
 	}
 
 	@Nullable
 	private DyeColor patternColor;
 	@Nullable
 	private DyeColor bodyColor;
-	private int pattern = -1;
 
 	@Override
 	protected boolean init(Literal<?>[] exprs, int matchedPattern, ParseResult parseResult) {
-		if (matchedPattern != 0)
-			pattern = matchedPattern - 1;
-		
 		if (exprs[2] != null) {
 			bodyColor = ((Literal<Color>) exprs[2]).getSingle().getWoolColor();
 			patternColor = bodyColor;
@@ -82,7 +82,7 @@ public class TropicalFishData extends EntityData<TropicalFish> {
 	@Override
 	protected boolean init(@Nullable Class<? extends TropicalFish> c, @Nullable TropicalFish tropicalFish) {
 		if (tropicalFish != null) {
-			pattern = tropicalFish.getPattern().ordinal();
+			matchedPattern = tropicalFish.getPattern().ordinal() + 1;
 			bodyColor = tropicalFish.getBodyColor();
 			patternColor = tropicalFish.getPatternColor();
 		}
@@ -91,10 +91,10 @@ public class TropicalFishData extends EntityData<TropicalFish> {
 
 	@Override
 	public void set(TropicalFish entity) {
-		if (pattern == -1)
+		if (matchedPattern == 0)
 			entity.setPattern((Pattern) patterns[ThreadLocalRandom.current().nextInt(patterns.length)]);
 		else
-			entity.setPattern((Pattern) patterns[pattern]);
+			entity.setPattern((Pattern) patterns[matchedPattern]);
 
 		if (bodyColor != null)
 			entity.setBodyColor(bodyColor);
@@ -104,8 +104,8 @@ public class TropicalFishData extends EntityData<TropicalFish> {
 
 	@Override
 	protected boolean match(TropicalFish entity) {
-		boolean samePattern = pattern == -1 || pattern == entity.getPattern().ordinal();
-		boolean sameBody = bodyColor != null ? bodyColor == entity.getBodyColor() : true;
+		boolean samePattern = matchedPattern == 0 || matchedPattern == entity.getPattern().ordinal() + 1;
+		boolean sameBody = bodyColor == null || bodyColor == entity.getBodyColor();
 
 		if (patternColor == null)
 			return samePattern && sameBody;
@@ -124,12 +124,13 @@ public class TropicalFishData extends EntityData<TropicalFish> {
 			return false;
 
 		TropicalFishData other = (TropicalFishData) obj;
-		return pattern == other.pattern && bodyColor == other.bodyColor && patternColor == other.patternColor;
+		return matchedPattern == other.matchedPattern
+			&& bodyColor == other.bodyColor && patternColor == other.patternColor;
 	}
 
 	@Override
 	protected int hashCode_i() {
-		return Objects.hash(pattern, bodyColor, patternColor);
+		return Objects.hash(matchedPattern, bodyColor, patternColor);
 	}
 
 	@Override
@@ -138,11 +139,12 @@ public class TropicalFishData extends EntityData<TropicalFish> {
 			return false;
 
 		TropicalFishData other = (TropicalFishData) e;
-		return pattern == other.pattern && bodyColor == other.bodyColor && patternColor == other.patternColor;
+		return matchedPattern == other.matchedPattern
+			&& bodyColor == other.bodyColor && patternColor == other.patternColor;
 	}
 
 	@Override
 	public EntityData getSuperType() {
-		return new TropicalFishData(pattern);
+		return new TropicalFishData(matchedPattern);
 	}
 }

--- a/src/main/java/ch/njol/skript/entity/TropicalFishData.java
+++ b/src/main/java/ch/njol/skript/entity/TropicalFishData.java
@@ -1,3 +1,22 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
 package ch.njol.skript.entity;
 
 import java.util.Objects;
@@ -15,6 +34,7 @@ import ch.njol.skript.util.Color;
 
 public class TropicalFishData extends EntityData<TropicalFish> {
 
+	@SuppressWarnings("null")
 	private static Object[] patterns;
 
 	static {

--- a/src/main/java/ch/njol/skript/entity/TropicalFishData.java
+++ b/src/main/java/ch/njol/skript/entity/TropicalFishData.java
@@ -1,0 +1,121 @@
+package ch.njol.skript.entity;
+
+import java.util.Objects;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.bukkit.DyeColor;
+import org.bukkit.entity.TropicalFish;
+import org.bukkit.entity.TropicalFish.Pattern;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.Literal;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.util.Color;
+
+public class TropicalFishData extends EntityData<TropicalFish> {
+
+	private static Object[] patterns;
+
+	static {
+		if (Skript.isRunningMinecraft(1, 13)) {
+			register(TropicalFishData.class, "tropical fish", TropicalFish.class, 0,
+					"tropical fish", "kob", "sunstreak", "snooper",
+					"dasher", "brinely", "spotty", "flopper",
+					"stripey", "glitter", "blockfish", "betty", "clayfish");
+			patterns = Pattern.values();
+		}
+	}
+
+	public TropicalFishData() {}
+
+	public TropicalFishData(int pattern) {
+		this.pattern = pattern;
+	}
+
+	@Nullable
+	private DyeColor patternColor;
+	@Nullable
+	private DyeColor bodyColor;
+	private int pattern = -1;
+
+	@Override
+	protected boolean init(Literal<?>[] exprs, int matchedPattern, SkriptParser.ParseResult parseResult) {
+		if (matchedPattern != 0)
+			pattern = matchedPattern - 1;
+
+		bodyColor = exprs.length > 0 ? ((Literal<Color>) exprs[0]).getSingle().getWoolColor() : null;
+		if (parseResult.mark == 2)
+			patternColor = bodyColor;
+		else
+			patternColor = exprs.length > 1 ? ((Literal<Color>) exprs[1]).getSingle().getWoolColor() : null;
+		return true;
+	}
+
+	@Override
+	protected boolean init(@Nullable Class<? extends TropicalFish> c, @Nullable TropicalFish tropicalFish) {
+		if (tropicalFish != null) {
+			pattern = tropicalFish.getPattern().ordinal();
+			bodyColor = tropicalFish.getBodyColor();
+			patternColor = tropicalFish.getPatternColor();
+		}
+		return true;
+	}
+
+	@Override
+	public void set(TropicalFish entity) {
+		if (pattern == -1)
+			entity.setPattern((Pattern) patterns[ThreadLocalRandom.current().nextInt(patterns.length)]);
+		else
+			entity.setPattern((Pattern) patterns[pattern]);
+
+		if (bodyColor != null)
+			entity.setBodyColor(bodyColor);
+		if (patternColor != null)
+			entity.setPatternColor(patternColor);
+	}
+
+	@Override
+	protected boolean match(TropicalFish entity) {
+		boolean samePattern = pattern == -1 || pattern == entity.getPattern().ordinal();
+		boolean sameBody = bodyColor != null ? bodyColor == entity.getBodyColor() : true;
+
+		if (patternColor == null)
+			return samePattern && sameBody;
+		else
+			return samePattern && sameBody && patternColor == entity.getPatternColor();
+	}
+
+	@Override
+	public Class<? extends TropicalFish> getType() {
+		return TropicalFish.class;
+	}
+
+	@Override
+	protected boolean equals_i(EntityData<?> obj) {
+		if (!(obj instanceof TropicalFishData))
+			return false;
+
+		TropicalFishData other = (TropicalFishData) obj;
+		return pattern == other.pattern && bodyColor == other.bodyColor && patternColor == other.patternColor;
+	}
+
+	@Override
+	protected int hashCode_i() {
+		return Objects.hash(pattern, bodyColor, patternColor);
+	}
+
+	@Override
+	public boolean isSupertypeOf(EntityData<?> e) {
+		if (!(e instanceof TropicalFishData))
+			return false;
+
+		TropicalFishData other = (TropicalFishData) e;
+		return pattern == other.pattern && bodyColor == other.bodyColor && patternColor == other.patternColor;
+	}
+
+	@Override
+	public EntityData getSuperType() {
+		return new TropicalFishData(pattern);
+	}
+}

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -628,43 +628,43 @@ entities:
 		pattern: fish(|1¦es)
 	tropical fish:
 		name: tropical fish¦es
-		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] tropical fish(|1¦es)
+		pattern: [(%-color%[-%-color%]|fully %-color%)] tropical fish(|1¦es)
 	kob:
 		name: kob¦s
-		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] kob(|1¦s)
+		pattern: [(%-color%[-%-color%]|fully %-color%)] kob(|1¦s)
 	sunstreak:
 		name: sunstreak¦s
-		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] sunstreak(|1¦s)
+		pattern: [(%-color%[-%-color%]|fully %-color%)] sunstreak(|1¦s)
 	snooper:
 		name: snooper¦s
-		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] snooper(|1¦s)
+		pattern: [(%-color%[-%-color%]|fully %-color%)] snooper(|1¦s)
 	dasher:
 		name: dasher¦s
-		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] dasher(|1¦s)
+		pattern: [(%-color%[-%-color%]|fully %-color%)] dasher(|1¦s)
 	brinely:
 		name: brinely¦s
-		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] brinely(|1¦s)
+		pattern: [(%-color%[-%-color%]|fully %-color%)] brinely(|1¦s)
 	spotty:
 		name: spotty¦s
-		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] spotty(|1¦s)
+		pattern: [(%-color%[-%-color%]|fully %-color%)] spotty(|1¦s)
 	flopper:
 		name: flopper¦s
-		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] flopper(|1¦s)
+		pattern: [(%-color%[-%-color%]|fully %-color%)] flopper(|1¦s)
 	stripey:
 		name: stripey¦s
-		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] stripey(|1¦s)
+		pattern: [(%-color%[-%-color%]|fully %-color%)] stripey(|1¦s)
 	glitter:
 		name: glitter¦s
-		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] glitter(|1¦s)
+		pattern: [(%-color%[-%-color%]|fully %-color%)] glitter(|1¦s)
 	blockfish:
 		name: blockfish¦s
-		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] blockfish(|1¦s)
+		pattern: [(%-color%[-%-color%]|fully %-color%)] blockfish(|1¦s)
 	betty:
 		name: betty¦s
-		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] betty(|1¦s)
+		pattern: [(%-color%[-%-color%]|fully %-color%)] betty(|1¦s)
 	clayfish:
 		name: clayfish¦s
-		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] clayfish(|1¦s)
+		pattern: [(%-color%[-%-color%]|fully %-color%)] clayfish(|1¦s)
 	ghast:
 		name: ghast¦s
 		pattern: ghast(|1¦s)

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -626,6 +626,45 @@ entities:
 	fish:
 		name: fish¦es
 		pattern: fish(|1¦es)
+	tropical fish:
+		name: tropical fish¦es
+		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] tropical fish(|1¦es)
+	kob:
+		name: kob¦s
+		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] kob(|1¦s)
+	sunstreak:
+		name: sunstreak¦s
+		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] sunstreak(|1¦s)
+	snooper:
+		name: snooper¦s
+		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] snooper(|1¦s)
+	dasher:
+		name: dasher¦s
+		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] dasher(|1¦s)
+	brinely:
+		name: brinely¦s
+		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] brinely(|1¦s)
+	spotty:
+		name: spotty¦s
+		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] spotty(|1¦s)
+	flopper:
+		name: flopper¦s
+		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] flopper(|1¦s)
+	stripey:
+		name: stripey¦s
+		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] stripey(|1¦s)
+	glitter:
+		name: glitter¦s
+		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] glitter(|1¦s)
+	blockfish:
+		name: blockfish¦s
+		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] blockfish(|1¦s)
+	betty:
+		name: betty¦s
+		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] betty(|1¦s)
+	clayfish:
+		name: clayfish¦s
+		pattern: [(%-color%[-%-color%]|2¦fully %-color%)] clayfish(|1¦s)
 	ghast:
 		name: ghast¦s
 		pattern: ghast(|1¦s)


### PR DESCRIPTION
Target Minecraft versions: 1.13+
Requirements: N/A
Related issues: #1385 
Description:
Adds support for tropical fish, which should add support for every entity once #1486 is merged.

This wasn't tested yet (I bet it doesn't even compile, I'll fix that later), I've made it just to receive input about how it is handled as soon as possible.
