### PR TITLE
Fix nav bar occasionally jumping on the docs

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -81,6 +81,8 @@ a:visited {
   height: calc(100vh - 3.2em);
   overflow: scroll;
   overflow-x: hidden;
+  position: sticky;
+  top: 3.2em;
 }
 
 #nav-contents > a {


### PR DESCRIPTION
Seems to fix the issue regarding the nav bar sometimes jumping up when clicking between elements at the bottom. I just added the same fields that control the outer `nav`'s positioning to the inner `div` as well. 

I've done web design before but I'm still not enough of a CSS aficionado to know why this was necessary, but it does seem to fix it when I edit the CSS live after the issue occurs. @Blueyescat confirmed as well.