### PR TITLE
Add notice that ban effect does not include kick

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffBan.java
+++ b/src/main/java/ch/njol/skript/effects/EffBan.java
@@ -45,7 +45,8 @@ import ch.njol.util.Kleenean;
  */
 @Name("Ban")
 @Description({"Bans/unbans a player or an IP address.",
-		"Starting with Skript 2.1.1 and Bukkit 1.7.2 R0.4, one can also ban players with a reason."})
+		"Starting with Skript 2.1.1 and Bukkit 1.7.2 R0.4, one can also ban players with a reason.",
+		"Note that banning a player will not automatically remove them from the server (use the kick effect for that)."})
 @Examples({"unban player",
 		"ban \"127.0.0.1\"",
 		"IP-ban the player because \"he is an idiot\""})

--- a/src/main/java/ch/njol/skript/effects/EffBan.java
+++ b/src/main/java/ch/njol/skript/effects/EffBan.java
@@ -46,7 +46,7 @@ import ch.njol.util.Kleenean;
 @Name("Ban")
 @Description({"Bans/unbans a player or an IP address.",
 		"Starting with Skript 2.1.1 and Bukkit 1.7.2 R0.4, one can also ban players with a reason.",
-		"Note that banning a player will not automatically remove them from the server (use the kick effect for that)."})
+		"Note that banning a player will not kick them from the server. You may use the <a href='effects.html#EffKick'>kick effect</a> if you wish so."})
 @Examples({"unban player",
 		"ban \"127.0.0.1\"",
 		"IP-ban the player because \"he is an idiot\""})


### PR DESCRIPTION
### Description
<!--- Add something that describes the pull request here --->
Since the ban effect does not include a kick, and some users may not know that, it should be mentioned in the documentation.

---
**Target Minecraft Versions:**     Any
**Requirements:**     None
**Related Issues:**     https://github.com/SkriptLang/Skript/issues/2344
