### PR TITLE
Clean up vector stuff

### DIFF
--- a/src/main/java/ch/njol/skript/classes/VectorArithmethic.java
+++ b/src/main/java/ch/njol/skript/classes/VectorArithmethic.java
@@ -19,7 +19,6 @@
  */
 package ch.njol.skript.classes;
 
-import ch.njol.skript.classes.Arithmetic;
 import org.bukkit.util.Vector;
 
 /**

--- a/src/main/java/ch/njol/skript/effects/EffVectorRotateAroundAnother.java
+++ b/src/main/java/ch/njol/skript/effects/EffVectorRotateAroundAnother.java
@@ -67,7 +67,7 @@ public class EffVectorRotateAroundAnother extends Effect {
 	protected void execute(Event e) {
 		Vector v2 = second.getSingle(e);
 		Number d = degree.getSingle(e);
-		if (v2 == null || d == null )
+		if (v2 == null || d == null)
 			return;
 		for (Vector v1 : first.getArray(e))
 			VectorMath.rot(v1, v2, d.doubleValue());

--- a/src/main/java/ch/njol/skript/effects/EffVectorRotateAroundAnother.java
+++ b/src/main/java/ch/njol/skript/effects/EffVectorRotateAroundAnother.java
@@ -19,6 +19,10 @@
  */
 package ch.njol.skript.effects;
 
+import org.bukkit.event.Event;
+import org.bukkit.util.Vector;
+import org.eclipse.jdt.annotation.Nullable;
+
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -26,59 +30,52 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import ch.njol.util.VectorMath;
-
-import org.bukkit.event.Event;
-import org.bukkit.util.Vector;
-import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * @author bi0qaw
  */
-@Name("Vectors - Rotate around vector")
+@Name("Vectors - Rotate Around Vector")
 @Description("Rotates a vector around another vector")
 @Examples({"rotate {_v} around vector 1, 0, 0 by 90"})
 @Since("2.2-dev28")
-public class EffVectorRotateAroundAnother extends Effect{
+public class EffVectorRotateAroundAnother extends Effect {
+
 	static {
 		Skript.registerEffect(EffVectorRotateAroundAnother.class, "rotate %vectors% around %vector% by %number% [degrees]");
 	}
 	
 	@SuppressWarnings("null")
 	private Expression<Vector> first, second;
+
 	@SuppressWarnings("null")
-	private Expression<Number> number;
+	private Expression<Number> degree;
 
-	
-	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "rotate " + first.toString(e, debug) + " around " + second.toString(e, debug);
-	}
-
-	
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
-	public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
-		first = (Expression<Vector>)expressions[0];
-		second = (Expression<Vector>)expressions[1];
-		number = (Expression<Number>)expressions[2];
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean kleenean, ParseResult parseResult) {
+		first = (Expression<Vector>) exprs[0];
+		second = (Expression<Vector>) exprs[1];
+		degree = (Expression<Number>) exprs[2];
 		return true;
 	}
 
 	@SuppressWarnings("null")
 	@Override
-	protected void execute(Event event) {
-		Vector v2 = second.getSingle(event);
-		Number n = number.getSingle(event);
-		if (v2 == null || n == null ){
+	protected void execute(Event e) {
+		Vector v2 = second.getSingle(e);
+		Number d = degree.getSingle(e);
+		if (v2 == null || d == null )
 			return;
-		}
-		for (Vector v1 : first.getArray(event)) {
-			VectorMath.rot(v1, v2, n.doubleValue());
-		}
+		for (Vector v1 : first.getArray(e))
+			VectorMath.rot(v1, v2, d.doubleValue());
 	}
 
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		return "rotate " + first.toString(e, debug) + " around " + second.toString(e, debug) + " by " + degree + "degrees";
+	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffVectorRotateXYZ.java
+++ b/src/main/java/ch/njol/skript/effects/EffVectorRotateXYZ.java
@@ -61,8 +61,8 @@ public class EffVectorRotateXYZ extends Effect {
 	@Override
 	@SuppressWarnings({"unchecked", "null"})
 	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		vectors = (Expression<Vector>)expressions[0];
-		degree = (Expression<Number>)expressions[1];
+		vectors = (Expression<Vector>) expressions[0];
+		degree = (Expression<Number>) expressions[1];
 		axis = parseResult.mark;
 		return true;
 	}
@@ -75,15 +75,15 @@ public class EffVectorRotateXYZ extends Effect {
 			return;
 		switch (axis) {
 			case 1:
-				for (Vector v : vectors.getAll(e))
+				for (Vector v : vectors.getArray(e))
 					VectorMath.rotX(v, d.doubleValue());
 				break;
 			case 2:
-				for (Vector v : vectors.getAll(e))
+				for (Vector v : vectors.getArray(e))
 					VectorMath.rotY(v, d.doubleValue());
 				break;
 			case 3:
-				for (Vector v : vectors.getAll(e))
+				for (Vector v : vectors.getArray(e))
 					VectorMath.rotZ(v, d.doubleValue());
 		}
 	}

--- a/src/main/java/ch/njol/skript/effects/EffVectorRotateXYZ.java
+++ b/src/main/java/ch/njol/skript/effects/EffVectorRotateXYZ.java
@@ -19,6 +19,10 @@
  */
 package ch.njol.skript.effects;
 
+import org.bukkit.event.Event;
+import org.bukkit.util.Vector;
+import org.eclipse.jdt.annotation.Nullable;
+
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -26,13 +30,9 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import ch.njol.util.VectorMath;
-
-import org.bukkit.event.Event;
-import org.bukkit.util.Vector;
-import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * @author bi0qaw
@@ -41,57 +41,56 @@ import org.eclipse.jdt.annotation.Nullable;
 @Description("Rotates a vector around x, y, or z axis by some degrees")
 @Examples({"rotate {_v} around x-axis by 90",
 		"rotate {_v} around y-axis by 90",
-		"rotate {_v} around z-axis by 90"})
+		"rotate {_v} around z-axis by 90 degrees"})
 @Since("2.2-dev28")
-public class EffVectorRotateXYZ extends Effect{
+public class EffVectorRotateXYZ extends Effect {
+
 	static {
 		Skript.registerEffect(EffVectorRotateXYZ.class, "rotate %vectors% around (1¦x|2¦y|3¦z)(-| )axis by %number% [degrees]");
 	}
+
 	private final static Character[] axes = new Character[] {'x', 'y', 'z'};
 
 	@SuppressWarnings("null")
 	private Expression<Vector> vectors;
-	@SuppressWarnings("null")
-	private Expression<Number> number;
-	private int mark;
 
-	@Override
-	public String toString(@Nullable Event event, boolean b) {
-		return "rotate " + vectors.toString() + " around " + axes[mark] + "-axis";
-	}
+	@SuppressWarnings("null")
+	private Expression<Number> degree;
+	private int axis;
 
 	@Override
 	@SuppressWarnings({"unchecked", "null"})
-	public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		vectors = (Expression<Vector>)expressions[0];
-		number = (Expression<Number>)expressions[1];
-		mark = parseResult.mark;
+		degree = (Expression<Number>)expressions[1];
+		axis = parseResult.mark;
 		return true;
 	}
 
 	@Override
 	@SuppressWarnings("null")
-	protected void execute(Event event) {
-		Number n = number.getSingle(event);
-		if (n == null){
+	protected void execute(Event e) {
+		Number d = degree.getSingle(e);
+		if (d == null)
 			return;
-		}
-		switch (mark) {
+		switch (axis) {
 			case 1:
-				for (Vector v : vectors.getAll(event)) {
-					VectorMath.rotX(v, n.doubleValue());
-				}
+				for (Vector v : vectors.getAll(e))
+					VectorMath.rotX(v, d.doubleValue());
 				break;
 			case 2:
-				for (Vector v : vectors.getAll(event)) {
-					VectorMath.rotY(v, n.doubleValue());
-				}
+				for (Vector v : vectors.getAll(e))
+					VectorMath.rotY(v, d.doubleValue());
 				break;
 			case 3:
-				for (Vector v : vectors.getAll(event)) {
-					VectorMath.rotZ(v, n.doubleValue());
-				}
-				break;
+				for (Vector v : vectors.getAll(e))
+					VectorMath.rotZ(v, d.doubleValue());
 		}
 	}
+
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		return "rotate " + vectors.toString(e, debug) + " around " + axes[axis] + "-axis" + " by " + degree + "degrees";
+	}
+
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprLocationFromVector.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLocationFromVector.java
@@ -19,32 +19,33 @@
  */
 package ch.njol.skript.expressions;
 
-import ch.njol.skript.Skript;
-import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
-import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.Since;
-import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
-import ch.njol.skript.lang.util.SimpleExpression;
-import ch.njol.util.Kleenean;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.event.Event;
 import org.bukkit.util.Vector;
 import org.eclipse.jdt.annotation.Nullable;
 
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
+
 /**
  * @author bi0qaw
  */
-@Name("Vectors - Create location from vector")
-@Description("Creates a location from a vector in a world")
+@Name("Vectors - Create Location from Vector")
+@Description("Creates a location from a vector in a world.")
 @Examples({"set {_loc} to {_v} to location in world \"world\"",
 		"set {_loc} to {_v} to location in world \"world\" with yaw 45 and pitch 90",
 		"set {_loc} to location of {_v} in \"world\" with yaw 45 and pitch 90"})
 @Since("2.2-dev28")
 public class ExprLocationFromVector extends SimpleExpression<Location> {
+
 	static {
 		// TODO fix slowdowns and enable again, for now nuked for greater good
 //		Skript.registerExpression(ExprLocationFromVector.class, Location.class, ExpressionType.SIMPLE,
@@ -55,11 +56,42 @@ public class ExprLocationFromVector extends SimpleExpression<Location> {
 
 	@SuppressWarnings("null")
 	private Expression<Vector> vector;
+
 	@SuppressWarnings("null")
 	private Expression<World> world;
+
 	@SuppressWarnings("null")
 	private Expression<Number> yaw, pitch;
 	private boolean yawpitch;
+
+	@Override
+	@SuppressWarnings({"unchecked", "null"})
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		if (exprs.length > 3)
+			yawpitch = true;
+		vector = (Expression<Vector>) exprs[0];
+		world = (Expression<World>) exprs[1];
+		if (yawpitch) {
+			yaw = (Expression<Number>) exprs[2];
+			pitch = (Expression<Number>) exprs[3];
+		}
+		return true;
+	}
+
+	@SuppressWarnings("null")
+	@Override
+	protected Location[] get(Event e) {
+		Vector v = vector.getSingle(e);
+		World w = world.getSingle(e);
+		Number y = yaw != null ? yaw.getSingle(e) : null;
+		Number p = pitch != null ? pitch.getSingle(e) : null;
+		if (v == null || w == null)
+			return null;
+		if (y == null || p == null)
+			return CollectionUtils.array(v.toLocation(w));
+		else
+			return CollectionUtils.array(v.toLocation(w, y.floatValue(), p.floatValue()));
+	}
 
 	@Override
 	public boolean isSingle() {
@@ -72,43 +104,10 @@ public class ExprLocationFromVector extends SimpleExpression<Location> {
 	}
 
 	@Override
-	@SuppressWarnings({"unchecked", "null"})
-	public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
-		if (expressions.length > 3) {
-			yawpitch = true;
-		}
-		vector = (Expression<Vector>)expressions[0];
-		world = (Expression<World>)expressions[1];
-		if (yawpitch) {
-			yaw = (Expression<Number>)expressions[2];
-			pitch = (Expression<Number>)expressions[3];
-		}
-		return true;
+	public String toString(@Nullable Event e, boolean debug) {
+		if (yawpitch)
+			return "location from " + vector.toString(e, debug) + " with yaw " + yaw.toString() + " and pitch " + pitch.toString(e, debug);
+		return "location from " + vector.toString(e, debug);
 	}
 
-	@SuppressWarnings("null")
-	@Override
-	protected Location[] get(Event event) {
-		Vector v = vector.getSingle(event);
-		World w = world.getSingle(event);
-		Number y = yaw != null ? yaw.getSingle(event) : null;
-		Number p = pitch != null ? pitch.getSingle(event) : null;
-		if (v == null || w == null){
-			return null;
-		}
-		if (y == null || p == null){
-			return new Location[]{ v.toLocation(w)};
-		}
-		else {
-			return new Location[]{v.toLocation(w, y.floatValue(), p.floatValue())};
-		}
-	}
-
-	@Override
-	public String toString(final @Nullable Event event, boolean b) {
-		if (yawpitch) {
-			return "location from " + vector.toString() + " with yaw " + yaw.toString() + " and pitch " + pitch.toString();
-		}
-		return "location from " + vector.toString();
-	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprLocationVectorOffset.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLocationVectorOffset.java
@@ -19,6 +19,11 @@
  */
 package ch.njol.skript.expressions;
 
+import org.bukkit.Location;
+import org.bukkit.event.Event;
+import org.bukkit.util.Vector;
+import org.eclipse.jdt.annotation.Nullable;
+
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -26,44 +31,51 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
-import org.bukkit.Location;
-import org.bukkit.event.Event;
-import org.bukkit.util.Vector;
-import org.eclipse.jdt.annotation.Nullable;
+import ch.njol.util.coll.CollectionUtils;
 
 
 /**
  * @author bi0qaw
  */
-@Name("Vectors - Location vector offset")
-@Description("Offset a location by a vector")
+@Name("Vectors - Location Vector Offset")
+@Description("Returns the location offset by vectors.")
 @Examples({"set {_loc} to {_loc} ~ {_v}"})
 @Since("2.2-dev28")
 public class ExprLocationVectorOffset extends SimpleExpression<Location> {
+
 	static {
-		Skript.registerExpression(ExprLocationVectorOffset.class, Location.class, ExpressionType.SIMPLE, "%location%[ ]~[~][ ]%vectors%");
+		Skript.registerExpression(ExprLocationVectorOffset.class, Location.class, ExpressionType.SIMPLE,
+				"%location% offset by [[the] vectors] %vectors%",
+				"%location%[ ]~[~][ ]%vectors%");
 	}
 
 	@SuppressWarnings("null")
 	private Expression<Location> location;
+
 	@SuppressWarnings("null")
 	private Expression<Vector> vectors;
 
+	@Override
+	@SuppressWarnings({"unchecked", "null"})
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		location = (Expression<Location>) exprs[0];
+		vectors = (Expression<Vector>) exprs[1];
+		return true;
+	}
+
 	@SuppressWarnings("null")
 	@Override
-	protected Location[] get(Event event) {
-		Location l = location.getSingle(event);
-		if (l == null) {
+	protected Location[] get(Event e) {
+		Location l = location.getSingle(e);
+		if (l == null)
 			return null;
-		}
 		Location clone = l.clone();
-		for (Vector v : vectors.getArray(event)) {
+		for (Vector v : vectors.getArray(e))
 			clone.add(v);
-		}
-		return new Location[] {clone};
+		return CollectionUtils.array(clone);
 	}
 
 	@Override
@@ -77,15 +89,8 @@ public class ExprLocationVectorOffset extends SimpleExpression<Location> {
 	}
 
 	@Override
-	public String toString(final @Nullable Event event, boolean b) {
-		return location.toString() + " offset by vector " + vectors.toString();
+	public String toString(@Nullable Event e, boolean debug) {
+		return location.toString() + " offset by " + vectors.toString();
 	}
 
-	@Override
-	@SuppressWarnings({"unchecked", "null"})
-	public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
-		location = (Expression<Location>) expressions[0];
-		vectors = (Expression<Vector>) expressions[1];
-		return true;
-	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorAngleBetween.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorAngleBetween.java
@@ -19,6 +19,10 @@
  */
 package ch.njol.skript.expressions;
 
+import org.bukkit.event.Event;
+import org.bukkit.util.Vector;
+import org.eclipse.jdt.annotation.Nullable;
+
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -26,29 +30,46 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import ch.njol.util.VectorMath;
-
-import org.bukkit.event.Event;
-import org.bukkit.util.Vector;
-import org.eclipse.jdt.annotation.Nullable;
+import ch.njol.util.coll.CollectionUtils;
 
 /**
  * @author bi0qaw
  */
-@Name("Vectors - Angle between")
+@Name("Vectors - Angle Between")
 @Description("Gets the angle between two vectors.")
-@Examples({"send \"%angle between vector 1, 0, 0 and vector 0, 1, 1%\""})
+@Examples({"send \"%the angle between vector 1, 0, 0 and vector 0, 1, 1%\""})
 @Since("2.2-dev28")
-public class ExprVectorAngleBetween extends SimpleExpression<Float> {
+public class ExprVectorAngleBetween extends SimpleExpression<Number> {
+
 	static {
-		Skript.registerExpression(ExprVectorAngleBetween.class, Float.class, ExpressionType.SIMPLE, "angle between %vector% and %vector%");
+		Skript.registerExpression(ExprVectorAngleBetween.class, Number.class, ExpressionType.SIMPLE,
+				"[the] angle between [[the] vectors] %vector% and %vector%");
 	}
 
 	@SuppressWarnings("null")
 	private Expression<Vector> first, second;
+
+	@SuppressWarnings({"unchecked", "null"})
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		first = (Expression<Vector>) exprs[0];
+		second = (Expression<Vector>) exprs[1];
+		return true;
+	}
+
+	@Override
+	@SuppressWarnings("null")
+	protected Number[] get(Event e) {
+		Vector v1 = first.getSingle(e);
+		Vector v2 = second.getSingle(e);
+		if (v1 == null || v2 == null)
+			return null;
+		return CollectionUtils.array(v1.angle(v2) * (float) VectorMath.RAD_TO_DEG);
+	}
 
 	@Override
 	public boolean isSingle() {
@@ -56,31 +77,13 @@ public class ExprVectorAngleBetween extends SimpleExpression<Float> {
 	}
 
 	@Override
-	public String toString(@Nullable Event event, boolean b) {
-		return "angle between " + first.toString() + " and " + second.toString() ;
+	public Class<? extends Number> getReturnType() {
+		return Number.class;
 	}
 
 	@Override
-	public Class<? extends Float> getReturnType() {
-		return Float.class;
+	public String toString(@Nullable Event e, boolean debug) {
+		return "the angle between " + first.toString(e, debug) + " and " + second.toString(e, debug);
 	}
 
-	@SuppressWarnings({"unchecked", "null"})
-	@Override
-	public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
-		first = (Expression<Vector>)expressions[0];
-		second = (Expression<Vector>)expressions[1];
-		return true;
-	}
-
-	@Override
-	@SuppressWarnings("null")
-	protected Float[] get(Event event) {
-		Vector v1 = first.getSingle(event);
-		Vector v2 = second.getSingle(event);
-		if (v1 == null || v2 == null){
-			return null;
-		}
-		return new Float[] { v1.angle(v2) * (float) VectorMath.RAD_TO_DEG };
-	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorBetweenLocations.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorBetweenLocations.java
@@ -19,6 +19,13 @@
  */
 package ch.njol.skript.expressions;
 
+import java.util.Collection;
+
+import org.bukkit.Location;
+import org.bukkit.event.Event;
+import org.bukkit.util.Vector;
+import org.eclipse.jdt.annotation.Nullable;
+
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -26,60 +33,58 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
-import org.bukkit.Location;
-import org.bukkit.event.Event;
-import org.bukkit.util.Vector;
-import org.eclipse.jdt.annotation.Nullable;
+import ch.njol.util.coll.CollectionUtils;
 
 /**
  * @author bi0qaw
  */
-@Name("Vectors - Between locations")
+@Name("Vectors - Vector Between Locations")
 @Description("Creates a vector between two locations.")
 @Examples({"set {_v} to vector between {_loc1} and {_loc2}"})
 @Since("2.2-dev28")
 public class ExprVectorBetweenLocations extends SimpleExpression<Vector> {
+
 	static {
-		Skript.registerExpression(ExprVectorBetweenLocations.class, Vector.class, ExpressionType.SIMPLE, "vector (from|between) %location% (to|and) %location%");
+		Skript.registerExpression(ExprVectorBetweenLocations.class, Vector.class, ExpressionType.SIMPLE,
+				"[the] vector (from|between) %location% (to|and) %location%");
 	}
 
 	@SuppressWarnings("null")
 	private Expression<Location> from, to;
 
 	@Override
-	public boolean isSingle() {
+	@SuppressWarnings({"unchecked", "null"})
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		from = (Expression<Location>) exprs[0];
+		to = (Expression<Location>) exprs[1];
 		return true;
 	}
 
 	@Override
-	public String toString(final @Nullable Event event, boolean b) {
-		return "vector from " + from.toString() + " to " + to.toString();
+	@SuppressWarnings("null")
+	protected Vector[] get(Event e) {
+		Location l1 = from.getSingle(e);
+		Location l2 = to.getSingle(e);
+		if (l1 == null || l2 == null)
+			return null;
+		return CollectionUtils.array(new Vector(l2.getX() - l1.getX(), l2.getY() - l1.getY(), l2.getZ() - l1.getZ()));
 	}
 
+	@Override
+	public boolean isSingle() {
+		return true;
+	}
 	@Override
 	public Class<? extends Vector> getReturnType() {
 		return Vector.class;
 	}
 
 	@Override
-	@SuppressWarnings({"unchecked", "null"})
-	public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
-		from = (Expression<Location>)expressions[0];
-		to = (Expression<Location>)expressions[1];
-		return true;
+	public String toString(@Nullable Event e, boolean debug) {
+		return "vector from " + from.toString(e, debug) + " to " + to.toString(e, debug);
 	}
 
-	@Override
-	@SuppressWarnings("null")
-	protected Vector[] get(Event event) {
-		Location l1 = from.getSingle(event);
-		Location l2 = to.getSingle(event);
-		if (l1 == null || l2 == null){
-			return null;
-		}
-		return new Vector[]{ new Vector(l2.getX() - l1.getX(), l2.getY() - l1.getY(), l2.getZ() - l1.getZ())};
-	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorCrossProduct.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorCrossProduct.java
@@ -19,6 +19,10 @@
  */
 package ch.njol.skript.expressions;
 
+import org.bukkit.event.Event;
+import org.bukkit.util.Vector;
+import org.eclipse.jdt.annotation.Nullable;
+
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -26,21 +30,20 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
-import org.bukkit.event.Event;
-import org.bukkit.util.Vector;
-import org.eclipse.jdt.annotation.Nullable;
+import ch.njol.util.coll.CollectionUtils;
 
 /**
  * @author bi0qaw
  */
-@Name("Vectors - Cross product")
+@Name("Vectors - Cross Product")
 @Description("Gets the cross product between two vectors.")
 @Examples({"send \"%vector 1, 0, 0 cross vector 0, 1, 0%\""})
 @Since("2.2-dev28")
 public class ExprVectorCrossProduct extends SimpleExpression<Vector> {
+
 	static {
 		Skript.registerExpression(ExprVectorCrossProduct.class, Vector.class, ExpressionType.SIMPLE, "%vector% cross %vector%");
 	}
@@ -49,13 +52,26 @@ public class ExprVectorCrossProduct extends SimpleExpression<Vector> {
 	private Expression<Vector> first, second;
 
 	@Override
-	public boolean isSingle() {
+	@SuppressWarnings({"unchecked", "null"})
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		first = (Expression<Vector>) exprs[0];
+		second = (Expression<Vector>) exprs[1];
 		return true;
 	}
 
 	@Override
-	public String toString(final @Nullable Event event, boolean b) {
-		return  first.toString() + " cross " + second.toString();
+	@SuppressWarnings("null")
+	protected Vector[] get(Event e) {
+		Vector v1 = first.getSingle(e);
+		Vector v2 = second.getSingle(e);
+		if (v1 == null || v2 == null)
+			return null;
+		return CollectionUtils.array(v1.clone().crossProduct(v2));
+	}
+
+	@Override
+	public boolean isSingle() {
+		return true;
 	}
 
 	@Override
@@ -64,21 +80,8 @@ public class ExprVectorCrossProduct extends SimpleExpression<Vector> {
 	}
 
 	@Override
-	@SuppressWarnings({"unchecked", "null"})
-	public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
-		first = (Expression<Vector>)expressions[0];
-		second = (Expression<Vector>)expressions[1];
-		return true;
+	public String toString(@Nullable Event e, boolean debug) {
+		return first.toString(e, debug) + " cross " + second.toString(e, debug);
 	}
 
-	@Override
-	@SuppressWarnings("null")
-	protected Vector[] get(Event event) {
-		Vector v1 = first.getSingle(event);
-		Vector v2 = second.getSingle(event);
-		if (v1 == null || v2 == null) {
-			return null;
-		}
-		return new Vector[]{ v1.clone().crossProduct(v2)};
-	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorDotProduct.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorDotProduct.java
@@ -19,6 +19,10 @@
  */
 package ch.njol.skript.expressions;
 
+import org.bukkit.event.Event;
+import org.bukkit.util.Vector;
+import org.eclipse.jdt.annotation.Nullable;
+
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -26,17 +30,15 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
-import org.bukkit.event.Event;
-import org.bukkit.util.Vector;
-import org.eclipse.jdt.annotation.Nullable;
+import ch.njol.util.coll.CollectionUtils;
 
 /**
  * @author bi0qaw
  */
-@Name("Vectors - Dot product")
+@Name("Vectors - Dot Product")
 @Description("Gets the dot product between two vectors.")
 @Examples({"set {_v} to {_v2} dot {_v3}"})
 @Since("2.2-dev28")
@@ -47,14 +49,32 @@ import org.eclipse.jdt.annotation.Nullable;
  * "z" takes the value 18. There must be some black magic
  * going on.
  */
+public class ExprVectorDotProduct extends SimpleExpression<Number> {
 
-public class ExprVectorDotProduct extends SimpleExpression<Double> {
 	static {
-		Skript.registerExpression(ExprVectorDotProduct.class, Double.class, ExpressionType.SIMPLE, "%vector% dot %vector%");
+		Skript.registerExpression(ExprVectorDotProduct.class, Number.class, ExpressionType.SIMPLE, "%vector% dot %vector%");
 	}
 
 	@SuppressWarnings("null")
 	private Expression<Vector> first, second;
+
+	@Override
+	@SuppressWarnings({"unchecked", "null"})
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		first = (Expression<Vector>) exprs[0];
+		second = (Expression<Vector>) exprs[1];
+		return true;
+	}
+
+	@Override
+	@SuppressWarnings("null")
+	protected Double[] get(Event e) {
+		Vector v1 = first.getSingle(e);
+		Vector v2 = second.getSingle(e);
+		if (v1 == null || v2 == null)
+			return null;
+		return CollectionUtils.array(v1.getX() * v2.getX() + v1.getY() * v2.getY() + v1.getZ() * v2.getZ());
+	}
 
 	@Override
 	public boolean isSingle() {
@@ -62,31 +82,13 @@ public class ExprVectorDotProduct extends SimpleExpression<Double> {
 	}
 
 	@Override
-	public String toString(final @Nullable Event event, boolean b) {
-		return first.toString() + " dot " + second.toString();
+	public Class<? extends Number> getReturnType() {
+		return Number.class;
 	}
 
 	@Override
-	public Class<? extends Double> getReturnType() {
-		return Double.class;
+	public String toString(@Nullable Event e, boolean debug) {
+		return first.toString(e, debug) + " dot " + second.toString(e, debug);
 	}
 
-	@Override
-	@SuppressWarnings({"unchecked", "null"})
-	public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
-		first = (Expression<Vector>)expressions[0];
-		second = (Expression<Vector>)expressions[1];
-		return true;
-	}
-
-	@Override
-	@SuppressWarnings("null")
-	protected Double[] get(Event event) {
-		Vector v1 = first.getSingle(event);
-		Vector v2 = second.getSingle(event);
-		if (v1 == null || v2 == null) {
-			return null;
-		}
-		return new Double[]{ v1.getX() * v2.getX() + v1.getY() * v2.getY() + v1.getZ() * v2.getZ()};
-	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorFromXYZ.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorFromXYZ.java
@@ -19,6 +19,10 @@
  */
 package ch.njol.skript.expressions;
 
+import org.bukkit.event.Event;
+import org.bukkit.util.Vector;
+import org.eclipse.jdt.annotation.Nullable;
+
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -26,38 +30,46 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
-import org.bukkit.event.Event;
-import org.bukkit.util.Vector;
-import org.eclipse.jdt.annotation.Nullable;
+import ch.njol.util.coll.CollectionUtils;
 
 /**
  * @author bi0qaw
  */
 @Name("Vectors - Create from XYZ")
-@Description("Creates a vector from an x, y and z value.")
+@Description("Creates a vector from x, y and z values.")
 @Examples({"set {_v} to vector 0, 1, 0"})
 @Since("2.2-dev28")
 public class ExprVectorFromXYZ extends SimpleExpression<Vector> {
+
 	static {
-		Skript.registerExpression(ExprVectorFromXYZ.class, Vector.class, ExpressionType.SIMPLE, "[new] vector [(from|at|to)] %number%,[ ]%number%(,[ ]| and )%number%");
+		Skript.registerExpression(ExprVectorFromXYZ.class, Vector.class, ExpressionType.SIMPLE,
+				"[a] [new] vector [(from|at|to)] %number%,[ ]%number%(,[ ]| and )%number%");
 	}
 
 	@SuppressWarnings("null")
 	private Expression<Number> x, y, z;
 
 	@Override
+	@SuppressWarnings({"unchecked", "null"})
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		x = (Expression<Number>) exprs[0];
+		y = (Expression<Number>) exprs[1];
+		z = (Expression<Number>) exprs[2];
+		return true;
+	}
+
+	@Override
 	@SuppressWarnings("null")
-	protected Vector[] get(Event event) {
-		Number x = this.x.getSingle(event);
-		Number y = this.y.getSingle(event);
-		Number z = this.z.getSingle(event);
-		if ( x == null || y == null || z == null) {
+	protected Vector[] get(Event e) {
+		Number x = this.x.getSingle(e);
+		Number y = this.y.getSingle(e);
+		Number z = this.z.getSingle(e);
+		if (x == null || y == null || z == null)
 			return null;
-		}
-		return new Vector[] {new Vector(x.doubleValue(), y.doubleValue(), z.doubleValue())};
+		return CollectionUtils.array(new Vector(x.doubleValue(), y.doubleValue(), z.doubleValue()));
 	}
 
 	@Override
@@ -71,16 +83,8 @@ public class ExprVectorFromXYZ extends SimpleExpression<Vector> {
 	}
 
 	@Override
-	public String toString(@Nullable Event event, boolean b) {
-		return "vector from x " + x.toString() + ", y " + y.toString() + ", z " + z.toString();
+	public String toString(@Nullable Event e, boolean debug) {
+		return "vector from x " + x.toString(e, debug) + ", y " + y.toString(e, debug) + ", z " + z.toString(e, debug);
 	}
 
-	@Override
-	@SuppressWarnings({"unchecked", "null"})
-	public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
-		x = (Expression<Number>) expressions[0];
-		y = (Expression<Number>) expressions[1];
-		z = (Expression<Number>) expressions[2];
-		return true;
-	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorFromYawAndPitch.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorFromYawAndPitch.java
@@ -19,6 +19,10 @@
  */
 package ch.njol.skript.expressions;
 
+import org.bukkit.event.Event;
+import org.bukkit.util.Vector;
+import org.eclipse.jdt.annotation.Nullable;
+
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -26,41 +30,47 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import ch.njol.util.VectorMath;
-
-import org.bukkit.event.Event;
-import org.bukkit.util.Vector;
-import org.eclipse.jdt.annotation.Nullable;
+import ch.njol.util.coll.CollectionUtils;
 
 /**
  * @author bi0qaw
  */
-@Name("Vectors - Create from pitch and yaw")
+@Name("Vectors - Vector from Pitch and Yaw")
 @Description("Creates a vector from a yaw and pitch value.")
 @Examples({"set {_v} to vector from yaw 45 and pitch 45"})
 @Since("2.2-dev28")
 public class ExprVectorFromYawAndPitch extends SimpleExpression<Vector> {
+
 	static {
-		Skript.registerExpression(ExprVectorFromYawAndPitch.class, Vector.class, ExpressionType.SIMPLE, "[new] vector from yaw %number% and pitch %number%");
+		Skript.registerExpression(ExprVectorFromYawAndPitch.class, Vector.class, ExpressionType.SIMPLE,
+				"[a] [new] vector (from|with) yaw %number% and pitch %number%");
 	}
 
 	@SuppressWarnings("null")
 	private Expression<Number> pitch, yaw;
 
 	@Override
+	@SuppressWarnings({"unchecked", "null"})
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		yaw = (Expression<Number>) exprs[0];
+		pitch = (Expression<Number>) exprs[1];
+		return true;
+	}
+
+	@Override
 	@SuppressWarnings("null")
-	protected Vector[] get(Event event) {
-		Number y = yaw.getSingle(event);
-		Number p = pitch.getSingle(event);
-		if (y == null || p == null) {
+	protected Vector[] get(Event e) {
+		Number y = yaw.getSingle(e);
+		Number p = pitch.getSingle(e);
+		if (y == null || p == null)
 			return null;
-		}
 		float yaw = VectorMath.fromSkriptYaw(VectorMath.wrapAngleDeg(y.floatValue()));
 		float pitch = VectorMath.fromSkriptPitch(VectorMath.wrapAngleDeg(p.floatValue()));
-		return new Vector[]{ VectorMath.fromYawAndPitch(yaw, pitch)};
+		return CollectionUtils.array(VectorMath.fromYawAndPitch(yaw, pitch));
 	}
 
 	@Override
@@ -74,15 +84,8 @@ public class ExprVectorFromYawAndPitch extends SimpleExpression<Vector> {
 	}
 
 	@Override
-	public String toString(final @Nullable Event event, boolean b) {
-		return "from yaw " + yaw.toString() + " and pitch " + pitch.toString();
+	public String toString(@Nullable Event e, boolean debug) {
+		return "vector from yaw " + yaw.toString(e, debug) + " and pitch " + pitch.toString(e, debug);
 	}
 
-	@Override
-	@SuppressWarnings({"unchecked", "null"})
-	public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
-		yaw = (Expression<Number>) expressions[0];
-		pitch = (Expression<Number>) expressions[1];
-		return true;
-	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorNormalize.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorNormalize.java
@@ -39,14 +39,14 @@ import ch.njol.util.coll.CollectionUtils;
  * @author bi0qaw
  */
 @Name("Vectors - Normalized")
-@Description("Normalizes a vector.")
+@Description("Returns the same vector but with length 1.")
 @Examples({"set {_v} to normalized {_v}"})
 @Since("2.2-dev28")
 public class ExprVectorNormalize extends SimpleExpression<Vector> {
 
 	static {
 		Skript.registerExpression(ExprVectorNormalize.class, Vector.class, ExpressionType.SIMPLE,
-				"normalized %vector%",
+				"normalize[d] %vector%",
 				"%vector% normalized");
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorNormalize.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorNormalize.java
@@ -19,6 +19,10 @@
  */
 package ch.njol.skript.expressions;
 
+import org.bukkit.event.Event;
+import org.bukkit.util.Vector;
+import org.eclipse.jdt.annotation.Nullable;
+
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -26,36 +30,48 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
-import org.bukkit.event.Event;
-import org.bukkit.util.Vector;
-import org.eclipse.jdt.annotation.Nullable;
+import ch.njol.util.coll.CollectionUtils;
 
 /**
  * @author bi0qaw
  */
-@Name("Vectors - Normalize")
+@Name("Vectors - Normalized")
 @Description("Normalizes a vector.")
-@Examples({"set {_v} to {_v} normalized"})
+@Examples({"set {_v} to normalized {_v}"})
 @Since("2.2-dev28")
 public class ExprVectorNormalize extends SimpleExpression<Vector> {
+
 	static {
-		Skript.registerExpression(ExprVectorNormalize.class, Vector.class, ExpressionType.SIMPLE, "normalize %vector%", "%vector% normalized");
+		Skript.registerExpression(ExprVectorNormalize.class, Vector.class, ExpressionType.SIMPLE,
+				"normalized %vector%",
+				"%vector% normalized");
 	}
 
 	@SuppressWarnings("null")
 	private Expression<Vector> vector;
 
 	@Override
-	public boolean isSingle() {
+	@SuppressWarnings({"unchecked", "null"})
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		vector = (Expression<Vector>) exprs[0];
 		return true;
 	}
 
 	@Override
-	public String toString(final @Nullable Event event, boolean b) {
-		return "normalized " + vector.toString();
+	@SuppressWarnings("null")
+	protected Vector[] get(Event e) {
+		Vector v = vector.getSingle(e);
+		if (v == null)
+			return null;
+		return CollectionUtils.array(v.clone().normalize());
+	}
+
+	@Override
+	public boolean isSingle() {
+		return true;
 	}
 
 	@Override
@@ -64,19 +80,8 @@ public class ExprVectorNormalize extends SimpleExpression<Vector> {
 	}
 
 	@Override
-	@SuppressWarnings({"unchecked", "null"})
-	public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
-		vector = (Expression<Vector>)expressions[0];
-		return true;
+	public String toString(@Nullable Event e, boolean debug) {
+		return "normalized " + vector.toString(e, debug);
 	}
 
-	@Override
-	@SuppressWarnings("null")
-	protected Vector[] get(Event event) {
-		Vector v = vector.getSingle(event);
-		if (v == null){
-			return null;
-		}
-		return new Vector[]{ v.clone().normalize() };
-	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorOfLocation.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorOfLocation.java
@@ -19,6 +19,11 @@
  */
 package ch.njol.skript.expressions;
 
+import org.bukkit.Location;
+import org.bukkit.event.Event;
+import org.bukkit.util.Vector;
+import org.eclipse.jdt.annotation.Nullable;
+
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -26,28 +31,44 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
-import org.bukkit.Location;
-import org.bukkit.event.Event;
-import org.bukkit.util.Vector;
-import org.eclipse.jdt.annotation.Nullable;
+import ch.njol.util.coll.CollectionUtils;
 
 /**
  * @author bi0qaw
  */
-@Name("Vectors - Create from location")
+@Name("Vectors - Vector from Location")
 @Description("Creates a vector from a location.")
 @Examples({"set {_v} to vector of {_loc}"})
 @Since("2.2-dev28")
 public class ExprVectorOfLocation extends SimpleExpression<Vector> {
+
 	static {
-		Skript.registerExpression(ExprVectorOfLocation.class, Vector.class, ExpressionType.SIMPLE, "vector (of|from|to) %location%", "%location%['s] vector");
+		Skript.registerExpression(ExprVectorOfLocation.class, Vector.class, ExpressionType.SIMPLE,
+				"[the] vector (of|from|to) %location%",
+				"%location%'s vector");
 	}
 
 	@SuppressWarnings("null")
 	private Expression<Location> location;
+
+	@Override
+	@SuppressWarnings({"unchecked", "null"})
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		location = (Expression<Location>) exprs[0];
+		return true;
+	}
+
+	@Override
+	@SuppressWarnings("null")
+	protected Vector[] get(Event e) {
+		Location l = location.getSingle(e);
+		if (l == null)
+			return null;
+		return CollectionUtils.array(l.toVector());
+	}
 
 	@Override
 	public boolean isSingle() {
@@ -60,24 +81,8 @@ public class ExprVectorOfLocation extends SimpleExpression<Vector> {
 	}
 
 	@Override
-	@SuppressWarnings({"unchecked", "null"})
-	public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
-		location = (Expression<Location>)expressions[0];
-		return true;
+	public String toString(@Nullable Event e, boolean debug) {
+		return "vector from " + location.toString(e, debug);
 	}
 
-	@Override
-	@SuppressWarnings("null")
-	protected Vector[] get(Event event) {
-		Location l = location.getSingle(event);
-		if (l == null){
-			return null;
-		}
-		return new Vector[] { l.toVector() };
-	}
-
-	@Override
-	public String toString(final @Nullable Event event, boolean b) {
-		return "vector of location " + location.toString();
-	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorRandom.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorRandom.java
@@ -19,6 +19,10 @@
  */
 package ch.njol.skript.expressions;
 
+import org.bukkit.event.Event;
+import org.bukkit.util.Vector;
+import org.eclipse.jdt.annotation.Nullable;
+
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -26,28 +30,32 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
-import org.bukkit.event.Event;
-import org.bukkit.util.Vector;
-import org.eclipse.jdt.annotation.Nullable;
+import ch.njol.util.coll.CollectionUtils;
 
 /**
  * @author bi0qaw
  */
-@Name("Vectors - Random")
+@Name("Vectors - Random Vector")
 @Description("Creates a random vector.")
-@Examples({"set {_v} to random vector"})
+@Examples({"set {_v} to a random vector"})
 @Since("2.2-dev28")
 public class ExprVectorRandom extends SimpleExpression<Vector> {
+
 	static {
-		Skript.registerExpression(ExprVectorRandom.class, Vector.class, ExpressionType.SIMPLE, "random vector");
+		Skript.registerExpression(ExprVectorRandom.class, Vector.class, ExpressionType.SIMPLE, "[a] random vector");
 	}
 
 	@Override
-	protected Vector[] get(Event event) {
-		return new Vector[] {Vector.getRandom()};
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		return true;
+	}
+
+	@Override
+	protected Vector[] get(Event e) {
+		return CollectionUtils.array(Vector.getRandom());
 	}
 
 	@Override
@@ -61,12 +69,8 @@ public class ExprVectorRandom extends SimpleExpression<Vector> {
 	}
 
 	@Override
-	public String toString(final @Nullable Event event, boolean b) {
+	public String toString(@Nullable Event e, boolean debug) {
 		return "random vector";
 	}
 
-	@Override
-	public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
-		return true;
-	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorSpherical.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorSpherical.java
@@ -19,6 +19,10 @@
  */
 package ch.njol.skript.expressions;
 
+import org.bukkit.event.Event;
+import org.bukkit.util.Vector;
+import org.eclipse.jdt.annotation.Nullable;
+
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -26,40 +30,54 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import ch.njol.util.VectorMath;
-
-import org.bukkit.event.Event;
-import org.bukkit.util.Vector;
-import org.eclipse.jdt.annotation.Nullable;
+import ch.njol.util.coll.CollectionUtils;
 
 /**
  * @author bi0qaw
  */
-@Name("Vectors - Spherical shape")
+@Name("Vectors - Spherical Shape")
 @Description("Forms a 'spherical shaped' vector using yaw and pitch to manipulate the current point.")
 @Examples({"loop 360 times:",
 		"	set {_v} to spherical vector radius 1, yaw loop-value, pitch loop-value",
 		"set {_v} to spherical vector radius 1, yaw 45, pitch 90"})
 @Since("2.2-dev28")
 public class ExprVectorSpherical extends SimpleExpression<Vector> {
+
 	static {
-		Skript.registerExpression(ExprVectorSpherical.class, Vector.class, ExpressionType.SIMPLE, "[new] spherical vector [(from|with)] [radius] %number%, [yaw] %number%(,| and) [pitch] %number%");
+		Skript.registerExpression(ExprVectorSpherical.class, Vector.class, ExpressionType.SIMPLE,
+				"[new] spherical vector [(from|with)] [radius] %number%, [yaw] %number%(,| and) [pitch] %number%");
 	}
 
 	@SuppressWarnings("null")
 	private Expression<Number> radius, yaw, pitch;
 
 	@Override
-	public boolean isSingle() {
+	@SuppressWarnings({"unchecked", "null"})
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		radius = (Expression<Number>) exprs[0];
+		yaw = (Expression<Number>) exprs[1];
+		pitch = (Expression<Number>) exprs[2];
 		return true;
 	}
 
 	@Override
-	public String toString(final @Nullable Event event, boolean b) {
-		return "spherical vector with radius " + radius.toString() + ", yaw " + yaw.toString() + ", pitch" + pitch.toString();
+	@SuppressWarnings("null")
+	protected Vector[] get(Event e) {
+		Number r = radius.getSingle(e);
+		Number y = yaw.getSingle(e);
+		Number p = pitch.getSingle(e);
+		if (r == null || y == null || p == null)
+			return null;
+		return CollectionUtils.array(VectorMath.fromSphericalCoordinates(r.doubleValue(), VectorMath.fromSkriptYaw(y.floatValue()), p.floatValue() + 90));
+	}
+
+	@Override
+	public boolean isSingle() {
+		return true;
 	}
 
 	@Override
@@ -68,23 +86,9 @@ public class ExprVectorSpherical extends SimpleExpression<Vector> {
 	}
 
 	@Override
-	@SuppressWarnings({"unchecked", "null"})
-	public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
-		radius = (Expression<Number>) expressions[0];
-		yaw = (Expression<Number>) expressions[1];
-		pitch = (Expression<Number>) expressions[2];
-		return true;
+	public String toString(@Nullable Event e, boolean debug) {
+		return "spherical vector with radius " + radius.toString(e, debug) + ", yaw " + yaw.toString(e, debug) +
+				" and pitch" + pitch.toString(e, debug);
 	}
 
-	@Override
-	@SuppressWarnings("null")
-	protected Vector[] get(Event event) {
-		Number r = radius.getSingle(event);
-		Number y = yaw.getSingle(event);
-		Number p = pitch.getSingle(event);
-		if (r == null || y == null || p == null) {
-			return null;
-		}
-		return new Vector[]{ VectorMath.fromSphericalCoordinates(r.doubleValue(), VectorMath.fromSkriptYaw(y.floatValue()), p.floatValue() + 90)};
-	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorSquaredLength.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorSquaredLength.java
@@ -19,32 +19,30 @@
  */
 package ch.njol.skript.expressions;
 
-import ch.njol.skript.Skript;
+import org.bukkit.util.Vector;
+
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
-import ch.njol.skript.lang.ExpressionType;
-
-import org.bukkit.util.Vector;
 
 /**
  * @author bi0qaw
  */
-@Name("Vectors - Squared length")
+@Name("Vectors - Squared Length")
 @Description("Gets the squared length of a vector.")
 @Examples({"send \"%squared length of vector 1, 2, 3%\""})
 @Since("2.2-dev28")
-public class ExprVectorSquaredLength extends SimplePropertyExpression<Vector, Double> {
+public class ExprVectorSquaredLength extends SimplePropertyExpression<Vector, Number> {
+
 	static {
-		Skript.registerExpression(ExprVectorSquaredLength.class, Double.class, ExpressionType.SIMPLE, "squared length of %vector%", "%vector%['s] squared length");
+		register(ExprVectorSquaredLength.class, Number.class, "squared length[s]", "vectors");
 	}
 
 	@SuppressWarnings({"null", "unused"})
 	@Override
-	public Double convert(Vector vector) {
-		if (vector == null) return null;
+	public Number convert(Vector vector) {
 		return vector.lengthSquared();
 	}
 
@@ -54,7 +52,8 @@ public class ExprVectorSquaredLength extends SimplePropertyExpression<Vector, Do
 	}
 
 	@Override
-	public Class<? extends Double> getReturnType() {
-		return Double.class;
+	public Class<? extends Number> getReturnType() {
+		return Number.class;
 	}
+
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorXYZ.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorXYZ.java
@@ -19,20 +19,21 @@
  */
 package ch.njol.skript.expressions;
 
-import ch.njol.skript.Skript;
+import org.bukkit.event.Event;
+import org.bukkit.util.Vector;
+import org.eclipse.jdt.annotation.Nullable;
+
 import ch.njol.skript.classes.Changer;
+import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
-import org.bukkit.event.Event;
-import org.bukkit.util.Vector;
-import org.eclipse.jdt.annotation.Nullable;
+import ch.njol.util.coll.CollectionUtils;
 
 /**
  * @author bi0qaw
@@ -51,46 +52,38 @@ import org.eclipse.jdt.annotation.Nullable;
 		"send \"%x of {_v}%, %y of {_v}%, %z of {_v}%\"",})
 @Since("2.2-dev28")
 public class ExprVectorXYZ extends SimplePropertyExpression<Vector, Number> {
+	
 	static {
-		Skript.registerExpression(ExprVectorXYZ.class, Number.class, ExpressionType.PROPERTY, "(0¦x|1¦y|2¦z) of %vector%");
+		register(ExprVectorXYZ.class, Number.class, "[vector] (0¦x|1¦y|2¦z)[(-| )coord[inate][s]]", "vectors");
 	}
-
-	private final static String[] axes = {"xx", "yy", "zz"};
-
+	
+	private final static Character[] axes = new Character[] {'x', 'y', 'z'};
+	
 	private int axis;
-
+	
 	@Override
-	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		super.init(exprs, matchedPattern, isDelayed, parseResult);
 		axis = parseResult.mark;
 		return true;
 	}
-
+	
 	@Override
-	public Double convert(final Vector v) {
-		return axis == 0 ? v.getX() : axis == 1 ? v.getY() : v.getZ();
+	public Double convert(Vector v) {
+		return axis == 0 ? v.getX() : (axis == 1 ? v.getY() : v.getZ());
 	}
-
-	@Override
-	protected String getPropertyName() {
-		return "the " + axes[axis] + "-coordinate";
-	}
-
-	@Override
-	public Class<Number> getReturnType() {
-		return Number.class;
-	}
-
+	
 	@Override
 	@SuppressWarnings("null")
-	public Class<?>[] acceptChange(final Changer.ChangeMode mode) {
-		if ((mode == Changer.ChangeMode.SET || mode == Changer.ChangeMode.ADD || mode == Changer.ChangeMode.REMOVE) && getExpr().isSingle() && Changer.ChangerUtils.acceptsChange(getExpr(), Changer.ChangeMode.SET, Vector.class))
-			return new Class[] { Number.class };
+	public Class<?>[] acceptChange(ChangeMode mode) {
+		if ((mode == ChangeMode.ADD || mode == ChangeMode.REMOVE || mode == ChangeMode.SET)
+				&& getExpr().isSingle() && Changer.ChangerUtils.acceptsChange(getExpr(), ChangeMode.SET, Vector.class))
+			return CollectionUtils.array(Number.class);
 		return null;
 	}
-
+	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final Changer.ChangeMode mode) throws UnsupportedOperationException {
+	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
 		assert delta != null;
 		final Vector v = getExpr().getSingle(e);
 		if (v == null)
@@ -101,30 +94,33 @@ public class ExprVectorXYZ extends SimplePropertyExpression<Vector, Number> {
 				n = -n;
 				//$FALL-THROUGH$
 			case ADD:
-				if (axis == 0) {
+				if (axis == 0)
 					v.setX(v.getX() + n);
-				} else if (axis == 1) {
+				else if (axis == 1)
 					v.setY(v.getY() + n);
-				} else {
+				else
 					v.setZ(v.getZ() + n);
-				}
-				getExpr().change(e, new Vector[] {v}, Changer.ChangeMode.SET);
+				getExpr().change(e, new Vector[] {v}, ChangeMode.SET);
 				break;
 			case SET:
-				if (axis == 0) {
+				if (axis == 0)
 					v.setX(n);
-				} else if (axis == 1) {
+				else if (axis == 1)
 					v.setY(n);
-				} else {
+				else
 					v.setZ(n);
-				}
-				getExpr().change(e, new Vector[] {v}, Changer.ChangeMode.SET);
-				break;
-			case DELETE:
-			case REMOVE_ALL:
-			case RESET:
-				assert false;
+				getExpr().change(e, new Vector[] {v}, ChangeMode.SET);
 		}
 	}
-
+	
+	@Override
+	protected String getPropertyName() {
+		return axes[axis] + " coordinate";
+	}
+	
+	@Override
+	public Class<Number> getReturnType() {
+		return Number.class;
+	}
+	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorXYZ.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorXYZ.java
@@ -46,15 +46,15 @@ import ch.njol.util.coll.CollectionUtils;
 		"add 2 to y of {_v}",
 		"add 3 to z of {_v}",
 		"send \"%x of {_v}%, %y of {_v}%, %z of {_v}%\"",
-		"set x-axis of {_v} to 1",
-		"set y-axis of {_v} to 2",
-		"set z-axis of {_v} to 3",
-		"send \"%x axis of {_v}%, %y axis of {_v}%, %z axis of {_v}%\"",})
+		"set x component of {_v} to 1",
+		"set y component of {_v} to 2",
+		"set z component of {_v} to 3",
+		"send \"%x component of {_v}%, %y component of {_v}%, %z component of {_v}%\"",})
 @Since("2.2-dev28")
 public class ExprVectorXYZ extends SimplePropertyExpression<Vector, Number> {
 	
 	static {
-		register(ExprVectorXYZ.class, Number.class, "[vector] (0¦x|1¦y|2¦z)[(-| )ax(is|es)]]", "vectors");
+		register(ExprVectorXYZ.class, Number.class, "[vector] (0¦x|1¦y|2¦z) [component[s]]", "vectors");
 	}
 	
 	private final static Character[] axes = new Character[] {'x', 'y', 'z'};
@@ -115,7 +115,7 @@ public class ExprVectorXYZ extends SimplePropertyExpression<Vector, Number> {
 	
 	@Override
 	protected String getPropertyName() {
-		return axes[axis] + "-axis";
+		return axes[axis] + " component";
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorXYZ.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorXYZ.java
@@ -38,23 +38,23 @@ import ch.njol.util.coll.CollectionUtils;
 /**
  * @author bi0qaw
  */
-@Name("Vectors - Coordinate")
-@Description("Gets or sets the x, y or z coordinate of a vector.")
+@Name("Vectors - Axis")
+@Description("Gets or sets the x, y or z axis of a vector.")
 @Examples({"set {_v} to vector 1, 2, 3",
 		"send \"%x of {_v}%, %y of {_v}%, %z of {_v}%\"",
 		"add 1 to x of {_v}",
 		"add 2 to y of {_v}",
 		"add 3 to z of {_v}",
 		"send \"%x of {_v}%, %y of {_v}%, %z of {_v}%\"",
-		"set x of {_v} to 1",
-		"set y of {_v} to 2",
-		"set z of {_v} to 3",
-		"send \"%x of {_v}%, %y of {_v}%, %z of {_v}%\"",})
+		"set x-axis of {_v} to 1",
+		"set y-axis of {_v} to 2",
+		"set z-axis of {_v} to 3",
+		"send \"%x axis of {_v}%, %y axis of {_v}%, %z axis of {_v}%\"",})
 @Since("2.2-dev28")
 public class ExprVectorXYZ extends SimplePropertyExpression<Vector, Number> {
 	
 	static {
-		register(ExprVectorXYZ.class, Number.class, "[vector] (0¦x|1¦y|2¦z)[(-| )coord[inate][s]]", "vectors");
+		register(ExprVectorXYZ.class, Number.class, "[vector] (0¦x|1¦y|2¦z)[(-| )ax(is|es)]]", "vectors");
 	}
 	
 	private final static Character[] axes = new Character[] {'x', 'y', 'z'};
@@ -69,7 +69,7 @@ public class ExprVectorXYZ extends SimplePropertyExpression<Vector, Number> {
 	}
 	
 	@Override
-	public Double convert(Vector v) {
+	public Number convert(Vector v) {
 		return axis == 0 ? v.getX() : (axis == 1 ? v.getY() : v.getZ());
 	}
 	
@@ -115,7 +115,7 @@ public class ExprVectorXYZ extends SimplePropertyExpression<Vector, Number> {
 	
 	@Override
 	protected String getPropertyName() {
-		return axes[axis] + " coordinate";
+		return axes[axis] + "-axis";
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorXYZ.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorXYZ.java
@@ -38,8 +38,8 @@ import ch.njol.util.coll.CollectionUtils;
 /**
  * @author bi0qaw
  */
-@Name("Vectors - Axis")
-@Description("Gets or sets the x, y or z axis of a vector.")
+@Name("Vectors - XYZ Component")
+@Description("Gets or changes the x, y or z component of a vector.")
 @Examples({"set {_v} to vector 1, 2, 3",
 		"send \"%x of {_v}%, %y of {_v}%, %z of {_v}%\"",
 		"add 1 to x of {_v}",

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorYawPitch.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorYawPitch.java
@@ -55,7 +55,7 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprVectorYawPitch extends SimplePropertyExpression<Vector, Number> {
 
 	static {
-		register(ExprVectorYawPitch.class, Number.class, "[vector] (0¦yaw|1¦pitch)[s]", "vectors");
+		register(ExprVectorYawPitch.class, Number.class, "[vector] (0¦yaw|1¦pitch)", "vectors");
 	}
 
 	private boolean usesYaw;

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorYawPitch.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorYawPitch.java
@@ -19,8 +19,13 @@
  */
 package ch.njol.skript.expressions;
 
+import org.bukkit.event.Event;
+import org.bukkit.util.Vector;
+import org.eclipse.jdt.annotation.Nullable;
+
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer;
+import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -28,18 +33,15 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import ch.njol.util.VectorMath;
-
-import org.bukkit.event.Event;
-import org.bukkit.util.Vector;
-import org.eclipse.jdt.annotation.Nullable;
+import ch.njol.util.coll.CollectionUtils;
 
 /**
  * @author bi0qaw
  */
-@Name("Vectors - Yaw and pitch")
+@Name("Vectors - Yaw and Pitch")
 @Description("Gets or sets the yaw or pitch value of a vector.")
 @Examples({"set {_v} to vector -1, 1, 1",
 		"send \"%vector yaw of {_v}%, %vector pitch of {_v}%\"",
@@ -51,32 +53,76 @@ import org.eclipse.jdt.annotation.Nullable;
 		"send \"%vector yaw of {_v}%, %vector pitch of {_v}%\"",})
 @Since("2.2-dev28")
 public class ExprVectorYawPitch extends SimplePropertyExpression<Vector, Number> {
+
 	static {
-		Skript.registerExpression(ExprVectorYawPitch.class, Number.class, ExpressionType.PROPERTY,"vector (0¦yaw|1¦pitch) of %vector%");
+		register(ExprVectorYawPitch.class, Number.class, "[vector] (0¦yaw|1¦pitch)[s]", "vectors");
 	}
 
-	private int mark;
-	private final static String[] type = new String[] {"yyaw", "ppitch"};
+	private boolean usesYaw;
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		super.init(exprs, matchedPattern, isDelayed, parseResult);
+		usesYaw = parseResult.mark == 0;
+		return true;
+	}
 
 	@Override
 	@SuppressWarnings("null")
 	public Number convert(Vector vector) {
 		if (vector != null) {
-			switch (mark) {
-				case 0:
-					return VectorMath.skriptYaw(VectorMath.getYaw(vector));
-				case 1:
-					return VectorMath.skriptPitch(VectorMath.getPitch(vector));
-				default:
-					break;
-			}
+			if (usesYaw)
+				return VectorMath.skriptYaw(VectorMath.getYaw(vector));
+			else
+				return VectorMath.skriptPitch(VectorMath.getPitch(vector));
 		}
 		return null;
 	}
 
 	@Override
+	@SuppressWarnings("null")
+	public Class<?>[] acceptChange(ChangeMode mode) {
+		if ((mode == ChangeMode.SET || mode == ChangeMode.ADD || mode == ChangeMode.REMOVE)
+				&& getExpr().isSingle() && Changer.ChangerUtils.acceptsChange(getExpr(), ChangeMode.SET, Vector.class))
+			return CollectionUtils.array(Number.class);
+		return null;
+	}
+
+	@Override
+	@SuppressWarnings("null")
+	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+		assert delta != null;
+		Vector v = getExpr().getSingle(e);
+		if (v == null)
+			return;
+		float n = ((Number) delta[0]).floatValue();
+		float yaw = VectorMath.getYaw(v);
+		float pitch = VectorMath.getPitch(v);
+		switch (mode) {
+			case ADD:
+				if (usesYaw)
+					yaw += n;
+				else
+					pitch -= n; // Negative because of Minecraft's / Skript's upside down pitch
+				v = VectorMath.fromYawAndPitch(yaw, pitch);
+				getExpr().change(e, new Vector[]{v}, ChangeMode.SET);
+				break;
+			case REMOVE:
+				n = -n;
+				//$FALL-THROUGH$
+			case SET:
+				if (usesYaw)
+					yaw = VectorMath.fromSkriptYaw(n);
+				else
+					pitch = VectorMath.fromSkriptPitch(n);
+				v = VectorMath.fromYawAndPitch(yaw, pitch);
+				getExpr().change(e, new Vector[]{v}, ChangeMode.SET);
+		}
+	}
+
+	@Override
 	protected String getPropertyName() {
-		return type[mark] + " of vector";
+		return usesYaw ? "yaw" : "pitch";
 	}
 
 	@Override
@@ -84,57 +130,4 @@ public class ExprVectorYawPitch extends SimplePropertyExpression<Vector, Number>
 		return Number.class;
 	}
 
-	@Override
-	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
-		super.init(exprs, matchedPattern, isDelayed, parseResult);
-		mark = parseResult.mark;
-		return true;
-	}
-
-	@Override
-	@SuppressWarnings("null")
-	public Class<?>[] acceptChange(Changer.ChangeMode mode) {
-		if ((mode == Changer.ChangeMode.SET || mode == Changer.ChangeMode.ADD || mode == Changer.ChangeMode.REMOVE) && getExpr().isSingle() && Changer.ChangerUtils.acceptsChange(getExpr(), Changer.ChangeMode.SET, Vector.class))
-			return new Class[] { Number.class };
-		return null;
-	}
-
-	@Override
-	@SuppressWarnings("null")
-	public void change(Event e, final @Nullable Object[] delta, Changer.ChangeMode mode) {
-		Vector v = getExpr().getSingle(e);
-		if (v == null){
-			return;
-		}
-		float n = ((Number) delta[0]).floatValue();
-		float yaw = VectorMath.getYaw(v);
-		float pitch = VectorMath.getPitch(v);
-		switch (mode) {
-			case REMOVE:
-				n = -n;
-				//$FALL-THROUGH$
-			case ADD:
-				if (mark == 0){
-					yaw += n;
-				} else if (mark == 1){
-					pitch -= n; // Negative because of minecraft's / skript's upside down pitch
-				}
-				v = VectorMath.fromYawAndPitch(yaw, pitch);
-				getExpr().change(e, new Vector[]{v}, Changer.ChangeMode.SET);
-				break;
-			case SET:
-				if (mark == 0){
-					yaw = VectorMath.fromSkriptYaw(n);
-				} else if (mark == 1){
-					pitch = VectorMath.fromSkriptPitch(n);
-				}
-				v = VectorMath.fromYawAndPitch(yaw, pitch);
-				getExpr().change(e, new Vector[]{v}, Changer.ChangeMode.SET);
-				break;
-			case REMOVE_ALL:
-			case DELETE:
-			case RESET:
-				assert false;
-		}
-	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVelocity.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVelocity.java
@@ -24,78 +24,75 @@ import org.bukkit.event.Event;
 import org.bukkit.util.Vector;
 import org.eclipse.jdt.annotation.Nullable;
 
-import ch.njol.skript.Skript;
-import ch.njol.skript.classes.Changer;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
-import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
-import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
 
 /**
  * @author Sashie
  */
 @Name("Vectors - Velocity")
-@Description("Gets, sets, adds or removes velocity to/from/of an entity")
+@Description("Gets or changes velocity of an entity.")
 @Examples({"set player's velocity to {_v}"})
 @Since("2.2-dev31")
 public class ExprVelocity extends SimplePropertyExpression<Entity, Vector> {
+
 	static {
-		register(ExprVelocity.class, Vector.class, "velocity", "entities");
+		register(ExprVelocity.class, Vector.class, "velocit(y|ies)", "entities");
 	}
-	
-	@Override
-	protected String getPropertyName() {
-		return "velocity";
-	}
-	
-	@Override
-	public Class<Vector> getReturnType() {
-		return Vector.class;
-	}
-	
-	@Override
-	@SuppressWarnings("null")
-	public Class<?>[] acceptChange(final Changer.ChangeMode mode) {
-		if ((mode == Changer.ChangeMode.SET || mode == Changer.ChangeMode.ADD || mode == Changer.ChangeMode.REMOVE || mode == Changer.ChangeMode.DELETE))
-			return new Class[] {Vector.class};
-		return null;
-	}
-	
+
 	@Override
 	@Nullable
 	public Vector convert(Entity e) {
 		return e.getVelocity();
 	}
-	
+
 	@Override
 	@SuppressWarnings("null")
-	public void change(final Event e, final @Nullable Object[] delta, final Changer.ChangeMode mode) throws UnsupportedOperationException {
-		for (final Entity ent : getExpr().getArray(e)) {
-			if (ent == null)
+	public Class<?>[] acceptChange(ChangeMode mode) {
+		if ((mode == ChangeMode.ADD || mode == ChangeMode.REMOVE || mode == ChangeMode.SET || mode == ChangeMode.DELETE || mode == ChangeMode.RESET))
+			return CollectionUtils.array(Vector.class);
+		return null;
+	}
+
+	@Override
+	@SuppressWarnings("null")
+	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+		assert delta != null;
+		for (final Entity entity : getExpr().getArray(e)) {
+			if (entity == null)
 				return;
 			switch (mode) {
 				case ADD:
-					ent.setVelocity(ent.getVelocity().add((Vector) delta[0]));
+					entity.setVelocity(entity.getVelocity().add((Vector) delta[0]));
 					break;
 				case REMOVE:
-					ent.setVelocity(ent.getVelocity().subtract((Vector) delta[0]));
+					entity.setVelocity(entity.getVelocity().subtract((Vector) delta[0]));
 					break;
 				case REMOVE_ALL:
 					break;
-				case RESET:
 				case DELETE:
-					ent.setVelocity(new Vector());
+				case RESET:
+					entity.setVelocity(new Vector());
 					break;	
 				case SET:
-					ent.setVelocity((Vector) delta[0]);
-					break;
+					entity.setVelocity((Vector) delta[0]);
 			}
 		}
 	}
+
+	@Override
+	protected String getPropertyName() {
+		return "velocity";
+	}
+
+	@Override
+	public Class<Vector> getReturnType() {
+		return Vector.class;
+	}
+
 }


### PR DESCRIPTION
### Description
Cleans up all the vector related stuff; import orders, method orders, unnecessary finals, parameter names, toStrings, getReturnTypes, used CollectionUtils for returns, docs, syntaxes, and other code standard things.

~~Small breaking change: now it is mandatory to use `normalized %vector%` instead of `normalize %vector%`, as suggested by bensku in the related issue.~~

Not sure if i made more breaking changes but probably i didn't

I didn't merge the vector coordinates expression with the MC expression, because allowing `x coord/position/location of vector` doesn't make sense. I used x [component] of vector instead. Anyways it will make the docs confusing if i merge them.

I didn't merge the yaw/pitch expressions too because will look weird in the docs. But only problem i see is `yaw of {_vector}` (when using a variable) will try to use the MC expression, but `vector yaw of {_vector}` can be used in this case. However i can merge them later if you don't like this... Or maybe some better solutions like making the `vector` part mandatory, `yaw/pitch rotation` etc.

---
**Related Issues:** #867 