### PR TITLE
Clean up cooldown stuff

### DIFF
--- a/src/main/java/ch/njol/skript/command/ScriptCommand.java
+++ b/src/main/java/ch/njol/skript/command/ScriptCommand.java
@@ -78,7 +78,6 @@ import ch.njol.util.Validate;
 
 /**
  * This class is used for user-defined commands.
- * 
  */
 public class ScriptCommand implements TabExecutor {
 
@@ -146,7 +145,7 @@ public class ScriptCommand implements TabExecutor {
 		this.cooldownStorage = cooldownStorage;
 
 		// remove aliases that are the same as the command
-		aliases.removeIf(s -> s.equalsIgnoreCase(label));
+		aliases.removeIf(label::equalsIgnoreCase);
 		this.aliases = aliases;
 		activeAliases = new ArrayList<>(aliases);
 
@@ -367,7 +366,7 @@ public class ScriptCommand implements TabExecutor {
 		help.addTopic(t);
 		helps.add(t);
 		final HelpTopic aliases = help.getHelpTopic("Aliases");
-		if (aliases != null && aliases instanceof IndexHelpTopic) {
+		if (aliases instanceof IndexHelpTopic) {
 			aliases.getFullText(Bukkit.getConsoleSender()); // CraftBukkit has a lazy IndexHelpTopic class (org.bukkit.craftbukkit.help.CustomIndexHelpTopic) - maybe its used for aliases as well
 			try {
 				final Field topics = IndexHelpTopic.class.getDeclaredField("allTopics");

--- a/src/main/java/ch/njol/skript/effects/EffCancelCooldown.java
+++ b/src/main/java/ch/njol/skript/effects/EffCancelCooldown.java
@@ -62,7 +62,7 @@ public class EffCancelCooldown extends Effect {
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
 		if (!ScriptLoader.isCurrentEvent(ScriptCommandEvent.class)) {
-			Skript.error("The cancel cooldown effect may only be used in a command.", ErrorQuality.SEMANTIC_ERROR);
+			Skript.error("The cancel cooldown effect may only be used in a command", ErrorQuality.SEMANTIC_ERROR);
 			return false;
 		}
 		cancel = matchedPattern == 0;

--- a/src/main/java/ch/njol/skript/expressions/ExprCmdCooldownInfo.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCmdCooldownInfo.java
@@ -19,6 +19,13 @@
  */
 package ch.njol.skript.expressions;
 
+import java.util.UUID;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
 import ch.njol.skript.ScriptLoader;
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer;
@@ -36,202 +43,185 @@ import ch.njol.skript.log.ErrorQuality;
 import ch.njol.skript.util.Date;
 import ch.njol.skript.util.Timespan;
 import ch.njol.util.Kleenean;
-import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
-import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
 
-import java.util.UUID;
-
-@Name("Cooldown Time/Remaining Time/Elapsed Time/Last Usage Date/Cooldown Bypass Permission")
-@Description({"Only usable in command events. Represents the cooldown time, the remaining time, or the elapsed time, or the last usage date, or the cooldown bypass permission."})
+@Name("Cooldown Time/Remaining Time/Elapsed Time/Last Usage/Bypass Permission")
+@Description({"Only usable in command events. Represents the cooldown time, the remaining time, the elapsed time,",
+		"the last usage date, or the cooldown bypass permission."})
 @Examples({
-        "command /home:",
-        "\tcooldown: 10 seconds",
-        "\tcooldown message: You last teleported home %elapsed time% ago, you may teleport home again in %remaining time%",
-        "\ttrigger:",
-        "\t\tteleport player to {home::%player%}"
-})
+		"command /home:",
+		"\tcooldown: 10 seconds",
+		"\tcooldown message: You last teleported home %elapsed time% ago, you may teleport home again in %remaining time%.",
+		"\ttrigger:",
+		"\t\tteleport player to {home::%player%}"})
 @Since("2.2-dev33")
 public class ExprCmdCooldownInfo extends SimpleExpression<Object> {
 
-    static {
-        Skript.registerExpression(ExprCmdCooldownInfo.class, Object.class, ExpressionType.SIMPLE,
-                "[the] (0¦remaining [time]|1¦elapsed [time]|2¦cooldown [time] [length]|3¦last usage [date]|4¦cooldown bypass perm[ission]) [of] [the] [(cooldown|wait)] [((of|for)[the] [current] command)]");
-    }
+	static {
+		Skript.registerExpression(ExprCmdCooldownInfo.class, Object.class, ExpressionType.SIMPLE,
+				"[the] remaining [time] [of [the] (cooldown|wait) [(of|for) [the] [current] command]]",
+				"[the] elapsed [time] [of [the] (cooldown|wait) [(of|for) [the] [current] command]]",
+				"[the] ((cooldown|wait) time|[wait] time of [the] (cooldown|wait) [(of|for) [the] [current] command])",
+				"[the] last usage [date] [of [the] (cooldown|wait) [(of|for) [the] [current] command]]",
+				"[the] [cooldown] bypass perm[ission] [of [the] (cooldown|wait) [(of|for) [the] [current] command]]");
+	}
 
-    private int mark;
+	private int pattern;
 
-    @Override
-    @Nullable
-    protected Object[] get(Event e) {
-        if (!(e instanceof ScriptCommandEvent)) {
-            return null;
-        }
-        ScriptCommandEvent event = ((ScriptCommandEvent) e);
-        ScriptCommand scriptCommand = event.getSkriptCommand();
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		pattern = matchedPattern;
+		if (!ScriptLoader.isCurrentEvent(ScriptCommandEvent.class)) {
+			Skript.error("The " + getExpressionName() + " expression can only be used within a command", ErrorQuality.SEMANTIC_ERROR);
+			return false;
+		}
+		return true;
+	}
 
-        CommandSender sender = event.getSender();
-        if (scriptCommand.getCooldown() == null || !(sender instanceof Player)) {
-            return null;
-        }
-        Player player = (Player) event.getSender();
-        UUID uuid = player.getUniqueId();
+	@Override
+	@Nullable
+	protected Object[] get(Event e) {
+		if (!(e instanceof ScriptCommandEvent))
+			return null;
+		ScriptCommandEvent event = ((ScriptCommandEvent) e);
+		ScriptCommand scriptCommand = event.getSkriptCommand();
+		
+		CommandSender sender = event.getSender();
+		if (scriptCommand.getCooldown() == null || !(sender instanceof Player))
+			return null;
+		Player player = (Player) event.getSender();
+		UUID uuid = player.getUniqueId();
+		
+		switch (pattern) {
+			case 0:
+			case 1:
+				long ms = pattern != 1
+						? scriptCommand.getRemainingMilliseconds(uuid, event)
+						: scriptCommand.getElapsedMilliseconds(uuid, event);
+				return new Timespan[] { new Timespan(ms) };
+			case 2:
+				return new Timespan[] {scriptCommand.getCooldown() };
+			case 3:
+				return new Date[] {scriptCommand.getLastUsage(uuid, event) };
+			case 4:
+				return new String[] {scriptCommand.getCooldownBypass() };
+		}
+		
+		return null;
+	}
 
-        switch (mark) {
-            case 0:
-            case 1:
-                long ms = mark != 1
-                        ? scriptCommand.getRemainingMilliseconds(uuid, event)
-                        : scriptCommand.getElapsedMilliseconds(uuid, event);
-                return new Timespan[]{new Timespan(ms)};
-            case 2:
-                return new Timespan[]{scriptCommand.getCooldown()};
-            case 3:
-                return new Date[]{scriptCommand.getLastUsage(uuid, event)};
-            case 4:
-                return new String[]{scriptCommand.getCooldownBypass()};
-        }
+	@Nullable
+	@Override
+	public Class<?>[] acceptChange(Changer.ChangeMode mode) {
+		switch (mode) {
+			case ADD:
+			case REMOVE:
+				if (pattern <= 1)
+					// remaining or elapsed time
+					return new Class<?>[] { Timespan.class };
+			case RESET:
+			case SET:
+				if (pattern <= 1)
+					// remaining or elapsed time
+					return new Class<?>[] { Timespan.class };
+				else if (pattern == 3)
+					// last usage date
+					return new Class<?>[] { Date.class };
+		}
+		return null;
+	}
 
-        return null;
-    }
+	@Override
+	public void change(Event e, @Nullable Object[] delta, Changer.ChangeMode mode) {
+		if (!(e instanceof ScriptCommandEvent))
+			return;
+		ScriptCommandEvent commandEvent = (ScriptCommandEvent) e;
+		ScriptCommand command = commandEvent.getSkriptCommand();
+		Timespan cooldown = command.getCooldown();
+		CommandSender sender = commandEvent.getSender();
+		if (cooldown == null || !(sender instanceof Player))
+			return;
+		long cooldownMs = cooldown.getMilliSeconds();
+		UUID uuid = ((Player) sender).getUniqueId();
+		
+		if (pattern <= 1) {
+			Timespan timespan = delta == null ? new Timespan(0) : (Timespan) delta[0];
+			switch (mode) {
+				case ADD:
+				case REMOVE:
+					long change = (mode == Changer.ChangeMode.ADD ? 1 : -1) * timespan.getMilliSeconds();
+					if (pattern == 0) {
+						long remaining = command.getRemainingMilliseconds(uuid, commandEvent);
+						long changed = remaining + change;
+						if (changed < 0)
+							changed = 0;
+						command.setRemainingMilliseconds(uuid, commandEvent, changed);
+					} else {
+						long elapsed = command.getElapsedMilliseconds(uuid, commandEvent);
+						long changed = elapsed + change;
+						if (changed > cooldownMs)
+							changed = cooldownMs;
+						command.setElapsedMilliSeconds(uuid, commandEvent, changed);
+					}
+					break;
+				case RESET:
+					if (pattern == 0)
+						command.setRemainingMilliseconds(uuid, commandEvent, cooldownMs);
+					else
+						command.setElapsedMilliSeconds(uuid, commandEvent, 0);
+					break;
+				case SET:
+					if (pattern == 0)
+						command.setRemainingMilliseconds(uuid, commandEvent, timespan.getMilliSeconds());
+					else
+						command.setElapsedMilliSeconds(uuid, commandEvent, timespan.getMilliSeconds());
+					break;
+			}
+		} else if (pattern == 3) {
+			switch (mode) {
+				case REMOVE_ALL:
+				case RESET:
+					command.setLastUsage(uuid, commandEvent, null);
+					break;
+				case SET:
+					Date date = delta == null ? null : (Date) delta[0];
+					command.setLastUsage(uuid, commandEvent, date);
+					break;
+			}
+		}
+	}
 
-    @Override
-    public boolean isSingle() {
-        return true;
-    }
+	@Override
+	public boolean isSingle() {
+		return true;
+	}
 
-    @Override
-    public Class<?> getReturnType() {
-        return mark <= 2 ? Timespan.class : String.class;
-    }
+	@Override
+	public Class<?> getReturnType() {
+		if (pattern <= 2)
+			return Timespan.class;
+		return pattern == 3 ? Date.class : String.class;
+	}
 
-    @Override
-    public String toString(@Nullable Event e, boolean debug) {
-        return "the " + getExpressionName();
-    }
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		return "the " + getExpressionName() + " of the cooldown";
+	}
 
-    @Override
-    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
-        mark = parseResult.mark;
-        if (!ScriptLoader.isCurrentEvent(ScriptCommandEvent.class)) {
-            Skript.error("The expression '" + getExpressionName() + " time' can only be used within a command", ErrorQuality.SEMANTIC_ERROR);
-            return false;
-        }
-        return true;
-    }
+	@Nullable
+	private String getExpressionName() {
+		switch (pattern) {
+			case 0:
+				return "remaining time";
+			case 1:
+				return "elapsed time";
+			case 2:
+				return "cooldown time";
+			case 3:
+				return "last usage date";
+			case 4:
+				return "bypass permission";
+		}
+		return null;
+	}
 
-    @Nullable
-    private String getExpressionName() {
-        switch (mark) {
-            case 0:
-                return "remaining time";
-            case 1:
-                return "elapsed time";
-            case 2:
-                return "cooldown time";
-            case 3:
-                return "last usage date";
-            case 4:
-                return "cooldown bypass permission";
-        }
-        return null;
-    }
-
-    @Nullable
-    @Override
-    public Class<?>[] acceptChange(Changer.ChangeMode mode) {
-        switch (mode) {
-            case ADD:
-            case REMOVE:
-                if (mark <= 1) {
-                    // remaining or elapsed time
-                    return new Class<?>[]{Timespan.class};
-                }
-            case REMOVE_ALL:
-            case RESET:
-            case SET:
-                if (mark <= 1) {
-                    // remaining or elapsed time
-                    return new Class<?>[]{Timespan.class};
-                } else if (mark == 3) {
-                    // last usage dtae
-                    return new Class<?>[]{Date.class};
-                }
-        }
-        return null;
-    }
-
-    @Override
-    public void change(Event e, @Nullable Object[] delta, Changer.ChangeMode mode) {
-        if (!(e instanceof ScriptCommandEvent)) {
-            return;
-        }
-        ScriptCommandEvent commandEvent = (ScriptCommandEvent) e;
-        ScriptCommand command = commandEvent.getSkriptCommand();
-        Timespan cooldown = command.getCooldown();
-        CommandSender sender = commandEvent.getSender();
-        if (cooldown == null || !(sender instanceof Player)) {
-            return;
-        }
-        long cooldownMs = cooldown.getMilliSeconds();
-        UUID uuid = ((Player) sender).getUniqueId();
-
-        if (mark <= 1) {
-            Timespan timespan = delta == null ? new Timespan(0) : (Timespan) delta[0];
-            switch (mode) {
-                case ADD:
-                case REMOVE:
-                    long change = (mode == Changer.ChangeMode.ADD ? 1 : -1) * timespan.getMilliSeconds();
-                    if (mark == 0) {
-                        // Remaining time
-                        long remaining = command.getRemainingMilliseconds(uuid, commandEvent);
-                        long changed = remaining + change;
-                        if (changed < 0) {
-                            changed = 0;
-                        }
-                        command.setRemainingMilliseconds(uuid, commandEvent, changed);
-                    } else {
-                        // Elapsed time
-                        long elapsed = command.getElapsedMilliseconds(uuid, commandEvent);
-                        long changed = elapsed + change;
-                        if (changed > cooldownMs) {
-                            changed = cooldownMs;
-                        }
-                        command.setElapsedMilliSeconds(uuid, commandEvent, changed);
-                    }
-                    break;
-                case REMOVE_ALL:
-                case RESET:
-                    if (mark == 0) {
-                        // Remaining time
-                        command.setRemainingMilliseconds(uuid, commandEvent, cooldownMs);
-                    } else {
-                        // Elapsed time
-                        command.setElapsedMilliSeconds(uuid, commandEvent, 0);
-                    }
-                    break;
-                case SET:
-                    if (mark == 0) {
-                        // Remaining time
-                        command.setRemainingMilliseconds(uuid, commandEvent, timespan.getMilliSeconds());
-                    } else {
-                        // Elapsed time
-                        command.setElapsedMilliSeconds(uuid, commandEvent, timespan.getMilliSeconds());
-                    }
-                    break;
-            }
-        } else if (mark == 3) {
-            switch (mode) {
-                case REMOVE_ALL:
-                case RESET:
-                    command.setLastUsage(uuid, commandEvent, null);
-                    break;
-                case SET:
-                    Date date = delta == null ? null : (Date) delta[0];
-                    command.setLastUsage(uuid, commandEvent, date);
-                    break;
-            }
-        }
-    }
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprCmdCooldownInfo.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCmdCooldownInfo.java
@@ -99,11 +99,11 @@ public class ExprCmdCooldownInfo extends SimpleExpression<Object> {
 						: scriptCommand.getElapsedMilliseconds(uuid, event);
 				return new Timespan[] { new Timespan(ms) };
 			case 2:
-				return new Timespan[] {scriptCommand.getCooldown() };
+				return new Timespan[] { scriptCommand.getCooldown() };
 			case 3:
-				return new Date[] {scriptCommand.getLastUsage(uuid, event) };
+				return new Date[] { scriptCommand.getLastUsage(uuid, event) };
 			case 4:
-				return new String[] {scriptCommand.getCooldownBypass() };
+				return new String[] { scriptCommand.getCooldownBypass() };
 		}
 		
 		return null;


### PR DESCRIPTION
### Description
- Converted this syntax
  ```hs
  [the] (0¦remaining [time]|1¦elapsed [time]|2¦cooldown [time] [length]|3¦last usage [date]|4¦cooldown 
  bypass perm[ission]) [of] [the] [(cooldown|wait)] [((of|for)[the] [current] command)]
  ```
  to
  ```hs
  [the] remaining [time] [of [the] (cooldown|wait) [(of|for) [the] [current] command]]
  [the] elapsed [time] [of [the] (cooldown|wait) [(of|for) [the] [current] command]]
  [the] ((cooldown|wait) time|[wait] time of [the] (cooldown|wait) [(of|for) [the] [current] command])
  [the] last usage [date] [of [the] (cooldown|wait) [(of|for) [the] [current] command]]
  [the] [cooldown] bypass perm[ission] [of [the] (cooldown|wait) [(of|for) [the] [current] command]]
  ```
- Removed curly braces from single-line statements
- Converted space indents to tabs
- Fixed that `last usage date` returns string
- Removed indents in empty lines
- Fixed method orders

---
**Target Minecraft Versions:** Any
**Requirements:** Nothing
**Related Issues:** None
