### PR TITLE
Specify English Locale in some case conversion methods

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -45,6 +45,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Scanner;
@@ -563,14 +564,14 @@ public final class Skript extends JavaPlugin implements Listener {
 					
 					@Override
 					public String getValue() {
-						return "" + SkriptConfig.verbosity.value().name().toLowerCase().replace('_', ' ');
+						return "" + SkriptConfig.verbosity.value().name().toLowerCase(Locale.ENGLISH).replace('_', ' ');
 					}
 				});
 				metrics.addCustomChart(new Metrics.SimplePie("pluginPriority") {
 					
 					@Override
 					public String getValue() {
-						return "" + SkriptConfig.defaultEventPriority.value().name().toLowerCase().replace('_', ' ');
+						return "" + SkriptConfig.defaultEventPriority.value().name().toLowerCase(Locale.ENGLISH).replace('_', ' ');
 					}
 				});
 				metrics.addCustomChart(new Metrics.SimplePie("logPlayerCommands") {
@@ -608,7 +609,7 @@ public final class Skript extends JavaPlugin implements Listener {
 					
 					@Override
 					public String getValue() {
-						return "" + ChatMessages.linkParseMode.name().toLowerCase();
+						return "" + ChatMessages.linkParseMode.name().toLowerCase(Locale.ENGLISH);
 					}
 				});
 				metrics.addCustomChart(new Metrics.SimplePie("colorResetCodes") {
@@ -658,7 +659,7 @@ public final class Skript extends JavaPlugin implements Listener {
 					public boolean isLoggable(final @Nullable LogRecord record) {
 						if (record == null)
 							return false;
-						if (record.getMessage() != null && record.getMessage().toLowerCase().startsWith("can't keep up!"))
+						if (record.getMessage() != null && record.getMessage().toLowerCase(Locale.ENGLISH).startsWith("can't keep up!"))
 							return false;
 						return true;
 					}

--- a/src/main/java/ch/njol/skript/SkriptConfig.java
+++ b/src/main/java/ch/njol/skript/SkriptConfig.java
@@ -26,14 +26,9 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.concurrent.locks.LockSupport;
-
-import ch.njol.skript.lang.Variable;
-import ch.njol.skript.lang.VariableString;
-import ch.njol.skript.lang.function.Function;
+import java.util.Locale;
 
 import org.bukkit.event.EventPriority;
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.classes.Converter;
@@ -42,13 +37,14 @@ import ch.njol.skript.config.EnumParser;
 import ch.njol.skript.config.Option;
 import ch.njol.skript.config.OptionSection;
 import ch.njol.skript.config.SectionNode;
+import ch.njol.skript.lang.VariableString;
+import ch.njol.skript.lang.function.Function;
 import ch.njol.skript.localization.Language;
 import ch.njol.skript.log.SkriptLogger;
 import ch.njol.skript.log.Verbosity;
 import ch.njol.skript.timings.SkriptTimings;
 import ch.njol.skript.update.ReleaseChannel;
 import ch.njol.skript.util.FileUtils;
-import ch.njol.skript.util.Task;
 import ch.njol.skript.util.Timespan;
 import ch.njol.skript.util.chat.ChatMessages;
 import ch.njol.skript.util.chat.LinkParseMode;
@@ -186,7 +182,7 @@ public abstract class SkriptConfig {
 		@Nullable
 		public EventPriority convert(final String s) {
 			try {
-				return EventPriority.valueOf(s.toUpperCase());
+				return EventPriority.valueOf(s.toUpperCase(Locale.ENGLISH));
 			} catch (final IllegalArgumentException e) {
 				Skript.error("The plugin priority has to be one of lowest, low, normal, high, or highest.");
 				return null;

--- a/src/main/java/ch/njol/skript/aliases/Aliases.java
+++ b/src/main/java/ch/njol/skript/aliases/Aliases.java
@@ -19,7 +19,6 @@
  */
 package ch.njol.skript.aliases;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
@@ -29,32 +28,22 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.bukkit.Material;
-import org.bukkit.enchantments.Enchantment;
-import org.bukkit.inventory.ItemStack;
 import org.eclipse.jdt.annotation.Nullable;
 
-import ch.njol.skript.ScriptLoader;
 import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptAddon;
-import ch.njol.skript.SkriptCommand;
 import ch.njol.skript.SkriptConfig;
 import ch.njol.skript.config.Config;
-import ch.njol.skript.config.EntryNode;
 import ch.njol.skript.config.Node;
 import ch.njol.skript.config.SectionNode;
-import ch.njol.skript.config.validate.SectionValidator;
 import ch.njol.skript.entity.EntityData;
-import ch.njol.skript.entity.EntityType;
 import ch.njol.skript.localization.ArgsMessage;
 import ch.njol.skript.localization.Language;
 import ch.njol.skript.localization.Message;
@@ -63,11 +52,8 @@ import ch.njol.skript.localization.RegexMessage;
 import ch.njol.skript.log.BlockingLogHandler;
 import ch.njol.skript.log.SkriptLogger;
 import ch.njol.skript.util.EnchantmentType;
-import ch.njol.skript.util.PotionEffectUtils;
 import ch.njol.skript.util.Utils;
 import ch.njol.skript.util.Version;
-import ch.njol.util.NonNullPair;
-import ch.njol.util.Setter;
 
 public abstract class Aliases {
 
@@ -239,7 +225,7 @@ public abstract class Aliases {
 			assert m != null;
 			ItemData data = new ItemData(m);
 			if (provider.getMaterialName(data) == null) { // Material name is missing
-				provider.setMaterialName(data, new MaterialName(m, "" + m.toString().toLowerCase().replace('_', ' '), "" + m.toString().toLowerCase().replace('_', ' '), 0));
+				provider.setMaterialName(data, new MaterialName(m, "" + m.toString().toLowerCase(Locale.ENGLISH).replace('_', ' '), "" + m.toString().toLowerCase().replace('_', ' '), 0));
 				missing.append(m + ", ");
 				r++;
 			}

--- a/src/main/java/ch/njol/skript/config/validate/EnumEntryValidator.java
+++ b/src/main/java/ch/njol/skript/config/validate/EnumEntryValidator.java
@@ -19,6 +19,8 @@
  */
 package ch.njol.skript.config.validate;
 
+import java.util.Locale;
+
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
@@ -64,7 +66,7 @@ public class EnumEntryValidator<E extends Enum<E>> extends EntryValidator {
 			return false;
 		final EntryNode n = (EntryNode) node;
 		try {
-			final E e = Enum.valueOf(enumType, n.getValue().toUpperCase().replace(' ', '_'));
+			final E e = Enum.valueOf(enumType, n.getValue().toUpperCase(Locale.ENGLISH).replace(' ', '_'));
 			assert e != null;
 //			if (setter != null)
 			setter.set(e);

--- a/src/main/java/ch/njol/skript/effects/EffOpenInventory.java
+++ b/src/main/java/ch/njol/skript/effects/EffOpenInventory.java
@@ -19,6 +19,8 @@
  */
 package ch.njol.skript.effects;
 
+import java.util.Locale;
+
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
@@ -100,7 +102,7 @@ public class EffOpenInventory extends Effect {
 				try {
 					p.openInventory(i);
 				} catch (IllegalArgumentException ex){
-					Skript.error("You can't open a " +i.getType().name().toLowerCase().replaceAll("_", "") + " inventory to a player.");
+					Skript.error("You can't open a " + i.getType().name().toLowerCase(Locale.ENGLISH).replaceAll("_", "") + " inventory to a player.");
 				}
 			}
 		} else {

--- a/src/main/java/ch/njol/skript/events/EvtEntityBlockChange.java
+++ b/src/main/java/ch/njol/skript/events/EvtEntityBlockChange.java
@@ -19,6 +19,8 @@
  */
 package ch.njol.skript.events;
 
+import java.util.Locale;
+
 import org.bukkit.Material;
 import org.bukkit.entity.Enderman;
 import org.bukkit.entity.Sheep;
@@ -119,7 +121,7 @@ public class EvtEntityBlockChange extends SkriptEvent {
 	
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
-		return "" + event.name().replace('_', ' ').toLowerCase();
+		return "" + event.name().toLowerCase(Locale.ENGLISH).replace('_', ' ');
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/events/EvtGameMode.java
+++ b/src/main/java/ch/njol/skript/events/EvtGameMode.java
@@ -19,6 +19,8 @@
  */
 package ch.njol.skript.events;
 
+import java.util.Locale;
+
 import org.bukkit.GameMode;
 import org.bukkit.event.Event;
 import org.bukkit.event.player.PlayerGameModeChangeEvent;
@@ -66,7 +68,7 @@ public final class EvtGameMode extends SkriptEvent {
 	
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
-		return "gamemode change" + (mode != null ? " to " + mode.toString().toLowerCase() : "");
+		return "gamemode change" + (mode != null ? " to " + mode.toString().toLowerCase(Locale.ENGLISH) : "");
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/util/chat/MessageComponent.java
+++ b/src/main/java/ch/njol/skript/util/chat/MessageComponent.java
@@ -22,20 +22,14 @@
 package ch.njol.skript.util.chat;
 
 import java.lang.reflect.Type;
+import java.util.Locale;
 
-import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
-import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
-
-import ch.njol.skript.Skript;
-import ch.njol.skript.lang.VariableString;
 
 /**
  * Component for chat messages. This can be serialized with GSON and then
@@ -112,7 +106,7 @@ public class MessageComponent {
 			
 			@SuppressWarnings("null")
 			Action() {
-				spigotName = this.name().toUpperCase();
+				spigotName = this.name().toUpperCase(Locale.ENGLISH);
 			}
 		}
 		


### PR DESCRIPTION
### Description
This PR specifies English locale in some case conversion methods to don't cause issues with some languages. For example Skript converts the value of the config option `plugin priority` to upper case using the default language. If the OS language is Turkish, that causes it to be converted to `HİGH` etc. and an enum named `HİGH` doesn't exist, causes this error: `The plugin priority has to be one of lowest, low, normal, high, or highest.` and doesn't provide a default value. This happens when converting to lower case, too: `I` -> `ı`

Also this problem exists in many plugins. Skript already used to specify Locales but looks like it is forgotten in some cases. The thing is specify English language if the text is certain to be English.

As a note this problem can be solved using these parameters to start the server:
```bash
-Duser.language=en -Duser.region=EN # region may not be even needed
```
But of course this will also affect the `in lower/upper case` expression

---
**Target Minecraft Versions:** Any
**Requirements:** Nothing
**Related Issues:** None
