### PR TITLE
Improve fishing

### DIFF
--- a/skript-worldguard6/.classpath
+++ b/skript-worldguard6/.classpath
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="bin/main" path="src/main/java">
+		<attributes>
+			<attribute name="gradle_scope" value="main"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
+	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
+	<classpathentry kind="output" path="bin/default"/>
+</classpath>

--- a/skript-worldguard6/.project
+++ b/skript-worldguard6/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>skript-worldguard6</name>
+	<comment>Project skript-worldguard6 created by Buildship.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+	</natures>
+</projectDescription>

--- a/skript-worldguard6/.settings/org.eclipse.buildship.core.prefs
+++ b/skript-worldguard6/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,2 @@
+connection.project.dir=..
+eclipse.preferences.version=1

--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -54,6 +54,7 @@ import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.event.player.PlayerResourcePackStatusEvent.Status;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.Inventory;
@@ -1562,7 +1563,7 @@ public class BukkitClasses {
 					}
 				})
 				.serializer(new EnumSerializer<>(Difficulty.class)));
-		
+
 		EnumUtils<Status> resourcePackStates = new EnumUtils<>(Status.class, "resource pack states");
 		Classes.registerClass(new ClassInfo<>(Status.class, "resourcepackstate")
 				.user("resource ?pack ?states?")
@@ -1594,7 +1595,7 @@ public class BukkitClasses {
 					}
 				})
 				.serializer(new EnumSerializer<>(Status.class)));
-		
+
 		if (Skript.classExists("org.bukkit.SoundCategory")) {
 			EnumUtils<SoundCategory> soundCategories = new EnumUtils<>(SoundCategory.class, "sound categories");
 			Classes.registerClass(new ClassInfo<>(SoundCategory.class, "soundcategory")
@@ -1611,18 +1612,18 @@ public class BukkitClasses {
 						public SoundCategory parse(final String s, final ParseContext context) {
 							return soundCategories.parse(s);
 						}
-						
+
 						@Override
 						public String toString(SoundCategory state, int flags) {
 							return soundCategories.toString(state, flags);
 						}
-						
+
 						@SuppressWarnings("null")
 						@Override
 						public String toVariableNameString(SoundCategory category) {
 							return category.name();
 						}
-						
+
 						@Override
 						public String getVariableNamePattern() {
 							return "\\S+";
@@ -1630,6 +1631,7 @@ public class BukkitClasses {
 					})
 					.serializer(new EnumSerializer<>(SoundCategory.class)));
 		}
+
 		if (Skript.classExists("org.bukkit.entity.Panda$Gene")) {
 			EnumUtils<Gene> genes = new EnumUtils<>(Gene.class, "genes");
 			Classes.registerClass(new ClassInfo<>(Gene.class, "gene")
@@ -1646,17 +1648,18 @@ public class BukkitClasses {
 						public Gene parse(String expr, ParseContext context) {
 							return genes.parse(expr);
 						}
-						
+
 						@Override
 						public String toString(Gene gene, int flags) {
 							return genes.toString(gene, flags);
 						}
-						
+
+						@SuppressWarnings("null")
 						@Override
 						public String toVariableNameString(Gene gene) {
 							return gene.name();
 						}
-						
+
 						@Override
 						public String getVariableNamePattern() {
 							return "\\S+";
@@ -1664,6 +1667,7 @@ public class BukkitClasses {
 					})
 					.serializer(new EnumSerializer<>(Gene.class)));
 		}
+
 		if (Skript.classExists("org.bukkit.entity.Cat$Type")) {
 			EnumUtils<Cat.Type> races = new EnumUtils<>(Cat.Type.class, "cat types");
 			Classes.registerClass(new ClassInfo<>(Cat.Type.class, "cattype")
@@ -1679,17 +1683,18 @@ public class BukkitClasses {
 						public Cat.Type parse(String expr, ParseContext context) {
 							return races.parse(expr);
 						}
-						
+
 						@Override
 						public String toString(Cat.Type race, int flags) {
 							return races.toString(race, flags);
 						}
-						
+
+						@SuppressWarnings("null")
 						@Override
 						public String toVariableNameString(Cat.Type race) {
 							return race.name();
 						}
-						
+
 						@Override
 						public String getVariableNamePattern() {
 							return "\\S+";
@@ -1697,6 +1702,39 @@ public class BukkitClasses {
 					})
 					.serializer(new EnumSerializer<>(Cat.Type.class)));
 		}
+
+		EnumUtils<PlayerFishEvent.State> fishingStates = new EnumUtils<>(PlayerFishEvent.State.class, "fishing states");
+		Classes.registerClass(new ClassInfo<>(PlayerFishEvent.State.class, "fishingstate")
+				.user("fish(ing)? states?")
+				.name("Fishing State")
+				.description("The fishing state in a <a href='events.html#fishing'>fishing</a> event.")
+				.examples(fishingStates.getAllNames())
+				.since("2.4")
+				.parser(new Parser<PlayerFishEvent.State>() {
+					@Nullable
+					@Override
+					public PlayerFishEvent.State parse(String input, ParseContext context) {
+						return fishingStates.parse(input);
+					}
+
+					@Override
+					public String toString(PlayerFishEvent.State state, int flags) {
+						return fishingStates.toString(state, flags);
+					}
+
+					@SuppressWarnings("null")
+					@Override
+					public String toVariableNameString(PlayerFishEvent.State state) {
+						return state.name();
+					}
+
+					@Override
+					public String getVariableNamePattern() {
+						return "\\S+";
+					}
+				})
+				.serializer(new EnumSerializer<>(PlayerFishEvent.State.class)));
+
 	}
 
 }

--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -32,6 +32,7 @@ import org.bukkit.block.BlockState;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Firework;
+import org.bukkit.entity.FishHook;
 import org.bukkit.entity.Hanging;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Item;
@@ -85,6 +86,7 @@ import org.bukkit.event.player.PlayerBucketFillEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerEditBookEvent;
 import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemBreakEvent;
@@ -999,6 +1001,7 @@ public final class BukkitEventValues {
 				}
 			}, 0);
 			EventValues.registerEventValue(FireworkExplodeEvent.class, FireworkEffect.class, new Getter<FireworkEffect, FireworkExplodeEvent>() {
+				@SuppressWarnings("null")
 				@Override
 				@Nullable
 				public FireworkEffect get(FireworkExplodeEvent e) {
@@ -1009,6 +1012,28 @@ public final class BukkitEventValues {
 				}
 			}, 0);
 		}
-
+		//PlayerFishEvent
+		EventValues.registerEventValue(PlayerFishEvent.class, Entity.class, new Getter<Entity, PlayerFishEvent>() {
+			@Override
+			@Nullable
+			public Entity get(PlayerFishEvent e) {
+				Entity entity = e.getCaught();
+				return entity == null ? null : entity;
+			}
+		}, 0);
+		EventValues.registerEventValue(PlayerFishEvent.class, PlayerFishEvent.State.class, new Getter<PlayerFishEvent.State, PlayerFishEvent>() {
+			@Override
+			@Nullable
+			public PlayerFishEvent.State get(PlayerFishEvent e) {
+				return e.getState();
+			}
+		}, 0);
+		EventValues.registerEventValue(PlayerFishEvent.class, FishHook.class, new Getter<FishHook, PlayerFishEvent>() {
+			@Override
+			@Nullable
+			public FishHook get(PlayerFishEvent e) {
+				return e.getHook();
+			}
+		}, 0);
 	}
 }

--- a/src/main/java/ch/njol/skript/effects/EffFireworkLaunch.java
+++ b/src/main/java/ch/njol/skript/effects/EffFireworkLaunch.java
@@ -43,7 +43,7 @@ import ch.njol.util.Kleenean;
 public class EffFireworkLaunch extends Effect {
 	
 	static {
-		Skript.registerEffect(EffFireworkLaunch.class, "(launch|deploy) [[a] firework [with effect[s]]] %fireworkeffects% at %locations% [([with] (duration|power)|timed) %number%]");
+		Skript.registerEffect(EffFireworkLaunch.class, "(launch|deploy) [a] [firework [with effect[s]]] %fireworkeffects% at %locations% [([with] (duration|power)|timed) %number%]");
 	}
 
 	@SuppressWarnings("null")

--- a/src/main/java/ch/njol/skript/events/EvtFishing.java
+++ b/src/main/java/ch/njol/skript/events/EvtFishing.java
@@ -1,0 +1,76 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.events;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.player.PlayerFishEvent;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.Literal;
+import ch.njol.skript.lang.SkriptEvent;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+
+public class EvtFishing extends SkriptEvent {
+
+	static {
+		Skript.registerEvent("Fishing", EvtFishing.class, PlayerFishEvent.class, "[player] fish[ing] [[state[s]] %-fishingstates%]")
+				.description("Called when a player triggers a fishing event; reeling in, catching a fish/entity, failing, etc.")
+				.examples("on fish:",
+						"\tmessage \"You did something relating to fishing!\"",
+						"on fishing states failed and in ground:", // Fun grappling hook.
+						"\tplayer is holding a fishing rod",
+						"\tname of player's tool is \"&6Grappling hook\"",
+						"\tpush player direction from player to fishing hook at speed 2.5")
+				.since("1.0");
+	}
+
+	@Nullable
+	private Literal<PlayerFishEvent.State> states;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean init(Literal<?>[] args, int matchedPattern, ParseResult parser) {
+		states = (Literal<PlayerFishEvent.State>) args[0];
+		return true;
+	}
+
+	@SuppressWarnings("null")
+	@Override
+	public boolean check(Event e) {
+		if (states == null)
+			return true;
+		PlayerFishEvent event = (PlayerFishEvent) e;
+		for (PlayerFishEvent.State state : states.getArray(event)) {
+			if (state == event.getState())
+				return true;
+		}
+		return false;
+	}
+
+	@SuppressWarnings("null")
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		if (states == null)
+			return "fishing";
+		return "fishing with states " + states.toString(e, debug);
+	}
+
+}

--- a/src/main/java/ch/njol/skript/events/SimpleEvents.java
+++ b/src/main/java/ch/njol/skript/events/SimpleEvents.java
@@ -58,7 +58,6 @@ import org.bukkit.event.player.PlayerBucketEmptyEvent;
 import org.bukkit.event.player.PlayerBucketFillEvent;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerEggThrowEvent;
-import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.event.player.PlayerItemBreakEvent;
 import org.bukkit.event.player.PlayerItemHeldEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -249,12 +248,6 @@ public class SimpleEvents {
 				.description("Called when a player throws an egg. You can just use the <a href='#shoot'>shoot event</a> in most cases, " +
 						"as this event is intended to support changing the hatched mob and its chance to hatch, but Skript does not yet support that.")
 				.examples("on throw of an egg:")
-				.since("1.0");
-		// TODO improve - on fish [of %entitydata%] (and/or itemtype), on reel, etc.
-		// Maybe something like RandomSK "[on] fishing state of %fishingstate%"
-		Skript.registerEvent("Fishing", SimpleEvent.class, PlayerFishEvent.class, "[player] fish[ing]")
-				.description("Called when a player fishes something. This is not of much use yet.")
-				.examples("on fish:")
 				.since("1.0");
 		if (Skript.classExists("org.bukkit.event.player.PlayerItemBreakEvent")) {
 			Skript.registerEvent("Item Break", SimpleEvent.class, PlayerItemBreakEvent.class, "[player] tool break[ing]", "[player] break[ing] (a|the|) tool")

--- a/src/main/java/ch/njol/skript/expressions/ExprFishingHook.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFishingHook.java
@@ -1,0 +1,55 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.expressions;
+
+import org.bukkit.entity.FishHook;
+import org.bukkit.event.Event;
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+import org.bukkit.event.player.PlayerFishEvent.State;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.EventValueExpression;
+import ch.njol.skript.lang.ExpressionType;
+
+@Name("Fishing Hook")
+@Description("The <a href='../classes.html#entity'>fishing hook</a> involved in a player fishing event.")
+@Examples({"on fishing:", "\tteleport player to fishing hook"})
+@Since("2.4")
+public class ExprFishingHook extends EventValueExpression<FishHook> {
+
+	static {
+		Skript.registerExpression(ExprFishingHook.class, FishHook.class, ExpressionType.SIMPLE, "[the] [fishing] hook");
+	}
+
+	public ExprFishingHook() {
+		super(FishHook.class);
+	}
+
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		return "the fishing hook";
+	}
+
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprFishingState.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFishingState.java
@@ -1,0 +1,54 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.expressions;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+import org.bukkit.event.player.PlayerFishEvent.State;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.EventValueExpression;
+import ch.njol.skript.lang.ExpressionType;
+
+@Name("Fishing State")
+@Description("The <a href='../classes.html#fishingstate'>fishing state</a> of a player fishing event.")
+@Examples("fishing state is failed or in ground")
+@Since("2.4")
+public class ExprFishingState extends EventValueExpression<State> {
+
+	static {
+		Skript.registerExpression(ExprFishingState.class, State.class, ExpressionType.SIMPLE, "[the] fishing state");
+	}
+
+	public ExprFishingState() {
+		super(State.class);
+	}
+
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		return "the fishing state";
+	}
+
+}

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -1660,7 +1660,6 @@ types:
 	fishingstate: fishing state¦s @a
 	genes: panda genes¦s @a
 	cattype: cat type¦s @a
-	fishingstate: fishing state¦s @a
 
 	# Skript
 	weathertype: weather type¦s @a

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -1577,6 +1577,30 @@ genes:
 	weak: weak
 	aggressive: aggressive, savage, wild
 
+# -- Cat Types --
+cat types:
+	all_black: all black
+	black: black
+	british_shorthair: british shorthair, shorthair
+	calico: calico
+	jellie: jellie
+	persian: persian
+	ragdoll: ragdoll
+	red: red
+	siamese: siamese
+	tabby: tabby
+	white: white
+
+# -- Fishing States --
+fishing states:
+	bite: bite
+	caught_entity: caught entity, caught loot, loot
+	caught_fish: caught, caught fish
+	failed_attempt: failed, failed attempt, failure
+	fishing: cast, fishing, cast rod
+	in_ground: in ground, in the ground, ground, grounded
+	reel_in: reel in
+
 # -- Boolean --
 boolean:
 	true:
@@ -1633,6 +1657,10 @@ types:
 	fireworkeffect: firework effect¦s @a
 	fireworktype: firework type¦s @a
 	soundcategory: sound categor¦y¦ies @a
+	fishingstate: fishing state¦s @a
+	genes: panda genes¦s @a
+	cattype: cat type¦s @a
+	fishingstate: fishing state¦s @a
 
 	# Skript
 	weathertype: weather type¦s @a

--- a/src/main/resources/scripts/fishing.sk
+++ b/src/main/resources/scripts/fishing.sk
@@ -1,0 +1,13 @@
+
+on fishing states caught entity and caught fish:
+	launch a trailing large ball firework coloured red, purple and lime at entity timed 0
+	message "&aCongrats you caught something!"
+
+# A fun grappling hook.
+on fishing failure and in ground:
+	player is holding a fishing rod
+	name of player's tool is "&6Grappling hook"
+	push player direction from player to fishing hook at speed 2.5
+
+on fish:
+	message "You just did something relating to fishing! %fishing state%" to player

--- a/src/main/resources/scripts/fishing.sk
+++ b/src/main/resources/scripts/fishing.sk
@@ -1,7 +1,8 @@
 
 on fishing states caught entity and caught fish:
 	launch a trailing large ball firework coloured red, purple and lime at entity timed 0
-	message "&aCongrats you caught something!"
+	# Since there is the fish entity and player in this event, you must define where to send this message to.
+	message "&aCongrats you caught something!" to player
 
 # A fun grappling hook.
 on fishing failure and in ground:


### PR DESCRIPTION
### Description
Improves fishing by adding fishing state, fishing hook, improved event with the fishing state, and getting of the caught entity.

Tested on Paper 1.14.4-138

Test script and new default example script:
```
on fishing states caught entity and caught fish:
	launch a trailing large ball firework coloured red, purple and lime at entity timed 0
	message "&aCongrats you caught something!" to player

# A fun grappling hook.
on fishing failure and in ground:
	player is holding a fishing rod
	name of player's tool is "&6Grappling hook"
	push player direction from player to fishing hook at speed 2.5

on fish:
	message "You just did something relating to fishing! %fishing state%" to player 
```
