### PR TITLE
Rework click events to be less hacky

### DIFF
--- a/src/main/java/ch/njol/skript/bukkitutil/ClickEventTracker.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/ClickEventTracker.java
@@ -1,0 +1,79 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.bukkitutil;
+
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.EventException;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.EventExecutor;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import com.destroystokyo.paper.event.server.ServerTickEndEvent;
+
+/**
+ * Tracks click events to remove extraneous events for one player click.
+ */
+public class ClickEventTracker {
+	
+	/**
+	 * First events by players during this tick. They're stored by their UUIDs.
+	 * This map is cleared once per tick.
+	 */
+	final Map<UUID, Cancellable> firstEvents;
+	
+	public ClickEventTracker(JavaPlugin plugin) {
+		this.firstEvents = new HashMap<>();
+		Bukkit.getPluginManager().registerEvent(ServerTickEndEvent.class, new Listener() {}, EventPriority.MONITOR, new EventExecutor() {
+			
+			@Override
+			public void execute(Listener listener, Event event) throws EventException {
+				firstEvents.clear(); // Clear all tracked data at end of tick
+			}
+		}, plugin);
+	}
+	
+	/**
+	 * Processes a click event from a player.
+	 * @param player Player who caused it.
+	 * @param event The event.
+	 * @return If the event should be passed to scripts.
+	 */
+	public boolean checkEvent(Player player, Cancellable event) {
+		UUID uuid = player.getUniqueId();
+		Cancellable first = firstEvents.get(uuid);
+		if (first != null && first != event) { // We've checked an event before, and it is not this one
+			// So ignore this, but set its cancelled status based on one set to first event
+			event.setCancelled(first.isCancelled());
+			return false;
+		} else { // Remember and run this
+			firstEvents.put(uuid, event);
+			return true;
+		}
+	}
+}

--- a/src/main/java/ch/njol/skript/bukkitutil/ClickEventTracker.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/ClickEventTracker.java
@@ -76,7 +76,7 @@ public class ClickEventTracker {
 	public boolean checkEvent(Player player, Cancellable event, EquipmentSlot hand) {
 		UUID uuid = player.getUniqueId();
 		TrackedEvent first = firstEvents.get(uuid);
-		if (first != null && first != event) { // We've checked an event before, and it is not this one
+		if (first != null && first.event != event) { // We've checked an event before, and it is not this one
 			if ((hand == EquipmentSlot.HAND && first.hand == EquipmentSlot.OFF_HAND)
 					|| (hand == EquipmentSlot.OFF_HAND && first.hand == EquipmentSlot.HAND)) {
 				// Previous event had different hand, so we've captured one complete click interaction

--- a/src/main/java/ch/njol/skript/bukkitutil/ClickEventTracker.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/ClickEventTracker.java
@@ -35,11 +35,6 @@ import org.bukkit.plugin.java.JavaPlugin;
  */
 public class ClickEventTracker {
 	
-	/**
-	 * Maximum tracked event lifetime in milliseconds.
-	 */
-	private static final int MAX_EVENT_LIFETIME = 100;
-	
 	private static class TrackedEvent {
 		
 		/**
@@ -51,16 +46,10 @@ public class ClickEventTracker {
 		 * Hand used in event.
 		 */
 		final EquipmentSlot hand;
-		
-		/**
-		 * When this event was captured.
-		 */
-		final long timestamp;
 
-		public TrackedEvent(Cancellable event, EquipmentSlot hand, long timestamp) {
+		public TrackedEvent(Cancellable event, EquipmentSlot hand) {
 			this.event = event;
 			this.hand = hand;
-			this.timestamp = timestamp;
 		}
 		
 	}
@@ -74,16 +63,7 @@ public class ClickEventTracker {
 	public ClickEventTracker(JavaPlugin plugin) {
 		this.firstEvents = new HashMap<>();
 		Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin,
-				() -> {
-					Iterator<Map.Entry<UUID, TrackedEvent>> it = firstEvents.entrySet().iterator();
-					long now = System.currentTimeMillis();
-					while (it.hasNext()) {
-						TrackedEvent tracked = it.next().getValue();
-						if (now - tracked.timestamp > MAX_EVENT_LIFETIME) {
-							it.remove();
-						}
-					}
-				}, 1, 1);
+				() -> firstEvents.clear(), 1, 1);
 	}
 	
 	/**
@@ -106,7 +86,7 @@ public class ClickEventTracker {
 			event.setCancelled(first.event.isCancelled());
 			return false;
 		} else { // Remember and run this
-			firstEvents.put(uuid, new TrackedEvent(event, hand, System.currentTimeMillis()));
+			firstEvents.put(uuid, new TrackedEvent(event, hand));
 			return true;
 		}
 	}

--- a/src/main/java/ch/njol/skript/events/EvtClick.java
+++ b/src/main/java/ch/njol/skript/events/EvtClick.java
@@ -155,7 +155,7 @@ public class EvtClick extends SkriptEvent {
 			
 			// PlayerInteractAtEntityEvent called only once for armor stands
 			if (!(e instanceof PlayerInteractAtEntityEvent)) {
-				if (!entityInteractTracker.checkEvent(clickEvent.getPlayer(), clickEvent)) {
+				if (!entityInteractTracker.checkEvent(clickEvent.getPlayer(), clickEvent, clickEvent.getHand())) {
 					return false; // Not first event this tick
 				}
 			}
@@ -184,7 +184,9 @@ public class EvtClick extends SkriptEvent {
 			if ((this.click & click) == 0)
 				return false; // We don't want to handle this kind of events
 			
-			if (!interactTracker.checkEvent(clickEvent.getPlayer(), clickEvent)) {
+			EquipmentSlot hand = clickEvent.getHand();
+			assert hand != null; // Not PHYSICAL interaction
+			if (!interactTracker.checkEvent(clickEvent.getPlayer(), clickEvent, hand)) {
 				return false; // Not first event this tick
 			}
 			


### PR DESCRIPTION
### Description
Click events are a long standing pain point in Skript. They're not reliable enough across all supported Minecraft versions. Some use cases, like clicks on entities, are almost univerally broken.

This pull request abandons lookup tables for click event deduplication. Instead, scripts will simply never receive more than one click event per tick from one player. Skript transparently cancels all events if the first one is cancelled.

There are potential problems with this change:
* Loss of functionality with event-item and 'click with'
  * Event-item gets item in *random* hand
  * 'click with' is now same as 'click holding'
* Two actual clicks within one tick may be sent by Minecraft client, at least in theory
  * Only hacked clients, though?
* Bad connections may split click events from one action over multiple ticks
  * Stable high latency is not an issue, packet loss or fluctuating ping might be

In short, more testing is needed.

---
**Target Minecraft Versions:**  any
**Requirements:**  none
**Related Issues:** #2176
