### PR TITLE
Condition cleanup

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondCanFly.java
+++ b/src/main/java/ch/njol/skript/conditions/CondCanFly.java
@@ -20,50 +20,35 @@
 package ch.njol.skript.conditions;
 
 import org.bukkit.entity.Player;
-import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
 
-import ch.njol.skript.Skript;
+import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
-import ch.njol.skript.lang.Condition;
-import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.util.Checker;
-import ch.njol.util.Kleenean;
 
 @Name("Can Fly")
 @Description("Whether a player is allowed to fly.")
 @Examples("player can fly")
 @Since("INSERT VERSION")
-public class CondCanFly extends Condition {
-
+public class CondCanFly extends PropertyCondition<Player> {
+	
 	static {
-		Skript.registerCondition(CondCanFly.class,
-			"%players% can fly",
-			"%players% (can't|can[ ]not) fly");
+		register(CondCanFly.class, PropertyType.CAN, "fly", "players");
 	}
-
-	@SuppressWarnings("null")
-	private Expression<Player> players;
-
-	@SuppressWarnings("unchecked")
+	
 	@Override
-	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
-		players = (Expression<Player>) exprs[0];
-		setNegated(matchedPattern == 1);
-		return true;
+	public boolean check(Player player) {
+		return player.getAllowFlight();
 	}
-
+	
 	@Override
-	public boolean check(final Event e) {
-		return players.check(e, Player::getAllowFlight, isNegated());
+	protected PropertyType getPropertyType() {
+		return PropertyType.CAN;
 	}
-
+	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return players.toString(e, debug) + (isNegated() ? " can " : " cannot ") + "fly";
+	protected String getPropertyName() {
+		return "fly";
 	}
 }

--- a/src/main/java/ch/njol/skript/conditions/CondCanSee.java
+++ b/src/main/java/ch/njol/skript/conditions/CondCanSee.java
@@ -24,6 +24,8 @@ import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.conditions.base.PropertyCondition.PropertyType;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -77,7 +79,8 @@ public class CondCanSee extends Condition {
 
 	@Override
 	public String toString(@Nullable Event e, boolean debug) {
-		return players.toString(e, debug) + (isNegated() ? " can't see " : " can see ") + targetPlayers.toString(e, debug);
+		return PropertyCondition.toString(this, PropertyType.CAN, e, debug, players,
+				"see" + targetPlayers.toString(e, debug));
 	}
 
 }

--- a/src/main/java/ch/njol/skript/conditions/CondCanSee.java
+++ b/src/main/java/ch/njol/skript/conditions/CondCanSee.java
@@ -19,6 +19,10 @@
  */
 package ch.njol.skript.conditions;
 
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -26,18 +30,13 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
-import ch.njol.util.Checker;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
-import org.bukkit.entity.Player;
-import org.bukkit.event.Event;
-import org.bukkit.Bukkit;
-import org.eclipse.jdt.annotation.Nullable;
 
 @Name("Can See")
 @Description("Checks whether the given players can see another players.")
 @Examples({"if the player can't see the player-argument:",
-		"	message \"<light red>The player %player-argument% is not online!\""})
+		"\tmessage \"<light red>The player %player-argument% is not online!\""})
 @Since("INSERT VERSION")
 public class CondCanSee extends Condition {
 
@@ -50,11 +49,13 @@ public class CondCanSee extends Condition {
 	}
 	
 	@SuppressWarnings("null")
-	private Expression<Player> players, targetPlayers;
+	private Expression<Player> players;
+	@SuppressWarnings("null")
+	private Expression<Player> targetPlayers;
 
+	@SuppressWarnings("unchecked")
 	@Override
-	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
-		setNegated(matchedPattern > 1 ^ parseResult.mark == 1);
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		if (matchedPattern == 1 || matchedPattern == 3) {
 			players = (Expression<Player>) exprs[0];
 			targetPlayers = (Expression<Player>) exprs[1];
@@ -62,22 +63,16 @@ public class CondCanSee extends Condition {
 			players = (Expression<Player>) exprs[1];
 			targetPlayers = (Expression<Player>) exprs[0];
 		}
+		setNegated(matchedPattern > 1 ^ parseResult.mark == 1);
 		return true;
 	}
 
 	@Override
 	public boolean check(Event e) {
-		return players.check(e, new Checker<Player>() {
-			@Override
-			public boolean check(final Player player) {
-				return targetPlayers.check(e, new Checker<Player>() {
-					@Override
-					public boolean check(final Player targetPlayer) {
-						return player.canSee(targetPlayer);
-					}
-				}, isNegated());
-			}
-		});
+		return players.check(e,
+				player -> targetPlayers.check(e,
+						player::canSee
+				), isNegated());
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/conditions/CondCancelled.java
+++ b/src/main/java/ch/njol/skript/conditions/CondCancelled.java
@@ -26,7 +26,7 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
@@ -47,6 +47,12 @@ public class CondCancelled extends Condition {
 				"[the] event (is not|isn't) cancel[l]ed"
 		);
 	}
+	
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		setNegated(matchedPattern == 1);
+		return true;
+	}
 
 	@Override
 	public boolean check(Event e) {
@@ -56,12 +62,6 @@ public class CondCancelled extends Condition {
 	@Override
 	public String toString(@Nullable Event e, boolean debug) {
 		return isNegated() ? "event is not cancelled" : "event is cancelled";
-	}
-
-	@Override
-	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
-		setNegated(matchedPattern == 1);
-		return true;
 	}
 
 }

--- a/src/main/java/ch/njol/skript/conditions/CondChance.java
+++ b/src/main/java/ch/njol/skript/conditions/CondChance.java
@@ -39,18 +39,19 @@ import ch.njol.util.Kleenean;
 @Description({"A condition that randomly succeeds or fails.",
 		"Valid values are between 0% and 100%, or if the percent sign is omitted between 0 and 1."})
 @Examples({"chance of 50%:",
-		"	drop a diamond",
+		"\tdrop a diamond",
 		"chance of {var}% # {var} between 0 and 100",
 		"chance of {var} # {var} between 0 and 1"})
 @Since("1.0")
 public class CondChance extends Condition {
+	
 	static {
 		Skript.registerCondition(CondChance.class, "chance of %number%(1¦\\%|)");
 	}
 	
 	@SuppressWarnings("null")
 	private Expression<Double> chance;
-	boolean percent;
+	private boolean percent;
 	
 	@SuppressWarnings({"unchecked", "null"})
 	@Override

--- a/src/main/java/ch/njol/skript/conditions/CondDamageCause.java
+++ b/src/main/java/ch/njol/skript/conditions/CondDamageCause.java
@@ -32,7 +32,6 @@ import ch.njol.skript.expressions.base.EventValueExpression;
 import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
 
 /**
@@ -42,25 +41,28 @@ import ch.njol.util.Kleenean;
 @Description("Tests what kind of damage caused a <a href='events.html#damage'>damage event</a>. Refer to the <a href='classes.html#damagecause'>Damage Cause</a> type for a list of all possible causes.")
 @Examples({"# make players use their potions of fire resistance whenever they take any kind of fire damage",
 		"on damage:",
-		"	damage was caused by lava, fire or burning",
-		"	victim is a player",
-		"	victim has a potion of fire resistance",
-		"	cancel event",
-		"	apply fire resistance to the victim for 30 seconds",
-		"	remove 1 potion of fire resistance from the victim",
+		"\tdamage was caused by lava, fire or burning",
+		"\tvictim is a player",
+		"\tvictim has a potion of fire resistance",
+		"\tcancel event",
+		"\tapply fire resistance to the victim for 30 seconds",
+		"\tremove 1 potion of fire resistance from the victim",
 		"# prevent mobs from dropping items under certain circumstances",
-		"on death;",
-		"	entity is not a player",
-		"	damage wasn't caused by a block explosion, an attack, a projectile, a potion, fire, burning, thorns or poison",
-		"	clear drops"})
+		"on death:",
+		"\tentity is not a player",
+		"\tdamage wasn't caused by a block explosion, an attack, a projectile, a potion, fire, burning, thorns or poison",
+		"\tclear drops"})
 @Since("2.0")
 public class CondDamageCause extends Condition {
+	
 	static {
 		Skript.registerCondition(CondDamageCause.class, "[the] damage (was|is|has)(0¦|1¦n('|o)t) [been] (caused|done|made) by %damagecause%");
 	}
 	
 	@SuppressWarnings("null")
-	private Expression<DamageCause> cause, expected;
+	private Expression<DamageCause> cause;
+	@SuppressWarnings("null")
+	private Expression<DamageCause> expected;
 	
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
@@ -74,15 +76,12 @@ public class CondDamageCause extends Condition {
 	
 	@Override
 	public boolean check(final Event e) {
-		final DamageCause c = cause.getSingle(e);
-		if (c == null)
+		final DamageCause cause = this.cause.getSingle(e);
+		if (cause == null)
 			return false;
-		return expected.check(e, new Checker<DamageCause>() {
-			@Override
-			public boolean check(final DamageCause o) {
-				return c == o;
-			}
-		}, isNegated());
+		return expected.check(e,
+				other -> cause == other,
+				isNegated());
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/conditions/CondDate.java
+++ b/src/main/java/ch/njol/skript/conditions/CondDate.java
@@ -49,6 +49,7 @@ import ch.njol.util.Kleenean;
 		"		# ... actual command trigger here ..."})
 @Since("2.0")
 public class CondDate extends Condition {
+	
 	static {
 		Skript.registerCondition(CondDate.class,
 				"%date% (was|were)( more|(n't| not) less) than %timespan% [ago]",
@@ -58,7 +59,7 @@ public class CondDate extends Condition {
 	@SuppressWarnings("null")
 	private Expression<Date> date;
 	@SuppressWarnings("null")
-	Expression<Timespan> delta;
+	private Expression<Timespan> delta;
 	
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
@@ -72,17 +73,10 @@ public class CondDate extends Condition {
 	@Override
 	public boolean check(final Event e) {
 		final long now = System.currentTimeMillis();
-		return date.check(e, new Checker<Date>() {
-			@Override
-			public boolean check(final Date d) {
-				return delta.check(e, new Checker<Timespan>() {
-					@Override
-					public boolean check(final Timespan t) {
-						return now - d.getTimestamp() >= t.getMilliSeconds();
-					}
-				}, isNegated());
-			}
-		});
+		return date.check(e,
+				date -> delta.check(e,
+						timespan -> now - date.getTimestamp() >= timespan.getMilliSeconds()
+				), isNegated());
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/conditions/CondHasClientWeather.java
+++ b/src/main/java/ch/njol/skript/conditions/CondHasClientWeather.java
@@ -20,50 +20,37 @@
 package ch.njol.skript.conditions;
 
 import org.bukkit.entity.Player;
-import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
 
-import ch.njol.skript.Skript;
+import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
-import ch.njol.skript.lang.Condition;
-import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.util.Kleenean;
 
 @Name("Has Client Weather")
 @Description("Checks whether the given players have a custom client weather")
 @Examples({"if the player has custom weather:",
 		"\tmessage \"Your custom weather is %player's weather%\""})
 @Since("INSERT VERSION")
-public class CondHasClientWeather extends Condition {
+public class CondHasClientWeather extends PropertyCondition<Player> {
 
 	static {
-		Skript.registerCondition(CondHasClientWeather.class,
-				"%players% (has|have) [a] (client|custom) weather [set]",
-				"%players% do[es](n't| not) have [a] (client|custom) weather [set]");
+		register(CondHasClientWeather.class, PropertyType.HAVE, "[a] (client|custom) weather [set]", "players");
 	}
 	
-	@SuppressWarnings("null")
-	private Expression<Player> players;
-
-	@SuppressWarnings("unchecked")
 	@Override
-	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		setNegated(matchedPattern == 1);
-		this.players = (Expression<Player>) exprs[0];
-		return true;
+	public boolean check(Player player) {
+		return player.getPlayerWeather() != null;
 	}
-
+	
 	@Override
-	public boolean check(Event e) {
-		return players.check(e, player -> player.getPlayerWeather() != null, isNegated());
+	protected PropertyType getPropertyType() {
+		return PropertyType.HAVE;
 	}
-
+	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return players.toString(e, debug) + (isNegated() ? " have " : " don't have ") + " custom weather";
+	protected String getPropertyName() {
+		return "custom weather set";
 	}
+	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondHasMetadata.java
+++ b/src/main/java/ch/njol/skript/conditions/CondHasMetadata.java
@@ -20,6 +20,8 @@
 package ch.njol.skript.conditions;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.conditions.base.PropertyCondition.PropertyType;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -39,17 +41,17 @@ import org.eclipse.jdt.annotation.Nullable;
 @SuppressWarnings("null")
 public class CondHasMetadata extends Condition {
 
-	@Nullable
-	private Expression<Metadatable> holders;
-	@Nullable
-	private Expression<String> values;
-
 	static {
 		Skript.registerCondition(CondHasMetadata.class,
 				"%metadataholders% (has|have) metadata [(value|tag)[s]] %strings%",
 				"%metadataholders% (doesn't|does not|do not|don't) have metadata [(value|tag)[s]] %strings%"
 		);
 	}
+	
+	@SuppressWarnings("null")
+	private Expression<Metadatable> holders;
+	@SuppressWarnings("null")
+	private Expression<String> values;
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -62,22 +64,16 @@ public class CondHasMetadata extends Condition {
 
 	@Override
 	public boolean check(Event e) {
-		String[] values = this.values.getArray(e);
-		if (values == null || values.length == 0)
-			return false;
-		return holders.check(e, h -> {
-			for (String value : values) {
-				if (!h.hasMetadata(value))
-					return false;
-			}
-			return true;
-		}, isNegated());
+		return holders.check(e,
+				holder -> values.check(e,
+						holder::hasMetadata
+				), isNegated());
 	}
 
 	@Override
 	public String toString(@Nullable Event e, boolean debug) {
-		if (!isNegated())
-			return holders.toString(e, debug) + " has metadata value " + values.toString(e, debug);
-		return holders.toString(e, debug) + " does not have metadata value " + values.toString(e, debug);
+		return PropertyCondition.toString(this, PropertyType.HAVE, e, debug, holders,
+				"metadata " + (values.isSingle() ? "value " : "values ") + values.toString(e, debug));
 	}
+	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondHasScoreboardTag.java
+++ b/src/main/java/ch/njol/skript/conditions/CondHasScoreboardTag.java
@@ -27,6 +27,8 @@ import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.conditions.base.PropertyCondition.PropertyType;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -41,19 +43,17 @@ import ch.njol.util.Kleenean;
 @Examples("if the targeted armor stand has the scoreboard tag \"test tag\":")
 @Since("INSERT VERSION")
 public class CondHasScoreboardTag extends Condition {
-
+	
 	static {
 		if (Skript.isRunningMinecraft(1, 11))
-			Skript.registerCondition(CondHasScoreboardTag.class,
-					"%entities% ha(s|ve) [the] score[ ]board tag[s] %strings%",
-					"%entities% (do[es]n't|don't|do[es] not) have [the] score[ ]board tag[s] %strings%");
+			PropertyCondition.register(CondHasScoreboardTag.class, PropertyType.HAVE, "[the] score[ ]board tag[s] %strings%", "entities");
 	}
 	
 	@SuppressWarnings("null")
 	private Expression<Entity> entities;
 	@SuppressWarnings("null")
 	private Expression<String> tags;
-
+	
 	@SuppressWarnings("unchecked")
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
@@ -62,17 +62,20 @@ public class CondHasScoreboardTag extends Condition {
 		setNegated(matchedPattern == 1);
 		return true;
 	}
-
+	
 	@SuppressWarnings("unchecked")
 	@Override
 	public boolean check(Event e) {
-		List<String> tagsList = (List) Arrays.asList(tags.getArray(e));
-		return entities.check(e, entity -> entity.getScoreboardTags().containsAll(tagsList), isNegated());
+		List<String> tagsList = Arrays.asList(tags.getArray(e));
+		return entities.check(e,
+				entity -> entity.getScoreboardTags().containsAll(tagsList),
+				isNegated());
 	}
-
+	
 	@Override
 	public String toString(@Nullable Event e, boolean debug) {
-		return entities.toString(e, debug) + (isNegated() ? " doesn't have " : " has ") + "the scoreboard tags " + tags.toString(e, debug);
+		return PropertyCondition.toString(this, PropertyType.HAVE, e, debug, entities,
+				"the scoreboard " + (tags.isSingle() ? "tag " : "tags ") + tags.toString(e, debug));
 	}
-
+	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsAlive.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsAlive.java
@@ -38,6 +38,7 @@ import ch.njol.util.Kleenean;
 @Examples({"{villager-buddy::%player's uuid%} is dead"})
 @Since("2.0")
 public class CondIsAlive extends PropertyCondition<LivingEntity> {
+	
 	static {
 		register(CondIsAlive.class, "(1¦alive|0¦dead)", "livingentities");
 	}

--- a/src/main/java/ch/njol/skript/conditions/CondIsBurning.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsBurning.java
@@ -37,6 +37,7 @@ import ch.njol.skript.doc.Since;
 		"	increase damage by 2"})
 @Since("1.4.4")
 public class CondIsBurning extends PropertyCondition<Entity> {
+	
 	static {
 		register(CondIsBurning.class, "(burning|ignited|on fire)", "entities");
 	}

--- a/src/main/java/ch/njol/skript/conditions/CondIsEmpty.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsEmpty.java
@@ -38,6 +38,7 @@ import ch.njol.skript.util.slot.Slot;
 @Examples("player's inventory is empty")
 @Since("<i>unknown</i> (before 2.1)")
 public class CondIsEmpty extends PropertyCondition<Object> {
+	
 	static {
 		register(CondIsEmpty.class, "empty", "inventories/slots/strings");
 	}
@@ -58,6 +59,7 @@ public class CondIsEmpty extends PropertyCondition<Object> {
 			final ItemStack i = s.getItem();
 			return i == null || i.getType() == Material.AIR;
 		}
+		assert false;
 		return false;
 	}
 	

--- a/src/main/java/ch/njol/skript/conditions/CondIsEnchanted.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsEnchanted.java
@@ -25,8 +25,9 @@ import org.bukkit.enchantments.Enchantment;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
-import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.conditions.base.PropertyCondition.PropertyType;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -35,7 +36,6 @@ import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.EnchantmentType;
-import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
 
 /**
@@ -49,15 +49,13 @@ import ch.njol.util.Kleenean;
 public class CondIsEnchanted extends Condition {
 	
 	static {
-		Skript.registerCondition(CondIsEnchanted.class,
-				"%itemtypes% (is|are) enchanted [with %-enchantmenttype%]",
-				"%itemtypes% (isn't|is not|aren't|are not) enchanted [with %-enchantmenttype%]");
+		PropertyCondition.register(CondIsEnchanted.class, "enchanted [with %-enchantmenttype%]", "itemtypes");
 	}
 	
 	@SuppressWarnings("null")
 	private Expression<ItemType> items;
 	@Nullable
-	Expression<EnchantmentType> enchs;
+	private Expression<EnchantmentType> enchs;
 	
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
@@ -70,28 +68,25 @@ public class CondIsEnchanted extends Condition {
 	
 	@Override
 	public boolean check(final Event e) {
-		return items.check(e, new Checker<ItemType>() {
-			@Override
-			public boolean check(final ItemType item) {
-				final Expression<EnchantmentType> es = enchs;
-				if (es == null) {
-					final Map<Enchantment, Integer> enchs = item.getEnchantments();
-					return isNegated() ^ (enchs != null && !enchs.isEmpty());
-				}
-				return es.check(e, new Checker<EnchantmentType>() {
-					@Override
-					public boolean check(final EnchantmentType ench) {
-						return ench.has(item);
+		return items.check(e,
+				item -> {
+					final Expression<EnchantmentType> enchsExpr = this.enchs;
+					if (enchsExpr == null) {
+						final Map<Enchantment, Integer> enchs = item.getEnchantments();
+						return isNegated() ^ (enchs != null && !enchs.isEmpty());
 					}
+					return enchsExpr.check(e,
+							ench -> ench.has(item)
+					);
 				}, isNegated());
-			}
-		});
 	}
 	
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
 		final Expression<EnchantmentType> es = enchs;
-		return items.toString(e, debug) + " " + (items.isSingle() ? "is" : "are") + (isNegated() ? " not" : "") + " enchanted" + (es == null ? "" : " with " + es.toString(e, debug));
+		
+		return PropertyCondition.toString(this, PropertyType.BE, e, debug, items,
+				"enchanted" + (es == null ? "" : " with " + es.toString(e, debug)));
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsFlammable.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsFlammable.java
@@ -24,6 +24,7 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
+
 import org.bukkit.inventory.ItemStack;
 
 @Name("Is Flammable")
@@ -31,19 +32,19 @@ import org.bukkit.inventory.ItemStack;
 @Examples({"wood is flammable", "player's tool is flammable"})
 @Since("2.2-dev36")
 public class CondIsFlammable extends PropertyCondition<ItemStack> {
-
+	
 	static {
-		PropertyCondition.register(CondIsFlammable.class, "flammable", "itemstacks");
+		register(CondIsFlammable.class, "flammable", "itemstacks");
 	}
-
+	
 	@Override
 	public boolean check(ItemStack i) {
 		return i.getType().isFlammable();
 	}
-
+	
 	@Override
 	protected String getPropertyName() {
 		return "flammable";
 	}
-
+	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsFlying.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsFlying.java
@@ -49,4 +49,5 @@ public class CondIsFlying extends PropertyCondition<Player> {
 	protected String getPropertyName() {
 		return "flying";
 	}
+	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsInWorld.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsInWorld.java
@@ -25,6 +25,8 @@ import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.conditions.base.PropertyCondition.PropertyType;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -32,7 +34,6 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
 
 /**
@@ -45,14 +46,15 @@ import ch.njol.util.Kleenean;
 		"the player is in the world of the victim"})
 @Since("1.4")
 public class CondIsInWorld extends Condition {
+	
 	static {
-		Skript.registerCondition(CondIsInWorld.class, "%entities% (is|are) in [[the] world[s]] %worlds%", "%entities% (is not|isn't|are not|aren't) in [[the] world[s]] %worlds%");
+		PropertyCondition.register(CondIsInWorld.class, "in [[the] world[s]] %worlds%", "entities");
 	}
 	
 	@SuppressWarnings("null")
 	private Expression<Entity> entities;
 	@SuppressWarnings("null")
-	Expression<World> worlds;
+	private Expression<World> worlds;
 	
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
@@ -65,22 +67,16 @@ public class CondIsInWorld extends Condition {
 	
 	@Override
 	public boolean check(final Event e) {
-		return entities.check(e, new Checker<Entity>() {
-			@Override
-			public boolean check(final Entity en) {
-				return worlds.check(e, new Checker<World>() {
-					@Override
-					public boolean check(final World w) {
-						return en.getWorld() == w;
-					}
-				}, isNegated());
-			}
-		});
+		return entities.check(e,
+				entity -> worlds.check(e,
+						world -> entity.getWorld() == world
+				), isNegated());
 	}
 	
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
-		return entities.toString(e, debug) + " " + (entities.isSingle() ? "is" : "are") + " " + (isNegated() ? "not " : "") + "in the world " + worlds.toString(e, debug);
+		return PropertyCondition.toString(this, PropertyType.BE, e, debug, entities,
+				"in the " + (worlds.isSingle() ? "world " : "worlds ") + worlds.toString(e, debug));
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsLoaded.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsLoaded.java
@@ -24,6 +24,7 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.World;
@@ -33,11 +34,11 @@ import org.bukkit.World;
 @Examples("if chunk at {home::%player's uuid%} is loaded:")
 @Since("INSERT VERSION")
 public class CondIsLoaded extends PropertyCondition<Object> {
-
+	
 	static {
 		register(CondIsLoaded.class, "loaded", "worlds/chunks");
 	}
-
+	
 	@Override
 	public boolean check(Object o) {
 		if (o instanceof Chunk)
@@ -46,10 +47,10 @@ public class CondIsLoaded extends PropertyCondition<Object> {
 			return Bukkit.getWorld(((World) o).getName()) != null;
 		return false;
 	}
-
+	
 	@Override
 	protected String getPropertyName() {
 		return "loaded";
 	}
-
+	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsOfType.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsOfType.java
@@ -23,10 +23,11 @@ import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
-import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.classes.Comparator.Relation;
 import ch.njol.skript.classes.data.DefaultComparators;
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.conditions.base.PropertyCondition.PropertyType;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -42,20 +43,21 @@ import ch.njol.util.Kleenean;
  * @author Peter Güttinger
  */
 @Name("Is of Type")
-@Description("Checks whether an item of entity is of the given type. This is mostly useful for variables, as you can use the general 'is' condition otherwise (e.g. 'victim is a creeper').")
+@Description("Checks whether an item of entity is of the given type. This is mostly useful for variables," +
+		" as you can use the general 'is' condition otherwise (e.g. 'victim is a creeper').")
 @Examples({"tool is of type {*selected type}",
 		"victim is of type {villager type}"})
 @Since("1.4")
 public class CondIsOfType extends Condition {
+	
 	static {
-		Skript.registerCondition(CondIsOfType.class,
-				"%itemstacks/entities% (is|are) of type[s] %itemtypes/entitydatas%", "%itemstacks/entities% (isn't|is not|aren't|are not) of type[s] %itemtypes/entitydatas%");
+		PropertyCondition.register(CondIsOfType.class, "of type[s] %entitytypes/entitydatas%", "itemstacks/entities");
 	}
 	
 	@SuppressWarnings("null")
 	private Expression<?> what;
 	@SuppressWarnings("null")
-	Expression<?> types;
+	private Expression<?> types;
 	
 	@SuppressWarnings("null")
 	@Override
@@ -68,30 +70,26 @@ public class CondIsOfType extends Condition {
 	
 	@Override
 	public boolean check(final Event e) {
-		return what.check(e, new Checker<Object>() {
-			@Override
-			public boolean check(final Object o1) {
-				return types.check(e, new Checker<Object>() {
-					@Override
-					public boolean check(final Object o2) {
-						if (o2 instanceof ItemType && o1 instanceof ItemType) {
-							return ((ItemType) o2).isSupertypeOf((ItemType) o1);
-						} else if (o2 instanceof EntityData && o1 instanceof Entity) {
-							return ((EntityData<?>) o2).isInstance((Entity) o1);
-						} else if (o2 instanceof ItemType && o1 instanceof Entity) {
-							return Relation.EQUAL.is(DefaultComparators.entityItemComparator.compare(EntityData.fromEntity((Entity) o1), (ItemType) o2));
-						} else {
-							return false;
-						}
-					}
-				}, isNegated());
-			}
-		});
+		return what.check(e,
+				(Checker<Object>) o1 -> types.check(e,
+						(Checker<Object>) o2 -> {
+							if (o2 instanceof ItemType && o1 instanceof ItemType) {
+								return ((ItemType) o2).isSupertypeOf((ItemType) o1);
+							} else if (o2 instanceof EntityData && o1 instanceof Entity) {
+								return ((EntityData<?>) o2).isInstance((Entity) o1);
+							} else if (o2 instanceof ItemType && o1 instanceof Entity) {
+								return Relation.EQUAL.is(DefaultComparators.entityItemComparator.compare(EntityData.fromEntity((Entity) o1), (ItemType) o2));
+							} else {
+								return false;
+							}
+						}),
+				isNegated());
 	}
 	
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
-		return what.toString(e, debug) + (what.isSingle() ? " is " : " are ") + (isNegated() ? "not " : "") + "of type " + types.toString(e, debug);
+		return PropertyCondition.toString(this, PropertyType.BE, e, debug, what,
+				"of " + (types.isSingle() ? "type " : "types") + types.toString(e, debug));
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsOnGround.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsOnGround.java
@@ -32,18 +32,19 @@ import ch.njol.skript.doc.Since;
 @Examples("player is not on ground")
 @Since("2.2-dev26")
 public class CondIsOnGround extends PropertyCondition<Entity> {
-
+	
 	static {
 		PropertyCondition.register(CondIsOnGround.class, "on [the] ground", "entities");
 	}
-
+	
 	@Override
 	public boolean check(Entity entity) {
 		return entity.isOnGround();
 	}
-
+	
 	@Override
 	protected String getPropertyName() {
 		return "on ground";
 	}
+	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsOnline.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsOnline.java
@@ -20,18 +20,14 @@
 package ch.njol.skript.conditions;
 
 import org.bukkit.OfflinePlayer;
-import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
 
-import ch.njol.skript.Skript;
+import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
-import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
 
 /**
@@ -42,36 +38,28 @@ import ch.njol.util.Kleenean;
 @Examples({"player is online",
 		"player-argument is offline"})
 @Since("1.4")
-public class CondIsOnline extends Condition {
+public class CondIsOnline extends PropertyCondition<OfflinePlayer> {
 	
 	static {
-		Skript.registerCondition(CondIsOnline.class, "%offlineplayers% ((is|are) online|(is not|isn't|are not|aren't) offline)", "%offlineplayers% ((is|are) offline|(is not|isn't|are not|aren't) online)");
+		register(CondIsOnline.class, "(online|1¦offline)", "offlineplayers");
 	}
-	
-	@SuppressWarnings("null")
-	private Expression<OfflinePlayer> players;
 	
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
 	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
-		players = (Expression<OfflinePlayer>) exprs[0];
-		setNegated(matchedPattern == 1);
+		setExpr((Expression<OfflinePlayer>) exprs[0]);
+		setNegated(matchedPattern == 1 ^ parseResult.mark == 1);
 		return true;
 	}
 	
 	@Override
-	public boolean check(final Event e) {
-		return players.check(e, new Checker<OfflinePlayer>() {
-			@Override
-			public boolean check(final OfflinePlayer p) {
-				return p.isOnline();
-			}
-		}, isNegated());
+	public boolean check(OfflinePlayer op) {
+		return op.isOnline();
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return players.toString(e, debug) + " " + (players.isSingle() ? "is" : "are") + " " + (isNegated() ? "offline" : "online");
+	protected String getPropertyName() {
+		return "online";
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsRiding.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsRiding.java
@@ -23,7 +23,8 @@ import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
-import ch.njol.skript.Skript;
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.conditions.base.PropertyCondition.PropertyType;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -32,7 +33,6 @@ import ch.njol.skript.entity.EntityData;
 import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
 
 /**
@@ -43,16 +43,15 @@ import ch.njol.util.Kleenean;
 @Examples({"player is riding a saddled pig"})
 @Since("2.0")
 public class CondIsRiding extends Condition {
+	
 	static {
-		Skript.registerCondition(CondIsRiding.class,
-				"%entities% (is|are) riding [%entitydatas%]",
-				"%entities% (isn't|is not|aren't|are not) riding [%entitydatas%]");
+		PropertyCondition.register(CondIsRiding.class, "riding [%entitydatas%]", "entities");
 	}
 	
 	@SuppressWarnings("null")
 	private Expression<Entity> entities;
 	@SuppressWarnings("null")
-	Expression<EntityData<?>> types;
+	private Expression<EntityData<?>> types;
 	
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
@@ -65,22 +64,16 @@ public class CondIsRiding extends Condition {
 	
 	@Override
 	public boolean check(final Event e) {
-		return entities.check(e, new Checker<Entity>() {
-			@Override
-			public boolean check(final Entity en) {
-				return types.check(e, new Checker<EntityData<?>>() {
-					@Override
-					public boolean check(final EntityData<?> d) {
-						return d.isInstance(en.getVehicle());
-					}
-				}, isNegated());
-			}
-		});
+		return entities.check(e,
+				entity -> types.check(e,
+						data -> data.isInstance(entity.getVehicle())
+				), isNegated());
 	}
 	
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
-		return entities.toString(e, debug) + (isNegated() ? " is" : " isn't") + " riding" + types.toString(e, debug);
+		return PropertyCondition.toString(this, PropertyType.BE, e, debug, entities,
+				"riding " + types.toString(e, debug));
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsSet.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsSet.java
@@ -83,7 +83,7 @@ public class CondIsSet extends Condition {
 	
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
-		return expr.toString(e, debug) + " " + (isNegated() ? "isn't" : "is") + " set";
+		return expr.toString(e, debug) + (isNegated() ? " isn't" : " is") + " set";
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsSlimeChunk.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsSlimeChunk.java
@@ -44,11 +44,11 @@ import ch.njol.skript.doc.Since;
 		"\t\t\tsend \"Nope, it isn't\""})
 @Since("INSERT VERSION")
 public class CondIsSlimeChunk extends PropertyCondition<Chunk> {
-
+	
 	static {
 		register(CondIsSlimeChunk.class, "([a] slime chunk|slime chunks|slimey)", "chunk");
 	}
-
+	
 	@Override
 	public boolean check(Chunk chunk) {
 		Random random = new Random(chunk.getWorld().getSeed() +
@@ -58,9 +58,10 @@ public class CondIsSlimeChunk extends PropertyCondition<Chunk> {
 				(long) (chunk.getZ() * 0x5f24f) ^ 0x3ad8025f);
 		return random.nextInt(10) == 0;
 	}
-
+	
 	@Override
 	protected String getPropertyName() {
 		return "slime chunk";
 	}
+	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsSolid.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsSolid.java
@@ -19,34 +19,32 @@
  */
 package ch.njol.skript.conditions;
 
+import org.bukkit.inventory.ItemStack;
+
 import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
-import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
-import ch.njol.util.Kleenean;
-import org.bukkit.inventory.ItemStack;
 
 @Name("Is Solid")
 @Description("Checks whether an item is solid.")
 @Examples({"grass block is solid", "player's tool isn't solid"})
 @Since("2.2-dev36")
 public class CondIsSolid extends PropertyCondition<ItemStack> {
-
+	
 	static {
-		PropertyCondition.register(CondIsSolid.class, "solid", "itemstacks");
+		register(CondIsSolid.class, "solid", "itemstacks");
 	}
-
+	
 	@Override
 	public boolean check(ItemStack i) {
 		return i.getType().isSolid();
 	}
-
+	
 	@Override
 	protected String getPropertyName() {
 		return "solid";
 	}
-
+	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsSprinting.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsSprinting.java
@@ -35,6 +35,7 @@ import ch.njol.skript.doc.Since;
 @Examples("player is not sprinting")
 @Since("1.4.4")
 public class CondIsSprinting extends PropertyCondition<Player> {
+	
 	static {
 		register(CondIsSprinting.class, "sprinting", "players");
 	}

--- a/src/main/java/ch/njol/skript/conditions/CondIsTransparent.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsTransparent.java
@@ -19,34 +19,32 @@
  */
 package ch.njol.skript.conditions;
 
+import org.bukkit.inventory.ItemStack;
+
 import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
-import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
-import ch.njol.util.Kleenean;
-import org.bukkit.inventory.ItemStack;
 
 @Name("Is Transparent")
 @Description("Checks whether an item is transparent.")
 @Examples({"glass is transparent", "player's tool is transparent."})
 @Since("2.2-dev36")
 public class CondIsTransparent extends PropertyCondition<ItemStack> {
-
+	
 	static {
-		PropertyCondition.register(CondIsTransparent.class, "transparent", "itemstacks");
+		register(CondIsTransparent.class, "transparent", "itemstacks");
 	}
-
+	
 	@Override
 	public boolean check(ItemStack i) {
 		return i.getType().isTransparent();
 	}
-
+	
 	@Override
 	protected String getPropertyName() {
 		return "transparent";
 	}
-
+	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondItemInHand.java
+++ b/src/main/java/ch/njol/skript/conditions/CondItemInHand.java
@@ -1,5 +1,5 @@
 /**
- *   This file is part of Skript.
+ * This file is part of Skript.
  *
  *  Skript is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -21,6 +21,8 @@ package ch.njol.skript.conditions;
 
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.Event;
+import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.inventory.ItemStack;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
@@ -48,28 +50,34 @@ public class CondItemInHand extends Condition {
 	static {
 		if (Skript.isRunningMinecraft(1, 9)) {
 			Skript.registerCondition(CondItemInHand.class,
-					"[%livingentities%] ha(s|ve) %itemtypes% in [main] hand", "[%livingentities%] (is|are) holding %itemtypes% [in main hand]",
-					"[%livingentities%] ha(s|ve) %itemtypes% in off[(-| )]hand", "[%livingentities%] (is|are) holding %itemtypes% in off[(-| )]hand",
-					"[%livingentities%] (ha(s|ve) not|do[es]n't have) %itemtypes% in [main] hand", "[%livingentities%] (is not|isn't) holding %itemtypes% [in main hand]",
-					"[%livingentities%] (ha(s|ve) not|do[es]n't have) %itemtypes% in off[(-| )]hand", "[%livingentities%] (is not|isn't) holding %itemtypes% in off[(-| )]hand");
+					"[%livingentities%] ha(s|ve) %itemtypes% in [main] hand",
+					"[%livingentities%] (is|are) holding %itemtypes% [in main hand]",
+					"[%livingentities%] ha(s|ve) %itemtypes% in off[(-| )]hand",
+					"[%livingentities%] (is|are) holding %itemtypes% in off[(-| )]hand",
+					"[%livingentities%] (ha(s|ve) not|do[es]n't have) %itemtypes% in [main] hand",
+					"[%livingentities%] (is not|isn't) holding %itemtypes% [in main hand]",
+					"[%livingentities%] (ha(s|ve) not|do[es]n't have) %itemtypes% in off[(-| )]hand",
+					"[%livingentities%] (is not|isn't) holding %itemtypes% in off[(-| )]hand");
 		} else {
 			Skript.registerCondition(CondItemInHand.class,
-					"[%livingentities%] ha(s|ve) %itemtypes% in hand", "[%livingentities%] (is|are) holding %itemtypes% in hand",
-					"[%livingentities%] (ha(s|ve) not|do[es]n't have) %itemtypes%", "[%livingentities%] (is not|isn't) holding %itemtypes%");
+					"[%livingentities%] ha(s|ve) %itemtypes% in hand",
+					"[%livingentities%] (is|are) holding %itemtypes% in hand",
+					"[%livingentities%] (ha(s|ve) not|do[es]n't have) %itemtypes%",
+					"[%livingentities%] (is not|isn't) holding %itemtypes%");
 		}
 	}
 	
 	@SuppressWarnings("null")
 	private Expression<LivingEntity> entities;
 	@SuppressWarnings("null")
-	Expression<ItemType> types;
-	boolean offTool;
+	private Expression<ItemType> types;
+	private boolean offTool;
 	
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
-	public boolean init(final Expression<?>[] vars, final int matchedPattern, final Kleenean isDelayed, final ParseResult parser) {
-		entities = (Expression<LivingEntity>) vars[0];
-		types = (Expression<ItemType>) vars[1];
+	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parser) {
+		entities = (Expression<LivingEntity>) exprs[0];
+		types = (Expression<ItemType>) exprs[1];
 		if (Skript.isRunningMinecraft(1, 9)) {
 			offTool = (matchedPattern == 2 || matchedPattern == 3 || matchedPattern == 6 || matchedPattern == 7);
 			setNegated(matchedPattern >= 4);
@@ -82,21 +90,20 @@ public class CondItemInHand extends Condition {
 	
 	@Override
 	public boolean check(final Event e) {
-		return entities.check(e, new Checker<LivingEntity>() {
-			@Override
-			public boolean check(final LivingEntity en) {
-				return types.check(e, new Checker<ItemType>() {
-					@SuppressWarnings("deprecation")
-					@Override
-					public boolean check(final ItemType type) {
-						if (Skript.isRunningMinecraft(1, 9))
-							return (offTool ? type.isOfType(en.getEquipment().getItemInOffHand()) : type.isOfType(en.getEquipment().getItemInMainHand()));
-						else
-							return type.isOfType(en.getEquipment().getItemInHand());
-					}
-				}, isNegated());
-			}
-		});
+		return entities.check(e,
+				en -> types.check(e,
+						type -> {
+							EntityEquipment equipment = en.getEquipment();
+							
+							if (Skript.isRunningMinecraft(1, 9)) {
+								return (offTool ? type.isOfType(equipment.getItemInOffHand()) : type.isOfType(equipment.getItemInMainHand()));
+							} else {
+								@SuppressWarnings("deprecation")
+								ItemStack itemInHand = equipment.getItemInHand();
+								
+								return type.isOfType(itemInHand);
+							}
+						}), isNegated());
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/conditions/CondPermission.java
+++ b/src/main/java/ch/njol/skript/conditions/CondPermission.java
@@ -24,6 +24,8 @@ import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.conditions.base.PropertyCondition.PropertyType;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -31,7 +33,6 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
 
 /**
@@ -44,53 +45,50 @@ import ch.njol.util.Kleenean;
 		"	send \"You're attacking an admin!\" to attacker"})
 @Since("1.0")
 public class CondPermission extends Condition {
+	
 	static {
 		Skript.registerCondition(CondPermission.class,
-				"[%commandsenders%] (do[es]n't|don't|do[es] not) have [the] permission[s] %strings%",
-				"[%commandsenders%] ha(s|ve) [the] permission[s] %strings%");
+				"%commandsenders% (has|have) [the] permission[s] %strings%",
+				"%commandsenders% (doesn't|does not|do not|don't) have [the] permission[s] %strings%");
 	}
 	
 	@SuppressWarnings("null")
-	Expression<String> permissions;
+	private Expression<String> permissions;
 	@SuppressWarnings("null")
 	private Expression<CommandSender> senders;
 	
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
-	public boolean init(final Expression<?>[] vars, final int matchedPattern, final Kleenean isDelayed, final ParseResult parser) {
-		senders = (Expression<CommandSender>) vars[0];
-		permissions = (Expression<String>) vars[1];
-		setNegated(matchedPattern == 0);
+	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
+		senders = (Expression<CommandSender>) exprs[0];
+		permissions = (Expression<String>) exprs[1];
+		setNegated(matchedPattern == 1);
 		return true;
 	}
 	
 	@Override
 	public boolean check(final Event e) {
-		return senders.check(e, new Checker<CommandSender>() {
-			@Override
-			public boolean check(final CommandSender s) {
-				return permissions.check(e, new Checker<String>() {
-					@Override
-					public boolean check(final String perm) {
-						if (s.hasPermission(perm))
-							return true;
-						// player has perm skript.foo.bar if he has skript.foo.* or skript.*, but not for other plugin's permissions since they can define their own *
-						if (perm.startsWith("skript.")) {
-							for (int i = perm.lastIndexOf('.'); i != -1; i = perm.lastIndexOf('.', i - 1)) {
-								if (s.hasPermission(perm.substring(0, i + 1) + "*"))
-									return true;
+		return senders.check(e,
+				s -> permissions.check(e,
+						perm -> {
+							if (s.hasPermission(perm))
+								return true;
+							// player has perm skript.foo.bar if he has skript.foo.* or skript.*,
+							// but not for other plugin's permissions since they can define their own *
+							if (perm.startsWith("skript.")) {
+								for (int i = perm.lastIndexOf('.'); i != -1; i = perm.lastIndexOf('.', i - 1)) {
+									if (s.hasPermission(perm.substring(0, i + 1) + "*"))
+										return true;
+								}
 							}
-						}
-						return false;
-					}
-				}, isNegated());
-			}
-		});
+							return false;
+						}), isNegated());
 	}
 	
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
-		return senders.toString(e, debug) + " " + (isNegated() ? "doesn't have" : "has") + " the permission " + permissions.toString(e, debug);
+		return PropertyCondition.toString(this, PropertyType.HAVE, e, debug, senders,
+				"the permission" + (permissions.isSingle() ? " " : "s ") + permissions.toString());
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondPlayedBefore.java
+++ b/src/main/java/ch/njol/skript/conditions/CondPlayedBefore.java
@@ -63,17 +63,14 @@ public class CondPlayedBefore extends Condition {
 	
 	@Override
 	public boolean check(final Event e) {
-		return player.check(e, new Checker<OfflinePlayer>() {
-			@Override
-			public boolean check(final OfflinePlayer p) {
-				return p.hasPlayedBefore();
-			}
-		}, isNegated());
+		return player.check(e,
+				OfflinePlayer::hasPlayedBefore,
+				isNegated());
 	}
 	
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
-		return player.toString(e, debug) + " " + (isNegated() ? "hasn't" : "has") + " played on this server before";
+		return player.toString(e, debug) + (isNegated() ? " hasn't" : " has") + " played on this server before";
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondPvP.java
+++ b/src/main/java/ch/njol/skript/conditions/CondPvP.java
@@ -50,7 +50,7 @@ public class CondPvP extends Condition {
 	
 	@SuppressWarnings("null")
 	private Expression<World> worlds;
-	boolean enabled;
+	private boolean enabled;
 	
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
@@ -61,18 +61,12 @@ public class CondPvP extends Condition {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "is PvP " + (enabled ? "enabled" : "disabled") + " in " + worlds.toString(e, debug);
+	public boolean check(final Event e) {
+		return worlds.check(e, w -> w.getPVP() == enabled, isNegated());
 	}
 	
 	@Override
-	public boolean check(final Event e) {
-		return worlds.check(e, new Checker<World>() {
-			@Override
-			public boolean check(final World w) {
-				return w.getPVP() == enabled;
-			}
-		}, isNegated());
+	public String toString(final @Nullable Event e, final boolean debug) {
+		return "PvP is " + (enabled ? "enabled" : "disabled") + " in " + worlds.toString(e, debug);
 	}
-	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondScriptLoaded.java
+++ b/src/main/java/ch/njol/skript/conditions/CondScriptLoaded.java
@@ -19,6 +19,11 @@
  */
 package ch.njol.skript.conditions;
 
+import java.io.File;
+
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
 import ch.njol.skript.ScriptLoader;
 import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptCommand;
@@ -29,21 +34,18 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
-import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
-import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
-
-import java.io.File;
 
 @Name("Is Script Loaded")
 @Description("Check if the current script or another script, is current loaded.")
-@Examples({"script is loaded","script \"example.sk\" is loaded"})
+@Examples({"script is loaded", "script \"example.sk\" is loaded"})
 @Since("2.2-dev31")
 public class CondScriptLoaded extends Condition {
 	
 	static {
-		Skript.registerCondition(CondScriptLoaded.class, "script[s] [%-strings%] (is|are) loaded", "script[s] [%-strings%] (isn't|is not|aren't|are not) loaded");
+		Skript.registerCondition(CondScriptLoaded.class,
+				"script[s] [%-strings%] (is|are) loaded",
+				"script[s] [%-strings%] (isn't|is not|aren't|are not) loaded");
 	}
 	
 	@Nullable
@@ -54,34 +56,40 @@ public class CondScriptLoaded extends Condition {
 	@SuppressWarnings({"unchecked"})
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
-		assert ScriptLoader.currentScript != null;
-		currentScriptFile = ScriptLoader.currentScript.getFile();
 		scripts = (Expression<String>) exprs[0];
 		setNegated(matchedPattern == 1);
+		assert ScriptLoader.currentScript != null;
+		currentScriptFile = ScriptLoader.currentScript.getFile();
 		return true;
 	}
 	
 	@Override
 	public boolean check(Event e) {
+		Expression<String> scripts = this.scripts;
 		if (scripts == null) {
 			return ScriptLoader.getLoadedFiles().contains(currentScriptFile);
 		}
 		
-		assert scripts != null;
-		return scripts.check(e, new Checker<String>() {
-			@Override
-			public boolean check(String scriptName) {
-				return ScriptLoader.getLoadedFiles().contains(SkriptCommand.getScriptFromName(scriptName));
-			}
-		}, isNegated());
+		return scripts.check(e,
+				scriptName -> ScriptLoader.getLoadedFiles().contains(SkriptCommand.getScriptFromName(scriptName)),
+				isNegated());
 	}
 	
-	@SuppressWarnings("null") // Look, we check for nullability there!
 	@Override
 	public String toString(@Nullable Event e, boolean debug) {
-		String scriptName = scripts == null ? "script" : (scripts.isSingle() ? "script" : "scripts" + " " + scripts.toString(e, debug));
+		Expression<String> scripts = this.scripts;
+		
+		String scriptName;
+		if (scripts == null)
+			scriptName = "script";
+		else
+			scriptName = (scripts.isSingle() ? "script" : "scripts" + " " + scripts.toString(e, debug));
+		
 		boolean isSingle = scripts == null || scripts.isSingle();
-		return scriptName + " " + (isSingle ? (isNegated() ? "isn't" : "is") : (isNegated() ? "aren't" : "are")) + " loaded";
+		if (isSingle)
+			return scriptName + (isNegated() ? " isn't" : " is") + " loaded";
+		else
+			return scriptName + (isNegated() ? " aren't" : " are") + " loaded";
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondStartsEndsWith.java
+++ b/src/main/java/ch/njol/skript/conditions/CondStartsEndsWith.java
@@ -39,19 +39,19 @@ import ch.njol.util.Kleenean;
 		"	send \"Stop!\""})
 @Since("2.2-dev36")
 public class CondStartsEndsWith extends Condition {
-
+	
 	static {
 		Skript.registerCondition(CondStartsEndsWith.class,
 				"%strings% (start|1¦end)[s] with %string%",
 				"%strings% (doesn't|does not|do not|don't) (start|1¦end) with %string%");
 	}
-
+	
 	@SuppressWarnings("null")
 	private Expression<String> strings;
 	@SuppressWarnings("null")
 	private Expression<String> affix;
 	private boolean usingEnds;
-
+	
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
@@ -61,18 +61,20 @@ public class CondStartsEndsWith extends Condition {
 		setNegated(matchedPattern == 1);
 		return true;
 	}
-
+	
 	@Override
 	public boolean check(Event e) {
-		String a = affix.getSingle(e);
-		return strings.check(e, new Checker<String>() {
-			@Override
-			public boolean check(String s) {
-				return usingEnds ? s.endsWith(a) : s.startsWith(a);
-			}
-		}, isNegated());
+		String affix = this.affix.getSingle(e);
+		
+		if (affix == null) {
+			return false;
+		}
+		
+		return strings.check(e,
+				string -> usingEnds ? string.endsWith(affix) : string.endsWith(affix),
+				isNegated());
 	}
-
+	
 	@Override
 	public String toString(@Nullable Event e, boolean debug) {
 		if (isNegated())
@@ -80,6 +82,5 @@ public class CondStartsEndsWith extends Condition {
 		else
 			return strings.toString(e, debug) + (usingEnds ? " ends" : " starts") + " with " + affix.toString(e, debug);
 	}
-
-
+	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondWeather.java
+++ b/src/main/java/ch/njol/skript/conditions/CondWeather.java
@@ -47,12 +47,14 @@ import ch.njol.util.Kleenean;
 		"is raining in \"world\" or \"world2\""})
 @Since("1.0")
 public class CondWeather extends Condition {
+	
 	static {
+		// TODO a better alternative syntax, without the 'is' at the beginning
 		Skript.registerCondition(CondWeather.class, "is %weathertypes% [in %worlds%]");
 	}
 	
 	@SuppressWarnings("null")
-	Expression<WeatherType> weathers;
+	private Expression<WeatherType> weathers;
 	@SuppressWarnings("null")
 	private Expression<World> worlds;
 	
@@ -66,23 +68,16 @@ public class CondWeather extends Condition {
 	
 	@Override
 	public boolean check(final Event e) {
-		return worlds.check(e, new Checker<World>() {
-			@Override
-			public boolean check(final World w) {
-				final WeatherType t;
-				if (e instanceof WeatherEvent && w.equals(((WeatherEvent) e).getWorld()) && !Delay.isDelayed(e)) {
-					t = WeatherType.fromEvent((WeatherEvent) e);
-				} else {
-					t = WeatherType.fromWorld(w);
-				}
-				return weathers.check(e, new Checker<WeatherType>() {
-					@Override
-					public boolean check(final WeatherType wt) {
-						return wt == t;
-					}
-				}, isNegated());
+		return worlds.check(e, w -> {
+			final WeatherType weatherType;
+			if (e instanceof WeatherEvent && w.equals(((WeatherEvent) e).getWorld()) && !Delay.isDelayed(e)) {
+				weatherType = WeatherType.fromEvent((WeatherEvent) e);
+			} else {
+				weatherType = WeatherType.fromWorld(w);
 			}
-		});
+			return weathers.check(e,
+					expectedType -> expectedType == weatherType);
+		}, isNegated());
 	}
 	
 	@Override


### PR DESCRIPTION
Copy-pasted from the message of the first commit (only reformatted line endings):
- changed some conditions to property conditions, where it made sense
- replaced `new Checker() { ... }` with lambdas
- utilized the static toString method of the PropertyCondition class in a few non-property conditions where it made sense, for guaranteed toString consistency and proper grammar
- in nested Expression#check calls, put the negation in the outer call, because this way it makes more sense logically. For some 'proof', see the CondCompare class written by Njol, it has always had the the `isNegated()` parameter only in the outer call. I've considered this deeply myself too and I am greatly convicted it makes more sense this way
- changed the method order in a few classes
- fixed up the nullability annotations in a few classes
- added tabs on empty lines in some files where they were missing (we plan to remove them afaik, but for now for consistency)
- added or removed empty lines in a few places, for consistency and readability
- suppressed a deprecation warning in one place where it was clear that we're aware that the method was deprecated although we still need to use it to support older Minecraft versions
- added `assert false;`s before `return false;`s that should never be run