### PR TITLE
Remove Correct Usage Prefix

### DIFF
--- a/src/main/java/ch/njol/skript/command/Commands.java
+++ b/src/main/java/ch/njol/skript/command/Commands.java
@@ -90,7 +90,6 @@ import ch.njol.util.StringUtils;
 public abstract class Commands {
 	
 	public final static ArgsMessage m_too_many_arguments = new ArgsMessage("commands.too many arguments");
-	public final static Message m_correct_usage = new Message("commands.correct usage");
 	public final static Message m_internal_error = new Message("commands.internal error");
 	
 	private final static Map<String, ScriptCommand> commands = new HashMap<>();

--- a/src/main/java/ch/njol/skript/command/ScriptCommand.java
+++ b/src/main/java/ch/njol/skript/command/ScriptCommand.java
@@ -274,7 +274,7 @@ public class ScriptCommand implements TabExecutor {
 				final LogEntry e = log.getError();
 				if (e != null)
 					sender.sendMessage(ChatColor.DARK_RED + e.getMessage());
-				sender.sendMessage(Commands.m_correct_usage + " " + usage);
+				sender.sendMessage(usage);
 				log.clear();
 				log.printLog();
 				return false;

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -156,6 +156,7 @@ commands:
 	executable by players: This command can only be used by players
 	executable by console: This command can only be used by the console
 	usage: Usage:
+	correct usage: Correct usage:
 	invalid argument: Invalid argument <gray>'%s<gray>'<reset>. Allowed are:
 	too many arguments: This command can only accept a single %2$s.
 	internal error: An internal error occurred while attempting to perform this command.

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -156,7 +156,6 @@ commands:
 	executable by players: This command can only be used by players
 	executable by console: This command can only be used by the console
 	usage: Usage:
-	correct usage: Correct usage:
 	invalid argument: Invalid argument <gray>'%s<gray>'<reset>. Allowed are:
 	too many arguments: This command can only accept a single %2$s.
 	internal error: An internal error occurred while attempting to perform this command.

--- a/src/main/resources/lang/german.lang
+++ b/src/main/resources/lang/german.lang
@@ -156,6 +156,7 @@ commands:
 	executable by players: Dieser Befehl kann nur von Spielern verwendet werden
 	executable by console: Dieser Befehl kann nur von der Konsole verwendet werden
 	usage: Syntax:
+	correct usage: Richtige Benutzung:
 	invalid argument: Unbekanntes Argument <gray>'%s<gray>'<reset>. Erlaubt sind:
 	too many arguments: Dieser Befehl akzeptiert nur %s %s.
 	internal error: Während der Ausführung des Befehls ist ein interner Fehler aufgetreten.

--- a/src/main/resources/lang/german.lang
+++ b/src/main/resources/lang/german.lang
@@ -156,7 +156,6 @@ commands:
 	executable by players: Dieser Befehl kann nur von Spielern verwendet werden
 	executable by console: Dieser Befehl kann nur von der Konsole verwendet werden
 	usage: Syntax:
-	correct usage: Richtige Benutzung:
 	invalid argument: Unbekanntes Argument <gray>'%s<gray>'<reset>. Erlaubt sind:
 	too many arguments: Dieser Befehl akzeptiert nur %s %s.
 	internal error: Während der Ausführung des Befehls ist ein interner Fehler aufgetreten.


### PR DESCRIPTION
### Description
This pull request removed the "Correct Usage:" prefix in front of the usage message in commands due to it being un-customizable.

---
**Target Minecraft Versions:** N/A
**Requirements:** N/A
**Related Issues:** #1844
