### PR TITLE
Added Swimming

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondIsSwimming.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsSwimming.java
@@ -42,7 +42,7 @@ public class CondIsSwimming extends PropertyCondition<LivingEntity> {
 	}
 	
 	@Override
-	public boolean check(final LivingEntity e) {
+	public boolean check(LivingEntity e) {
 		return e.isSwimming();
 	}
 	

--- a/src/main/java/ch/njol/skript/events/EvtEntitySwimming.java
+++ b/src/main/java/ch/njol/skript/events/EvtEntitySwimming.java
@@ -32,19 +32,19 @@ public class EvtEntitySwimming extends SkriptEvent {
 
 	static {
 		if (Skript.classExists("org.bukkit.event.entity.EntityToggleSwimEvent"))
-			Skript.registerEvent("Entity Swim", EvtEntitySwimming.class, EntityToggleSwimEvent.class, "[entity] [(0¦start|1¦stop)] swim[ming]", "[entity] swim[ming] (0¦start|1¦stop)")
+			Skript.registerEvent("Entity Swim", EvtEntitySwimming.class, EntityToggleSwimEvent.class, "[entity] [(1¦start|2¦stop)] swim[ming]", "[entity] swim[ming] (1¦start|2¦stop)")
 					.description("Called when a living entity toggles their swimming state.")
 					.examples("on entity stop swimming:",
 							"\tbroadcast \"A %entity% has stopped swimming\"")
 					.since("INSERT VERSION");
 	}
 	
-	private boolean both, stop;
+	private boolean both, start;
 	
 	@Override
 	public boolean init(Literal<?>[] args, int matchedPattern, ParseResult parser) {
-		stop = parser.mark == 0;
-		both = parser.mark < 0;
+		start = parser.mark == 1;
+		both = parser.mark == 0;
 		return true;
 	}
 	
@@ -52,12 +52,12 @@ public class EvtEntitySwimming extends SkriptEvent {
 	public boolean check(Event e) {
 		if (both)
 			return true;
-		return ((EntityToggleSwimEvent) e).isSwimming() ? stop : !stop;
+		return ((EntityToggleSwimEvent) e).isSwimming() ? start : !start;
 	}
 	
 	@Override
 	public String toString(@Nullable Event e, boolean debug) {
-		return "entity " + ((both) ? "" : (stop ? "stopped" : "started")) + " swimming";
+		return "entity " + ((both) ? "" : (start ? "started" : "stopped")) + " swimming";
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/events/EvtEntitySwimming.java
+++ b/src/main/java/ch/njol/skript/events/EvtEntitySwimming.java
@@ -1,0 +1,63 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.events;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.entity.EntityToggleSwimEvent;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.Literal;
+import ch.njol.skript.lang.SkriptEvent;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+
+public class EvtEntitySwimming extends SkriptEvent {
+
+	static {
+		if (Skript.classExists("org.bukkit.event.entity.EntityToggleSwimEvent"))
+			Skript.registerEvent("Entity Swim", EvtEntitySwimming.class, EntityToggleSwimEvent.class, "[entity] [(0¦start|1¦stop)] swim[ming]", "[entity] swim[ming] (0¦start|1¦stop)")
+					.description("Called when a living entity toggles their swimming state.")
+					.examples("on entity stop swimming:",
+							"\tbroadcast \"A %entity% has stopped swimming\"")
+					.since("INSERT VERSION");
+	}
+	
+	private boolean both, stop;
+	
+	@Override
+	public boolean init(Literal<?>[] args, int matchedPattern, ParseResult parser) {
+		stop = parser.mark == 0;
+		both = parser.mark < 0;
+		return true;
+	}
+	
+	@Override
+	public boolean check(Event e) {
+		if (both)
+			return true;
+		return ((EntityToggleSwimEvent) e).isSwimming() ? stop : !stop;
+	}
+	
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		return "entity " + ((both) ? "" : (stop ? "stopped" : "started")) + " swimming";
+	}
+	
+}

--- a/src/main/java/ch/njol/skript/events/EvtSkript.java
+++ b/src/main/java/ch/njol/skript/events/EvtSkript.java
@@ -37,7 +37,6 @@ import ch.njol.util.coll.CollectionUtils;
 /**
  * @author Peter Güttinger
  */
-@SuppressWarnings("unchecked")
 public class EvtSkript extends SelfRegisteringSkriptEvent {
 	static {
 		Skript.registerEvent("Server Start/Stop", EvtSkript.class, CollectionUtils.array(SkriptStartEvent.class, SkriptStopEvent.class), "(0¦server|1¦skript) (start|load|enable)", "(0¦server|1¦skript) (stop|unload|disable)")

--- a/src/main/java/ch/njol/skript/events/SimpleEvents.java
+++ b/src/main/java/ch/njol/skript/events/SimpleEvents.java
@@ -505,16 +505,5 @@ public class SimpleEvents {
 						"	set the fake max players count to (online players count + 1)",
 						"	set the shown icon to a random server icon out of {server-icons::*}")
 				.since("2.3");
-		
-		if (Skript.classExists("org.bukkit.event.entity.EntityToggleSwimEvent")) {
-			Skript.registerEvent("Swim Toggle", SimpleEvent.class, EntityToggleSwimEvent.class, "[entity] toggl(e|ing) swim",
-					"[entity] swim toggl(e|ing)")
-					.description("Called when an entity swims or stops swimming")
-					.requiredPlugins("1.13 or newer")
-					.examples("on swim toggle:",
-							"	event-entity does not have permission \"swim\"",
-							"	cancel event")
-					.since("2.3");
-		}
 	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprRemainingAir.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprRemainingAir.java
@@ -63,8 +63,8 @@ public class ExprRemainingAir extends SimplePropertyExpression<LivingEntity, Tim
 		return Timespan.fromTicks_i(entity.getRemainingAir());
 	}
 	
-	@Nullable
 	@Override
+	@Nullable
 	public Class<?>[] acceptChange(Changer.ChangeMode mode) {
 		return (mode != ChangeMode.REMOVE_ALL) ? CollectionUtils.array(Timespan.class) : null;
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprSwimming.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSwimming.java
@@ -24,20 +24,13 @@ import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
-import ch.njol.skript.classes.Converter;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
-import ch.njol.skript.expressions.base.PropertyExpression;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
-import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.skript.util.Getter;
-import ch.njol.skript.util.Timespan;
-import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 
 @Name("Swimming")

--- a/src/main/java/ch/njol/skript/expressions/ExprSwimming.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSwimming.java
@@ -1,0 +1,82 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.expressions;
+
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.classes.Converter;
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.PropertyExpression;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.util.Getter;
+import ch.njol.skript.util.Timespan;
+import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
+
+@Name("Swimming")
+@Description("The swimming state of living entities, present in 1.13+")
+@Examples("set the swimming state of target entity to true")
+@Since("INSERT VERSION")
+public class ExprSwimming extends SimplePropertyExpression<LivingEntity, Boolean> {
+
+	static {
+		if (Skript.methodExists(LivingEntity.class, "isSwimming"))
+			register(ExprSwimming.class, Boolean.class, "swimming [state]", "livingentities");
+	}
+	
+	@Override
+	public Class<Boolean> getReturnType() {
+		return Boolean.class;
+	}
+	
+	@Override
+	protected String getPropertyName() {
+		return "swimming state";
+	}
+	
+	@Override
+	public Boolean convert(LivingEntity entity) {
+		return entity.isSwimming();
+	}
+	
+	@Override
+	@Nullable
+	public Class<?>[] acceptChange(ChangeMode mode) {
+		return (mode != ChangeMode.SET) ? null : CollectionUtils.array(Boolean.class);
+	}
+	
+	@SuppressWarnings("null")
+	@Override
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+		for (LivingEntity entity : getExpr().getArray(event))
+			entity.setSwimming((Boolean)delta[0]);
+	}
+	
+}


### PR DESCRIPTION
### Description
Adds 1.13 swimming state to Skript

**Target Minecraft Versions:** 1.13+
**Requirements:** This does exist in Paper so it will work with PaperSpigot

Test script:
```
on entity stop swimming:
	broadcast "&c%entity% has stopped swimming!"
on entity swimming start:
	broadcast "&a%entity% has started swimming!"
on entity swim:
	wait a tick
	set {_state} to swimming state of entity
	broadcast "&6%entity% toggled swim general %{_state}%"
```