### PR TITLE
Fix inventory name

### DIFF
--- a/src/main/java/ch/njol/skript/entity/SimpleEntityData.java
+++ b/src/main/java/ch/njol/skript/entity/SimpleEntityData.java
@@ -296,8 +296,8 @@ public class SimpleEntityData extends EntityData<Entity> {
 		types.add(new SimpleEntityDataInfo("human", HumanEntity.class, true));
 		types.add(new SimpleEntityDataInfo("damageable", Damageable.class, true));
 		types.add(new SimpleEntityDataInfo("monster", Monster.class, true)); //I don't know why Njol never included that. I did now ^^
-		if (Skript.classExists("org.bukkit.entity.Mob")) // Apparently not in 1.9.4
-			types.add(new SimpleEntityDataInfo("mob", Mob.class, true)); //Same goes for this one
+		if (Skript.classExists("org.bukkit.entity.Mob"))
+			types.add(new SimpleEntityDataInfo("mob", Mob.class, true));
 		types.add(new SimpleEntityDataInfo("creature", Creature.class, true));
 		types.add(new SimpleEntityDataInfo("animal", Animals.class, true));
 		types.add(new SimpleEntityDataInfo("golem", Golem.class, true));

--- a/src/main/java/ch/njol/skript/entity/SimpleEntityData.java
+++ b/src/main/java/ch/njol/skript/entity/SimpleEntityData.java
@@ -296,7 +296,8 @@ public class SimpleEntityData extends EntityData<Entity> {
 		types.add(new SimpleEntityDataInfo("human", HumanEntity.class, true));
 		types.add(new SimpleEntityDataInfo("damageable", Damageable.class, true));
 		types.add(new SimpleEntityDataInfo("monster", Monster.class, true)); //I don't know why Njol never included that. I did now ^^
-		types.add(new SimpleEntityDataInfo("mob", Mob.class, true)); //Same goes for this one
+		if (Skript.classExists("org.bukkit.entity.Mob")) // Apparently not in 1.9.4
+			types.add(new SimpleEntityDataInfo("mob", Mob.class, true)); //Same goes for this one
 		types.add(new SimpleEntityDataInfo("creature", Creature.class, true));
 		types.add(new SimpleEntityDataInfo("animal", Animals.class, true));
 		types.add(new SimpleEntityDataInfo("golem", Golem.class, true));

--- a/src/main/java/ch/njol/skript/expressions/ExprName.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprName.java
@@ -69,13 +69,16 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprName extends SimplePropertyExpression<Object, String> {
 	
 	private static final boolean inventoryTitles = Skript.methodExists(Inventory.class, "getTitle");
+	
 	@SuppressWarnings("null")
-	private static Method TITLE_METHOD;
+	private static final Method TITLE_METHOD;
 	
 	static {
+		Method _METHOD = null;
 		try {
-			TITLE_METHOD = Inventory.class.getMethod("getName");
+			_METHOD = Inventory.class.getMethod("getName");
 		} catch (NoSuchMethodException ignore) {}
+		TITLE_METHOD = _METHOD;
 	}
 	
 	final static int ITEMSTACK = 1, ENTITY = 2, PLAYER = 4, INVENTORY = 8;

--- a/src/main/java/ch/njol/skript/expressions/ExprName.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprName.java
@@ -70,11 +70,11 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 	
 	private static final boolean inventoryTitles = Skript.methodExists(Inventory.class, "getTitle");
 	@SuppressWarnings("null")
-	private static Method getTitle;
+	private static Method TITLE_METHOD;
 	
 	static {
 		try {
-			getTitle = Inventory.class.getMethod("getName");
+			TITLE_METHOD = Inventory.class.getMethod("getName");
 		} catch (NoSuchMethodException ignore) {}
 	}
 	
@@ -137,7 +137,7 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 						return ((Inventory) o).getViewers().get(0).getOpenInventory().getTitle();
 					else {
 						try {
-							return ((String) getTitle.invoke(o));
+							return ((String) TITLE_METHOD.invoke(o));
 						} catch (IllegalAccessException e) {
 							assert false;
 							return null;
@@ -203,7 +203,7 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 						return ((Inventory) o).getViewers().get(0).getOpenInventory().getTitle();
 					else {
 						try {
-							return ((String) getTitle.invoke(o));
+							return ((String) TITLE_METHOD.invoke(o));
 						} catch (IllegalAccessException e) {
 							assert false;
 							return null;

--- a/src/main/java/ch/njol/skript/expressions/ExprName.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprName.java
@@ -138,8 +138,11 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 					else {
 						try {
 							return ((String) getTitle.invoke(o));
-						} catch (IllegalAccessException | InvocationTargetException e) {
-							e.printStackTrace();
+						} catch (IllegalAccessException e) {
+							assert false;
+							return null;
+						} catch (InvocationTargetException e) {
+							Skript.exception(e);
 							return null;
 						}
 					}
@@ -201,8 +204,11 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 					else {
 						try {
 							return ((String) getTitle.invoke(o));
-						} catch (IllegalAccessException | InvocationTargetException e) {
-							e.printStackTrace();
+						} catch (IllegalAccessException e) {
+							assert false;
+							return null;
+						} catch (InvocationTargetException e) {
+							Skript.exception(e);
 							return null;
 						}
 					}

--- a/src/main/java/ch/njol/skript/expressions/ExprName.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprName.java
@@ -19,8 +19,9 @@
  */
 package ch.njol.skript.expressions;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -71,13 +72,13 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 	private static final boolean inventoryTitles = Skript.methodExists(Inventory.class, "getTitle");
 	
 	@Nullable
-	private static final Method TITLE_METHOD;
+	private static final MethodHandle TITLE_METHOD;
 	
 	static {
-		Method _METHOD = null;
+		MethodHandle _METHOD = null;
 		try {
-			_METHOD = Inventory.class.getMethod("getName");
-		} catch (NoSuchMethodException ignore) {}
+			_METHOD = MethodHandles.lookup().findVirtual(Inventory.class, "getName", MethodType.methodType(String.class));
+		} catch (IllegalAccessException | NoSuchMethodException ignore) {}
 		TITLE_METHOD = _METHOD;
 	}
 	
@@ -145,7 +146,7 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 						} catch (IllegalAccessException e) {
 							assert false;
 							return null;
-						} catch (InvocationTargetException e) {
+						} catch (Throwable e) {
 							Skript.exception(e);
 							return null;
 						}
@@ -212,7 +213,7 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 						} catch (IllegalAccessException e) {
 							assert false;
 							return null;
-						} catch (InvocationTargetException e) {
+						} catch (Throwable e) {
 							Skript.exception(e);
 							return null;
 						}

--- a/src/main/java/ch/njol/skript/expressions/ExprName.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprName.java
@@ -70,7 +70,7 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 	
 	private static final boolean inventoryTitles = Skript.methodExists(Inventory.class, "getTitle");
 	
-	@SuppressWarnings("null")
+	@Nullable
 	private static final Method TITLE_METHOD;
 	
 	static {
@@ -140,6 +140,7 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 						return ((Inventory) o).getViewers().get(0).getOpenInventory().getTitle();
 					else {
 						try {
+							assert TITLE_METHOD != null;
 							return ((String) TITLE_METHOD.invoke(o));
 						} catch (IllegalAccessException e) {
 							assert false;
@@ -206,6 +207,7 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 						return ((Inventory) o).getViewers().get(0).getOpenInventory().getTitle();
 					else {
 						try {
+							assert TITLE_METHOD != null;
 							return ((String) TITLE_METHOD.invoke(o));
 						} catch (IllegalAccessException e) {
 							assert false;


### PR DESCRIPTION
### Description
Due to the removal of Inventory#getTitle in 1.14, inventory names were no longer available.
With the help of Wheezy I was able to bring this back.

---
**Target Minecraft Versions:** Any
**Requirements:** None
**Related Issues:** #2069 

### Note:
- When I added the MOB entity class, I didn't realize it wasn't in 1.9.4 so I put a condition in for that as well. I know it's not related but it was such a tiny little fix I didn't want to another small PR for that.