### PR TITLE
Add Cancel Drops and Keep Inventory/Experience effects, improve ExprDrops

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffCancelDrops.java
+++ b/src/main/java/ch/njol/skript/effects/EffCancelDrops.java
@@ -1,0 +1,112 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.effects;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.entity.EntityDeathEvent;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.ScriptLoader;
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Events;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.RequiredPlugins;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+
+@Name("Cancel Drops")
+@Description("Cancels drops of items or experiences in a death or block break event. " +
+		"Please note that this doesn't keep items or experiences of a dead player. If you want to do that, " +
+		"use the <a href='effects.html#EffKeepInventory'>Keep Inventory / Experience</a> effect.")
+@Examples({"on death of a zombie:",
+		"\tif name of the entity is \"&cSpecial\":",
+		"\t\tcancel drops of items",
+		"",
+		"on break of a coal ore:",
+		"\tcancel the experience drops"})
+@Since("INSERT VERSION")
+@RequiredPlugins("1.12.2 or newer (cancelling item drops of blocks)")
+@Events({"death", "break / mine"})
+public class EffCancelDrops extends Effect {
+
+	private static final boolean CAN_CANCEL_BLOCK_ITEM_DROPS = Skript.methodExists(BlockBreakEvent.class, "setDropItems", boolean.class);
+
+	static {
+		Skript.registerEffect(EffCancelDrops.class,
+			"(cancel|clear|delete) [the] drops [of (1¦items|2¦[e]xp[erience][s])]",
+			"(cancel|clear|delete) [the] (1¦item|2¦[e]xp[erience]) drops");
+	}
+
+	private boolean cancelItems, cancelExps;
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		cancelItems = parseResult.mark == 0 || parseResult.mark == 1;
+		cancelExps = parseResult.mark == 0 || parseResult.mark == 2;
+		if (ScriptLoader.isCurrentEvent(BlockBreakEvent.class)) {
+			if (cancelItems && !CAN_CANCEL_BLOCK_ITEM_DROPS) {
+				Skript.error("Cancelling drops of items in a block break event requires Minecraft 1.12 or newer");
+				return false;
+			}
+		} else if (!ScriptLoader.isCurrentEvent(EntityDeathEvent.class)) {
+			Skript.error("The cancel drops effect can't be used outside of a death" +
+				(CAN_CANCEL_BLOCK_ITEM_DROPS ? " or block break" : "") + " event");
+			return false;
+		}
+		if (isDelayed.isTrue()) {
+			Skript.error("Can't cancel the drops anymore after the event has already passed");
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	protected void execute(Event e) {
+		if (e instanceof EntityDeathEvent) {
+			EntityDeathEvent event = (EntityDeathEvent) e;
+			if (cancelItems)
+				event.getDrops().clear();
+			if (cancelExps)
+				event.setDroppedExp(0);
+		} else {
+			BlockBreakEvent event = (BlockBreakEvent) e;
+			if (cancelItems)
+				event.setDropItems(false);
+			if (cancelExps)
+				event.setExpToDrop(0);
+		}
+	}
+
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		if (cancelItems && !cancelExps)
+			return "cancel the drops of items";
+		else if (cancelExps && !cancelItems)
+			return "cancel the drops of experiences";
+		return "cancel the drops";
+	}
+
+}

--- a/src/main/java/ch/njol/skript/effects/EffKeepInventory.java
+++ b/src/main/java/ch/njol/skript/effects/EffKeepInventory.java
@@ -1,0 +1,89 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.effects;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.ScriptLoader;
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Events;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+
+@Name("Keep Inventory / Experience")
+@Description("Keeps the inventory or/and experiences of the dead player in a death event.")
+@Examples({"on death of a player:",
+		"\tif the victim is an op:",
+		"\t\tkeep the inventory and experiences"})
+@Since("INSERT VERSION")
+@Events("death")
+public class EffKeepInventory extends Effect {
+
+	static {
+		Skript.registerEffect(EffKeepInventory.class,
+			"keep [the] (inventory|items) [(1¦and [e]xp[erience][s] [point[s]])]",
+			"keep [the] [e]xp[erience][s] [point[s]] [(1¦and (inventory|items))]");
+	}
+
+	private boolean keepItems, keepExp;
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		keepItems = matchedPattern == 0 || parseResult.mark == 1;
+		keepExp = matchedPattern == 1 || parseResult.mark == 1;
+		if (!ScriptLoader.isCurrentEvent(PlayerDeathEvent.class)) {
+			Skript.error("The keep inventory/experience effect can't be used outside of a death event");
+			return false;
+		}
+		if (isDelayed.isTrue()) {
+			Skript.error("Can't keep the inventory/experience anymore after the event has already passed");
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	protected void execute(Event e) {
+		if (e instanceof PlayerDeathEvent) {
+			PlayerDeathEvent event = (PlayerDeathEvent) e;
+			if (keepItems)
+				event.setKeepInventory(true);
+			if (keepExp)
+				event.setKeepLevel(true);
+		}
+	}
+
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		if (keepItems && !keepExp)
+			return "keep the inventory";
+		else
+			return "keep the experience" + (keepItems ? " and inventory" : "");
+	}
+
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprDrops.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDrops.java
@@ -41,7 +41,6 @@ import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.skript.log.ErrorQuality;
-import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.util.Experience;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
@@ -57,10 +56,10 @@ import ch.njol.util.coll.iterator.IteratorIterable;
 		"remove 4 planks from the drops"})
 @Since("1.0")
 @Events("death")
-public class ExprDrops extends SimpleExpression<ItemStack> {
+public class ExprDrops extends SimpleExpression<ItemType> {
 
 	static {
-		Skript.registerExpression(ExprDrops.class, ItemStack.class, ExpressionType.SIMPLE, "[the] drops");
+		Skript.registerExpression(ExprDrops.class, ItemType.class, ExpressionType.SIMPLE, "[the] drops");
 	}
 
 	@Override
@@ -74,8 +73,11 @@ public class ExprDrops extends SimpleExpression<ItemStack> {
 
 	@Override
 	@Nullable
-	protected ItemStack[] get(Event e) {
-		return ((EntityDeathEvent) e).getDrops().toArray(new ItemStack[0]);
+	protected ItemType[] get(Event e) {
+		return ((EntityDeathEvent) e).getDrops()
+			.stream()
+			.map(ItemType::new)
+			.toArray(ItemType[]::new);
 	}
 
 	@Override
@@ -159,15 +161,13 @@ public class ExprDrops extends SimpleExpression<ItemStack> {
 	}
 
 	@Override
-	public Class<? extends ItemStack> getReturnType() {
-		return ItemStack.class;
+	public Class<? extends ItemType> getReturnType() {
+		return ItemType.class;
 	}
 
 	@Override
 	public String toString(@Nullable Event e, boolean debug) {
-		if (e == null)
-			return "the drops";
-		return Classes.getDebugMessage(getAll(e));
+		return "the drops";
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprDrops.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDrops.java
@@ -52,63 +52,54 @@ import ch.njol.util.coll.iterator.IteratorIterable;
  * @author Peter Güttinger
  */
 @Name("Drops")
-@Description("Only works in block break and death events. Holds the drops of the dying creature. Drops can be prevented by removing them with \"remove ... from drops\", e.g. \"remove all pickaxes from the drops\", or \"clear drops\" if you don't want any drops at all. " +
-		"In break events, drops can only be cleared, and is only available in 1.12+")
+@Description("Only works in death events. Holds the drops of the dying creature. Drops can be prevented by removing them with " +
+		"\"remove ... from drops\", e.g. \"remove all pickaxes from the drops\", or \"clear drops\" if you don't want any drops at all.")
 @Examples({"clear drops",
-		"remove 4 planks from the drops", "on break of diamond ore:", "\tclear drops"})
-@Since("1.0, 2.4 (block break event drops)")
-@Events("break / mine, death")
+		"remove 4 planks from the drops"})
+@Since("1.0")
+@Events("death")
 public class ExprDrops extends SimpleExpression<ItemStack> {
+
 	static {
 		Skript.registerExpression(ExprDrops.class, ItemStack.class, ExpressionType.SIMPLE, "[the] drops");
 	}
-	
-	private final boolean BREAK_DROPS = Skript.methodExists(BlockBreakEvent.class, "setDropItems", boolean.class);
-	
-	@SuppressWarnings("null")
-	private Kleenean delayed;
-	
+
 	@Override
-	public boolean init(final Expression<?>[] vars, final int matchedPattern, final Kleenean isDelayed, final ParseResult parser) {
-		if (BREAK_DROPS) {
-			if (!ScriptLoader.isCurrentEvent(EntityDeathEvent.class, BlockBreakEvent.class)) {
-				Skript.error("The expression 'drops' can only be used in block break and death events", ErrorQuality.SEMANTIC_ERROR);
-				return false;
-			}
-		} else {
-			if (!ScriptLoader.isCurrentEvent(EntityDeathEvent.class)) {
-				Skript.error("The expression 'drops' can only be used in death events", ErrorQuality.SEMANTIC_ERROR);
-				return false;
-			}
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		if (!ScriptLoader.isCurrentEvent(EntityDeathEvent.class)) {
+			Skript.error("The expression 'drops' can only be used in death events", ErrorQuality.SEMANTIC_ERROR);
+			return false;
 		}
-		delayed = isDelayed;
 		return true;
 	}
-	
+
 	@Override
 	@Nullable
-	protected ItemStack[] get(final Event e) {
-		if (!(e instanceof EntityDeathEvent))
-			return new ItemStack[0];
+	protected ItemStack[] get(Event e) {
 		return ((EntityDeathEvent) e).getDrops().toArray(new ItemStack[0]);
 	}
-	
-	@SuppressWarnings("unchecked")
+
 	@Override
 	@Nullable
-	public Class<?>[] acceptChange(final ChangeMode mode) {
-		if (mode == ChangeMode.RESET)
-			return null;
-		if (delayed.isTrue()) {
+	public Class<?>[] acceptChange(ChangeMode mode) {
+		if (ScriptLoader.hasDelayBefore.isTrue()) {
 			Skript.error("Can't change the drops anymore after the event has already passed");
 			return null;
 		}
-		return CollectionUtils.array(ItemType[].class, Inventory[].class, Experience[].class);
+		switch (mode) {
+			case ADD:
+			case REMOVE:
+			case REMOVE_ALL:
+			case SET:
+			case DELETE:
+				return CollectionUtils.array(ItemType[].class, Inventory[].class, Experience[].class);
+			default:
+				return null;
+		}
 	}
-	
-	@SuppressWarnings({"unchecked", "null"})
+
 	@Override
-	public void change(final Event e, final @Nullable Object[] deltas, final ChangeMode mode) {
+	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
 		assert mode != ChangeMode.RESET;
 		if (e instanceof BlockBreakEvent) {
 			if (mode == ChangeMode.DELETE) {
@@ -120,23 +111,23 @@ public class ExprDrops extends SimpleExpression<ItemStack> {
 			assert false;
 			return;
 		}
-		
+
 		final List<ItemStack> drops = ((EntityDeathEvent) e).getDrops();
 		if (mode == ChangeMode.DELETE) {
 			drops.clear();
 			return;
 		}
 		boolean cleared = false;
-		
-		assert deltas != null;
-		for (final Object delta : deltas) {
-			if (delta instanceof Experience) {
-				if (mode == ChangeMode.REMOVE_ALL || mode == ChangeMode.REMOVE && ((Experience) delta).getInternalXP() == -1) {
+
+		assert delta != null;
+		for (Object o : delta) {
+			if (o instanceof Experience) {
+				if (mode == ChangeMode.REMOVE_ALL || mode == ChangeMode.REMOVE && ((Experience) o).getInternalXP() == -1) {
 					((EntityDeathEvent) e).setDroppedExp(0);
 				} else if (mode == ChangeMode.SET) {
-					((EntityDeathEvent) e).setDroppedExp(((Experience) delta).getXP());
+					((EntityDeathEvent) e).setDroppedExp(((Experience) o).getXP());
 				} else {
-					((EntityDeathEvent) e).setDroppedExp(Math.max(0, ((EntityDeathEvent) e).getDroppedExp() + (mode == ChangeMode.ADD ? 1 : -1) * ((Experience) delta).getXP()));
+					((EntityDeathEvent) e).setDroppedExp(Math.max(0, ((EntityDeathEvent) e).getDroppedExp() + (mode == ChangeMode.ADD ? 1 : -1) * ((Experience) o).getXP()));
 				}
 			} else {
 				switch (mode) {
@@ -147,19 +138,19 @@ public class ExprDrops extends SimpleExpression<ItemStack> {
 						}
 						//$FALL-THROUGH$
 					case ADD:
-						if (delta instanceof Inventory) {
-							for (final ItemStack is : new IteratorIterable<>(((Inventory) delta).iterator())) {
+						if (o instanceof Inventory) {
+							for (final ItemStack is : new IteratorIterable<>(((Inventory) o).iterator())) {
 								if (is != null)
 									drops.add(is);
 							}
 						} else {
-							((ItemType) delta).addTo(drops);
+							((ItemType) o).addTo(drops);
 						}
 						break;
 					case REMOVE:
 					case REMOVE_ALL:
-						if (delta instanceof Inventory) {
-							for (final ItemStack is : new IteratorIterable<>(((Inventory) delta).iterator())) {
+						if (o instanceof Inventory) {
+							for (final ItemStack is : new IteratorIterable<>(((Inventory) o).iterator())) {
 								if (is == null)
 									continue;
 								if (mode == ChangeMode.REMOVE)
@@ -169,9 +160,9 @@ public class ExprDrops extends SimpleExpression<ItemStack> {
 							}
 						} else {
 							if (mode == ChangeMode.REMOVE)
-								((ItemType) delta).removeFrom(drops);
+								((ItemType) o).removeFrom(drops);
 							else
-								((ItemType) delta).removeAll(drops);
+								((ItemType) o).removeAll(drops);
 						}
 						break;
 					case DELETE:
@@ -181,22 +172,22 @@ public class ExprDrops extends SimpleExpression<ItemStack> {
 			}
 		}
 	}
-	
-	@Override
-	public Class<? extends ItemStack> getReturnType() {
-		return ItemStack.class;
-	}
-	
-	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		if (e == null)
-			return "the drops";
-		return Classes.getDebugMessage(getAll(e));
-	}
-	
+
 	@Override
 	public boolean isSingle() {
 		return false;
 	}
-	
+
+	@Override
+	public Class<? extends ItemStack> getReturnType() {
+		return ItemStack.class;
+	}
+
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		if (e == null)
+			return "the drops";
+		return Classes.getDebugMessage(getAll(e));
+	}
+
 }


### PR DESCRIPTION
### Description
ExprDrops will no longer work in block break events, which is returning always null.
I wanted to improve ExprDrops much more, like support for experience drops of blocks, but i failed because of some confusing reasons lol.

```autohotkey
(cancel|clear|delete) [the] drops [of (items|[e]xp[erience][s])]
(cancel|clear|delete) [the] (item|[e]xp[erience]) drops
```
```autohotkey
keep [the] (inventory|items) [(and [e]xp[erience][s] [point[s]])]
keep [the] [e]xp[erience][s] [point[s]] [(and (inventory|items))]
```

---
**Target Minecraft Versions:** Any, 1.12+ for cancelling block item drops
**Requirements:** None
**Related Issues:** None
