### PR TITLE
added Hopper/Dropper/Dispenser to open inventory effect

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffOpenInventory.java
+++ b/src/main/java/ch/njol/skript/effects/EffOpenInventory.java
@@ -47,11 +47,11 @@ import ch.njol.util.Kleenean;
 @Since("2.0, 2.1.1 (closing), 2.2-Fixes-V10 (anvil)")
 public class EffOpenInventory extends Effect {
 	
-	private final static int WORKBENCH = 0, CHEST = 1, ANVIL = 2, HOPPER = 3, DROPPER = 4, DISPENSER = 5, FURNACE = 6;
+	private final static int WORKBENCH = 0, CHEST = 1, ANVIL = 2, HOPPER = 3, DROPPER = 4, DISPENSER = 5, FURNACE = 6, BREWING = 7, BEACON = 8;
 	
 	static {
 		Skript.registerEffect(EffOpenInventory.class,
-				"(0¦open|1¦show) ((2¦(crafting [table]|workbench)|3¦chest|4¦anvil|5¦hopper|6¦dropper|7¦dispenser|8¦furnace) (view|window|inventory|)|%-inventory%) (to|for) %players%",
+				"(0¦open|1¦show) ((2¦(crafting [table]|workbench)|3¦chest|4¦anvil|5¦hopper|6¦dropper|7¦dispenser|8¦furnace|9¦brewing|10¦beacon) (view|window|inventory|)|%-inventory%) (to|for) %players%",
 				"close [the] inventory [view] (to|of|for) %players%", "close %players%'[s] inventory [view]");
 	}
 	
@@ -68,7 +68,13 @@ public class EffOpenInventory extends Effect {
 	@Override
 	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
 		int openFlag = 0;
-		if(parseResult.mark >= 8) {
+		if(parseResult.mark >= 10) {
+			openFlag = parseResult.mark ^ 10;
+			invType = BEACON;
+		} else if(parseResult.mark >= 9) {
+			openFlag = parseResult.mark ^ 9;
+			invType = BREWING;
+		} else if(parseResult.mark >= 8) {
 			openFlag = parseResult.mark ^ 8;
 			invType = FURNACE;
 		} else if(parseResult.mark >= 7) {
@@ -139,6 +145,12 @@ public class EffOpenInventory extends Effect {
 							break;
 						case FURNACE:
 							p.openInventory(Bukkit.createInventory(p, InventoryType.FURNACE));
+							break;
+						case BREWING:
+							p.openInventory(Bukkit.createInventory(p, InventoryType.BREWING));
+							break;
+						case BEACON:
+							p.openInventory(Bukkit.createInventory(p, InventoryType.BEACON));
 							
 					}
 				} else

--- a/src/main/java/ch/njol/skript/effects/EffOpenInventory.java
+++ b/src/main/java/ch/njol/skript/effects/EffOpenInventory.java
@@ -47,11 +47,11 @@ import ch.njol.util.Kleenean;
 @Since("2.0, 2.1.1 (closing), 2.2-Fixes-V10 (anvil)")
 public class EffOpenInventory extends Effect {
 	
-	private final static int WORKBENCH = 0, CHEST = 1, ANVIL = 2, HOPPER = 3, DROPPER = 4;
+	private final static int WORKBENCH = 0, CHEST = 1, ANVIL = 2, HOPPER = 3, DROPPER = 4, DISPENSER = 5, FURNACE = 6;
 	
 	static {
 		Skript.registerEffect(EffOpenInventory.class,
-				"(0¦open|1¦show) ((2¦(crafting [table]|workbench)|3¦chest|4¦anvil|5¦hopper|6¦dropper) (view|window|inventory|)|%-inventory%) (to|for) %players%",
+				"(0¦open|1¦show) ((2¦(crafting [table]|workbench)|3¦chest|4¦anvil|5¦hopper|6¦dropper|7¦dispenser|8¦furnace) (view|window|inventory|)|%-inventory%) (to|for) %players%",
 				"close [the] inventory [view] (to|of|for) %players%", "close %players%'[s] inventory [view]");
 	}
 	
@@ -68,7 +68,13 @@ public class EffOpenInventory extends Effect {
 	@Override
 	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
 		int openFlag = 0;
-		if(parseResult.mark >= 6) {
+		if(parseResult.mark >= 8) {
+			openFlag = parseResult.mark ^ 8;
+			invType = FURNACE;
+		} else if(parseResult.mark >= 7) {
+			openFlag = parseResult.mark ^ 7;
+			invType = DISPENSER;
+		} else if(parseResult.mark >= 6) {
 			openFlag = parseResult.mark ^ 6;
 			invType = DROPPER;
 		} else if(parseResult.mark >= 5) {
@@ -127,6 +133,13 @@ public class EffOpenInventory extends Effect {
 							break;
 						case DROPPER:
 							p.openInventory(Bukkit.createInventory(p, InventoryType.DROPPER));
+							break;
+						case DISPENSER:
+							p.openInventory(Bukkit.createInventory(p, InventoryType.DISPENSER));
+							break;
+						case FURNACE:
+							p.openInventory(Bukkit.createInventory(p, InventoryType.FURNACE));
+							
 					}
 				} else
 					p.closeInventory();

--- a/src/main/java/ch/njol/skript/effects/EffOpenInventory.java
+++ b/src/main/java/ch/njol/skript/effects/EffOpenInventory.java
@@ -44,14 +44,14 @@ import ch.njol.util.Kleenean;
 		"Please note that currently 'show' and 'open' have the same effect, but 'show' will eventually show an unmodifiable view of the inventory in the future."})
 @Examples({"show the victim's inventory to the player",
 		"open the player's inventory for the player"})
-@Since("2.0, 2.1.1 (closing), 2.2-Fixes-V10 (anvil)")
+@Since("2.0, 2.1.1 (closing), 2.2-Fixes-V10 (anvil), {INSERT VERSION} (hopper, dropper, dispenser, furnace, brewing, beacon, enchanting table")
 public class EffOpenInventory extends Effect {
 	
-	private final static int WORKBENCH = 0, CHEST = 1, ANVIL = 2, HOPPER = 3, DROPPER = 4, DISPENSER = 5, FURNACE = 6, BREWING = 7, BEACON = 8;
+	private final static int WORKBENCH = 0, CHEST = 1, ANVIL = 2, HOPPER = 3, DROPPER = 4, DISPENSER = 5, FURNACE = 6, BREWING = 7, BEACON = 8, ENCHANTTABLE = 9;
 	
 	static {
 		Skript.registerEffect(EffOpenInventory.class,
-				"(0¦open|1¦show) ((2¦(crafting [table]|workbench)|3¦chest|4¦anvil|5¦hopper|6¦dropper|7¦dispenser|8¦furnace|9¦brewing|10¦beacon) (view|window|inventory|)|%-inventory%) (to|for) %players%",
+				"(0¦open|1¦show) ((2¦(crafting [table]|workbench)|3¦chest|4¦anvil|5¦hopper|6¦dropper|7¦dispenser|8¦furnace|9¦brewing|10¦beacon|11¦enchant(ing|ment) table) (view|window|inventory|)|%-inventory%) (to|for) %players%",
 				"close [the] inventory [view] (to|of|for) %players%", "close %players%'[s] inventory [view]");
 	}
 	
@@ -68,7 +68,10 @@ public class EffOpenInventory extends Effect {
 	@Override
 	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
 		int openFlag = 0;
-		if(parseResult.mark >= 10) {
+		if(parseResult.mark >= 11) {
+			openFlag = parseResult.mark ^ 11;
+			invType = ENCHANTTABLE;
+		} else if(parseResult.mark >= 10) {
 			openFlag = parseResult.mark ^ 10;
 			invType = BEACON;
 		} else if(parseResult.mark >= 9) {
@@ -151,7 +154,10 @@ public class EffOpenInventory extends Effect {
 							break;
 						case BEACON:
 							p.openInventory(Bukkit.createInventory(p, InventoryType.BEACON));
-							
+							break;
+						case ENCHANTTABLE:
+							p.openInventory(Bukkit.createInventory(p, InventoryType.ENCHANTING));
+						
 					}
 				} else
 					p.closeInventory();

--- a/src/main/java/ch/njol/skript/effects/EffOpenInventory.java
+++ b/src/main/java/ch/njol/skript/effects/EffOpenInventory.java
@@ -47,11 +47,11 @@ import ch.njol.util.Kleenean;
 @Since("2.0, 2.1.1 (closing), 2.2-Fixes-V10 (anvil)")
 public class EffOpenInventory extends Effect {
 	
-	private final static int WORKBENCH = 0, CHEST = 1, ANVIL = 2;
+	private final static int WORKBENCH = 0, CHEST = 1, ANVIL = 2, HOPPER = 3, DROPPER = 4;
 	
 	static {
 		Skript.registerEffect(EffOpenInventory.class,
-				"(0¦open|1¦show) ((20¦(crafting [table]|workbench)|40¦chest|60¦anvil) (view|window|inventory|)|%-inventory%) (to|for) %players%",
+				"(0¦open|1¦show) ((2¦(crafting [table]|workbench)|3¦chest|4¦anvil|5¦hopper|6¦dropper) (view|window|inventory|)|%-inventory%) (to|for) %players%",
 				"close [the] inventory [view] (to|of|for) %players%", "close %players%'[s] inventory [view]");
 	}
 	
@@ -68,15 +68,21 @@ public class EffOpenInventory extends Effect {
 	@Override
 	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
 		int openFlag = 0;
-		if (parseResult.mark >= 60) {
-			openFlag = parseResult.mark ^ 60;
+		if(parseResult.mark >= 6) {
+			openFlag = parseResult.mark ^ 6;
+			invType = DROPPER;
+		} else if(parseResult.mark >= 5) {
+			openFlag = parseResult.mark ^ 5;
+			invType = HOPPER;
+		} else if (parseResult.mark >= 4) {
+			openFlag = parseResult.mark ^ 4;
 			invType = ANVIL;
-		} else if (parseResult.mark >= 40) {
-			openFlag = parseResult.mark ^ 40;
+		} else if (parseResult.mark >= 3) {
+			openFlag = parseResult.mark ^ 3;
 			invType = CHEST;
-		} else if (parseResult.mark >= 20) {
+		} else if (parseResult.mark >= 2) {
 			invType = WORKBENCH;
-			openFlag = parseResult.mark ^ 20;
+			openFlag = parseResult.mark ^ 2;
 		} else {
 			openFlag = parseResult.mark;
 		}
@@ -115,6 +121,12 @@ public class EffOpenInventory extends Effect {
 							break;
 						case ANVIL:
 							p.openInventory(Bukkit.createInventory(p, InventoryType.ANVIL));
+							break;
+						case HOPPER:
+							p.openInventory(Bukkit.createInventory(p, InventoryType.HOPPER));
+							break;
+						case DROPPER:
+							p.openInventory(Bukkit.createInventory(p, InventoryType.DROPPER));
 					}
 				} else
 					p.closeInventory();

--- a/src/main/java/ch/njol/skript/effects/EffOpenInventory.java
+++ b/src/main/java/ch/njol/skript/effects/EffOpenInventory.java
@@ -44,14 +44,14 @@ import ch.njol.util.Kleenean;
 		"Please note that currently 'show' and 'open' have the same effect, but 'show' will eventually show an unmodifiable view of the inventory in the future."})
 @Examples({"show the victim's inventory to the player",
 		"open the player's inventory for the player"})
-@Since("2.0, 2.1.1 (closing), 2.2-Fixes-V10 (anvil), {INSERT VERSION} (hopper, dropper, dispenser, furnace, brewing, beacon, enchanting table")
+@Since("2.0, 2.1.1 (closing), 2.2-Fixes-V10 (anvil), {INSERT VERSION} (hopper, dropper, dispenser")
 public class EffOpenInventory extends Effect {
 	
-	private final static int WORKBENCH = 0, CHEST = 1, ANVIL = 2, HOPPER = 3, DROPPER = 4, DISPENSER = 5, FURNACE = 6, BREWING = 7, BEACON = 8, ENCHANTTABLE = 9;
+	private final static int WORKBENCH = 0, CHEST = 1, ANVIL = 2, HOPPER = 3, DROPPER = 4, DISPENSER = 5;
 	
 	static {
 		Skript.registerEffect(EffOpenInventory.class,
-				"(0¦open|1¦show) ((2¦(crafting [table]|workbench)|3¦chest|4¦anvil|5¦hopper|6¦dropper|7¦dispenser|8¦furnace|9¦brewing|10¦beacon|11¦enchant(ing|ment) table) (view|window|inventory|)|%-inventory%) (to|for) %players%",
+				"(0¦open|1¦show) ((2¦(crafting [table]|workbench)|3¦chest|4¦anvil|5¦hopper|6¦dropper|7¦dispenser) (view|window|inventory|)|%-inventory%) (to|for) %players%",
 				"close [the] inventory [view] (to|of|for) %players%", "close %players%'[s] inventory [view]");
 	}
 	
@@ -68,19 +68,7 @@ public class EffOpenInventory extends Effect {
 	@Override
 	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
 		int openFlag = 0;
-		if(parseResult.mark >= 11) {
-			openFlag = parseResult.mark ^ 11;
-			invType = ENCHANTTABLE;
-		} else if(parseResult.mark >= 10) {
-			openFlag = parseResult.mark ^ 10;
-			invType = BEACON;
-		} else if(parseResult.mark >= 9) {
-			openFlag = parseResult.mark ^ 9;
-			invType = BREWING;
-		} else if(parseResult.mark >= 8) {
-			openFlag = parseResult.mark ^ 8;
-			invType = FURNACE;
-		} else if(parseResult.mark >= 7) {
+		if(parseResult.mark >= 7) {
 			openFlag = parseResult.mark ^ 7;
 			invType = DISPENSER;
 		} else if(parseResult.mark >= 6) {
@@ -145,19 +133,7 @@ public class EffOpenInventory extends Effect {
 							break;
 						case DISPENSER:
 							p.openInventory(Bukkit.createInventory(p, InventoryType.DISPENSER));
-							break;
-						case FURNACE:
-							p.openInventory(Bukkit.createInventory(p, InventoryType.FURNACE));
-							break;
-						case BREWING:
-							p.openInventory(Bukkit.createInventory(p, InventoryType.BREWING));
-							break;
-						case BEACON:
-							p.openInventory(Bukkit.createInventory(p, InventoryType.BEACON));
-							break;
-						case ENCHANTTABLE:
-							p.openInventory(Bukkit.createInventory(p, InventoryType.ENCHANTING));
-						
+					
 					}
 				} else
 					p.closeInventory();


### PR DESCRIPTION
### Description
Added the hopper, dropper and dispenser to the open inventory effect

---
**Target Minecraft Versions:**     any (1.9+_
**Requirements:**     none
**Related Issues:**    none

### Note:
I changed the numbers of the parsing from the 20's down to 2,3,4,5,6
I never really understood why its that way.
I tested it, works fine, has no affect on it.

If anyone feels more inventory types should be added, let me know, and I'll quickly throw them in.