### PR TITLE
NewBlockCompat - Fixes

### DIFF
--- a/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
@@ -228,7 +229,7 @@ public class NewBlockCompat implements BlockCompat {
 				}
 				
 				// Top-down bisected blocks (doors etc.)
-				if (Bisected.class.isAssignableFrom(dataType)) {
+				if (Bisected.class.isAssignableFrom(dataType) && !Tag.STAIRS.isTagged(type) && !Tag.TRAPDOORS.isTagged(type)) {
 					Bisected data;
 					if (ourValues != null)
 						data = (Bisected) ourValues.data;


### PR DESCRIPTION
### Description
There was an issue where when setting a block to stairs, it would place a stair block, and a mirrored stair block above it.
I was told this was an issue due to Stairs and Trapdoors were extending the Bisected class.
Fixed this issue by ignoring stairs and trap doors when checking for bisected blocks.

---
**Target Minecraft Versions:** Target fix for 1.13+
**Requirements:** none
**Related Issues:**  #1977 
