### PR TITLE
ExprTypeOf - Fix

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprTypeOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTypeOf.java
@@ -19,6 +19,7 @@
  */
 package ch.njol.skript.expressions;
 
+import org.bukkit.block.Block;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.eclipse.jdt.annotation.Nullable;
@@ -43,7 +44,7 @@ import edu.umd.cs.findbugs.ba.bcp.New;
 @Since("1.4")
 public class ExprTypeOf extends SimplePropertyExpression<Object, Object> {
 	static {
-		register(ExprTypeOf.class, Object.class, "type", "entitydatas/itemstacks/inventories");
+		register(ExprTypeOf.class, Object.class, "type", "entitydatas/itemstacks/inventories/blocks");
 	}
 	
 	@Override
@@ -60,6 +61,8 @@ public class ExprTypeOf extends SimplePropertyExpression<Object, Object> {
 			return new ItemStack(((ItemStack) o).getType(), 1, ((ItemStack) o).getDurability());
 		} else if (o instanceof Inventory) {
 			return ((Inventory) o).getType();
+		} else if (o instanceof Block) {
+			return new ItemStack(((Block) o).getType(), 1, ((Block) o).getData());
 		}
 		assert false;
 		return null;

--- a/src/main/java/ch/njol/skript/expressions/ExprTypeOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTypeOf.java
@@ -24,6 +24,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.eclipse.jdt.annotation.Nullable;
 
+import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -62,7 +63,7 @@ public class ExprTypeOf extends SimplePropertyExpression<Object, Object> {
 		} else if (o instanceof Inventory) {
 			return ((Inventory) o).getType();
 		} else if (o instanceof Block) {
-			return new ItemStack(((Block) o).getType(), 1, ((Block) o).getData());
+			return new ItemType((Block) o);
 		}
 		assert false;
 		return null;


### PR DESCRIPTION
### Description
- Fixed `type of %block%` returning `<none>`

---
**Target Minecraft Versions:** all
**Requirements:** none
**Related Issues:** #2105 