### PR TITLE
Add horse jumping

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -1010,6 +1010,7 @@ public final class BukkitEventValues {
 				}
 			}, 0);
 		}
+		//HorseJumpEvent
 		EventValues.registerEventValue(HorseJumpEvent.class, Entity.class, new Getter<Entity, HorseJumpEvent>() {
 			@Override
 			@Nullable

--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -62,6 +62,7 @@ import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.EntityEvent;
 import org.bukkit.event.entity.EntityTameEvent;
 import org.bukkit.event.entity.FireworkExplodeEvent;
+import org.bukkit.event.entity.HorseJumpEvent;
 import org.bukkit.event.entity.ItemDespawnEvent;
 import org.bukkit.event.entity.ItemMergeEvent;
 import org.bukkit.event.entity.ItemSpawnEvent;
@@ -1009,6 +1010,12 @@ public final class BukkitEventValues {
 				}
 			}, 0);
 		}
-
+		EventValues.registerEventValue(HorseJumpEvent.class, Entity.class, new Getter<Entity, HorseJumpEvent>() {
+			@Override
+			@Nullable
+			public Entity get(HorseJumpEvent e) {
+				return e.getEntity();
+			}
+		}, 0);
 	}
 }

--- a/src/main/java/ch/njol/skript/events/SimpleEvents.java
+++ b/src/main/java/ch/njol/skript/events/SimpleEvents.java
@@ -43,6 +43,7 @@ import org.bukkit.event.entity.EntityToggleGlideEvent;
 import org.bukkit.event.entity.EntityToggleSwimEvent;
 import org.bukkit.event.entity.ExplosionPrimeEvent;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
+import org.bukkit.event.entity.HorseJumpEvent;
 import org.bukkit.event.entity.PigZapEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.entity.ProjectileLaunchEvent;
@@ -516,5 +517,10 @@ public class SimpleEvents {
 							"	cancel event")
 					.since("2.3");
 		}
+		Skript.registerEvent("Horse Jump", SimpleEvent.class, HorseJumpEvent.class, "horse jump[ing]")
+				.description("Called when a horse jumps.")
+				.examples("on horse jump:",
+						"\tcancel event")
+				.since("2.4");
 	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprPower.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPower.java
@@ -1,0 +1,106 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.expressions;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.entity.FireworkExplodeEvent;
+import org.bukkit.event.entity.HorseJumpEvent;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.ScriptLoader;
+import ch.njol.skript.Skript;
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.skript.log.ErrorQuality;
+import ch.njol.util.Kleenean;
+
+@Name("Power")
+@Description("Gets the power/force within a supported event.")
+@Examples("power is greater than or equal to 2")
+@Since("2.4")
+public class ExprPower extends SimpleExpression<Number> {
+
+	static {
+		Skript.registerExpression(ExprPower.class, Number.class, ExpressionType.SIMPLE, "power");
+	}
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		if (ScriptLoader.isCurrentEvent(HorseJumpEvent.class, FireworkExplodeEvent.class))
+			return true;
+		Skript.error("The power event expression can only be used within HorseJumpEvent and FireworkExplodeEvent", ErrorQuality.SEMANTIC_ERROR);
+		return false;
+	}
+
+	@Override
+	protected Number[] get(Event e) {
+		Number power = 0;
+		if (e instanceof HorseJumpEvent)
+			power = ((HorseJumpEvent)e).getPower();
+		else 
+			power = ((FireworkExplodeEvent)e).getEntity().getFireworkMeta().getPower();
+		return new Number[] {power};
+	}
+
+	@Override
+	public boolean isSingle() {
+		return true;
+	}
+
+	@Override
+	public Class<? extends Number> getReturnType() {
+		return Number.class;
+	}
+
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		return "power";
+	}
+
+	@Override
+	@Nullable
+	public Class<?>[] acceptChange(ChangeMode mode) {
+		if (mode == ChangeMode.ADD || mode == ChangeMode.SET || mode == ChangeMode.REMOVE)
+			return new Class[] {Number.class};
+		return null;
+	}
+
+	@SuppressWarnings("deprecation")
+	@Override
+	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+		if (delta == null)
+			return;
+		Number power = (Number) delta[0];
+		if (e instanceof FireworkExplodeEvent)
+			((HorseJumpEvent)e).setPower(power.floatValue());
+		else
+			((FireworkExplodeEvent)e).getEntity().getFireworkMeta().setPower(power.intValue());
+	}
+
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprPower.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPower.java
@@ -97,10 +97,41 @@ public class ExprPower extends SimpleExpression<Number> {
 		if (delta == null)
 			return;
 		Number power = (Number) delta[0];
-		if (e instanceof FireworkExplodeEvent)
-			((HorseJumpEvent)e).setPower(power.floatValue());
-		else
-			((FireworkExplodeEvent)e).getEntity().getFireworkMeta().setPower(power.intValue());
+		switch (mode) {
+			case ADD:
+				if (e instanceof HorseJumpEvent) {
+					HorseJumpEvent event = (HorseJumpEvent) e;
+					float old = event.getPower();
+					event.setPower(old + power.floatValue());
+				} else {
+					FireworkExplodeEvent event = (FireworkExplodeEvent) e;
+					int old = event.getEntity().getFireworkMeta().getPower();
+					event.getEntity().getFireworkMeta().setPower(old + power.intValue());
+				}
+				break;
+			case REMOVE:
+				if (e instanceof HorseJumpEvent) {
+					HorseJumpEvent event = (HorseJumpEvent) e;
+					float old = event.getPower();
+					event.setPower(old - power.floatValue());
+				} else {
+					FireworkExplodeEvent event = (FireworkExplodeEvent) e;
+					int old = event.getEntity().getFireworkMeta().getPower();
+					event.getEntity().getFireworkMeta().setPower(old - power.intValue());
+				}
+				break;
+			case SET:
+				if (e instanceof HorseJumpEvent)
+					((HorseJumpEvent)e).setPower(power.floatValue());
+				else
+					((FireworkExplodeEvent)e).getEntity().getFireworkMeta().setPower(power.intValue());
+				break;
+			case REMOVE_ALL:
+			case DELETE:
+			case RESET:
+			default:
+				break;
+		}
 	}
 
 }


### PR DESCRIPTION
Adds horse jumping and a proper management for power event values. No conflicts with conduit power, power enchantment and works flawless in 1.8+.

```
on firework explode:
	broadcast "%power%"
	
on horse jump:
	broadcast "%power%"
	set name of entity to "&6Super horsie"
```