### PR TITLE
Add Action Bar Support (not just paper)

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffActionBar.java
+++ b/src/main/java/ch/njol/skript/effects/EffActionBar.java
@@ -62,7 +62,7 @@ public class EffActionBar extends Effect {
 	@Override
 	protected void execute(final Event e) {
 		String msg = message.getSingle(e);
-		for (Player player : recipients.getAll(e)) {
+		for (Player player : recipients.getArray(e)) {
 			player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(msg));
 		}
 	}

--- a/src/main/java/ch/njol/skript/effects/EffActionBar.java
+++ b/src/main/java/ch/njol/skript/effects/EffActionBar.java
@@ -1,0 +1,75 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.effects;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
+
+@Name("Action Bar")
+@Description("Sends an action bar message to the given player(s).")
+@Examples("send action bar \"Hello player!\" to player")
+@Since("INSERT VERSION")
+public class EffActionBar extends Effect {
+
+	static {
+		Skript.registerEffect(EffActionBar.class, "send [the] action bar [with text] %string% to %players%");
+	}
+
+	@SuppressWarnings("null")
+	private Expression<String> message;
+
+	@SuppressWarnings("null")
+	private Expression<Player> recipients;
+
+	@SuppressWarnings({"unchecked", "null"})
+	@Override
+	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final SkriptParser.ParseResult parser) {
+		message = (Expression<String>) exprs[0];
+		recipients = (Expression<Player>) exprs[1];
+		return true;
+	}
+
+	@Override
+	protected void execute(final Event e) {
+		String msg = message.getSingle(e);
+		for (Player player : recipients.getAll(e)) {
+			player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(msg));
+		}
+	}
+
+	@Override
+	public String toString(final @Nullable Event e, final boolean debug) {
+		return "send action bar " + message.toString(e, debug) + " to " + recipients.toString(e, debug);
+	}
+
+}


### PR DESCRIPTION
Target Minecraft versions: 1.9+ 
Requirements: N/A
Related issues: Closes #1351 & Closes #1589 (Poorer implimentation that required paper)

Description:
This pull request adds action bar support for all spigot versions on all supported versions of skript 😄 

Syntax: 
`send [the] action bar [with text] %string% to %players%`
