### PR TITLE
Improve sound stuff

### DIFF
--- a/src/main/java/ch/njol/skript/classes/ClassInfo.java
+++ b/src/main/java/ch/njol/skript/classes/ClassInfo.java
@@ -79,6 +79,8 @@ public class ClassInfo<T> implements Debuggable {
 	private String[] examples = null;
 	@Nullable
 	private String since = null;
+	@Nullable
+	private String[] requiredPlugins = null;
 	
 	/**
 	 * @param c The class
@@ -232,6 +234,20 @@ public class ClassInfo<T> implements Debuggable {
 	public ClassInfo<T> since(final String since) {
 		assert this.since == null;
 		this.since = since;
+		return this;
+	}
+	
+	/**
+	 * Other plugin dependencies for this ClassInfo.
+	 *
+	 * Only used for Skript's documentation.
+	 *
+	 * @param pluginNames
+	 * @return This ClassInfo object
+	 */
+	public ClassInfo<T> requiredPlugins(final String... pluginNames) {
+		assert this.requiredPlugins == null;
+		this.requiredPlugins = pluginNames;
 		return this;
 	}
 	

--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -19,7 +19,6 @@
  */
 package ch.njol.skript.classes.data;
 
-import java.io.NotSerializableException;
 import java.io.StreamCorruptedException;
 import java.util.List;
 import java.util.Locale;
@@ -31,10 +30,12 @@ import java.util.regex.Pattern;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Difficulty;
+import org.bukkit.FireworkEffect;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.SoundCategory;
 import org.bukkit.World;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
@@ -50,6 +51,7 @@ import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.player.PlayerResourcePackStatusEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
@@ -92,7 +94,6 @@ import ch.njol.yggdrasil.Fields;
 /**
  * @author Peter Güttinger
  */
-// TODO vectors
 public class BukkitClasses {
 
 	public BukkitClasses() {}
@@ -102,7 +103,8 @@ public class BukkitClasses {
 				.user("entit(y|ies)")
 				.name("Entity")
 				.description("An entity is something in a <a href='#world'>world</a> that's not a <a href='#block'>block</a>, " +
-						"e.g. a <a href='#player'>player</a>, a skeleton, or a zombie, but also <a href='#projectile'>projectiles</a> like arrows, fireballs or thrown potions, " +
+						"e.g. a <a href='#player'>player</a>, a skeleton, or a zombie, but also " +
+						"<a href='#projectile'>projectiles</a> like arrows, fireballs or thrown potions, " +
 						"or special entities like dropped items, falling blocks or paintings.")
 				.usage("player, op, wolf, tamed ocelot, powered creeper, zombie, unsaddled pig, fireball, arrow, dropped item, item frame, etc.")
 				.examples("entity is a zombie or creeper",
@@ -117,22 +119,22 @@ public class BukkitClasses {
 					public Entity parse(final String s, final ParseContext context) {
 						return null;
 					}
-					
+
 					@Override
 					public boolean canParse(final ParseContext context) {
 						return false;
 					}
-					
+
 					@Override
 					public String toVariableNameString(final Entity e) {
 						return "entity:" + e.getUniqueId().toString().toLowerCase(Locale.ENGLISH);
 					}
-					
+
 					@Override
 					public String getVariableNamePattern() {
 						return "entity:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
 					}
-					
+
 					@Override
 					public String toString(final Entity e, final int flags) {
 						return EntityData.toString(e, flags);
@@ -143,7 +145,8 @@ public class BukkitClasses {
 		Classes.registerClass(new ClassInfo<>(LivingEntity.class, "livingentity")
 				.user("living ?entit(y|ies)")
 				.name("Living Entity")
-				.description("A living <a href='#entity'>entity</a>, i.e. a mob or <a href='#player'>player</a>, not inanimate entities like <a href='#projectile'>projectiles</a> or dropped items.")
+				.description("A living <a href='#entity'>entity</a>, i.e. a mob or <a href='#player'>player</a>, " +
+						"not inanimate entities like <a href='#projectile'>projectiles</a> or dropped items.")
 				.usage("see <a href='#entity'>entity</a>, but ignore inanimate objects")
 				.examples("spawn 5 powered creepers",
 						"shoot a zombie from the creeper")
@@ -166,7 +169,7 @@ public class BukkitClasses {
 				.user("blocks?")
 				.name("Block")
 				.description("A block in a <a href='#world'>world</a>. It has a <a href='#location'>location</a> and a <a href='#itemstack'>type</a>, " +
-						"and can also have a <a href='#direction'>direction</a> (mostly a <a href='../expressions.html#ExprFacing'>facing</a>), an <a href='#inventory'>inventory</a>, or other special properties.")
+						"and can also have a <a href='#direction'>direction</a> (mostly a <a href='expressions.html#ExprFacing'>facing</a>), an <a href='#inventory'>inventory</a>, or other special properties.")
 				.usage("")
 				.examples("")
 				.since("1.0")
@@ -177,27 +180,27 @@ public class BukkitClasses {
 					public Block parse(final String s, final ParseContext context) {
 						return null;
 					}
-					
+
 					@Override
 					public boolean canParse(final ParseContext context) {
 						return false;
 					}
-					
+
 					@Override
 					public String toString(final Block b, final int flags) {
 						return ItemType.toString(b, flags);
 					}
-					
+
 					@Override
 					public String toVariableNameString(final Block b) {
 						return b.getWorld().getName() + ":" + b.getX() + "," + b.getY() + "," + b.getZ();
 					}
-					
+
 					@Override
 					public String getVariableNamePattern() {
 						return ".+:-?\\d+,-?\\d+,-?\\d+";
 					}
-					
+
 					@Override
 					public String getDebugMessage(final Block b) {
 						return toString(b, 0) + " block (" + b.getWorld().getName() + ":" + b.getX() + "," + b.getY() + "," + b.getZ() + ")";
@@ -205,9 +208,7 @@ public class BukkitClasses {
 				})
 				.changer(DefaultChangers.blockChanger)
 				.serializer(new Serializer<Block>() {
-					@SuppressWarnings("null")
 					@Override
-					@Nullable
 					public Fields serialize(final Block b) {
 						final Fields f = new Fields();
 						f.putObject("world", b.getWorld());
@@ -216,12 +217,12 @@ public class BukkitClasses {
 						f.putPrimitive("z", b.getZ());
 						return f;
 					}
-					
+
 					@Override
 					public void deserialize(final Block o, final Fields f) {
 						assert false;
 					}
-					
+
 					@Override
 					protected Block deserialize(final Fields fields) throws StreamCorruptedException {
 						final World w = fields.getObject("world", World.class);
@@ -231,18 +232,18 @@ public class BukkitClasses {
 							throw new StreamCorruptedException();
 						return b;
 					}
-					
+
 					@Override
 					public boolean mustSyncDeserialization() {
 						return true;
 					}
-					
+
 					@Override
 					public boolean canBeInstantiated() {
 						return false;
 					}
-					
-//					return b.getWorld().getName() + ":" + b.getX() + "," + b.getY() + "," + b.getZ();
+
+					// return b.getWorld().getName() + ":" + b.getX() + "," + b.getY() + "," + b.getZ();
 					@Override
 					@Nullable
 					public Block deserialize(final String s) {
@@ -250,9 +251,8 @@ public class BukkitClasses {
 						if (split.length != 4)
 							return null;
 						final World w = Bukkit.getWorld(split[0]);
-						if (w == null) {
+						if (w == null)
 							return null;
-						}
 						try {
 							final int[] l = new int[3];
 							for (int i = 0; i < 3; i++)
@@ -279,34 +279,34 @@ public class BukkitClasses {
 					public Location parse(final String s, final ParseContext context) {
 						return null;
 					}
-					
+
 					@Override
 					public boolean canParse(final ParseContext context) {
 						return false;
 					}
-					
+
 					@Override
 					public String toString(final Location l, final int flags) {
 						return "x: " + Skript.toString(l.getX()) + ", y: " + Skript.toString(l.getY()) + ", z: " + Skript.toString(l.getZ());
 					}
-					
+
 					@Override
 					public String toVariableNameString(final Location l) {
 						return l.getWorld().getName() + ":" + l.getX() + "," + l.getY() + "," + l.getZ();
 					}
-					
+
 					@Override
 					public String getVariableNamePattern() {
 						return "\\S:-?\\d+(\\.\\d+)?,-?\\d+(\\.\\d+)?,-?\\d+(\\.\\d+)?";
 					}
-					
+
 					@Override
 					public String getDebugMessage(final Location l) {
 						return "(" + l.getWorld().getName() + ":" + l.getX() + "," + l.getY() + "," + l.getZ() + "|yaw=" + l.getYaw() + "/pitch=" + l.getPitch() + ")";
 					}
 				}).serializer(new Serializer<Location>() {
 					@Override
-					public Fields serialize(final Location l) throws NotSerializableException {
+					public Fields serialize(final Location l) {
 						final Fields f = new Fields();
 						f.putObject("world", l.getWorld());
 						f.putPrimitive("x", l.getX());
@@ -316,30 +316,30 @@ public class BukkitClasses {
 						f.putPrimitive("pitch", l.getPitch());
 						return f;
 					}
-					
+
 					@Override
-					public void deserialize(final Location o, final Fields f) throws StreamCorruptedException {
+					public void deserialize(final Location o, final Fields f) {
 						assert false;
 					}
-					
+
 					@Override
-					public Location deserialize(final Fields f) throws StreamCorruptedException, NotSerializableException {
+					public Location deserialize(final Fields f) throws StreamCorruptedException {
 						return new Location(f.getObject("world", World.class),
 								f.getPrimitive("x", double.class), f.getPrimitive("y", double.class), f.getPrimitive("z", double.class),
 								f.getPrimitive("yaw", float.class), f.getPrimitive("pitch", float.class));
 					}
-					
+
 					@Override
 					public boolean canBeInstantiated() {
 						return false; // no nullary constructor - also, saving the location manually prevents errors should Location ever be changed
 					}
-					
+
 					@Override
 					public boolean mustSyncDeserialization() {
 						return true;
 					}
 					
-//					return l.getWorld().getName() + ":" + l.getX() + "," + l.getY() + "," + l.getZ() + "|" + l.getYaw() + "/" + l.getPitch();
+					// return l.getWorld().getName() + ":" + l.getX() + "," + l.getY() + "," + l.getZ() + "|" + l.getYaw() + "/" + l.getPitch();
 					@Override
 					@Nullable
 					public Location deserialize(final String s) {
@@ -374,36 +374,35 @@ public class BukkitClasses {
 					public Vector parse(final String s, final ParseContext context) {
 						return null;
 					}
-					
+
 					@Override
 					public boolean canParse(final ParseContext context) {
 						return false;
 					}
-					
+
 					@Override
 					public String toString(final Vector vec, final int flags) {
 						return "x: " + Skript.toString(vec.getX()) + ", y: " + Skript.toString(vec.getY()) + ", z: " + Skript.toString(vec.getZ());
 					}
-					
+
 					@Override
 					public String toVariableNameString(final Vector vec) {
 						return "vector:" + vec.getX() + "," + vec.getY() + "," + vec.getZ();
 					}
-					
+
 					@Override
 					public String getVariableNamePattern() {
 						return "\\S:-?\\d+(\\.\\d+)?,-?\\d+(\\.\\d+)?,-?\\d+(\\.\\d+)?";
 					}
-					
+
 					@Override
 					public String getDebugMessage(final Vector vec) {
 						return "(" + vec.getX() + "," + vec.getY() + "," + vec.getZ() + ")";
 					}
 				})
 				.serializer(new Serializer<Vector>() {
-
 					@Override
-					public Fields serialize(Vector o) throws NotSerializableException {
+					public Fields serialize(Vector o) {
 						Fields f = new Fields();
 						f.putPrimitive("x", o.getX());
 						f.putPrimitive("y", o.getY());
@@ -412,12 +411,12 @@ public class BukkitClasses {
 					}
 
 					@Override
-					public void deserialize(Vector o, Fields f) throws StreamCorruptedException, NotSerializableException {
+					public void deserialize(Vector o, Fields f) {
 						assert false;
 					}
-					
+
 					@Override
-					public Vector deserialize(final Fields f) throws StreamCorruptedException, NotSerializableException {
+					public Vector deserialize(final Fields f) throws StreamCorruptedException {
 						return new Vector(f.getPrimitive("x", double.class), f.getPrimitive("y", double.class), f.getPrimitive("z", double.class));
 					}
 
@@ -430,11 +429,8 @@ public class BukkitClasses {
 					protected boolean canBeInstantiated() {
 						return false;
 					}
-					
-				})
-				);
+				}));
 
-		// FIXME update doc
 		Classes.registerClass(new ClassInfo<>(World.class, "world")
 				.user("worlds?")
 				.name("World")
@@ -460,17 +456,17 @@ public class BukkitClasses {
 							return Bukkit.getWorld(m.group(1));
 						return null;
 					}
-					
+
 					@Override
 					public String toString(final World w, final int flags) {
 						return "" + w.getName();
 					}
-					
+
 					@Override
 					public String toVariableNameString(final World w) {
 						return "" + w.getName();
 					}
-					
+
 					@Override
 					public String getVariableNamePattern() {
 						return "\\S+";
@@ -482,17 +478,17 @@ public class BukkitClasses {
 						f.putObject("name", w.getName());
 						return f;
 					}
-					
+
 					@Override
 					public void deserialize(final World o, final Fields f) {
 						assert false;
 					}
-					
+
 					@Override
 					public boolean canBeInstantiated() {
 						return false;
 					}
-					
+
 					@Override
 					protected World deserialize(final Fields fields) throws StreamCorruptedException {
 						final String name = fields.getObject("name", String.class);
@@ -501,8 +497,8 @@ public class BukkitClasses {
 							throw new StreamCorruptedException("Missing world " + name);
 						return w;
 					}
-					
-//					return w.getName();
+
+					// return w.getName();
 					@Override
 					@Nullable
 					public World deserialize(final String s) {
@@ -518,9 +514,11 @@ public class BukkitClasses {
 		Classes.registerClass(new ClassInfo<>(Inventory.class, "inventory")
 				.user("inventor(y|ies)")
 				.name("Inventory")
-				.description("An inventory of a <a href='#player'>player</a> or <a href='#block'>block</a>. Inventories have many effects and conditions regarding the items contained.",
+				.description("An inventory of a <a href='#player'>player</a> or <a href='#block'>block</a>. " +
+						"Inventories have many effects and conditions regarding the items contained.",
 						"An inventory has a fixed amount of <a href='#slot'>slots</a> which represent a specific place in the inventory, " +
-						"e.g. the <a href='../expressions.html#ExprArmorSlot'>helmet slot</a> for players (Please note that slot support is still very limited but will be improved eventually).")
+						"e.g. the <a href='expressions.html#ExprArmorSlot'>helmet slot</a> for players " +
+						"(Please note that slot support is still very limited but will be improved eventually).")
 				.usage("")
 				.examples("")
 				.since("1.0")
@@ -531,27 +529,27 @@ public class BukkitClasses {
 					public Inventory parse(final String s, final ParseContext context) {
 						return null;
 					}
-					
+
 					@Override
 					public boolean canParse(final ParseContext context) {
 						return false;
 					}
-					
+
 					@Override
 					public String toString(final Inventory i, final int flags) {
 						return "inventory of " + Classes.toString(i.getHolder());
 					}
-					
+
 					@Override
 					public String getDebugMessage(final Inventory i) {
 						return "inventory of " + Classes.getDebugMessage(i.getHolder());
 					}
-					
+
 					@Override
 					public String toVariableNameString(final Inventory i) {
 						return "inventory of " + Classes.toString(i.getHolder(), StringMode.VARIABLE_NAME);
 					}
-					
+
 					@Override
 					public String getVariableNamePattern() {
 						return "inventory of .+";
@@ -559,7 +557,7 @@ public class BukkitClasses {
 				}).changer(DefaultChangers.inventoryChanger));
 
 		Classes.registerClass(new ClassInfo<>(InventoryAction.class, "inventoryaction")
-				.user("inventory actions?")
+				.user("inventory ?actions?")
 				.name("Inventory Action")
 				.description("What player just did in inventory event. Note that when in creative game mode, most actions do not work correctly.")
 				.usage(InventoryActions.getAllNames())
@@ -567,7 +565,6 @@ public class BukkitClasses {
 				.since("2.2-dev16")
 				.defaultExpression(new EventValueExpression<>(InventoryAction.class))
 				.parser(new Parser<InventoryAction>() {
-
 					@Override
 					@Nullable
 					public InventoryAction parse(String s, ParseContext context) {
@@ -589,14 +586,14 @@ public class BukkitClasses {
 					public String getVariableNamePattern() {
 						return "\\S+";
 					}
-					
 				}));
 
-		final EnumUtils<ClickType> invClicks = new EnumUtils<>(ClickType.class, "click types"); // Less boilerplate code!
+		final EnumUtils<ClickType> invClicks = new EnumUtils<>(ClickType.class, "click types");
 		Classes.registerClass(new ClassInfo<>(ClickType.class, "clicktype")
-				.user("click types?")
+				.user("click ?types?")
 				.name("Click Type")
-				.description("Click type, mostly for inventory events. Tells exactly which keys/buttons player pressed, assuming that default keybindings are used in client side.")
+				.description("Click type, mostly for inventory events. Tells exactly which keys/buttons player pressed, " +
+						"assuming that default keybindings are used in client side.")
 				.usage(invClicks.getAllNames())
 				.examples("")
 				.since("2.2-dev16b, 2.2-dev35 (renamed to click type)")
@@ -623,12 +620,11 @@ public class BukkitClasses {
 					public String getVariableNamePattern() {
 						return "\\S+";
 					}
-					
 				}));
 
 		final EnumUtils<InventoryType> invTypes = new EnumUtils<>(InventoryType.class, "inventory types");
 		Classes.registerClass(new ClassInfo<>(InventoryType.class, "inventorytype")
-				.user("inventory types?")
+				.user("inventory ?types?")
 				.name("Inventory Type")
 				.description("Minecraft has several different inventory types with their own use cases.")
 				.usage(invTypes.getAllNames())
@@ -657,7 +653,6 @@ public class BukkitClasses {
 					public String getVariableNamePattern() {
 						return "\\S+";
 					}
-					
 				}));
 
 		Classes.registerClass(new ClassInfo<>(Player.class, "player")
@@ -689,22 +684,22 @@ public class BukkitClasses {
 								Skript.error(String.format(Language.get("commands.multiple players start with"), s));
 							return null;
 						}
-//						if (s.matches("\"\\S+\""))
-//							return Bukkit.getPlayerExact(s.substring(1, s.length() - 1));
+						// if (s.matches("\"\\S+\""))
+						// 	return Bukkit.getPlayerExact(s.substring(1, s.length() - 1));
 						assert false;
 						return null;
 					}
-					
+
 					@Override
 					public boolean canParse(final ParseContext context) {
 						return context == ParseContext.COMMAND;
 					}
-					
+
 					@Override
 					public String toString(final Player p, final int flags) {
 						return "" + p.getName();
 					}
-					
+
 					@Override
 					public String toVariableNameString(final Player p) {
 						if (SkriptConfig.usePlayerUUIDsInVariableNames.value())
@@ -712,7 +707,7 @@ public class BukkitClasses {
 						else
 							return "" + p.getName();
 					}
-					
+
 					@Override
 					public String getVariableNamePattern() {
 						if (SkriptConfig.usePlayerUUIDsInVariableNames.value())
@@ -720,7 +715,7 @@ public class BukkitClasses {
 						else
 							return "\\S+";
 					}
-					
+
 					@Override
 					public String getDebugMessage(final Player p) {
 						return p.getName() + " " + Classes.getDebugMessage(p.getLocation());
@@ -731,9 +726,10 @@ public class BukkitClasses {
 
 		Classes.registerClass(new ClassInfo<>(OfflinePlayer.class, "offlineplayer")
 				.user("offline ?players?")
-				.name("Offlineplayer")
+				.name("Offline Player")
 				.description("A player that is possibly offline. See <a href='#player'>player</a> for more information. " +
-						"Please note that while all effects and conditions that require a player can be used with an offline player as well, they will not work if the player is not actually online.")
+						"Please note that while all effects and conditions that require a player can be used with an " +
+						"offline player as well, they will not work if the player is not actually online.")
 				.usage("")
 				.examples("")
 				.since("")
@@ -752,24 +748,24 @@ public class BukkitClasses {
 							return Bukkit.getOfflinePlayer(s);
 							// TODO return an unresolved player and resolve it on a different thread after the command was parsed, and block the command until it is ready
 							// FIXME add note to changelog if not fixed in the next update
-//							return new UnresolvedOfflinePlayer(s);
+							// return new UnresolvedOfflinePlayer(s);
 						}
-//						if (s.matches("\"\\S+\""))
-//							return Bukkit.getOfflinePlayer(s.substring(1, s.length() - 1));
+						// if (s.matches("\"\\S+\""))
+						// 	return Bukkit.getOfflinePlayer(s.substring(1, s.length() - 1));
 						assert false;
 						return null;
 					}
-					
+
 					@Override
 					public boolean canParse(final ParseContext context) {
 						return context == ParseContext.COMMAND;
 					}
-					
+
 					@Override
 					public String toString(final OfflinePlayer p, final int flags) {
 						return "" + p.getName();
 					}
-					
+
 					@Override
 					public String toVariableNameString(final OfflinePlayer p) {
 						if (SkriptConfig.usePlayerUUIDsInVariableNames.value())
@@ -777,7 +773,7 @@ public class BukkitClasses {
 						else
 							return "" + p.getName();
 					}
-					
+
 					@Override
 					public String getVariableNamePattern() {
 						if (SkriptConfig.usePlayerUUIDsInVariableNames.value())
@@ -785,7 +781,7 @@ public class BukkitClasses {
 						else
 							return "\\S+";
 					}
-					
+
 					@Override
 					public String getDebugMessage(final OfflinePlayer p) {
 						if (p.isOnline())
@@ -794,7 +790,7 @@ public class BukkitClasses {
 					}
 				}).serializer(new Serializer<OfflinePlayer>() {
 					private final boolean uuidSupported = Skript.methodExists(OfflinePlayer.class, "getUniqueId");
-					
+
 					@Override
 					public Fields serialize(final OfflinePlayer p) {
 						final Fields f = new Fields();
@@ -803,17 +799,17 @@ public class BukkitClasses {
 						f.putObject("name", p.getName());
 						return f;
 					}
-					
+
 					@Override
 					public void deserialize(final OfflinePlayer o, final Fields f) {
 						assert false;
 					}
-					
+
 					@Override
 					public boolean canBeInstantiated() {
 						return false;
 					}
-					
+
 					@SuppressWarnings("deprecation")
 					@Override
 					protected OfflinePlayer deserialize(final Fields fields) throws StreamCorruptedException {
@@ -831,15 +827,15 @@ public class BukkitClasses {
 							return p;
 						}
 					}
-					
-//					return p.getName();
+
+					// return p.getName();
 					@SuppressWarnings("deprecation")
 					@Override
 					@Nullable
 					public OfflinePlayer deserialize(final String s) {
 						return Bukkit.getOfflinePlayer(s);
 					}
-					
+
 					@Override
 					public boolean mustSyncDeserialization() {
 						return true;
@@ -847,10 +843,10 @@ public class BukkitClasses {
 				}));
 
 		Classes.registerClass(new ClassInfo<>(CommandSender.class, "commandsender")
-				.user("(commands?)? ?(sender|executor)s?")
+				.user("((commands?)? ?)?(sender|executor)s?")
 				.name("Command Sender")
 				.description("A player or the console.")
-				.usage("use <a href='../expressions.html#LitConsole'>the console</a> for the console",
+				.usage("use <a href='expressions.html#LitConsole'>the console</a> for the console",
 						"see <a href='#player'>player</a> for players.")
 				.examples("on command /pm:",
 						"	command sender is not the console",
@@ -865,22 +861,22 @@ public class BukkitClasses {
 					public CommandSender parse(final String s, final ParseContext context) {
 						return null;
 					}
-					
+
 					@Override
 					public boolean canParse(final ParseContext context) {
 						return false;
 					}
-					
+
 					@Override
 					public String toString(final CommandSender s, final int flags) {
 						return "" + s.getName();
 					}
-					
+
 					@Override
 					public String toVariableNameString(final CommandSender s) {
 						return "" + s.getName();
 					}
-					
+
 					@Override
 					public String getVariableNamePattern() {
 						return "\\S+";
@@ -909,7 +905,7 @@ public class BukkitClasses {
 							names[i++] = new Message("game modes." + m.name());
 						}
 					}
-					
+
 					@Override
 					@Nullable
 					public GameMode parse(final String s, final ParseContext context) {
@@ -919,17 +915,17 @@ public class BukkitClasses {
 						}
 						return null;
 					}
-					
+
 					@Override
 					public String toString(final GameMode m, final int flags) {
 						return names[m.ordinal()].toString();
 					}
-					
+
 					@Override
 					public String toVariableNameString(final GameMode o) {
 						return "" + o.toString().toLowerCase(Locale.ENGLISH);
 					}
-					
+
 					@Override
 					public String getVariableNamePattern() {
 						return "[a-z]+";
@@ -962,17 +958,17 @@ public class BukkitClasses {
 							Skript.error("'" + s + "' represents multiple materials");
 							return null;
 						}
-						
+
 						final ItemStack i = t.getRandom();
 						assert i != null;
 						return i;
 					}
-					
+
 					@Override
 					public String toString(final ItemStack i, final int flags) {
 						return ItemType.toString(i, flags);
 					}
-					
+
 					@Override
 					public String toVariableNameString(final ItemStack i) {
 						final StringBuilder b = new StringBuilder("item:");
@@ -985,7 +981,7 @@ public class BukkitClasses {
 						}
 						return "" + b.toString();
 					}
-					
+
 					@Override
 					public String getVariableNamePattern() {
 						return "item:.+";
@@ -1011,17 +1007,17 @@ public class BukkitClasses {
 					public Biome parse(final String s, final ParseContext context) {
 						return BiomeUtils.parse(s);
 					}
-					
+
 					@Override
 					public String toString(final Biome b, final int flags) {
 						return BiomeUtils.toString(b, flags);
 					}
-					
+
 					@Override
 					public String toVariableNameString(final Biome b) {
 						return "" + b.name();
 					}
-					
+
 					@Override
 					public String getVariableNamePattern() {
 						return "\\S+";
@@ -1029,7 +1025,7 @@ public class BukkitClasses {
 				})
 				.serializer(new EnumSerializer<>(Biome.class)));
 
-//		PotionEffect is not used; ItemType is used instead
+		// PotionEffect is not used; ItemType is used instead
 		Classes.registerClass(new ClassInfo<>(PotionEffectType.class, "potioneffecttype")
 				.user("potion( ?effect)?( ?type)?s?")
 				.name("Potion Effect Type")
@@ -1045,17 +1041,17 @@ public class BukkitClasses {
 					public PotionEffectType parse(final String s, final ParseContext context) {
 						return PotionEffectUtils.parseType(s);
 					}
-					
+
 					@Override
 					public String toString(final PotionEffectType p, final int flags) {
 						return PotionEffectUtils.toString(p, flags);
 					}
-					
+
 					@Override
 					public String toVariableNameString(final PotionEffectType p) {
 						return "" + p.getName();
 					}
-					
+
 					@Override
 					public String getVariableNamePattern() {
 						return ".+";
@@ -1068,17 +1064,17 @@ public class BukkitClasses {
 						f.putObject("name", o.getName());
 						return f;
 					}
-					
+
 					@Override
 					public boolean canBeInstantiated() {
 						return false;
 					}
-					
+
 					@Override
-					public void deserialize(final PotionEffectType o, final Fields f) throws StreamCorruptedException {
+					public void deserialize(final PotionEffectType o, final Fields f) {
 						assert false;
 					}
-					
+
 					@Override
 					protected PotionEffectType deserialize(final Fields fields) throws StreamCorruptedException {
 						final String name = fields.getObject("name", String.class);
@@ -1087,14 +1083,14 @@ public class BukkitClasses {
 							throw new StreamCorruptedException("Invalid PotionEffectType " + name);
 						return t;
 					}
-					
-//					return o.getName();
+
+					// return o.getName();
 					@Override
 					@Nullable
 					public PotionEffectType deserialize(final String s) {
 						return PotionEffectType.getByName(s);
 					}
-					
+
 					@Override
 					public boolean mustSyncDeserialization() {
 						return false;
@@ -1103,10 +1099,11 @@ public class BukkitClasses {
 
 		// REMIND make my own damage cause class (that e.g. stores the attacker entity, the projectile, or the attacking block)
 		Classes.registerClass(new ClassInfo<>(DamageCause.class, "damagecause")
-				.user("damage causes?")
+				.user("damage ?causes?")
 				.name("Damage Cause")
-				.description("The cause/type of a <a href='../events.html#damage'>damage event</a>, e.g. lava, fall, fire, drowning, explosion, poison, etc.",
-						"Please note that support for this type is very rudimentary, e.g. lava, fire and burning, as well as projectile and attack are considered different types.")
+				.description("The cause/type of a <a href='events.html#damage'>damage event</a>, e.g. lava, fall, fire, drowning, explosion, poison, etc.",
+						"Please note that support for this type is very rudimentary, e.g. lava, fire and burning, " +
+						"as well as projectile and attack are considered different types.")
 				.usage(DamageCauseUtils.getAllNames())
 				.examples("")
 				.since("2.0")
@@ -1118,17 +1115,17 @@ public class BukkitClasses {
 					public DamageCause parse(final String s, final ParseContext context) {
 						return DamageCauseUtils.parse(s);
 					}
-					
+
 					@Override
 					public String toString(final DamageCause d, final int flags) {
 						return DamageCauseUtils.toString(d, flags);
 					}
-					
+
 					@Override
 					public String toVariableNameString(final DamageCause d) {
 						return "" + d.name();
 					}
-					
+
 					@Override
 					public String getVariableNamePattern() {
 						return "[a-z0-9_-]+";
@@ -1149,31 +1146,29 @@ public class BukkitClasses {
 					public Chunk parse(final String s, final ParseContext context) {
 						return null;
 					}
-					
+
 					@Override
 					public boolean canParse(final ParseContext context) {
 						return false;
 					}
-					
+
 					@Override
 					public String toString(final Chunk c, final int flags) {
 						return "chunk (" + c.getX() + "," + c.getZ() + ") of " + c.getWorld().getName();
 					}
-					
+
 					@Override
 					public String toVariableNameString(final Chunk c) {
 						return c.getWorld().getName() + ":" + c.getX() + "," + c.getZ();
 					}
-					
+
 					@Override
 					public String getVariableNamePattern() {
 						return ".+:-?[0-9]+,-?[0-9]+";
 					}
 				})
 				.serializer(new Serializer<Chunk>() {
-					@SuppressWarnings("null")
 					@Override
-					@Nullable
 					public Fields serialize(final Chunk c) {
 						final Fields f = new Fields();
 						f.putObject("world", c.getWorld());
@@ -1181,17 +1176,17 @@ public class BukkitClasses {
 						f.putPrimitive("z", c.getZ());
 						return f;
 					}
-					
+
 					@Override
-					public void deserialize(final Chunk o, final Fields f) throws StreamCorruptedException {
+					public void deserialize(final Chunk o, final Fields f) {
 						assert false;
 					}
-					
+
 					@Override
 					public boolean canBeInstantiated() {
 						return false;
 					}
-					
+
 					@Override
 					protected Chunk deserialize(final Fields fields) throws StreamCorruptedException {
 						final World w = fields.getObject("world", World.class);
@@ -1201,8 +1196,8 @@ public class BukkitClasses {
 							throw new StreamCorruptedException();
 						return c;
 					}
-					
-//					return c.getWorld().getName() + ":" + c.getX() + "," + c.getZ();
+
+					// return c.getWorld().getName() + ":" + c.getX() + "," + c.getZ();
 					@Override
 					@Nullable
 					public Chunk deserialize(final String s) {
@@ -1220,7 +1215,7 @@ public class BukkitClasses {
 							return null;
 						}
 					}
-					
+
 					@Override
 					public boolean mustSyncDeserialization() {
 						return true;
@@ -1230,7 +1225,8 @@ public class BukkitClasses {
 		Classes.registerClass(new ClassInfo<>(Enchantment.class, "enchantment")
 				.user("enchantments?")
 				.name("Enchantment")
-				.description("An enchantment, e.g. 'sharpness' or 'furtune'. Unlike <a href='#enchantmenttype'>enchantment type</a> this type has no level, but you usually don't need to use this type anyway.")
+				.description("An enchantment, e.g. 'sharpness' or 'furtune'. Unlike <a href='#enchantmenttype'>enchantment type</a> " +
+						"this type has no level, but you usually don't need to use this type anyway.")
 				.usage(StringUtils.join(EnchantmentType.getNames(), ", "))
 				.examples("")
 				.since("1.4.6")
@@ -1241,17 +1237,17 @@ public class BukkitClasses {
 					public Enchantment parse(final String s, final ParseContext context) {
 						return EnchantmentType.parseEnchantment(s);
 					}
-					
+
 					@Override
 					public String toString(final Enchantment e, final int flags) {
 						return EnchantmentType.toString(e, flags);
 					}
-					
+
 					@Override
 					public String toVariableNameString(final Enchantment e) {
 						return "" + e.getName();
 					}
-					
+
 					@Override
 					public String getVariableNamePattern() {
 						return ".+";
@@ -1264,17 +1260,17 @@ public class BukkitClasses {
 						f.putObject("name", e.getName());
 						return f;
 					}
-					
+
 					@Override
 					public boolean canBeInstantiated() {
 						return false;
 					}
-					
+
 					@Override
-					public void deserialize(final Enchantment o, final Fields f) throws StreamCorruptedException {
+					public void deserialize(final Enchantment o, final Fields f) {
 						assert false;
 					}
-					
+
 					@Override
 					protected Enchantment deserialize(final Fields fields) throws StreamCorruptedException {
 						final String name = fields.getObject("name", String.class);
@@ -1283,8 +1279,8 @@ public class BukkitClasses {
 							throw new StreamCorruptedException("Invalid enchantment " + name);
 						return e;
 					}
-					
-//					return "" + e.getId();
+
+					// return "" + e.getId();
 					@Override
 					@Nullable
 					public Enchantment deserialize(final String s) {
@@ -1294,7 +1290,7 @@ public class BukkitClasses {
 							return null;
 						}
 					}
-					
+
 					@Override
 					public boolean mustSyncDeserialization() {
 						return false;
@@ -1306,19 +1302,18 @@ public class BukkitClasses {
 				.name(ClassInfo.NO_DOC)
 				.since("aliases-rework")
 				.serializer(new Serializer<Material>() {
-
 					@Override
-					public Fields serialize(Material o) throws NotSerializableException {
+					public Fields serialize(Material o) {
 						Fields f = new Fields();
 						f.putObject("i", o.ordinal());
 						return f;
 					}
 
 					@Override
-					public void deserialize(Material o, Fields f) throws StreamCorruptedException, NotSerializableException {
+					public void deserialize(Material o, Fields f) {
 						assert false;
 					}
-					
+
 					@Override
 					public Material deserialize(Fields f) throws StreamCorruptedException {
 						Material mat = allMaterials[(int) f.getPrimitive("i")];
@@ -1335,11 +1330,10 @@ public class BukkitClasses {
 					protected boolean canBeInstantiated() {
 						return false; // It is an enum, come on
 					}
-					
 				}));
 
 		Classes.registerClass(new ClassInfo<>(Metadatable.class, "metadataholder")
-				.user("metadata holders?")
+				.user("metadata ?holders?")
 				.name("Metadata Holder")
 				.description("Something that can hold metadata (e.g. an entity or block)")
 				.examples("set metadata value \"super cool\" of player to true")
@@ -1347,7 +1341,7 @@ public class BukkitClasses {
 
 		EnumUtils<TeleportCause> teleportCauses = new EnumUtils<>(TeleportCause.class, "teleport causes");
 		Classes.registerClass(new ClassInfo<>(TeleportCause.class, "teleportcause")
-				.user("teleport (cause|reason|type)s?")
+				.user("teleport ?(cause|reason|type)s?")
 				.name("Teleport Cause")
 				.description("The teleport cause in a <a href='events.html#teleport'>teleport</a> event.")
 				.examples(teleportCauses.getAllNames())
@@ -1378,7 +1372,7 @@ public class BukkitClasses {
 
 		EnumUtils<SpawnReason> spawnReasons = new EnumUtils<>(SpawnReason.class, "spawn reasons");
 		Classes.registerClass(new ClassInfo<>(SpawnReason.class, "spawnreason")
-				.user("spawn(ing)? reasons?")
+				.user("spawn(ing)? ?reasons?")
 				.name("Spawn Reason")
 				.description("The spawn reason in a <a href='events.html#spawn'>spawn</a> event.")
 				.examples(spawnReasons.getAllNames())
@@ -1443,6 +1437,73 @@ public class BukkitClasses {
 					}));
 		}
 
+		EnumUtils<FireworkEffect.Type> fireworktypes = new EnumUtils<>(FireworkEffect.Type.class, "firework types");
+		Classes.registerClass(new ClassInfo<>(FireworkEffect.Type.class, "fireworktype")
+				.user("firework ?types?")
+				.name("Firework Type")
+				.description("The type of a <a href='#fireworkeffect'>fireworkeffect</a>.")
+				.defaultExpression(new EventValueExpression<>(FireworkEffect.Type.class))
+				.examples(fireworktypes.getAllNames())
+				.since("INSERT VERSION")
+				.parser(new Parser<FireworkEffect.Type>() {
+					@Override
+					@Nullable
+					public FireworkEffect.Type parse(String input, ParseContext context) {
+						return fireworktypes.parse(input);
+					}
+
+					@Override
+					public String toString(FireworkEffect.Type type, int flags) {
+						return fireworktypes.toString(type, flags);
+					}
+
+					@SuppressWarnings("null")
+					@Override
+					public String toVariableNameString(FireworkEffect.Type type) {
+						return type.name();
+					}
+
+					@Override
+					public String getVariableNamePattern() {
+						return "\\S+";
+					}
+				})
+				.serializer(new EnumSerializer<>(FireworkEffect.Type.class)));
+
+		Classes.registerClass(new ClassInfo<>(FireworkEffect.class, "fireworkeffect")
+				.user("firework ?effects?")
+				.name("Firework Effect")
+				.description("A configuration of effects that defines the firework when exploded.")
+				.defaultExpression(new EventValueExpression<>(FireworkEffect.class))
+				.since("INSERT VERSION")
+				.parser(new Parser<FireworkEffect>() {
+					@Override
+					@Nullable
+					public FireworkEffect parse(String input, ParseContext context) {
+						return null;
+					}
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return false;
+					}
+
+					@Override
+					public String toString(FireworkEffect effect, int flags) {
+						return "Firework effect " + effect.toString();
+					}
+
+					@Override
+					public String toVariableNameString(FireworkEffect effect) {
+						return "firework effect " + effect.toString();
+					}
+
+					@Override
+					public String getVariableNamePattern() {
+						return "\\S+";
+					}
+				}));
+
 		EnumUtils<Difficulty> difficulties = new EnumUtils<>(Difficulty.class, "difficulties");
 		Classes.registerClass(new ClassInfo<>(Difficulty.class, "difficulty")
 				.user("difficult(y|ies)")
@@ -1451,13 +1512,12 @@ public class BukkitClasses {
 				.examples(difficulties.getAllNames())
 				.since("2.3")
 				.parser(new Parser<Difficulty>() {
-					
 					@Override
 					@Nullable
 					public Difficulty parse(final String input, final ParseContext context) {
 						return difficulties.parse(input);
 					}
-					
+
 					@Override
 					public String toString(Difficulty difficulty, int flags) {
 						return difficulties.toString(difficulty, flags);
@@ -1475,6 +1535,74 @@ public class BukkitClasses {
 					}
 				})
 				.serializer(new EnumSerializer<>(Difficulty.class)));
+
+		EnumUtils<PlayerResourcePackStatusEvent.Status> resourcePackStates = new EnumUtils<>(PlayerResourcePackStatusEvent.Status.class, "resource pack states");
+		Classes.registerClass(new ClassInfo<>(PlayerResourcePackStatusEvent.Status.class, "resourcepackstate")
+				.user("resource ?pack ?states?")
+				.name("Resource Pack State")
+				.description("The state in a <a href='events.html#resource_pack_request_action'>resource pack request response</a> event.")
+				.examples(resourcePackStates.getAllNames())
+				.since("INSERT VERSION")
+				.parser(new Parser<PlayerResourcePackStatusEvent.Status>() {
+					@Override
+					public String toString(PlayerResourcePackStatusEvent.Status state, int flags) {
+						return resourcePackStates.toString(state, flags);
+					}
+
+					@Override
+					@Nullable
+					public PlayerResourcePackStatusEvent.Status parse(final String s, final ParseContext context) {
+						return resourcePackStates.parse(s);
+					}
+
+					@SuppressWarnings("null")
+					@Override
+					public String toVariableNameString(PlayerResourcePackStatusEvent.Status state) {
+						return state.name();
+					}
+
+					@Override
+					public String getVariableNamePattern() {
+						return "\\S+";
+					}
+				})
+				.serializer(new EnumSerializer<>(PlayerResourcePackStatusEvent.Status.class)));
+
+		if (Skript.classExists("org.bukkit.SoundCategory")) {
+			EnumUtils<SoundCategory> soundCategories = new EnumUtils<>(SoundCategory.class, "sound categories");
+			Classes.registerClass(new ClassInfo<>(SoundCategory.class, "soundcategory")
+					.user("sound ?categor(y|ies)")
+					.name("Sound Category")
+					.description("The category of a sound, they are used for sound options of Minecraft. " +
+							"See the <a href='effects.html#EffPlaySound'>play sound</a> and <a href='effects.html#EffStopSound'>stop sound</a> effects.")
+					.examples(soundCategories.getAllNames())
+					.since("INSERT VERSION")
+					.requiredPlugins("Minecraft 1.11 or newer")
+					.parser(new Parser<SoundCategory>() {
+						@Override
+						public String toString(SoundCategory state, int flags) {
+							return soundCategories.toString(state, flags);
+						}
+
+						@Override
+						@Nullable
+						public SoundCategory parse(final String s, final ParseContext context) {
+							return soundCategories.parse(s);
+						}
+
+						@SuppressWarnings("null")
+						@Override
+						public String toVariableNameString(SoundCategory category) {
+							return category.name();
+						}
+
+						@Override
+						public String getVariableNamePattern() {
+							return "\\S+";
+						}
+					})
+					.serializer(new EnumSerializer<>(SoundCategory.class)));
+		}
 
 	}
 

--- a/src/main/java/ch/njol/skript/effects/EffPlaySound.java
+++ b/src/main/java/ch/njol/skript/effects/EffPlaySound.java
@@ -49,7 +49,7 @@ import ch.njol.util.Kleenean;
 		"Please note that sound names can get changed in any Minecraft or Spigot version, or even removed from Minecraft itself."})
 @Examples({"play sound \"block.note_block.pling\" # It is block.note.pling in 1.12.2",
 		"play sound \"entity.experience_orb.pickup\" with volume 0.5 to the player",
-		"play sound \"custom.music.1\" in category jukeboxes at {speakerBlock}"})
+		"play sound \"custom.music.1\" in jukebox category at {speakerBlock}"})
 @Since("2.2-dev28, INSERT VERSION (sound categories)")
 @RequiredPlugins("Minecraft 1.11+ (sound categories)")
 public class EffPlaySound extends Effect {
@@ -59,16 +59,16 @@ public class EffPlaySound extends Effect {
 	static {
 		if (SOUND_CATEGORIES_EXIST) {
 			Skript.registerEffect(EffPlaySound.class,
-					"play sound[s] %strings% [(in|from) category %-soundcategory%] " +
-							"[with volume %-number%] [(and|with) pitch %-number%] at %locations% [for %-players%]",
-					"play sound[s] %strings% [(in|from) category %-soundcategory%] " +
-							"[with volume %-number%] [(and|with) pitch %-number%] [(to|for) %players%] [(at|from) %-locations%]");
+					"play sound[s] %strings% [(in|from) %-soundcategory%] " +
+							"[(at|with) volume %-number%] [(and|at|with) pitch %-number%] at %locations% [for %-players%]",
+					"play sound[s] %strings% [(in|from) %-soundcategory%] " +
+							"[(at|with) volume %-number%] [(and|at|with) pitch %-number%] [(to|for) %players%] [(at|from) %-locations%]");
 		} else {
 			Skript.registerEffect(EffPlaySound.class,
-					"play sound[s] %strings% [with volume %-number%] " +
-							"[(and|with) pitch %-number%] at %locations% [for %-players%]",
-					"play sound[s] %strings% [with volume %-number%] " +
-							"[(and|with) pitch %-number%] [(to|for) %players%] [(at|from) %-locations%]");
+					"play sound[s] %strings% [(at|with) volume %-number%] " +
+							"[(and|at|with) pitch %-number%] at %locations% [for %-players%]",
+					"play sound[s] %strings% [(at|with) volume %-number%] " +
+							"[(and|at|with) pitch %-number%] [(to|for) %players%] [(at|from) %-locations%]");
 		}
 	}
 
@@ -200,16 +200,15 @@ public class EffPlaySound extends Effect {
 	public String toString(@Nullable Event e, boolean debug) {
 		if (locations != null)
 			return "play sound " + sounds.toString(e, debug) +
-					(category != null ? " in category " + category.toString(e, debug) : "") +
-					(volume != null ? " with volume " + volume.toString(e, debug) : "") +
-					(pitch != null ? " with pitch " + pitch.toString(e, debug) : "") +
+					(category != null ? " in " + category.toString(e, debug) : "") +
+					(volume != null ? " at volume " + volume.toString(e, debug) : "") +
+					(pitch != null ? " at pitch " + pitch.toString(e, debug) : "") +
 					(locations != null ? " at " + locations.toString(e, debug) : "") +
 					(players != null ? " for " + players.toString(e, debug) : "");
 		else
 			return "play sound " + sounds.toString(e, debug) +
-					(category != null ? " in category " + category.toString(e, debug) : "") +
-					(volume != null ? " with volume " + volume.toString(e, debug) : "") +
-					(pitch != null ? " with pitch " + pitch.toString(e, debug) : "") +
+					(volume != null ? " at volume " + volume.toString(e, debug) : "") +
+					(pitch != null ? " at pitch " + pitch.toString(e, debug) : "") +
 					(players != null ? " to " + players.toString(e, debug) : "");
 	}
 

--- a/src/main/java/ch/njol/skript/effects/EffStopSound.java
+++ b/src/main/java/ch/njol/skript/effects/EffStopSound.java
@@ -41,49 +41,72 @@ import ch.njol.util.Kleenean;
 @Name("Stop Sound")
 @Description({"Stops a sound from playing to the specified players. Both Minecraft sound names and " +
 		"<a href=\"https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Sound.html\">Spigot sound names</a> " +
-		"are supported. Playing resource packs sounds are supported too.",
+		"are supported. Resource pack sounds are supported too. The sound category is 'master' by default. " +
+		"A sound can't be stopped from a different category. ",
 		"",
 		"Please note that sound names can get changed in any Minecraft or Spigot version, or even removed from Minecraft itself."})
-@Examples({"stop sound \"block.chest.open\" from playing to player",
+@Examples({"stop sound \"block.chest.open\" for the player",
 		"stop playing sounds \"ambient.underwater.loop\" and \"ambient.underwater.loop.additions\" to the player"})
 @Since("INSERT VERSION")
-@RequiredPlugins("Minecraft 1.10.2 or newer")
+@RequiredPlugins("Minecraft 1.10.2+, Minecraft 1.11+ (sound categories)")
 public class EffStopSound extends Effect {
-
-	static {
-		if (Skript.methodExists(Player.class, "stopSound", String.class))
-			Skript.registerEffect(EffStopSound.class,
-					"stop sound[s] %strings% [(from playing to|for) %players%]",
-					"stop playing sound[s] %strings% [(to|for) %players%]");
-	}
 
 	private static final boolean SOUND_CATEGORIES_EXIST = Skript.classExists("org.bukkit.SoundCategory");
 
+	static {
+		if (Skript.methodExists(Player.class, "stopSound", String.class)) {
+			if (SOUND_CATEGORIES_EXIST) {
+				Skript.registerEffect(EffStopSound.class,
+						"stop sound[s] %strings% [(in|from) category %-soundcategory%] [(from playing to|for) %players%]",
+						"stop playing sound[s] %strings% [(in|from) category %-soundcategory%] [(to|for) %players%]");
+			} else {
+				Skript.registerEffect(EffStopSound.class,
+						"stop sound[s] %strings% [(in|from) category %-soundcategory%] [(from playing to|for) %players%]",
+						"stop playing sound[s] %strings% [(in|from) category %-soundcategory%] [(to|for) %players%]");
+			}
+		}
+	}
+
 	@SuppressWarnings("null")
 	private Expression<String> sounds;
+	@Nullable
+	private Expression<SoundCategory> category;
 	@SuppressWarnings("null")
 	private Expression<Player> players;
 
 	@Override
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"unchecked", "null"})
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		sounds = (Expression<String>) exprs[0];
-		players = (Expression<Player>) exprs[1];
+		if (SOUND_CATEGORIES_EXIST) {
+			category = (Expression<SoundCategory>) exprs[1];
+			players = (Expression<Player>) exprs[2];
+		} else {
+			players = (Expression<Player>) exprs[1];
+		}
 		return true;
 	}
 
 	@Override
 	protected void execute(Event e) {
+		Object category = null;
+		if (SOUND_CATEGORIES_EXIST) {
+			category = SoundCategory.MASTER;
+			if (this.category != null) {
+				category = this.category.getSingle(e);
+				if (category == null)
+					return;
+			}
+		}
 		for (String sound : sounds.getArray(e)) {
 			Sound soundEnum = null;
 			try {
 				soundEnum = Sound.valueOf(sound.toUpperCase(Locale.ENGLISH));
 			} catch (IllegalArgumentException ignored) {}
-			
 			if (soundEnum == null) {
 				if (SOUND_CATEGORIES_EXIST) {
 					for (Player p : players.getArray(e))
-						p.stopSound(sound, SoundCategory.MASTER);
+						p.stopSound(sound, (SoundCategory) category);
 				} else {
 					for (Player p : players.getArray(e))
 						p.stopSound(sound);
@@ -91,7 +114,7 @@ public class EffStopSound extends Effect {
 			} else {
 				if (SOUND_CATEGORIES_EXIST) {
 					for (Player p : players.getArray(e))
-						p.stopSound(soundEnum, SoundCategory.MASTER);
+						p.stopSound(soundEnum, (SoundCategory) category);
 				} else {
 					for (Player p : players.getArray(e))
 						p.stopSound(soundEnum);
@@ -102,9 +125,9 @@ public class EffStopSound extends Effect {
 
 	@Override
 	public String toString(@Nullable Event e, boolean debug) {
-		if (e != null)
-			return "stop sound " + sounds.toString(e, debug) + " from playing to " + players.toString(e, debug);
-		return "stop sound";
+		return "stop sound " + sounds.toString(e, debug) +
+				(category != null ? " in category " + category.toString(e, debug) : "") +
+				" from playing to " + players.toString(e, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffStopSound.java
+++ b/src/main/java/ch/njol/skript/effects/EffStopSound.java
@@ -57,12 +57,12 @@ public class EffStopSound extends Effect {
 		if (Skript.methodExists(Player.class, "stopSound", String.class)) {
 			if (SOUND_CATEGORIES_EXIST) {
 				Skript.registerEffect(EffStopSound.class,
-						"stop sound[s] %strings% [(in|from) category %-soundcategory%] [(from playing to|for) %players%]",
-						"stop playing sound[s] %strings% [(in|from) category %-soundcategory%] [(to|for) %players%]");
+						"stop sound[s] %strings% [(in|from) %-soundcategory%] [(from playing to|for) %players%]",
+						"stop playing sound[s] %strings% [(in|from) %-soundcategory%] [(to|for) %players%]");
 			} else {
 				Skript.registerEffect(EffStopSound.class,
-						"stop sound[s] %strings% [(in|from) category %-soundcategory%] [(from playing to|for) %players%]",
-						"stop playing sound[s] %strings% [(in|from) category %-soundcategory%] [(to|for) %players%]");
+						"stop sound[s] %strings% [(in|from) %-soundcategory%] [(from playing to|for) %players%]",
+						"stop playing sound[s] %strings% [(in|from) %-soundcategory%] [(to|for) %players%]");
 			}
 		}
 	}
@@ -126,7 +126,7 @@ public class EffStopSound extends Effect {
 	@Override
 	public String toString(@Nullable Event e, boolean debug) {
 		return "stop sound " + sounds.toString(e, debug) +
-				(category != null ? " in category " + category.toString(e, debug) : "") +
+				(category != null ? " in " + category.toString(e, debug) : "") +
 				" from playing to " + players.toString(e, debug);
 	}
 

--- a/src/main/java/ch/njol/skript/effects/EffStopSound.java
+++ b/src/main/java/ch/njol/skript/effects/EffStopSound.java
@@ -1,0 +1,110 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.effects;
+
+import java.util.Locale;
+
+import org.bukkit.Sound;
+import org.bukkit.SoundCategory;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.RequiredPlugins;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+
+@Name("Stop Sound")
+@Description({"Stops a sound from playing to the specified players. Both Minecraft sound names and " +
+		"<a href=\"https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Sound.html\">Spigot sound names</a> " +
+		"are supported. Playing resource packs sounds are supported too.",
+		"",
+		"Please note that sound names can get changed in any Minecraft or Spigot version, or even removed from Minecraft itself."})
+@Examples({"stop sound \"block.chest.open\" from playing to player",
+		"stop playing sounds \"ambient.underwater.loop\" and \"ambient.underwater.loop.additions\" to the player"})
+@Since("INSERT VERSION")
+@RequiredPlugins("Minecraft 1.10.2 or newer")
+public class EffStopSound extends Effect {
+
+	static {
+		if (Skript.methodExists(Player.class, "stopSound", String.class))
+			Skript.registerEffect(EffStopSound.class,
+					"stop sound[s] %strings% [(from playing to|for) %players%]",
+					"stop playing sound[s] %strings% [(to|for) %players%]");
+	}
+
+	private static final boolean SOUND_CATEGORIES_EXIST = Skript.classExists("org.bukkit.SoundCategory");
+
+	@SuppressWarnings("null")
+	private Expression<String> sounds;
+	@SuppressWarnings("null")
+	private Expression<Player> players;
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		sounds = (Expression<String>) exprs[0];
+		players = (Expression<Player>) exprs[1];
+		return true;
+	}
+
+	@Override
+	protected void execute(Event e) {
+		for (String sound : sounds.getArray(e)) {
+			Sound soundEnum = null;
+			try {
+				soundEnum = Sound.valueOf(sound.toUpperCase(Locale.ENGLISH));
+			} catch (IllegalArgumentException ignored) {}
+			
+			if (soundEnum == null) {
+				if (SOUND_CATEGORIES_EXIST) {
+					for (Player p : players.getArray(e))
+						p.stopSound(sound, SoundCategory.MASTER);
+				} else {
+					for (Player p : players.getArray(e))
+						p.stopSound(sound);
+				}
+			} else {
+				if (SOUND_CATEGORIES_EXIST) {
+					for (Player p : players.getArray(e))
+						p.stopSound(soundEnum, SoundCategory.MASTER);
+				} else {
+					for (Player p : players.getArray(e))
+						p.stopSound(soundEnum);
+				}
+			}
+		}
+	}
+
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		if (e != null)
+			return "stop sound " + sounds.toString(e, debug) + " from playing to " + players.toString(e, debug);
+		return "stop sound";
+	}
+
+}

--- a/src/main/java/ch/njol/skript/lang/Expression.java
+++ b/src/main/java/ch/njol/skript/lang/Expression.java
@@ -285,15 +285,20 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 			for (int i = 0; i < delta.length; i++) {
 				Object value = delta[i];
 				if (value instanceof Slot) {
+					ItemStack item = ((Slot) value).getItem();
+					if (item != null) {
+						item = item.clone(); // ItemStack in inventory is mutable
+					}
+					
 					if (newDelta != null) { // Always store to new array if it has been initialized
-						newDelta[i] =  ((Slot) value).getItem();
+						newDelta[i] = item;
 					} else if (!delta.getClass().getComponentType().isAssignableFrom(ItemStack.class)) {
 						// Initialize new delta to avoid storing incompatible type to array
 						newDelta = new Object[delta.length];
 						System.arraycopy(delta, 0, newDelta, 0, i); // Copy previously processed elements
-						newDelta[i] =  ((Slot) value).getItem(); // Convert this slot to item
+						newDelta[i] = item; // Convert this slot to item
 					} else {
-						delta[i] =  ((Slot) value).getItem();
+						delta[i] = item;
 					}
 				} else if (value instanceof ItemType) {
 					delta[i] = ((ItemType) value).clone();

--- a/src/main/java/ch/njol/skript/lang/SkriptEventInfo.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptEventInfo.java
@@ -126,7 +126,7 @@ public final class SkriptEventInfo<E extends SkriptEvent> extends SyntaxElementI
 	}
 
 	/**
-	 * A non critical ID remapping for syntax elements register using the a class multiple times.
+	 * A non critical ID remapping for syntax elements register using the same class multiple times.
 	 *
 	 * Only used for Skript's documentation.
 	 *
@@ -140,7 +140,7 @@ public final class SkriptEventInfo<E extends SkriptEvent> extends SyntaxElementI
 	}
 
 	/**
-	 * Other plugin dependencies for a syntax element
+	 * Other plugin dependencies for this SkriptEvent.
 	 *
 	 * Only used for Skript's documentation.
 	 *

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -1364,6 +1364,34 @@ difficulties:
 	hard: hard
 	peaceful: peaceful
 
+# -- Firework types --
+firework types:
+	ball_large: large ball, ball large, large
+	creeper: creeper, creeper face
+	ball: ball, small, small ball
+	star: star, star shaped
+	burst: burst
+
+# -- Resource Pack States --
+resource pack states:
+	accepted: accept, accepted
+	declined: decline, refuse, reject, declined, refused, rejected
+	failed_download: download fail, fail, failed to download, failed
+	successfully_loaded: successfully load, successfully install, success, successfully loaded, successfully installed
+
+# -- Sound Categories --
+sound categories:
+	ambient: ambient, environment
+	blocks: block, blocks
+	hostile: hostile, hostile creature, hostile creatures, hostile mob, hostile mobs
+	master: master, master volume
+	music: music
+	neutral: neutral, friendly creature, friendly creatures, friendly mob, friendly mobs
+	players: player, players
+	records: record, records, jukebox, jukeboxes, noteblock, noteblocks, note block, note blocks
+	voice: voice, speech
+	weather: weather
+
 # -- Boolean --
 boolean:
 	true:
@@ -1416,7 +1444,11 @@ types:
 	metadataholder: metadata holder¦s @a
 	spawnreason: spawn reason¦s @a
 	cachedservericon: server icon¦s @a
-	difficulty: (difficulty|difficulties) @a
+	difficulty: difficult¦y¦ies @a
+	fireworkeffect: firework effect¦s @a
+	fireworktype: firework type¦s @a
+	resourcepackstate: resource pack state¦s @a
+	soundcategory: sound categor¦y¦ies @a
 	
 	# Skript
 	weathertype: weather type¦s @a
@@ -1436,7 +1468,6 @@ types:
 	experience.pattern: (e?xp|experience( points?)?)
 	classinfo: type¦s @a
 	visualeffect: visual effect¦s @a
-
 	
 	# Hooks
 	money: money
@@ -1446,4 +1477,3 @@ types:
 io exceptions:
 	unknownhostexception: Cannot connect to %s
 	accessdeniedexception: Access denied for %s
-

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -1381,16 +1381,16 @@ resource pack states:
 
 # -- Sound Categories --
 sound categories:
-	ambient: ambient, environment
-	blocks: block, blocks
-	hostile: hostile, hostile creature, hostile creatures, hostile mob, hostile mobs
-	master: master, master volume
-	music: music
-	neutral: neutral, friendly creature, friendly creatures, friendly mob, friendly mobs
-	players: player, players
-	records: record, records, jukebox, jukeboxes, noteblock, noteblocks, note block, note blocks
-	voice: voice, speech
-	weather: weather
+	ambient: ambient category, environment category
+	blocks: block category, blocks category
+	hostile: hostile category, hostile creature category, hostile creatures category, hostile mob category, hostile mobs category
+	master: master category, master volume category
+	music: music category
+	neutral: neutral category, friendly creature category, friendly creatures category, friendly mob category, friendly mobs category
+	players: player category, players category
+	records: record category, records category, jukebox category, jukeboxes category, noteblock category, noteblocks category, note block category, note blocks category
+	voice: voice category, speech category
+	weather: weather category
 
 # -- Boolean --
 boolean:


### PR DESCRIPTION
### Description
* Fixes the issues with play sound effect and improves its code
* Adds more description and examples to the play sound effect
* Adds multiple sounds support to the play sound effect
* Adds multiple locations support to the play sound effect
* Adds ability to specify sound category in the play sound effect
* Adds ability to playing sounds to players without specifying a location as suggested by @TheLimeGlass in #1921.
* Adds stop sound effect
* Adds sound category enum type, used in play and stop sound effects
* Adds requiredPlugins method to ClassInfo because i needed it for the sound category type
* Fixes inconsistent empty line indentations in BukkitClasses, cleans up its code

---
**Target Minecraft Versions:** any, 1.10.2+ for Stop Sound, 1.11+ for sound categories
**Requirements:** none
**Related Issues:** #1914 and  #1949
