### PR TITLE
Enable/Disable/Reload Scripts Programmatically 

### DIFF
--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -44,10 +44,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.Server;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.jdt.annotation.NonNull;
 
 import ch.njol.skript.aliases.Aliases;
-import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.aliases.ScriptAliases;
 import ch.njol.skript.bukkitutil.CommandReloader;
 import ch.njol.skript.classes.ClassInfo;
@@ -78,7 +76,6 @@ import ch.njol.skript.lang.While;
 import ch.njol.skript.lang.function.Function;
 import ch.njol.skript.lang.function.FunctionEvent;
 import ch.njol.skript.lang.function.Functions;
-import ch.njol.skript.lang.function.Signature;
 import ch.njol.skript.localization.Language;
 import ch.njol.skript.localization.Message;
 import ch.njol.skript.localization.PluralizingArgsMessage;
@@ -231,7 +228,7 @@ final public class ScriptLoader {
 		
 		/**
 		 * Copy constructor.
-		 * @param loadedscripts
+		 * @param o
 		 */
 		public ScriptInfo(ScriptInfo o) {
 			files = o.files;
@@ -945,7 +942,7 @@ final public class ScriptLoader {
 	 * @param script
 	 * @return Info on the unloaded script
 	 */
-	static ScriptInfo unloadScript(final File script) {
+	public static ScriptInfo unloadScript(final File script) {
 		final ScriptInfo r = unloadScript_(script);
 		Functions.clearFunctions(script);
 		Functions.validateFunctions();

--- a/src/main/java/ch/njol/skript/effects/EffScriptFile.java
+++ b/src/main/java/ch/njol/skript/effects/EffScriptFile.java
@@ -74,20 +74,18 @@ public class EffScriptFile extends Effect {
 		String name = fileName != null ? fileName.getSingle(e) : "";
 		File f = SkriptCommand.getScriptFromName(name != null ? name : "");
 		if (f == null) {
-			Skript.error(name != null ? "Invalid script file name: " + name : "Invalid script file name!");
 			return;
 		}
 		switch (mark) {
 			case ENABLE: {
 				if (!f.getName().startsWith("-")) {
-					Skript.warning("Script file, " + name + ", is already enabled.");
 					return;
 				}
 				
 				try {
 					f = FileUtils.move(f, new File(f.getParentFile(), f.getName().substring(1)), false);
 				} catch (final IOException ex) {
-					Skript.error("Error while enabling script file: " + name);
+					Skript.exception(ex, "Error while enabling script file: " + name);
 					return;
 				}
 				Config config = ScriptLoader.loadStructure(f);
@@ -96,7 +94,6 @@ public class EffScriptFile extends Effect {
 			}
 			case RELOAD: {
 				if (f.getName().startsWith("-")) {
-					Skript.warning("Script file, " + name + ", is disabled.");
 					return;
 				}
 				
@@ -108,7 +105,6 @@ public class EffScriptFile extends Effect {
 			}
 			case DISABLE: {
 				if (f.getName().startsWith("-")) {
-					Skript.warning("Script file, " + name + ", is already disabled.");
 					return;
 				}
 				
@@ -116,13 +112,14 @@ public class EffScriptFile extends Effect {
 				try {
 					FileUtils.move(f, new File(f.getParentFile(), "-" + f.getName()), false);
 				} catch (final IOException ex) {
-					Skript.error("Error while disabling script file: " + name);
+					Skript.exception(ex, "Error while disabling script file: " + name);
 					return;
 				}
 				break;
 			}
 			default: {
-				throw new AssertionError();
+				assert false;
+				return;
 			}
 		}
 	}

--- a/src/main/java/ch/njol/skript/effects/EffScriptFile.java
+++ b/src/main/java/ch/njol/skript/effects/EffScriptFile.java
@@ -1,0 +1,119 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.effects;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.ScriptLoader;
+import ch.njol.skript.Skript;
+import ch.njol.skript.SkriptCommand;
+import ch.njol.skript.config.Config;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.util.FileUtils;
+import ch.njol.util.Kleenean;
+
+public class EffScriptFile extends Effect {
+	static {
+		Skript.registerEffect(EffScriptFile.class, "(1¦enable|1¦load|2¦reload|3¦disable|3¦unload) s(c|k)ript [file] %string%");
+	}
+	
+	private static final int ENABLE = 1, RELOAD = 2, DISABLE = 3;
+	
+	private int mark;
+	@Nullable
+	private Expression<String> fileName;
+	
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		mark = parseResult.mark;
+		fileName = (Expression<String>) exprs[0];
+		return true;
+	}
+	
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		return (mark == ENABLE ? "enable" : mark == RELOAD ? "disable" : mark == DISABLE ? "unload" : "") + " script file " + (fileName != null ? fileName.toString(e, debug) : "");
+	}
+	
+	@Override
+	protected void execute(Event e) {
+		String name = fileName != null ? fileName.getSingle(e) : "";
+		File f = SkriptCommand.getScriptFromName(name != null ? name : "");
+		if (f == null) {
+			Skript.error(name != null ? "Invalid script file name: " + name : "Invalid script file name!");
+			return;
+		}
+		switch (mark) {
+			case ENABLE: {
+				if (!f.getName().startsWith("-")) {
+					Skript.warning("Script file, " + name + ", is already enabled.");
+					return;
+				}
+				
+				try {
+					f = FileUtils.move(f, new File(f.getParentFile(), f.getName().substring(1)), false);
+				} catch (final IOException ex) {
+					Skript.error("Error while enabling script file: " + name);
+					return;
+				}
+				Config config = ScriptLoader.loadStructure(f);
+				ScriptLoader.loadScripts(config);
+				break;
+			}
+			case RELOAD: {
+				if (f.getName().startsWith("-")) {
+					Skript.warning("Script file, " + name + ", is disabled.");
+					return;
+				}
+				
+				if (!ScriptLoader.isAsync())
+					ScriptLoader.unloadScript(f);
+				Config config = ScriptLoader.loadStructure(f);
+				ScriptLoader.loadScripts(config);
+				break;
+			}
+			case DISABLE: {
+				if (f.getName().startsWith("-")) {
+					Skript.warning("Script file, " + name + ", is already disabled.");
+					return;
+				}
+				
+				ScriptLoader.unloadScript(f);
+				try {
+					FileUtils.move(f, new File(f.getParentFile(), "-" + f.getName()), false);
+				} catch (final IOException ex) {
+					Skript.error("Error while disabling script file: " + name);
+					return;
+				}
+				break;
+			}
+			default: {
+				throw new AssertionError();
+			}
+		}
+	}
+}

--- a/src/main/java/ch/njol/skript/effects/EffScriptFile.java
+++ b/src/main/java/ch/njol/skript/effects/EffScriptFile.java
@@ -29,12 +29,22 @@ import ch.njol.skript.ScriptLoader;
 import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptCommand;
 import ch.njol.skript.config.Config;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.util.FileUtils;
 import ch.njol.util.Kleenean;
 
+@Name("Enable/Disable/Reload Script File")
+@Description("Enables, disables, or reloads a script file.")
+@Examples({"reload script \"test\"",
+			"enable script file \"testing\"",
+			"unload script file \"script.sk\""})
+@Since("INSERT VERSION")
 public class EffScriptFile extends Effect {
 	static {
 		Skript.registerEffect(EffScriptFile.class, "(1¦enable|1¦load|2¦reload|3¦disable|3¦unload) s(c|k)ript [file] %string%");


### PR DESCRIPTION
### Description
Adds the following self-explanatory syntax which allows users to programmatically enable/disable/reload scripts:
```vbs
(enable|load) s(c|k)ript [file] %string% [[logging] in %objects%]

reload s(c|k)ript [file] %string% [[logging] in %objects%]

(disable|unload) s(c|k)ript [file] %string%
```

---
**Target Minecraft Versions:** N/A
**Requirements:** N/A
**Related Issues:** #822
