### PR TITLE
Use 1 as default volume and pitch in EffPlaySound

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffPlaySound.java
+++ b/src/main/java/ch/njol/skript/effects/EffPlaySound.java
@@ -83,8 +83,8 @@ public class EffPlaySound extends Effect {
 		String s = sound.getSingle(e);
 
 		if (s != null) {
-			float vol = volume != null ? volume.getSingle(e).floatValue() : 0;
-			float pi = pitch != null ? pitch.getSingle(e).floatValue() : 0;
+			float vol = volume != null ? volume.getSingle(e).floatValue() : 1;
+			float pi = pitch != null ? pitch.getSingle(e).floatValue() : 1;
 
 			try {
 				soundEnum = Sound.valueOf(s.toUpperCase(Locale.ENGLISH));


### PR DESCRIPTION
### Description

Updates `EffPlaySound` to default volume and pitch to 1 instead of 0.
<!--- Add something that describes the pull request here --->
---
**Target Minecraft Versions:** any    <!-- 'any' means 1.9+ -->
**Requirements:** none    <!-- Is Paper required? Are there plugin requirements?... -->
**Related Issues:** resolves #1677    <!-- Specify the related issues if any, like #ID -->