### PR TITLE
ExprDamagedItem

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprDamagedItem.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDamagedItem.java
@@ -64,9 +64,10 @@ public class ExprDamagedItem extends PropertyExpression<ItemType, ItemType> {
 	@Override
 	protected ItemType[] get(Event e, ItemType[] source) {
 		Number damage = this.damage.getSingle(e);
-		int num = damage != null ? damage.intValue() : 0;
+		if (damage == null)
+			return null;
 		return get(source.clone(), item -> {
-			item.iterator().forEachRemaining(i -> i.setDurability(num));
+			item.iterator().forEachRemaining(i -> i.setDurability(damage.intValue()));
 			return item;
 		});
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprDamagedItem.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDamagedItem.java
@@ -21,12 +21,12 @@
 package ch.njol.skript.expressions;
 
 import org.bukkit.event.Event;
-import org.bukkit.inventory.meta.Damageable;
-import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.ItemStack;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.bukkitutil.ItemUtils;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -41,9 +41,9 @@ import ch.njol.util.Kleenean;
 @Name("Damaged Item")
 @Description("Directly damages an item. In MC versions 1.12.2 and lower, this can be used to apply data values to items/blocks")
 @Examples({"give player diamond sword with damage value 100", "set player's tool to diamond hoe damaged by 250",
-		"give player diamond sword with damage 700 named \"BROKEN SWORD\"",
-		"set {_item} to diamond hoe with damage value 50 named \"SAD HOE\"",
-		"set target block of player to wool with data value 1", "set target block of player to potato plant with data value 7"})
+	"give player diamond sword with damage 700 named \"BROKEN SWORD\"",
+	"set {_item} to diamond hoe with damage value 50 named \"SAD HOE\"",
+	"set target block of player to wool with data value 1", "set target block of player to potato plant with data value 7"})
 @Since("INSERT VERSION")
 public class ExprDamagedItem extends PropertyExpression<ItemType, ItemType> {
 	
@@ -70,15 +70,9 @@ public class ExprDamagedItem extends PropertyExpression<ItemType, ItemType> {
 		return get(source, new Getter<ItemType, ItemType>() {
 			@Override
 			public ItemType get(ItemType item) {
-				int value = damage != null ? damage.intValue() : 0;
-				item = item.clone();
-				if (Skript.isRunningMinecraft(1, 13)) {
-					ItemMeta meta = item.getItemMeta();
-					((Damageable) meta).setDamage(value);
-					item.setItemMeta(meta);
-				} else {
-					item.iterator().forEachRemaining(d -> d.setDurability(value));
-				}
+				ItemStack newItem = new ItemStack(item.getRandom());
+				ItemUtils.setDamage(newItem, damage != null ? damage.intValue() : 0);
+				item = new ItemType(newItem);
 				return item;
 			}
 		});

--- a/src/main/java/ch/njol/skript/expressions/ExprDamagedItem.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDamagedItem.java
@@ -68,7 +68,7 @@ public class ExprDamagedItem extends PropertyExpression<ItemType, ItemType> {
 	@SuppressWarnings({"deprecation"})
 	@Override
 	protected ItemType[] get(Event e, ItemType[] source) {
-		Number value = damage.getSingle(e) != null ? damage.getSingle(e) : 0;
+		Number value = damage != null ? damage.getSingle(e) : 0;
 		return get(source, new Getter<ItemType, ItemType>() {
 			@Override
 			public ItemType get(ItemType item) {

--- a/src/main/java/ch/njol/skript/expressions/ExprDamagedItem.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDamagedItem.java
@@ -1,0 +1,100 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+
+package ch.njol.skript.expressions;
+
+import org.bukkit.event.Event;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.PropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.util.Getter;
+import ch.njol.util.Kleenean;
+
+@Name("Damaged Item")
+@Description("Directly damages an item. In MC versions 1.12.2 and lower, this can be used to apply data values to items/blocks")
+@Examples({"give player diamond sword with damage value 100", "set player's tool to diamond hoe with damage 250",
+		"give player diamond sword with damage 700 named \"BROKEN SWORD\"",
+		"set {_item} to diamond hoe with damage value 50 named \"SAD HOE\"",
+		"set target block of player to dirt with data value 1", "set target block of player to potato plant with data value 7"})
+@Since("INSERT VERSION")
+public class ExprDamagedItem extends PropertyExpression<ItemType, ItemType> {
+	
+	static {
+		Skript.registerExpression(ExprDamagedItem.class, ItemType.class, ExpressionType.COMBINED,
+				"%itemtype% with (damage|data) [value] %number%",
+				"%itemtype% damaged by %number%");
+	}
+	
+	@SuppressWarnings("null")
+	private Expression<Number> damage;
+	
+	@SuppressWarnings({"unchecked", "null"})
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		setExpr((Expression<ItemType>) exprs[0]);
+		damage = (Expression<Number>) exprs[1];
+		return true;
+	}
+	
+	@SuppressWarnings({"deprecation"})
+	@Override
+	protected ItemType[] get(Event e, ItemType[] source) {
+		Number value = damage.getSingle(e) != null ? damage.getSingle(e) : 0;
+		return get(source, new Getter<ItemType, ItemType>() {
+			@Override
+			public ItemType get(ItemType item) {
+				item = item.clone();
+				if (Skript.isRunningMinecraft(1, 13)) {
+					ItemMeta meta = item.getItemMeta();
+					((Damageable) meta).setDamage(value != null ? value.intValue() : 0);
+					item.setItemMeta(meta);
+				} else {
+					ItemStack stack = new ItemStack(item.getRandom());
+					stack.setDurability(value != null ? value.shortValue() : 0);
+					item = new ItemType(stack);
+				}
+				return item;
+			}
+		});
+	}
+	
+	@Override
+	public Class<? extends ItemType> getReturnType() {
+		return ItemType.class;
+	}
+	
+	@Override
+	public String toString(final @Nullable Event e, boolean debug) {
+		return getExpr().toString(e, debug) + " with damage value " + damage;
+	}
+	
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprDamagedItem.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDamagedItem.java
@@ -65,7 +65,7 @@ public class ExprDamagedItem extends PropertyExpression<ItemType, ItemType> {
 	protected ItemType[] get(Event e, ItemType[] source) {
 		Number damage = this.damage.getSingle(e);
 		if (damage == null)
-			return null;
+			return source;
 		return get(source.clone(), item -> {
 			item.iterator().forEachRemaining(i -> i.setDurability(damage.intValue()));
 			return item;

--- a/src/main/java/ch/njol/skript/expressions/ExprDamagedItem.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDamagedItem.java
@@ -63,7 +63,7 @@ public class ExprDamagedItem extends PropertyExpression<ItemType, ItemType> {
 	
 	@Override
 	protected ItemType[] get(Event e, ItemType[] source) {
-		Number damage = this.damage != null ? this.damage.getSingle(e) : 0;
+		Number damage = this.damage.getSingle(e);
 		int num = damage != null ? damage.intValue() : 0;
 		return get(source.clone(), item -> {
 			item.iterator().forEachRemaining(i -> i.setDurability(num));
@@ -78,7 +78,7 @@ public class ExprDamagedItem extends PropertyExpression<ItemType, ItemType> {
 	
 	@Override
 	public String toString(final @Nullable Event e, boolean debug) {
-		return getExpr().toString(e, debug) + " with damage value " + damage;
+		return getExpr().toString(e, debug) + " with damage value " + damage.toString(e, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprDamagedItem.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDamagedItem.java
@@ -21,12 +21,10 @@
 package ch.njol.skript.expressions;
 
 import org.bukkit.event.Event;
-import org.bukkit.inventory.ItemStack;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
-import ch.njol.skript.bukkitutil.ItemUtils;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -35,7 +33,6 @@ import ch.njol.skript.expressions.base.PropertyExpression;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser;
-import ch.njol.skript.util.Getter;
 import ch.njol.util.Kleenean;
 
 @Name("Damaged Item")
@@ -67,14 +64,10 @@ public class ExprDamagedItem extends PropertyExpression<ItemType, ItemType> {
 	@Override
 	protected ItemType[] get(Event e, ItemType[] source) {
 		Number damage = this.damage != null ? this.damage.getSingle(e) : 0;
-		return get(source, new Getter<ItemType, ItemType>() {
-			@Override
-			public ItemType get(ItemType item) {
-				ItemStack newItem = new ItemStack(item.getRandom());
-				ItemUtils.setDamage(newItem, damage != null ? damage.intValue() : 0);
-				item = new ItemType(newItem);
-				return item;
-			}
+		int num = damage != null ? damage.intValue() : 0;
+		return get(source.clone(), item -> {
+			item.iterator().forEachRemaining(i -> i.setDurability(num));
+			return item;
 		});
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprDamagedItem.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDamagedItem.java
@@ -21,7 +21,6 @@
 package ch.njol.skript.expressions;
 
 import org.bukkit.event.Event;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.eclipse.jdt.annotation.Nullable;
@@ -41,10 +40,10 @@ import ch.njol.util.Kleenean;
 
 @Name("Damaged Item")
 @Description("Directly damages an item. In MC versions 1.12.2 and lower, this can be used to apply data values to items/blocks")
-@Examples({"give player diamond sword with damage value 100", "set player's tool to diamond hoe with damage 250",
+@Examples({"give player diamond sword with damage value 100", "set player's tool to diamond hoe damaged by 250",
 		"give player diamond sword with damage 700 named \"BROKEN SWORD\"",
 		"set {_item} to diamond hoe with damage value 50 named \"SAD HOE\"",
-		"set target block of player to dirt with data value 1", "set target block of player to potato plant with data value 7"})
+		"set target block of player to wool with data value 1", "set target block of player to potato plant with data value 7"})
 @Since("INSERT VERSION")
 public class ExprDamagedItem extends PropertyExpression<ItemType, ItemType> {
 	
@@ -65,22 +64,20 @@ public class ExprDamagedItem extends PropertyExpression<ItemType, ItemType> {
 		return true;
 	}
 	
-	@SuppressWarnings({"deprecation"})
 	@Override
 	protected ItemType[] get(Event e, ItemType[] source) {
-		Number value = damage != null ? damage.getSingle(e) : 0;
+		Number damage = this.damage != null ? this.damage.getSingle(e) : 0;
 		return get(source, new Getter<ItemType, ItemType>() {
 			@Override
 			public ItemType get(ItemType item) {
+				int value = damage != null ? damage.intValue() : 0;
 				item = item.clone();
 				if (Skript.isRunningMinecraft(1, 13)) {
 					ItemMeta meta = item.getItemMeta();
-					((Damageable) meta).setDamage(value != null ? value.intValue() : 0);
+					((Damageable) meta).setDamage(value);
 					item.setItemMeta(meta);
 				} else {
-					ItemStack stack = new ItemStack(item.getRandom());
-					stack.setDurability(value != null ? value.shortValue() : 0);
-					item = new ItemType(stack);
+					item.iterator().forEachRemaining(d -> d.setDurability(value));
 				}
 				return item;
 			}


### PR DESCRIPTION
### Description
Can be used to give/set a damaged item.
ie:
```
give player diamond sword with damage value 750
set {_item} to wood hoe with damage value 10
set player's tool to player's tool with damage value 50
```
No one would use that last example, but it works.

In 1.12.2 or lower, you can use this to give/set a damaged item or set a block to a block with a data value.
ie:
```
set target block to target block with data value 7
set target block to potato plant with data value 3
```

---
**Target Minecraft Versions:** Any
**Requirements:** None
**Related Issues:** I'm sure this may relate to a few issues, but #1682 directly
