### PR TITLE
Add non-living entity support to CondIsAlive

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondIsAlive.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsAlive.java
@@ -30,17 +30,17 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 
-@Name("Is Alive/Available")
-@Description("Checks whether an entity is alive/available. Using 'alive' for non-living entities works too.")
+@Name("Is Alive/Valid")
+@Description("Checks whether an entity is alive/valid. Using 'alive' for non-living entities works too.")
 @Examples({"if {villager-buddy::%player's uuid%} is not dead:",
 	"",
 	"on shoot:",
-	"\twhile the projectile is available:"})
+	"\twhile the projectile is valid:"})
 @Since("2.0, INSERT VERSION (non-living entity support)")
 public class CondIsAlive extends PropertyCondition<Entity> {
 
 	static {
-		register(CondIsAlive.class, "(alive|available|valid|1¦dead|1¦unavailable|1¦invalid)", "entities");
+		register(CondIsAlive.class, "(alive|valid|1¦dead|1¦invalid)", "entities");
 	}
 
 	private boolean isNegated;

--- a/src/main/java/ch/njol/skript/conditions/CondIsAlive.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsAlive.java
@@ -30,7 +30,7 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 
-@Name("Is Alive/Valid")
+@Name("Is Alive")
 @Description("Checks whether an entity is alive. Works for non-living entities too.")
 @Examples({"if {villager-buddy::%player's uuid%} is not dead:",
 	"",

--- a/src/main/java/ch/njol/skript/conditions/CondIsAlive.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsAlive.java
@@ -19,7 +19,7 @@
  */
 package ch.njol.skript.conditions;
 
-import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Entity;
 
 import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
@@ -30,35 +30,35 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 
-/**
- * @author Peter Güttinger
- */
-@Name("Is Alive")
-@Description("Checks whether an entity is alive. This is mostly useful to check whether an entity stored in a variable does still exist.")
-@Examples({"{villager-buddy::%player's uuid%} is dead"})
-@Since("2.0")
-public class CondIsAlive extends PropertyCondition<LivingEntity> {
-	
+@Name("Is Alive/Available")
+@Description("Checks whether an entity is alive/available. Using 'alive' for non-living entities works too.")
+@Examples({"if {villager-buddy::%player's uuid%} is not dead:",
+	"",
+	"on shoot:",
+	"\twhile the projectile is available:"})
+@Since("2.0, INSERT VERSION (non-living entity support)")
+public class CondIsAlive extends PropertyCondition<Entity> {
+
 	static {
-		register(CondIsAlive.class, "(1¦alive|0¦dead)", "livingentities");
+		register(CondIsAlive.class, "(alive|available|valid|1¦dead|1¦unavailable|1¦invalid)", "entities");
 	}
-	
-	private boolean alive;
-	
+
+	private boolean isNegated;
+
 	@Override
-	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
-		alive = parseResult.mark == 1;
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		isNegated = parseResult.mark == 1;
 		return super.init(exprs, matchedPattern, isDelayed, parseResult);
 	}
-	
+
 	@Override
-	public boolean check(final LivingEntity e) {
-		return alive != e.isDead();
+	public boolean check(Entity e) {
+		return isNegated == e.isDead();
 	}
-	
+
 	@Override
 	protected String getPropertyName() {
-		return alive ? "alive" : "dead";
+		return isNegated ? "dead" : "alive";
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsAlive.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsAlive.java
@@ -31,16 +31,16 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 
 @Name("Is Alive/Valid")
-@Description("Checks whether an entity is alive/valid. Using 'alive' for non-living entities works too.")
+@Description("Checks whether an entity is alive. Works for non-living entities too.")
 @Examples({"if {villager-buddy::%player's uuid%} is not dead:",
 	"",
 	"on shoot:",
-	"\twhile the projectile is valid:"})
+	"\twhile the projectile is alive:"})
 @Since("2.0, INSERT VERSION (non-living entity support)")
 public class CondIsAlive extends PropertyCondition<Entity> {
 
 	static {
-		register(CondIsAlive.class, "(alive|valid|1¦dead|1¦invalid)", "entities");
+		register(CondIsAlive.class, "(alive|1¦dead)", "entities");
 	}
 
 	private boolean isNegated;


### PR DESCRIPTION
### Description
Adds non-living entity support to the Is Alive condition and improves its code, docs and syntax.

Using "alive" or "dead" on a non-living entity looks weird, even if this is fine since we use `kill` to delete non-living entities in Minecraft and Skript, i still wanted to add some alternative words: "available" and "valid"

---
**Target Minecraft Versions:** Any
**Requirements:** None
**Related Issues:** None
