### PR TITLE
Changes to the Color util due to compatibility issues

### DIFF
--- a/src/main/java/ch/njol/skript/util/Color.java
+++ b/src/main/java/ch/njol/skript/util/Color.java
@@ -28,91 +28,75 @@ import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.localization.Adjective;
 import ch.njol.skript.localization.Language;
-import ch.njol.skript.localization.LanguageChangeListener;
 import ch.njol.yggdrasil.YggdrasilSerializable;
 
-/**
- * @author Peter Güttinger
- */
-@SuppressWarnings({"deprecation", "null"})
 public enum Color implements YggdrasilSerializable {
 	
-	BLACK(DyeColor.BLACK, ChatColor.BLACK, org.bukkit.Color.fromRGB(0x191919)),
-	DARK_GREY(DyeColor.GRAY, ChatColor.DARK_GRAY, org.bukkit.Color.fromRGB(0x4C4C4C)),
+	BLACK(DyeColor.BLACK, ChatColor.BLACK),
+	DARK_GREY(DyeColor.GRAY, ChatColor.DARK_GRAY),
 	// DyeColor.LIGHT_GRAY on 1.13, DyeColor.SILVER on earlier
-	LIGHT_GREY(DyeColor.getByColor(org.bukkit.Color.fromRGB(0x9D9D97)), ChatColor.GRAY, org.bukkit.Color.fromRGB(0x999999)),
-	WHITE(DyeColor.WHITE, ChatColor.WHITE, org.bukkit.Color.fromRGB(0xFFFFFF)),
+	LIGHT_GREY(DyeColor.getByColor(org.bukkit.Color.fromRGB(0x9D9D97)), ChatColor.GRAY),
+	WHITE(DyeColor.WHITE, ChatColor.WHITE),
 	
-	DARK_BLUE(DyeColor.BLUE, ChatColor.DARK_BLUE, org.bukkit.Color.fromRGB(0x334CB2)),
-	BROWN(DyeColor.BROWN, ChatColor.BLUE, org.bukkit.Color.fromRGB(0x664C33)),
-	DARK_CYAN(DyeColor.CYAN, ChatColor.DARK_AQUA, org.bukkit.Color.fromRGB(0x4C7F99)),
-	LIGHT_CYAN(DyeColor.LIGHT_BLUE, ChatColor.AQUA, org.bukkit.Color.fromRGB(0x6699D8)),
+	DARK_BLUE(DyeColor.BLUE, ChatColor.DARK_BLUE),
+	BROWN(DyeColor.BROWN, ChatColor.BLUE),
+	DARK_CYAN(DyeColor.CYAN, ChatColor.DARK_AQUA),
+	LIGHT_CYAN(DyeColor.LIGHT_BLUE, ChatColor.AQUA),
 	
-	DARK_GREEN(DyeColor.GREEN, ChatColor.DARK_GREEN, org.bukkit.Color.fromRGB(0x667F33)),
-	LIGHT_GREEN(DyeColor.LIME, ChatColor.GREEN, org.bukkit.Color.fromRGB(0x7FCC19)),
+	DARK_GREEN(DyeColor.GREEN, ChatColor.DARK_GREEN),
+	LIGHT_GREEN(DyeColor.LIME, ChatColor.GREEN),
 	
-	YELLOW(DyeColor.YELLOW, ChatColor.YELLOW, org.bukkit.Color.fromRGB(0xE5E533)),
-	ORANGE(DyeColor.ORANGE, ChatColor.GOLD, org.bukkit.Color.fromRGB(0xD87F33)),
+	YELLOW(DyeColor.YELLOW, ChatColor.YELLOW),
+	ORANGE(DyeColor.ORANGE, ChatColor.GOLD),
 	
-	DARK_RED(DyeColor.RED, ChatColor.DARK_RED, org.bukkit.Color.fromRGB(0x993333)),
-	LIGHT_RED(DyeColor.PINK, ChatColor.RED, org.bukkit.Color.fromRGB(0xF27FA5)),
+	DARK_RED(DyeColor.RED, ChatColor.DARK_RED),
+	LIGHT_RED(DyeColor.PINK, ChatColor.RED),
 	
-	DARK_PURPLE(DyeColor.PURPLE, ChatColor.DARK_PURPLE, org.bukkit.Color.fromRGB(0x7F3FB2)),
-	LIGHT_PURPLE(DyeColor.MAGENTA, ChatColor.LIGHT_PURPLE, org.bukkit.Color.fromRGB(0xB24CD8));
+	DARK_PURPLE(DyeColor.PURPLE, ChatColor.DARK_PURPLE),
+	LIGHT_PURPLE(DyeColor.MAGENTA, ChatColor.LIGHT_PURPLE);
 	
-	public final static String LANGUAGE_NODE = "colors";
+	public static final String LANGUAGE_NODE = "colors";
 	
-	private final DyeColor wool;
-	private final ChatColor chat;
-	private final org.bukkit.Color bukkit;
-	
+	private DyeColor wool;
+	private ChatColor chat;
 	@Nullable
-	Adjective adjective;
+	private Adjective adjective;
 	
-	private Color(final DyeColor wool, final ChatColor chat, final org.bukkit.Color bukkit) {
+	
+	Color(final DyeColor wool, final ChatColor chat) {
 		this.wool = wool;
 		this.chat = chat;
-		this.bukkit = bukkit;
+	}
+	private static final Map<DyeColor, Color> BY_WOOL = new HashMap<>();
+	
+	static {
+		for (Color c : values())
+			BY_WOOL.put(c.getWoolColor(), c);
+		
 	}
 	
-	private final static Color[] byWool = new Color[16];
-	static {
-		for (final Color c : values()) {
-			byWool[c.wool.getWoolData()] = c;
-		}
-	}
+	final static Map<String, Color> BY_NAME = new HashMap<>();
+	final static Map<String, Color> BY_ENGLISH_NAME = new HashMap<>();
 	
-	final static Map<String, Color> byName = new HashMap<>();
-	final static Map<String, Color> byEnglishName = new HashMap<>();
 	static {
-		Language.addListener(new LanguageChangeListener() {
-			@Override
-			public void onLanguageChange() {
-				final boolean english = byEnglishName.isEmpty();
-				byName.clear();
-				for (final Color c : values()) {
-					final String[] names = Language.getList(LANGUAGE_NODE + "." + c.name() + ".names");
-					for (final String name : names) {
-						byName.put(name.toLowerCase(), c);
-						if (english)
-							byEnglishName.put(name.toLowerCase(), c);
-					}
-					c.adjective = new Adjective(LANGUAGE_NODE + "." + c.name() + ".adjective");
+		Language.addListener(() -> {
+			boolean english = BY_ENGLISH_NAME.isEmpty();
+			BY_NAME.clear();
+			
+			for (Color c : values()) {
+				String[] names = Language.getList(LANGUAGE_NODE + "." + c.name() + ".names");
+				for (final String name : names) {
+					BY_NAME.put(name.toLowerCase(), c);
+					if (english)
+						BY_ENGLISH_NAME.put(name.toLowerCase(), c);
 				}
+				c.setAdjective(new Adjective(LANGUAGE_NODE + "." + c.name() + ".adjective"));
 			}
+			
 		});
 	}
-	
-	public byte getDye() {
-		return (byte) (15 - wool.getWoolData());
-	}
-	
 	public DyeColor getWoolColor() {
 		return wool;
-	}
-	
-	public byte getWool() {
-		return wool.getWoolData();
 	}
 	
 	public String getChat() {
@@ -123,47 +107,39 @@ public enum Color implements YggdrasilSerializable {
 		return chat;
 	}
 	
+	public final org.bukkit.Color getBukkitColor() {
+		return wool.getColor();
+	}
+	
 	// currently only used by SheepData
+	@Nullable
 	public Adjective getAdjective() {
 		return adjective;
+	}
+	
+	public void setAdjective(Adjective adjective) {
+		this.adjective = adjective;
+	}
+	
+	@Nullable
+	public static Color byName(final String name) {
+		return BY_NAME.get(name.toLowerCase());
+	}
+	
+	@Nullable
+	public static Color byEnglishName(final String name) {
+		return BY_ENGLISH_NAME.get(name.toLowerCase());
+	}
+	
+	
+	public static Color byWoolColor(final DyeColor color) {
+		return BY_WOOL.get(color);
 	}
 	
 	@Override
 	public String toString() {
 		final Adjective a = adjective;
 		return a == null ? "" + name() : a.toString(-1, 0);
-	}
-	
-	@Nullable
-	public static Color byName(final String name) {
-		return byName.get(name.toLowerCase());
-	}
-	
-	@Nullable
-	public static Color byEnglishName(final String name) {
-		return byEnglishName.get(name.toLowerCase());
-	}
-	
-	@Nullable
-	public static Color byWool(final short data) {
-		if (data < 0 || data >= 16)
-			return null;
-		return byWool[data];
-	}
-	
-	@Nullable
-	public static Color byDye(final short data) {
-		if (data < 0 || data >= 16)
-			return null;
-		return byWool[15 - data];
-	}
-	
-	public static Color byWoolColor(final DyeColor color) {
-		return byWool(color.getWoolData());
-	}
-	
-	public final org.bukkit.Color getBukkitColor() {
-		return bukkit;
 	}
 	
 }


### PR DESCRIPTION
Target Minecraft versions: N/A
Requirements: N/A
Related issues: #1627 

Description:
For whatever reason, this class is restricting Skript from loading in older versions.

And since I was already changing this class, decided to make some changes to it. The main changes are:
* The Bukkit Color isn't referenced anymore (we can use DyeColor#getColor for that).
* Removal of methods using magic values.

The main reason why I am PRing this is due to the removal of these methods, I'd like to know if you guys think it's better to just deprecate them. I am pretty sure any addon nor Skript itself uses these methods so they were just there but I'd still like input on it.