### PR TITLE
Add EffDoIf

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffDoIf.java
+++ b/src/main/java/ch/njol/skript/effects/EffDoIf.java
@@ -56,23 +56,23 @@ public class EffDoIf extends Effect  {
 		String eff = parseResult.regexes.get(0).group();
 		String cond = parseResult.regexes.get(1).group();
 		effect = Effect.parse(eff, "Can't understand this effect: " + eff);
-		condition = Condition.parse(cond, "Can't understand this condition: " + cond);
 		if (effect instanceof EffDoIf) {
 			Skript.error("Do if effects may not be nested!");
 			return false;
 		}
+		condition = Condition.parse(cond, "Can't understand this condition: " + cond);
 		return effect != null && condition != null;
 	}
 
 	@Override
-	protected void execute(Event event) {
-		if (condition.check(event))
-			effect.run(event);
+	protected void execute(Event e) {
+		if (condition.check(e))
+			effect.run(e);
 	}
 
 	@Override
-	public String toString(@Nullable Event event, boolean debug) {
-		return effect.toString(event, debug) + " if " + condition.toString(event, debug);
+	public String toString(@Nullable Event e, boolean debug) {
+		return effect.toString(e, debug) + " if " + condition.toString(e, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffDoIf.java
+++ b/src/main/java/ch/njol/skript/effects/EffDoIf.java
@@ -1,3 +1,22 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
 package ch.njol.skript.effects;
 
 import org.bukkit.event.Event;

--- a/src/main/java/ch/njol/skript/effects/EffDoIf.java
+++ b/src/main/java/ch/njol/skript/effects/EffDoIf.java
@@ -20,6 +20,7 @@
 package ch.njol.skript.effects;
 
 import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
@@ -34,17 +35,21 @@ import ch.njol.util.Kleenean;
 
 @Name("Do If")
 @Description("Execute an effect if a condition is true.")
-@Examples("on join:\n\tgive diamond to player if player has permission \"rank.vip\"")
+@Examples({"on join:",
+		"\tgive a diamond to the player if the player has permission \"rank.vip\""})
 @Since("INSERT VERSION")
 public class EffDoIf extends Effect  {
 
+	static {
+		Skript.registerEffect(EffDoIf.class, "<.+> if <.+>");
+	}
+
+	@SuppressWarnings({"unchecked", "null"})
 	private Effect effect;
+
+	@SuppressWarnings({"unchecked", "null"})
 	private Condition condition;
 
-	static {
-		Skript.registerEffect(EffDoIf.class, "[(do|execute)] <.+> if <.+>");
-	}
-	
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
@@ -52,7 +57,7 @@ public class EffDoIf extends Effect  {
 		String cond = parseResult.regexes.get(1).group();
 		effect = Effect.parse(eff, "Can't understand this effect: " + eff);
 		condition = Condition.parse(cond, "Can't understand this condition: " + cond);
-		return effect != null && condition != null;
+		return effect != null || condition != null;
 	}
 
 	@Override
@@ -62,8 +67,8 @@ public class EffDoIf extends Effect  {
 	}
 
 	@Override
-	public String toString(Event event, boolean debug) {
-		return "do " + effect.toString(event, debug) + " if " + condition.toString(event, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return effect.toString(event, debug) + " if " + condition.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffDoIf.java
+++ b/src/main/java/ch/njol/skript/effects/EffDoIf.java
@@ -31,6 +31,7 @@ import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.TriggerItem;
 import ch.njol.util.Kleenean;
 
 @Name("Do If")

--- a/src/main/java/ch/njol/skript/effects/EffDoIf.java
+++ b/src/main/java/ch/njol/skript/effects/EffDoIf.java
@@ -65,10 +65,18 @@ public class EffDoIf extends Effect  {
 	}
 
 	@Override
-	protected void execute(Event e) {
-		if (condition.check(e))
-			effect.run(e);
-	}
+    	protected void execute(Event e) {
+        	walk(e);
+    	}
+
+    	@Override
+    	public TriggerItem walk(Event e) {
+        	if (condition.check(e)) {
+            		effect.setNext(getNext());
+            		return effect;
+        	}
+        	return getNext();
+    	}
 
 	@Override
 	public String toString(@Nullable Event e, boolean debug) {

--- a/src/main/java/ch/njol/skript/effects/EffDoIf.java
+++ b/src/main/java/ch/njol/skript/effects/EffDoIf.java
@@ -45,6 +45,7 @@ public class EffDoIf extends Effect  {
 		Skript.registerEffect(EffDoIf.class, "[(do|execute)] <.+> if <.+>");
 	}
 	
+	@SuppressWarnings({"unchecked", "null"})
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
 		String eff = parseResult.regexes.get(0).group();

--- a/src/main/java/ch/njol/skript/effects/EffDoIf.java
+++ b/src/main/java/ch/njol/skript/effects/EffDoIf.java
@@ -57,7 +57,7 @@ public class EffDoIf extends Effect  {
 		String cond = parseResult.regexes.get(1).group();
 		effect = Effect.parse(eff, "Can't understand this effect: " + eff);
 		condition = Condition.parse(cond, "Can't understand this condition: " + cond);
-		return effect != null || condition != null;
+		return effect != null && condition != null;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/effects/EffDoIf.java
+++ b/src/main/java/ch/njol/skript/effects/EffDoIf.java
@@ -45,7 +45,7 @@ public class EffDoIf extends Effect  {
 		Skript.registerEffect(EffDoIf.class, "<.+> if <.+>");
 	}
 
-	@SuppressWarnings("null"})
+	@SuppressWarnings("null")
 	private Effect effect;
 
 	@SuppressWarnings("null")

--- a/src/main/java/ch/njol/skript/effects/EffDoIf.java
+++ b/src/main/java/ch/njol/skript/effects/EffDoIf.java
@@ -1,0 +1,49 @@
+package ch.njol.skript.effects;
+
+import org.bukkit.event.Event;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Condition;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
+
+@Name("Do If")
+@Description("Execute an effect if a condition is true.")
+@Examples("on join:\n\tgive diamond to player if player has permission \"rank.vip\"")
+@Since("INSERT VERSION")
+public class EffDoIf extends Effect  {
+
+	private Effect effect;
+	private Condition condition;
+
+	static {
+		Skript.registerEffect(EffDoIf.class, "[(do|execute)] <.+> if <.+>");
+	}
+	
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		String eff = parseResult.regexes.get(0).group();
+		String cond = parseResult.regexes.get(1).group();
+		effect = Effect.parse(eff, "Can't understand this effect: " + eff);
+		condition = Condition.parse(cond, "Can't understand this condition: " + cond);
+		return effect != null && condition != null;
+	}
+
+	@Override
+	protected void execute(Event event) {
+		if (condition.check(event))
+			effect.run(event);
+	}
+
+	@Override
+	public String toString(Event event, boolean debug) {
+		return "do " + effect.toString(event, debug) + " if " + condition.toString(event, debug);
+	}
+
+}

--- a/src/main/java/ch/njol/skript/effects/EffDoIf.java
+++ b/src/main/java/ch/njol/skript/effects/EffDoIf.java
@@ -45,13 +45,13 @@ public class EffDoIf extends Effect  {
 		Skript.registerEffect(EffDoIf.class, "<.+> if <.+>");
 	}
 
-	@SuppressWarnings({"unchecked", "null"})
+	@SuppressWarnings("null"})
 	private Effect effect;
 
-	@SuppressWarnings({"unchecked", "null"})
+	@SuppressWarnings("null")
 	private Condition condition;
 
-	@SuppressWarnings({"unchecked", "null"})
+	@SuppressWarnings("null")
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
 		String eff = parseResult.regexes.get(0).group();
@@ -70,6 +70,7 @@ public class EffDoIf extends Effect  {
         	walk(e);
     	}
 
+	@SuppressWarnings("null")
     	@Override
     	public TriggerItem walk(Event e) {
         	if (condition.check(e)) {

--- a/src/main/java/ch/njol/skript/effects/EffDoIf.java
+++ b/src/main/java/ch/njol/skript/effects/EffDoIf.java
@@ -33,6 +33,7 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.TriggerItem;
 import ch.njol.util.Kleenean;
+import org.eclipse.jdt.annotation.Nullable;
 
 @Name("Do If")
 @Description("Execute an effect if a condition is true.")
@@ -66,11 +67,9 @@ public class EffDoIf extends Effect  {
 	}
 
 	@Override
-    	protected void execute(Event e) {
-        	walk(e);
-    	}
-
-	@SuppressWarnings("null")
+    	protected void execute(Event e) {}
+	
+	@Nullable
     	@Override
     	public TriggerItem walk(Event e) {
         	if (condition.check(e)) {

--- a/src/main/java/ch/njol/skript/effects/EffDoIf.java
+++ b/src/main/java/ch/njol/skript/effects/EffDoIf.java
@@ -57,6 +57,10 @@ public class EffDoIf extends Effect  {
 		String cond = parseResult.regexes.get(1).group();
 		effect = Effect.parse(eff, "Can't understand this effect: " + eff);
 		condition = Condition.parse(cond, "Can't understand this condition: " + cond);
+		if (effect instanceof EffDoIf) {
+			Skript.error("Do if effects may not be nested!");
+			return false;
+		}
 		return effect != null && condition != null;
 	}
 


### PR DESCRIPTION
Target Minecraft versions: any
Requirements: none
Related issues: none

Description: 
This executes an effect if a condition is true. The syntax is `[(do|execute)] <.+> if <.+>` where the first regex is an effect and the second is the condition.
Ex:
```java
on join:
	give diamond to player if player has permission "rank.vip"
```
Standalone this effect does not conflict with ternaries but if a ternary is used within the effect parenthesis must be used:
```
#invalid
give diamond if {diamond::%player%} is true else emerald to player if player has permission "rank.vip"

#valid
give (diamond if {diamond::%player%} is true else emerald) to player if player has permission "rank.vip"
