### PR TITLE
Rethink chat safety features

### DIFF
--- a/src/main/java/ch/njol/skript/PatcherTool.java
+++ b/src/main/java/ch/njol/skript/PatcherTool.java
@@ -97,6 +97,7 @@ public class PatcherTool {
 			copy("effects.EffMessage", true);
 			copy("expressions.ExprArgument", true);
 			copy("expressions.ExprColoured", true);
+			copy("lang.VariableString", true);
 			copy("util.chat.BungeeConverter", true);
 			copy("util.chat.ChatCode", true);
 			copy("util.chat.ChatMessages", true);

--- a/src/main/java/ch/njol/skript/effects/EffMessage.java
+++ b/src/main/java/ch/njol/skript/effects/EffMessage.java
@@ -88,10 +88,10 @@ public class EffMessage extends Effect {
 						((Player) receiver).spigot().sendMessage(BungeeConverter
 								.convert(((VariableString) message).getMessageComponents(e)));
 					} else if (message instanceof ExprColoured) { // Manually marked as trusted
-						String text = message.getSingle(e);
-						if (text != null) {
+						for (String string : message.getArray(e)) {
+							assert string != null;
 							((Player) receiver).spigot().sendMessage(BungeeConverter
-									.convert(ChatMessages.parse(text)));
+									.convert(ChatMessages.parse(string)));
 						}
 					} else { // It is just a string, no idea if it comes from a trusted source -> don't parse anything
 						for (String string : message.getArray(e)) {

--- a/src/main/java/ch/njol/skript/effects/EffMessage.java
+++ b/src/main/java/ch/njol/skript/effects/EffMessage.java
@@ -31,6 +31,7 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.ExprColoured;
 import ch.njol.skript.hooks.regions.RegionsPlugin;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
@@ -43,13 +44,14 @@ import ch.njol.skript.util.chat.MessageComponent;
 import ch.njol.util.Kleenean;
 
 @Name("Message")
-@Description("Sends a message to the given player.")
+@Description({"Sends a message to the given player. Only styles written",
+		"in given string or in 'coloured' expressions will be parsed."})
 @Examples({"message \"A wild %player% appeared!\"",
 		"message \"This message is a distraction. Mwahaha!\"",
 		"send \"Your kill streak is %{kill streak::%uuid of player%}%.\" to player",
 		"if the targeted entity exists:",
 		"	message \"You're currently looking at a %type of the targeted entity%!\""})
-@Since("1.0, 2.2-dev26 (advanced features)")
+@Since("1.0, 2.2-dev26 (advanced features), 2.3.8 (send json)")
 public class EffMessage extends Effect {
 	
 	static {
@@ -82,14 +84,20 @@ public class EffMessage extends Effect {
 		for (Expression<? extends String> message : messages) {
 			for (CommandSender receiver : recipients.getArray(e)) {
 				if (receiver instanceof Player) { // Can use JSON formatting
-					if (message instanceof VariableString) { // Avoid processing ANY chat codes
-						((Player) receiver).spigot().sendMessage(BungeeConverter.convert(
-								ChatMessages.parse(((VariableString) message).toUnformattedString(e))));
-					} else { // It is just a string, parse components from it
+					if (message instanceof VariableString) { // Process formatting that is safe
+						((Player) receiver).spigot().sendMessage(BungeeConverter
+								.convert(((VariableString) message).getMessageComponents(e)));
+					} else if (message instanceof ExprColoured) { // Manually marked as trusted
+						String text = message.getSingle(e);
+						if (text != null) {
+							((Player) receiver).spigot().sendMessage(BungeeConverter
+									.convert(ChatMessages.parse(text)));
+						}
+					} else { // It is just a string, no idea if it comes from a trusted source -> don't parse anything
 						for (String string : message.getArray(e)) {
 							assert string != null;
-							((Player) receiver).spigot().sendMessage(BungeeConverter.convert(
-									ChatMessages.parse(string)));
+							assert string != null;
+							receiver.sendMessage(string);
 						}
 					}
 				} else { // Not a player, send plain text with legacy formatting

--- a/src/main/java/ch/njol/skript/expressions/ExprArgument.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprArgument.java
@@ -165,20 +165,7 @@ public class ExprArgument extends SimpleExpression<Object> {
 	protected Object[] get(final Event e) {
 		if (!(e instanceof ScriptCommandEvent))
 			return null;
-		Object[] values = arg.getCurrent(e);
-		if (values == null)
-			return null;
-		
-		// Process all string arguments to remove formatting
-		// Fixes a security issue #2198
-		for (int i = 0; i < values.length; i++) {
-			if (values[i] instanceof String) {
-				String text = (String) values[i];
-				assert text != null;
-				values[i] = ChatMessages.stripStyles(text);
-			}
-		}
-		return values;
+		return arg.getCurrent(e);
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprColoured.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprColoured.java
@@ -37,11 +37,10 @@ import ch.njol.skript.util.Utils;
 import ch.njol.skript.util.chat.ChatMessages;
 import ch.njol.util.Kleenean;
 
-/**
- * @author Peter Güttinger
- */
 @Name("Coloured / Uncoloured")
-@Description("Parses &lt;colour&gt;s (including chat styles) in a message or removes any colours & chat styles from the message.")
+@Description({"Parses &lt;colour&gt;s and styles in a message or removes",
+		"any colours <i>and</i> chat styles from the message. Note that",
+		"parsing styles from user input is dangerous."})
 @Examples({"on chat:",
 		"	set message to coloured message",
 		"command /fade <player>:",

--- a/src/main/java/ch/njol/skript/lang/VariableString.java
+++ b/src/main/java/ch/njol/skript/lang/VariableString.java
@@ -39,6 +39,7 @@ import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.classes.Parser;
 import ch.njol.skript.config.Config;
+import ch.njol.skript.expressions.ExprColoured;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.skript.localization.Language;
@@ -87,6 +88,12 @@ public class VariableString implements Expression<String> {
 	@Nullable
 	private final String simpleUnformatted;
 	private final StringMode mode;
+	
+	/**
+	 * Message components that this string consists of. Only simple parts have
+	 * been evaluated here.
+	 */
+	private final MessageComponent[] components;
 
 	public static boolean disableVariableStartingWithExpressionWarnings = false;
 	
@@ -99,11 +106,14 @@ public class VariableString implements Expression<String> {
 		simpleUnformatted = s.replace("%%", "%"); // This doesn't contain variables, so this wasn't done in newInstance!
 		assert simpleUnformatted != null;
 		simple = Utils.replaceChatStyles(simpleUnformatted);
-		
+				
 		orig = simple;
 		string = null;
 		assert simple != null;
 		mode = StringMode.MESSAGE;
+		
+		assert simpleUnformatted != null;
+		components = new MessageComponent[] {ChatMessages.plainText(simpleUnformatted)};
 	}
 	
 	/**
@@ -116,20 +126,28 @@ public class VariableString implements Expression<String> {
 		this.orig = orig;
 		this.string = new Object[string.length];
 		this.stringUnformatted = new Object[string.length];
+		
+		// Construct unformatted string and components
+		List<MessageComponent> components = new ArrayList<>(string.length);
 		for (int i = 0; i < string.length; i++) {
 			Object o = string[i];
 			if (o instanceof String) {
 				assert this.string != null;
 				this.string[i] = Utils.replaceChatStyles((String) o);
+				components.addAll(ChatMessages.parse((String) o));
 			} else {
 				assert this.string != null;
 				this.string[i] = o;
+				components.add(null); // Not known parse-time
 			}
 			
 			// For unformatted string, don't format stuff
 			assert this.stringUnformatted != null;
 			this.stringUnformatted[i] = o;
 		}
+		MessageComponent[] array = components.toArray(new MessageComponent[components.size()]);
+		assert array != null;
+		this.components = array;
 		
 		this.mode = mode;
 		
@@ -468,7 +486,6 @@ public class VariableString implements Expression<String> {
 	/**
 	 * Parses all expressions in the string and returns it.
 	 * Does not parse formatting codes!
-	 * 
 	 * @param e Event to pass to the expressions.
 	 * @return The input string with all expressions replaced.
 	 */
@@ -505,8 +522,76 @@ public class VariableString implements Expression<String> {
 		return "" + b.toString();
 	}
 	
-	public List<MessageComponent> getMessageComponents(final Event e) {
-		if (isSimple) {
+	/**
+	 * Gets message components from this string. Formatting is parsed only
+	 * in simple parts for security reasons.
+	 * @param e Currently running event.
+	 * @return Message components.
+	 */
+	public List<MessageComponent> getMessageComponents(Event e) {
+		if (isSimple) { // Trusted, constant string in a script
+			assert simpleUnformatted != null;
+			return ChatMessages.parse(simpleUnformatted);
+		}
+		
+		// Parse formating
+		Object[] string = this.stringUnformatted;
+		assert string != null;
+		List<MessageComponent> message = new ArrayList<>(components.length); // At least this much space
+		int stringPart = 0;
+		for (MessageComponent component : components) {
+			if (component == null) { // This component holds place for variable part
+				Object o = string[stringPart];
+				
+				// Convert it to plain text
+				String text = null;
+				if (o instanceof ExprColoured) { // Special case: user wants to process formatting
+					String unformatted = ((ExprColoured) o).getSingle(e);
+					if (unformatted != null) {
+						message.addAll(ChatMessages.parse(unformatted));
+					}
+					continue;
+				} else if (o instanceof Expression<?>) {
+					assert mode != StringMode.MESSAGE;
+					text = Classes.toString(((Expression<?>) o).getArray(e), true, mode);
+				} else if (o instanceof ExpressionInfo) {
+					assert mode == StringMode.MESSAGE;
+					final ExpressionInfo info = (ExpressionInfo) o;
+					int flags = info.flags;
+					
+					// TODO plural handling?
+//					if ((flags & Language.F_PLURAL) == 0 && b.length() > 0 && Math.abs(StringUtils.numberBefore(b, b.length() - 1)) != 1)
+//						flags |= Language.F_PLURAL;
+					if (info.toChatStyle) {
+						final String s = Classes.toString(info.expr.getArray(e), flags, null);
+						final String style = Utils.getChatStyle(s);
+						text = style == null ? "<" + s + ">" : style;
+					} else {
+						text = Classes.toString(info.expr.getArray(e), flags, null);
+					}
+				} else {
+					assert false;
+				}
+				
+				assert text != null;
+				message.add(ChatMessages.plainText(text));
+				stringPart += 2; // Previous literal part and this variable part are now processed
+			} else {
+				message.add(component);
+			}
+		}
+		
+		return message;
+	}
+	
+	/**
+	 * Gets message components from this string. Formatting is parsed
+	 * everywhere, which is a potential security risk.
+	 * @param e Currently running event.
+	 * @return Message components.
+	 */
+	public List<MessageComponent> getMessageComponentsUnsafe(Event e) {
+		if (isSimple) { // Trusted, constant string in a script
 			assert simpleUnformatted != null;
 			return ChatMessages.parse(simpleUnformatted);
 		}

--- a/src/main/java/ch/njol/skript/lang/VariableString.java
+++ b/src/main/java/ch/njol/skript/lang/VariableString.java
@@ -567,6 +567,13 @@ public class VariableString implements Expression<String> {
 						final String style = Utils.getChatStyle(s);
 						text = style == null ? "<" + s + ">" : style;
 					} else {
+						if (info.expr instanceof ExprColoured) { // Special case: user wants to process formatting
+							String unformatted = ((ExprColoured) info.expr).getSingle(e);
+							if (unformatted != null) {
+								message.addAll(ChatMessages.parse(unformatted));
+							}
+							continue;
+						}
 						text = Classes.toString(info.expr.getArray(e), flags, null);
 					}
 				} else {
@@ -575,10 +582,10 @@ public class VariableString implements Expression<String> {
 				
 				assert text != null;
 				message.add(ChatMessages.plainText(text));
-				stringPart += 2; // Previous literal part and this variable part are now processed
 			} else {
 				message.add(component);
 			}
+			stringPart++;
 		}
 		
 		return message;

--- a/src/main/java/ch/njol/skript/util/chat/ChatMessages.java
+++ b/src/main/java/ch/njol/skript/util/chat/ChatMessages.java
@@ -489,9 +489,9 @@ public class ChatMessages {
 	}
 	
 	/**
-	 * Strips all style markup from given string.
-	 * @param text String to strip markup from.
-	 * @return A string without markup.
+	 * Strips all styles from given string.
+	 * @param text String to strip styles from.
+	 * @return A string without styles.
 	 */
 	public static String stripStyles(String text) {
 		List<MessageComponent> components = parse(text);
@@ -500,6 +500,9 @@ public class ChatMessages {
 			sb.append(component.text);
 		}
 		String plain = sb.toString();
+		
+		// To be extra safe, strip <, >, § and &; protects against bugs in parser
+		plain = plain.replace("<", "").replace(">", "").replace("§", "").replace("&", "");
 		assert plain != null;
 		return plain;
 	}


### PR DESCRIPTION
### Description
A few days ago, a security issue was noticed in chat system. It was fixed fast, at expense of quality of the fix. We also hit unforeseen issues with new 2.4 alpha release, because it was hurried.

After a few days of thinking about this, I've figured out a better solution. Instead of flat-out removing formatting from command arguments, the send effect now ignores formatting in variable parts (expressions). For users who need formatting in them, there are two ways to disable this:

1. In string that is about to be sent, use 'coloured' expression to indicate which parts are safe to process formatting from.
2. Use 'coloured' directly as parameter to 'send' effect.

Please let me know your thoughts about this change. Would it be good enough to be added in next 2.4 release? Should 2.3 also receive this?
---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #2208
