### PR TITLE
Event-CanBuildCheck

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -354,6 +354,16 @@ public final class BukkitEventValues {
 				return new BlockStateBlock(s, true);
 			}
 		}, 0);
+		// The .getPlayer() was added in 1.13
+		if (Skript.isRunningMinecraft(1, 13)) {
+			EventValues.registerEventValue(BlockCanBuildEvent.class, Player.class, new Getter<Player, BlockCanBuildEvent>() {
+				@Override
+				@Nullable
+				public Player get(final BlockCanBuildEvent e) {
+					return e.getPlayer();
+				}
+			}, 0);
+		}
 		// SignChangeEvent
 		EventValues.registerEventValue(SignChangeEvent.class, Player.class, new Getter<Player, SignChangeEvent>() {
 			@Override


### PR DESCRIPTION
### Description
In the `can build check event`, there is no event value for player.
This was previously reported and said it couldn't be fixed, because until 1.13 there was no `getPlayer()` method. This has now been added.

---
**Target Minecraft Versions:**  1.13+
**Requirements:**  none
**Related Issues:** #375