### PR TITLE
Add Difficulty

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -30,6 +30,7 @@ import java.util.regex.Pattern;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
+import org.bukkit.Difficulty;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -1439,7 +1440,6 @@ public class BukkitClasses {
 							return "server icon";
 						}
 
-						@SuppressWarnings("null")
 						@Override
 						public String toVariableNameString(final CachedServerIcon o) {
 							return "server icon";
@@ -1451,6 +1451,39 @@ public class BukkitClasses {
 						}
 					}));
 		}
+
+		EnumUtils<Difficulty> difficulties = new EnumUtils<>(Difficulty.class, "difficulty");
+		Classes.registerClass(new ClassInfo<>(Difficulty.class, "difficulty")
+				.user("difficult(y|ies)")
+				.name("Difficulty")
+				.description("The difficulty of a <a href='#world'>world</a>.")
+				.examples(difficulties.getAllNames())
+				.since("INSERT VERSION")
+				.parser(new Parser<Difficulty>() {
+					
+					@Override
+					@Nullable
+					public Difficulty parse(final String input, final ParseContext context) {
+						return difficulties.parse(input);
+					}
+					
+					@Override
+					public String toString(Difficulty difficulty, int flags) {
+						return difficulties.toString(difficulty, flags);
+					}
+
+					@SuppressWarnings("null")
+					@Override
+					public String toVariableNameString(Difficulty difficulty) {
+						return difficulty.name();
+					}
+
+					@Override
+					public String getVariableNamePattern() {
+						return "\\S+";
+					}
+				})
+				.serializer(new EnumSerializer<>(Difficulty.class)));
 
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprDifficulty.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDifficulty.java
@@ -1,0 +1,90 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.expressions;
+
+import org.bukkit.Difficulty;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.event.Event;
+import org.bukkit.event.world.SpawnChangeEvent;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.classes.Converter;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.effects.Delay;
+import ch.njol.skript.expressions.base.PropertyExpression;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
+
+@Name("Difficulty")
+@Description("The difficulty of a world.")
+@Examples("set the difficulty of \"world\" to hard")
+@Since("INSERT VERSION")
+public class ExprDifficulty extends SimplePropertyExpression<World, Difficulty> {
+
+	static {
+		register(ExprDifficulty.class, Difficulty.class, "difficulty", "worlds");
+	}
+	
+	@Override
+	@Nullable
+	public Difficulty convert(World world) {
+		return world.getDifficulty();
+	}
+	
+	@Override
+	@Nullable
+	public Class<?>[] acceptChange(ChangeMode mode) {
+		if (mode == ChangeMode.SET)
+			return CollectionUtils.array(Difficulty.class);
+		return null;
+	}
+	
+	@Override
+	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+		if (delta == null)
+			return;
+		
+		Difficulty difficulty = (Difficulty) delta[0];
+		for (World world : getExpr().getArray(e)) {
+			world.setDifficulty(difficulty);
+		}
+	}
+	
+	@Override
+	protected String getPropertyName() {
+		return "difficulty";
+	}
+	
+	@Override
+	public Class<Difficulty> getReturnType() {
+		return Difficulty.class;
+	}
+
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprDifficulty.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDifficulty.java
@@ -49,7 +49,7 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprDifficulty extends SimplePropertyExpression<World, Difficulty> {
 
 	static {
-		register(ExprDifficulty.class, Difficulty.class, "difficulty", "worlds");
+		register(ExprDifficulty.class, Difficulty.class, "difficult(y|ies)", "worlds");
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprSpawn.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSpawn.java
@@ -84,7 +84,6 @@ public class ExprSpawn extends PropertyExpression<World, Location> {
 		return "spawn of " + getExpr().toString(e, debug);
 	}
 	
-	@SuppressWarnings("unchecked")
 	@Override
 	@Nullable
 	public Class<?>[] acceptChange(final ChangeMode mode) {
@@ -94,7 +93,7 @@ public class ExprSpawn extends PropertyExpression<World, Location> {
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
+	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
 		assert mode == ChangeMode.SET;
 		assert delta != null;
 		

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -1297,6 +1297,13 @@ spawn reasons:
 	trap: trap
 	village_defense: village defense, golem defense, iron golem defense
 	village_invasion: village invasion, village invading
+	
+# -- Difficulties --
+difficulty:
+	easy: easy
+	normal: medium, normal
+	hard: hard
+	peaceful: peaceful
 
 # -- Boolean --
 boolean:
@@ -1348,6 +1355,7 @@ types:
 	inventorytype: inventory type¦s @an
 	metadataholder: metadata holder¦s @a
 	spawnreason: spawn reason¦s @a
+	difficulty: (difficulty|difficulties) @a
 	
 	# Skript
 	weathertype: weather type¦s @a


### PR DESCRIPTION
Target Minecraft versions: Any

Description: I was surprised when I saw that Skript doesn't have any world difficulty support, so here it is.

Notes:
- I also removed a weird un-needed throw of UnsupportedOperationException when I was looking for similar syntax by Njol to compare from. #SuperOldJava
- I haven't tested if the `normal` difficulty English type name conflicts with `normal` from the villager types. Skript "should" handle it properly since this is implemented properly, and there is support for checking similar names.
