### PR TITLE
EffTabHead & EffTabFoot (ON HOLD)

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffTabFoot.java
+++ b/src/main/java/ch/njol/skript/effects/EffTabFoot.java
@@ -34,49 +34,44 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.util.Kleenean;
 
-@Name("Tablist Header/Footer")
-@Description("Add multiple line headers and footers to your tablist")
-@Examples({"on join:", "\tset tablist header \"This is my header\" with footer \"This is my footer\" for player",
-		"every 5 seconds:", "\tset tab header \"Welcome to our server\" with footer \"\" for all players",
-		"every minute:", "\tloop all players:", "\t\tset tab header \"&aMyServer\" and \"Thanks for stopping in\" with footer " +
+@Name("Tablist Footer")
+@Description("Add multiple line footers to your tablist")
+@Examples({"on join:", "\tset tablist footer \"This is my footer\" for player",
+		"every minute:", "\tset tab footer \"Dont forget to VOTE today\" for all players",
+		"every 30 seconds:", "\tloop all players:", "\t\tset tab footer " +
 		"\"Balance: %balance of loop-player%\" and \"World: %world of loop-player\" for loop-player"})
 @RequiredPlugins("Minecraft 1.13+")
 @Since("{INSERT VERSION}")
-public class EffTabHeadFoot extends Effect {
+public class EffTabFoot extends Effect {
 	
 	static {
 		if(Skript.isRunningMinecraft(1, 13))
-			Skript.registerEffect(EffTabHeadFoot.class, "set tab[list] header[ to] %strings% (with|and) footer[ to] %strings% for %players%");
+			Skript.registerEffect(EffTabFoot.class, "set tab[list] footer[ to] %strings% for %players%");
 	}
 	
 	@SuppressWarnings("null")
 	private Expression<Player> player;
-	@SuppressWarnings("null")
-	private Expression<String> header;
 	@SuppressWarnings("null")
 	private Expression<String> footer;
 	
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parser) {
-		header = (Expression<String>) exprs[0];
-		footer = (Expression<String>) exprs[1];
-		player = (Expression<Player>) exprs[2];
+		footer = (Expression<String>) exprs[0];
+		player = (Expression<Player>) exprs[1];
 		return true;
 	}
 	
 	@Override
 	protected void execute(Event e) {
-		String header = String.join("\n", this.header.getArray(e));
 		String footer = String.join("\n", this.footer.getArray(e));
 		for (Player p : player.getArray(e))
-			p.setPlayerListHeaderFooter(header, footer);
+			p.setPlayerListFooter(footer);
 	}
 	
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
-		return ("set tablist header to " + header.toString(e, debug) + " and footer to " + footer.toString(e, debug) +
-				" for " + player.toString(e, debug));
+		return ("set tablist footer to " + footer.toString(e, debug) +  " for " + player.toString(e, debug));
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffTabHead.java
+++ b/src/main/java/ch/njol/skript/effects/EffTabHead.java
@@ -1,0 +1,76 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.effects;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.RequiredPlugins;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
+
+@Name("Tablist Header")
+@Description("Add multiple line headers to your tablist")
+@Examples({"on join:", "\tset tablist header \"This is my header\" for player",
+		"every 5 seconds:", "\tset tab header \"Welcome to our server\" with footer \"\" for all players",
+		"every minute:", "\tloop all players:", "\t\tset tab header \"&aMyServer\" and \"Thanks for stopping in\" for loop-player"})
+@RequiredPlugins("Minecraft 1.13+")
+@Since("{INSERT VERSION}")
+public class EffTabHead extends Effect {
+	
+	static {
+		if(Skript.isRunningMinecraft(1, 13))
+			Skript.registerEffect(EffTabHead.class, "set tab[list] header[ to] %strings% for %players%");
+	}
+	
+	@SuppressWarnings("null")
+	private Expression<Player> player;
+	@SuppressWarnings("null")
+	private Expression<String> header;
+	
+	@SuppressWarnings({"unchecked", "null"})
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parser) {
+		header = (Expression<String>) exprs[0];
+		player = (Expression<Player>) exprs[1];
+		return true;
+	}
+	
+	@Override
+	protected void execute(Event e) {
+		String header = String.join("\n", this.header.getArray(e));
+		for (Player p : player.getArray(e))
+			p.setPlayerListHeader(header);
+	}
+	
+	@Override
+	public String toString(final @Nullable Event e, final boolean debug) {
+		return ("set tablist header to " + header.toString(e, debug) + " for " + player.toString(e, debug));
+	}
+	
+}

--- a/src/main/java/ch/njol/skript/effects/EffTabHeadFoot.java
+++ b/src/main/java/ch/njol/skript/effects/EffTabHeadFoot.java
@@ -1,9 +1,28 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
 package ch.njol.skript.effects;
 
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
 
-import com.sun.istack.internal.Nullable;
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -32,9 +51,9 @@ public class EffTabHeadFoot extends Effect {
 	
 	@SuppressWarnings("null")
 	private Expression<Player> player;
-	@Nullable
+	@SuppressWarnings("null")
 	private Expression<String> header;
-	@Nullable
+	@SuppressWarnings("null")
 	private Expression<String> footer;
 	
 	@SuppressWarnings({"unchecked", "null"})
@@ -55,9 +74,9 @@ public class EffTabHeadFoot extends Effect {
 	}
 	
 	@Override
-	public String toString(@Nullable Event event, boolean debug) {
-		return ("set tablist header to " + header.toString(event, debug) + " and footer to " + footer.toString(event, debug) +
-				" for " + player.toString(event, debug));
+	public String toString(final @Nullable Event e, final boolean debug) {
+		return ("set tablist header to " + header.toString(e, debug) + " and footer to " + footer.toString(e, debug) +
+				" for " + player.toString(e, debug));
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffTabHeadFoot.java
+++ b/src/main/java/ch/njol/skript/effects/EffTabHeadFoot.java
@@ -1,0 +1,63 @@
+package ch.njol.skript.effects;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+
+import com.sun.istack.internal.Nullable;
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.RequiredPlugins;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
+
+@Name("Tablist Header/Footer")
+@Description("Add multiple line headers and footers to your tablist")
+@Examples({"on join:", "\tset tablist header \"This is my header\" with footer \"This is my footer\" for player",
+		"every 5 seconds:", "\tset tab header \"Welcome to our server\" with footer \"\" for all players",
+		"every minute:", "\tloop all players:", "\t\tset tab header \"&aMyServer\" and \"Thanks for stopping in\" with footer " +
+		"\"Balance: %balance of loop-player%\" and \"World: %world of loop-player\" for loop-player"})
+@RequiredPlugins("Minecraft 1.13+")
+@Since("{INSERT VERSION}")
+public class EffTabHeadFoot extends Effect {
+	
+	static {
+		if(Skript.isRunningMinecraft(1, 13))
+			Skript.registerEffect(EffTabHeadFoot.class, "set tab[list] header[ to] %strings% (with|and) footer[ to] %strings% for %players%");
+	}
+	
+	@SuppressWarnings("null")
+	private Expression<Player> player;
+	@Nullable
+	private Expression<String> header;
+	@Nullable
+	private Expression<String> footer;
+	
+	@SuppressWarnings({"unchecked", "null"})
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parser) {
+		header = (Expression<String>) exprs[0];
+		footer = (Expression<String>) exprs[1];
+		player = (Expression<Player>) exprs[2];
+		return true;
+	}
+	
+	@Override
+	protected void execute(Event e) {
+		String header = String.join("\n", this.header.getArray(e));
+		String footer = String.join("\n", this.footer.getArray(e));
+		for (Player p : player.getArray(e))
+			p.setPlayerListHeaderFooter(header, footer);
+	}
+	
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return ("set tablist header to " + header.toString(event, debug) + " and footer to " + footer.toString(event, debug) +
+				" for " + player.toString(event, debug));
+	}
+	
+}


### PR DESCRIPTION
### Description
Added two effects for setting the tablist header and footer for player[s]
Skripters can set 1 string or multiple strings **per** header or footer

---
**Target Minecraft Versions:** 1.13+ due to a new method in the SpigotAPI
**Requirements:** 1.13+
**Related Issues:**  None

### Visual of the docs:

![](https://i.imgur.com/bz83H7J.png)
