### PR TITLE
triggers -> events

### DIFF
--- a/docs/templates/navbar.html
+++ b/docs/templates/navbar.html
@@ -1,6 +1,6 @@
 <nav id="global-navigation">
   <a href="index.html">Home</a>
-  <a href="events.html">Triggers</a>
+  <a href="events.html">Events</a>
   <a href="conditions.html">Conditions</a>
   <a href="effects.html">Effects</a>
   <a href="expressions.html">Expressions</a>


### PR DESCRIPTION
### Description
this renames "Triggers" on the navbar to "Events", why isn't it already like this?