### PR TITLE
EvtClick - Fixes

### DIFF
--- a/src/main/java/ch/njol/skript/events/EvtClick.java
+++ b/src/main/java/ch/njol/skript/events/EvtClick.java
@@ -189,6 +189,13 @@ public class EvtClick extends SkriptEvent {
 				}
 			}
 			
+			if (tools != null && !tools.check(e, t -> {
+				ItemStack mainHand = clickEvent.getPlayer().getInventory().getItemInMainHand();
+				return t.isOfType(mainHand);
+			})) {
+				return false;
+			}
+			
 			entity = clicked;
 			block = null;
 		} else if (e instanceof PlayerInteractEvent) {


### PR DESCRIPTION
### Description
Fix issue with right-click on entity ignoring itemtype

---
**Target Minecraft Versions:** All
**Requirements:** None
**Related Issues:** #2084