### PR TITLE
Fix on WorldEdit building failure.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
 	}
 	
 	maven {
-	    url = 'url = 'https://repo.codemc.org/repository/maven-public''
+	    url = 'https://repo.codemc.org/repository/maven-public'
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
 	}
 	
 	maven {
-	    url = 'https://repo.bstats.org/content/repositories/releases/'
+	    url = 'url = 'https://repo.codemc.org/repository/maven-public''
 	}
 }
 


### PR DESCRIPTION
Fix on WorldEdit building.

### Description
Skript fails to build without this fix. WorldEdit changed from Jitpack to CodeMC on their bStats maven url. https://github.com/sk89q/WorldEdit/commit/bf98dcff094c80b5aa789885b07a0b1f7d70dbf6

This fix allows Skript to successfully build again. Talked to the bStats developer and he said if it looks for the repo in Jitpack before CodeMC it will fail. This allows the build to search CodeMC and not fail build.

The bStats developer also says that the repo.bstats.org url hasn't been used in a long time and won't be anymore, just CodeMC and Jitpack.

No one responded in Discord to my conversation I placed about this.

Image of build failure without this:
<img width="660" alt="wat" src="https://user-images.githubusercontent.com/16087552/48316816-99f2f080-e5a5-11e8-86a2-34d97321e4c9.png">
