### PR TITLE
Add Warning Suppressing Effect

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffChange.java
+++ b/src/main/java/ch/njol/skript/effects/EffChange.java
@@ -25,6 +25,7 @@ import java.util.logging.Level;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
+import ch.njol.skript.ScriptLoader;
 import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptConfig;
 import ch.njol.skript.classes.Changer;
@@ -46,6 +47,7 @@ import ch.njol.skript.log.ParseLogHandler;
 import ch.njol.skript.log.SkriptLogger;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.util.Patterns;
+import ch.njol.skript.util.ScriptOptions;
 import ch.njol.skript.util.Utils;
 import ch.njol.util.Kleenean;
 
@@ -256,8 +258,15 @@ public class EffChange extends Effect {
 			
 			if (changed instanceof Variable && !((Variable<?>) changed).isLocal() && (mode == ChangeMode.SET || ((Variable<?>) changed).isList() && mode == ChangeMode.ADD)) {
 				final ClassInfo<?> ci = Classes.getSuperClassInfo(ch.getReturnType());
-				if (ci.getC() != Object.class && ci.getSerializer() == null && ci.getSerializeAs() == null && !SkriptConfig.disableObjectCannotBeSavedWarnings.value())
-					Skript.warning(ci.getName().withIndefiniteArticle() + " cannot be saved, i.e. the contents of the variable " + changed + " will be lost when the server stops.");
+				if (ci.getC() != Object.class && ci.getSerializer() == null && ci.getSerializeAs() == null && !SkriptConfig.disableObjectCannotBeSavedWarnings.value()) {
+					if (ScriptLoader.currentScript != null) {
+						if (!ScriptOptions.getInstance().suppressesWarning(ScriptLoader.currentScript.getFile(), "instance var")) {
+							Skript.warning(ci.getName().withIndefiniteArticle() + " cannot be saved, i.e. the contents of the variable " + changed + " will be lost when the server stops.");
+						}
+					} else {
+						Skript.warning(ci.getName().withIndefiniteArticle() + " cannot be saved, i.e. the contents of the variable " + changed + " will be lost when the server stops.");
+					}
+				}
 			}
 		}
 		return true;

--- a/src/main/java/ch/njol/skript/effects/EffSuppressWarnings.java
+++ b/src/main/java/ch/njol/skript/effects/EffSuppressWarnings.java
@@ -1,0 +1,96 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2018 Peter Güttinger and contributors
+ */
+package ch.njol.skript.effects;
+
+import java.io.File;
+
+import ch.njol.skript.ScriptLoader;
+import ch.njol.skript.Skript;
+import ch.njol.skript.config.Config;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.util.ScriptOptions;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+@Name("Locally Suppress Warning")
+@Description("Suppresses target warnings from the current script.")
+@Examples({"locally suppress conflict warnings",
+			"suppress variable save warnings"})
+@Since("INSERT VERSION")
+public class EffSuppressWarnings extends Effect {
+	static {
+		Skript.registerEffect(EffSuppressWarnings.class, "[local[ly]] suppress (1¦conflict|2¦variable save|3¦[missing] conjunction[s]|4¦starting [with] expression[s]) warning[s]");
+	}
+	
+	private int CONFLICT = 1, INSTANCE = 2, CONJUNCTION = 3, STARTEXPR = 4;
+	private int mark = 0;
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		Config cs = ScriptLoader.currentScript;
+		if (cs == null) {
+			Skript.error("Current script is null!");
+			return false;
+		}
+		File scriptFile = cs.getFile();
+		mark = parseResult.mark;
+		switch (parseResult.mark) {
+			case 1: { //Possible variable conflicts
+				ScriptOptions.getInstance().setSuppressWarning(scriptFile, "conflict");
+				break;
+			}
+			case 2: { //Variables cannot be saved
+				ScriptOptions.getInstance().setSuppressWarning(scriptFile, "instance var");
+				break;
+			}
+			case 3: { //Missing "and" or "or"
+				ScriptOptions.getInstance().setSuppressWarning(scriptFile, "conjunction");
+				break;
+			}
+			case 4: { //Variable starts with expression
+				ScriptOptions.getInstance().setSuppressWarning(scriptFile, "start expression");
+				break;
+			}
+			default: { //How did this happen?
+				Skript.error("Skript returned an invalid parse mark, this should never happen. Please report this!");
+				return false;
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		return "supress " + (mark == CONFLICT ? "conflict" : mark == INSTANCE ? "variable save" : mark == CONJUNCTION ? "missing conjunction" : mark == STARTEXPR ? "starting expression" : "") + " warnings";
+	}
+
+	@Override
+	protected void execute(Event e) {
+
+	}
+
+}

--- a/src/main/java/ch/njol/skript/effects/EffSuppressWarnings.java
+++ b/src/main/java/ch/njol/skript/effects/EffSuppressWarnings.java
@@ -39,11 +39,11 @@ import org.eclipse.jdt.annotation.Nullable;
 @Name("Locally Suppress Warning")
 @Description("Suppresses target warnings from the current script.")
 @Examples({"locally suppress conflict warnings",
-			"suppress variable save warnings"})
+			"suppress the variable save warnings"})
 @Since("INSERT VERSION")
 public class EffSuppressWarnings extends Effect {
 	static {
-		Skript.registerEffect(EffSuppressWarnings.class, "[local[ly]] suppress (1¦conflict|2¦variable save|3¦[missing] conjunction[s]|4¦starting [with] expression[s]) warning[s]");
+		Skript.registerEffect(EffSuppressWarnings.class, "[local[ly]] suppress [the] (1¦conflict|2¦variable save|3¦[missing] conjunction[s]|4¦starting [with] expression[s]) warning[s]");
 	}
 	
 	private int CONFLICT = 1, INSTANCE = 2, CONJUNCTION = 3, STARTEXPR = 4;

--- a/src/main/java/ch/njol/skript/effects/EffSuppressWarnings.java
+++ b/src/main/java/ch/njol/skript/effects/EffSuppressWarnings.java
@@ -15,7 +15,7 @@
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
  *
- * Copyright 2011-2018 Peter Güttinger and contributors
+ * Copyright 2011-2017 Peter Güttinger and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffSuppressWarnings.java
+++ b/src/main/java/ch/njol/skript/effects/EffSuppressWarnings.java
@@ -53,7 +53,7 @@ public class EffSuppressWarnings extends Effect {
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
 		Config cs = ScriptLoader.currentScript;
 		if (cs == null) {
-			Skript.error("Current script is null!");
+			Skript.error("You can only suppress warnings for script files!");
 			return false;
 		}
 		File scriptFile = cs.getFile();
@@ -75,9 +75,8 @@ public class EffSuppressWarnings extends Effect {
 				ScriptOptions.getInstance().setSuppressWarning(scriptFile, "start expression");
 				break;
 			}
-			default: { //How did this happen?
-				Skript.error("Skript returned an invalid parse mark, this should never happen. Please report this!");
-				return false;
+			default: {
+				throw new AssertionError();
 			}
 		}
 		return true;
@@ -85,7 +84,7 @@ public class EffSuppressWarnings extends Effect {
 
 	@Override
 	public String toString(@Nullable Event e, boolean debug) {
-		return "supress " + (mark == CONFLICT ? "conflict" : mark == INSTANCE ? "variable save" : mark == CONJUNCTION ? "missing conjunction" : mark == STARTEXPR ? "starting expression" : "") + " warnings";
+		return "suppress " + (mark == CONFLICT ? "conflict" : mark == INSTANCE ? "variable save" : mark == CONJUNCTION ? "missing conjunction" : mark == STARTEXPR ? "starting expression" : "") + " warnings";
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -47,6 +47,7 @@ import ch.njol.skript.command.Argument;
 import ch.njol.skript.command.Commands;
 import ch.njol.skript.command.ScriptCommand;
 import ch.njol.skript.command.ScriptCommandEvent;
+import ch.njol.skript.config.Config;
 import ch.njol.skript.expressions.ExprParse;
 import ch.njol.skript.lang.function.ExprFunctionCall;
 import ch.njol.skript.lang.function.FunctionReference;
@@ -60,6 +61,7 @@ import ch.njol.skript.log.ParseLogHandler;
 import ch.njol.skript.log.RetainingLogHandler;
 import ch.njol.skript.log.SkriptLogger;
 import ch.njol.skript.registrations.Classes;
+import ch.njol.skript.util.ScriptOptions;
 import ch.njol.skript.util.Time;
 import ch.njol.skript.util.Utils;
 import ch.njol.util.Kleenean;
@@ -618,6 +620,10 @@ public class SkriptParser {
 					// Hack as items use '..., ... and ...' for enchantments. Numbers and times are parsed beforehand as they use the same (deprecated) id[:data] syntax.
 					final SkriptParser p = new SkriptParser(expr, PARSE_LITERALS, context);
 					p.suppressMissingAndOrWarnings = suppressMissingAndOrWarnings; // If we suppress warnings here, we suppress them in parser what we created too
+					if (ScriptLoader.currentScript != null) {
+						Config cs = ScriptLoader.currentScript;
+						p.suppressMissingAndOrWarnings = ScriptOptions.getInstance().suppressesWarning(cs.getFile(), "conjunction");
+					}
 					for (final Class<?> c : new Class[] {Number.class, Time.class, ItemType.class, ItemStack.class}) {
 						final Expression<?> e = p.parseExpression(c);
 						if (e != null) {
@@ -767,8 +773,15 @@ public class SkriptParser {
 			if (ts.size() == 1)
 				return ts.get(0);
 			
-			if (and.isUnknown() && !suppressMissingAndOrWarnings)
-				Skript.warning(MISSING_AND_OR + ": " + expr);
+			if (and.isUnknown() && !suppressMissingAndOrWarnings) {
+				if (ScriptLoader.currentScript != null) {
+					Config cs = ScriptLoader.currentScript;
+					if (!ScriptOptions.getInstance().suppressesWarning(cs.getFile(), "conjunction"))
+						Skript.warning(MISSING_AND_OR + ": " + expr);
+				} else {
+					Skript.warning(MISSING_AND_OR + ": " + expr);
+				}
+			}
 			
 			final Class<? extends T>[] exprRetTypes = new Class[ts.size()];
 			for (int i = 0; i < ts.size(); i++)
@@ -802,6 +815,10 @@ public class SkriptParser {
 					// Hack as items use '..., ... and ...' for enchantments. Numbers and times are parsed beforehand as they use the same (deprecated) id[:data] syntax.
 					final SkriptParser p = new SkriptParser(expr, PARSE_LITERALS, context);
 					p.suppressMissingAndOrWarnings = suppressMissingAndOrWarnings; // If we suppress warnings here, we suppress them in parser what we created too
+					if (ScriptLoader.currentScript != null) {
+						Config cs = ScriptLoader.currentScript;
+						p.suppressMissingAndOrWarnings = ScriptOptions.getInstance().suppressesWarning(cs.getFile(), "conjunction");
+					}
 					for (final Class<?> c : new Class[] {Number.class, Time.class, ItemType.class, ItemStack.class}) {
 						@SuppressWarnings("unchecked")
 						final Expression<?> e = p.parseExpression(c);
@@ -964,8 +981,15 @@ public class SkriptParser {
 				return ts.get(0);
 			}
 			
-			if (and.isUnknown() && !suppressMissingAndOrWarnings)
-				Skript.warning(MISSING_AND_OR + ": " + expr);
+			if (and.isUnknown() && !suppressMissingAndOrWarnings) {
+				if (ScriptLoader.currentScript != null) {
+					Config cs = ScriptLoader.currentScript;
+					if (!ScriptOptions.getInstance().suppressesWarning(cs.getFile(), "conjunction"))
+						Skript.warning(MISSING_AND_OR + ": " + expr);
+				} else {
+					Skript.warning(MISSING_AND_OR + ": " + expr);
+				}
+			}
 			
 			final Class<?>[] exprRetTypes = new Class[ts.size()];
 			for (int i = 0; i < ts.size(); i++)

--- a/src/main/java/ch/njol/skript/util/ScriptOptions.java
+++ b/src/main/java/ch/njol/skript/util/ScriptOptions.java
@@ -42,13 +42,20 @@
 package ch.njol.skript.util;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * @author Mirreducki
  * 
  */
 public class ScriptOptions {
+	
+	private HashMap<File, List<String>> localWarningSuppression = new HashMap<>();
 	
 	private HashMap<File, Boolean> usesNewLoops = new HashMap<>();
 	
@@ -72,5 +79,17 @@ public class ScriptOptions {
 	
 	public void setUsesNewLoops(File file, boolean b){
 		usesNewLoops.put(file, b);
+	}
+	
+	public boolean suppressesWarning(@Nullable File scriptFile, String warning) {
+		if (localWarningSuppression.containsKey(scriptFile))
+			return localWarningSuppression.get(scriptFile).contains(warning);
+		return false;
+	}
+	
+ 	public void setSuppressWarning(@Nullable File scriptFile, String warning) {
+		if (!localWarningSuppression.containsKey(scriptFile))
+			localWarningSuppression.put(scriptFile, new ArrayList<>());
+		localWarningSuppression.get(scriptFile).add(warning);
 	}
 }

--- a/src/main/java/ch/njol/skript/util/ScriptOptions.java
+++ b/src/main/java/ch/njol/skript/util/ScriptOptions.java
@@ -44,18 +44,18 @@ package ch.njol.skript.util;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * @author Mirreducki
  * 
  */
-public class ScriptOptions {
+public final class ScriptOptions {
 	
-	private HashMap<File, List<String>> localWarningSuppression = new HashMap<>();
+	private HashMap<File, Set<String>> localWarningSuppression = new HashMap<>();
 	
 	private HashMap<File, Boolean> usesNewLoops = new HashMap<>();
 	
@@ -82,14 +82,11 @@ public class ScriptOptions {
 	}
 	
 	public boolean suppressesWarning(@Nullable File scriptFile, String warning) {
-		if (localWarningSuppression.containsKey(scriptFile))
-			return localWarningSuppression.get(scriptFile).contains(warning);
-		return false;
+		Set<String> suppressed = localWarningSuppression.get(scriptFile);
+		return suppressed != null && suppressed.contains(warning);
 	}
 	
  	public void setSuppressWarning(@Nullable File scriptFile, String warning) {
-		if (!localWarningSuppression.containsKey(scriptFile))
-			localWarningSuppression.put(scriptFile, new ArrayList<>());
-		localWarningSuppression.get(scriptFile).add(warning);
+ 		localWarningSuppression.computeIfAbsent(scriptFile, k -> new HashSet<>()).add(warning);
 	}
 }


### PR DESCRIPTION
Target Minecraft versions: *Any*
Requirements: *N/A*
Related issues: Closes #1260 

Description:
This pull request adds script-specific warning suppression for the following warnings:
* Variable Conflict
* Variable will not be saved
* List missing conjunctions
* Starting Variable with expression

This is accomplished through EffSuppressWarnings:
`[local[ly]] suppress [the] (1¦conflict|2¦variable save|3¦[missing] conjunction[s]|4¦starting [with] expression[s]) warning[s]`

This effect uses the ScriptOptions class to manage what scripts are suppressing what errors.
