### PR TITLE
ExprViewDistance - New

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprPlayerViewDistance.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPlayerViewDistance.java
@@ -113,7 +113,7 @@ public class ExprPlayerViewDistance extends PropertyExpression<Player, Number> {
 	
 	@Override
 	public String toString(@Nullable Event e, boolean debug) {
-		return "the view distance of " + getExpr().toString(e, d);
+		return "the view distance of " + getExpr().toString(e, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprPlayerViewDistance.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPlayerViewDistance.java
@@ -44,11 +44,11 @@ import ch.njol.util.coll.CollectionUtils;
 		"reset view distance of all players", "add 2 to view distance of player"})
 @RequiredPlugins("Paper 1.9-1.13.2")
 @Since("INSERT VERSION")
-public class ExprPlayerViewDistance extends PropertyExpression<Player, Integer> {
+public class ExprPlayerViewDistance extends PropertyExpression<Player, Number> {
 	
 	static {
 		if (Skript.methodExists(Player.class, "getViewDistance"))
-			register(ExprPlayerViewDistance.class, Integer.class, "view distance", "players");
+			register(ExprPlayerViewDistance.class, Number.class, "view distance", "players");
 	}
 	
 	@Override
@@ -59,7 +59,7 @@ public class ExprPlayerViewDistance extends PropertyExpression<Player, Integer> 
 	}
 	
 	@Override
-	protected Integer[] get(Event e, Player[] source) {
+	protected Number[] get(Event e, Player[] source) {
 		return get(source, new Getter<Integer, Player>() {
 			@SuppressWarnings("null")
 			@Override
@@ -107,8 +107,8 @@ public class ExprPlayerViewDistance extends PropertyExpression<Player, Integer> 
 	}
 	
 	@Override
-	public Class<? extends Integer> getReturnType() {
-		return Integer.class;
+	public Class<? extends Number> getReturnType() {
+		return Number.class;
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprPlayerViewDistance.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPlayerViewDistance.java
@@ -29,6 +29,7 @@ import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.RequiredPlugins;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.PropertyExpression;
 import ch.njol.skript.lang.Expression;
@@ -37,10 +38,11 @@ import ch.njol.skript.util.Getter;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 
-@Name("Player View Distance")
-@Description("The view distance of a player. This expression requires PaperMC.")
+@Name("View Distance")
+@Description("The view distance of a player. Can be changed.")
 @Examples({"set view distance of player to 10", "set {_view} to view distance of player",
 		"reset view distance of all players", "add 2 to view distance of player"})
+@RequiredPlugins("Paper 1.9-1.13.2")
 @Since("INSERT VERSION")
 public class ExprPlayerViewDistance extends PropertyExpression<Player, Integer> {
 	
@@ -49,8 +51,8 @@ public class ExprPlayerViewDistance extends PropertyExpression<Player, Integer> 
 			register(ExprPlayerViewDistance.class, Integer.class, "view distance", "players");
 	}
 	
-	@SuppressWarnings({"unchecked", "null"})
 	@Override
+	@SuppressWarnings({"unchecked", "null"})
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
 		setExpr((Expression<Player>) exprs[0]);
 		return true;
@@ -67,12 +69,18 @@ public class ExprPlayerViewDistance extends PropertyExpression<Player, Integer> 
 		});
 	}
 	
-	@Nullable
 	@Override
+	@Nullable
 	public Class<?>[] acceptChange(ChangeMode mode) {
-		if (mode == ChangeMode.REMOVE_ALL)
-			return null;
-		return CollectionUtils.array(Number.class);
+		switch (mode) {
+			case DELETE:
+			case SET:
+			case ADD:
+			case REMOVE:
+			case RESET:
+				return CollectionUtils.array(Number.class);
+		}
+		return null;
 	}
 	
 	@Override
@@ -81,27 +89,20 @@ public class ExprPlayerViewDistance extends PropertyExpression<Player, Integer> 
 		switch (mode) {
 			case DELETE:
 			case SET:
-				for (Player player : getExpr().getArray(e)) {
+				for (Player player : getExpr().getArray(e))
 					player.setViewDistance(distance);
-				}
 				break;
 			case ADD:
-				for (Player player : getExpr().getArray(e)) {
+				for (Player player : getExpr().getArray(e))
 					player.setViewDistance(player.getViewDistance() + distance);
-				}
 				break;
 			case REMOVE:
-				for (Player player : getExpr().getArray(e)) {
+				for (Player player : getExpr().getArray(e))
 					player.setViewDistance(player.getViewDistance() - distance);
-				}
 				break;
 			case RESET:
-				for (Player player : getExpr().getArray(e)) {
+				for (Player player : getExpr().getArray(e))
 					player.setViewDistance(Bukkit.getServer().getViewDistance());
-				}
-				break;
-			case REMOVE_ALL:
-				assert false;
 		}
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprPlayerViewDistance.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPlayerViewDistance.java
@@ -112,7 +112,7 @@ public class ExprPlayerViewDistance extends PropertyExpression<Player, Number> {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean d) {
+	public String toString(@Nullable Event e, boolean debug) {
 		return "the view distance of " + getExpr().toString(e, d);
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprPlayerViewDistance.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPlayerViewDistance.java
@@ -1,0 +1,118 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.expressions;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.PropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.util.Getter;
+import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
+
+@Name("Player View Distance")
+@Description("The view distance of a player. This expression requires PaperMC.")
+@Examples({"set view distance of player to 10", "set {_view} to view distance of player",
+		"reset view distance of all players", "add 2 to view distance of player"})
+@Since("INSERT VERSION")
+public class ExprPlayerViewDistance extends PropertyExpression<Player, Integer> {
+	
+	static {
+		if (Skript.methodExists(Player.class, "getViewDistance"))
+			register(ExprPlayerViewDistance.class, Integer.class, "view distance", "players");
+	}
+	
+	@SuppressWarnings({"unchecked", "null"})
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		setExpr((Expression<Player>) exprs[0]);
+		return true;
+	}
+	
+	@Override
+	protected Integer[] get(Event e, Player[] source) {
+		return get(source, new Getter<Integer, Player>() {
+			@SuppressWarnings("null")
+			@Override
+			public Integer get(Player arg) {
+				return arg.getViewDistance();
+			}
+		});
+	}
+	
+	@Nullable
+	@Override
+	public Class<?>[] acceptChange(ChangeMode mode) {
+		if (mode == ChangeMode.REMOVE_ALL)
+			return null;
+		return CollectionUtils.array(Number.class);
+	}
+	
+	@Override
+	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+		int distance = delta == null ? 0 : ((Number) delta[0]).intValue();
+		switch (mode) {
+			case DELETE:
+			case SET:
+				for (Player player : getExpr().getArray(e)) {
+					player.setViewDistance(distance);
+				}
+				break;
+			case ADD:
+				for (Player player : getExpr().getArray(e)) {
+					player.setViewDistance(player.getViewDistance() + distance);
+				}
+				break;
+			case REMOVE:
+				for (Player player : getExpr().getArray(e)) {
+					player.setViewDistance(player.getViewDistance() - distance);
+				}
+				break;
+			case RESET:
+				for (Player player : getExpr().getArray(e)) {
+					player.setViewDistance(Bukkit.getServer().getViewDistance());
+				}
+				break;
+			case REMOVE_ALL:
+				assert false;
+		}
+	}
+	
+	@Override
+	public Class<? extends Integer> getReturnType() {
+		return Integer.class;
+	}
+	
+	@Override
+	public String toString(@Nullable Event e, boolean d) {
+		return "the view distance of " + getExpr().toString(e, d);
+	}
+	
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprPlayerViewDistance.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPlayerViewDistance.java
@@ -48,7 +48,7 @@ public class ExprPlayerViewDistance extends PropertyExpression<Player, Number> {
 	
 	static {
 		if (Skript.methodExists(Player.class, "getViewDistance"))
-			register(ExprPlayerViewDistance.class, Number.class, "view distance", "players");
+			register(ExprPlayerViewDistance.class, Number.class, "view distance[s]", "players");
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprPlayerViewDistance.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPlayerViewDistance.java
@@ -85,7 +85,7 @@ public class ExprPlayerViewDistance extends PropertyExpression<Player, Number> {
 	
 	@Override
 	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
-		int distance = delta == null ? 0 : ((Number) delta[0]).intValue();
+		int distance = delta == null ? 0 : (int) delta[0];
 		switch (mode) {
 			case DELETE:
 			case SET:


### PR DESCRIPTION
### Description
- New expression for view distance of player

---
**Target Minecraft Versions:** All (see notes for 1.14.x)
**Requirements:** Requires PaperMC
**Related Issues:** #2010 

### Notes:
- This is currently not working in PaperMC 1.14+
- They removed it from 1.14 with the intention to re-add it back in the future.  (See [**paper**](https://github.com/PaperMC/Paper/issues/2098))
For now this expression will work on 1.9-1.13.2