### PR TITLE
Info Command

### DIFF
--- a/src/main/java/ch/njol/skript/SkriptCommand.java
+++ b/src/main/java/ch/njol/skript/SkriptCommand.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
+import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -97,7 +98,8 @@ public class SkriptCommand implements CommandExecutor {
 //					.add("set", "Creates a new variable or changes an existing one")
 //					.add("delete", "Deletes a variable")
 //					.add("find", "Find variables")
-			).add("help");
+			).add("info")
+			.add("help");
 	
 	static {
 		if (new File(Skript.getInstance().getDataFolder() + "/doc-templates").exists()) {
@@ -338,6 +340,11 @@ public class SkriptCommand implements CommandExecutor {
 				Skript.info(sender, "Generating docs...");
 				generator.generate(); // Try to generate docs... hopefully
 				Skript.info(sender, "Documentation generated!");
+			} else if (args[0].equalsIgnoreCase("info")) {
+				String aliases = ChatColor.AQUA + "https://github.com/SkriptLang/skript-aliases";
+				String docs = ChatColor.AQUA + "http://skriptlang.github.io/Skript/";
+				Skript.info(sender, "Skript's aliases can be found here: " + aliases);
+				Skript.info(sender, "Skript's documentation can be found here: " + docs);
 			}
 		} catch (final Exception e) {
 			Skript.exception(e, "Exception occurred in Skript's main command", "Used command: /" + label + " " + StringUtils.join(args, " "));

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -55,6 +55,7 @@ skript command:
 	help:
 		description: Skript's main command
 		help: Prints this help message. Use '/skript reload/enable/disable/update' to get more info
+		info: Prints a message with links to Skript's aliases and documentation
 		reload:
 			description: Reloads the config, all scripts, everything, or a specific script
 			all: Reloads all configs and all scripts


### PR DESCRIPTION
### Description
Added a simple /sk info command to print out links to the aliases and docs website

---
**Target Minecraft Versions:**  Any
**Requirements:**     None
**Related Issues:**     #1825 

#### Notes:
Im not really sure why the commit shows like i deleted the whole damn file ¯\_(ツ)_/¯  (Silly thing)
But its actually just a few lines to add the new command.

Here is a print out of what the command looks like (the new one is /sk info - Snow suggested one command that prints out links to both the docs and aliases)
![](https://i.imgur.com/fV4MVUh.png)

Here are a couple of screen shots to show the actual differences (Since GitHub didnt agree with me)
![](https://i.imgur.com/MIiztka.png)
![](https://i.imgur.com/E3Ks5l5.png)