### PR TITLE
EffDrop - Fixes

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffDrop.java
+++ b/src/main/java/ch/njol/skript/effects/EffDrop.java
@@ -54,10 +54,8 @@ import ch.njol.util.Kleenean;
 @Since("1.0")
 public class EffDrop extends Effect {
 	static {
-		Skript.registerEffect(EffDrop.class, "drop %itemtypes% [%directions% %locations%]",
-				"drop %itemtypes% [%directions% %locations%] without velocity",
-				"drop %experience% [%directions% %locations%]",
-				"drop %experience% [%directions% %locations%] without velocity");
+		Skript.registerEffect(EffDrop.class, "drop %itemtypes/experiences% [%directions% %locations%]",
+				"drop %itemtypes/experiences% [%directions% %locations%] without velocity");
 	}
 	
 	@Nullable

--- a/src/main/java/ch/njol/skript/effects/EffDrop.java
+++ b/src/main/java/ch/njol/skript/effects/EffDrop.java
@@ -54,8 +54,10 @@ import ch.njol.util.Kleenean;
 @Since("1.0")
 public class EffDrop extends Effect {
 	static {
-		Skript.registerEffect(EffDrop.class, "drop %itemtypes/experience% [%directions% %locations%]",
-				"drop %itemtypes/experience% [%directions% %locations%] without velocity");
+		Skript.registerEffect(EffDrop.class, "drop %itemtypes% [%directions% %locations%]",
+				"drop %itemtypes% [%directions% %locations%] without velocity",
+				"drop %experience% [%directions% %locations%]",
+				"drop %experience% [%directions% %locations%] without velocity");
 	}
 	
 	@Nullable


### PR DESCRIPTION
### Description
- Fix issue with not being able to drop from a list variable
- Based on what I could see and my testing, the issue came from `"%itemtypes/experience%"`, it looks like the issue was the fact we have 2 types, one which is plural (item types) and one which is singular (experience). My guess the reason its denying the list variable, is because the variable could be either a list of items or a single experience, and at the time of init, the variable's contents are unknown. By allowing multiple experiences this issue is fixed.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #1917 