### PR TITLE
Improve EffFeed

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffFeed.java
+++ b/src/main/java/ch/njol/skript/effects/EffFeed.java
@@ -65,7 +65,7 @@ public class EffFeed extends Effect {
             level = n.intValue();
         }
         for (Player player : players.getArray(e)) {
-            player.setFoodLevel(level);
+            player.setFoodLevel(player.getFoodLevel() + level);
         }
     }
 


### PR DESCRIPTION
### Description
Makes EffFeed add to the player's food level instead of setting the food level (e.g. `feed the player by 5 beefs` used to set the player's hunger to 5)