### PR TITLE
Add check for non-skript files

### DIFF
--- a/src/main/java/ch/njol/skript/SkriptCommand.java
+++ b/src/main/java/ch/njol/skript/SkriptCommand.java
@@ -24,8 +24,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
-import org.apache.commons.io.FilenameUtils;
-
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -370,7 +368,8 @@ public class SkriptCommand implements CommandExecutor {
 		if (isFolder) {
 			script = script.replace('/', File.separatorChar).replace('\\', File.separatorChar);
 		} else if (!StringUtils.endsWithIgnoreCase(script, ".sk")) {
-			if(!FilenameUtils.getExtension(script).equals("")) {
+			int dot = script.lastIndexOf('.');
+			if (dot > 0 && !script.substring(dot+1).equals("")) {
 				return null;
 			}
 			script = script + ".sk";

--- a/src/main/java/ch/njol/skript/SkriptCommand.java
+++ b/src/main/java/ch/njol/skript/SkriptCommand.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
+import org.apache.commons.io.FilenameUtils;
+
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -368,6 +370,9 @@ public class SkriptCommand implements CommandExecutor {
 		if (isFolder) {
 			script = script.replace('/', File.separatorChar).replace('\\', File.separatorChar);
 		} else if (!StringUtils.endsWithIgnoreCase(script, ".sk")) {
+			if(!FilenameUtils.getExtension(script).equals("")) {
+				return null;
+			}
 			script = script + ".sk";
 		}
 		if (script.startsWith("-"))


### PR DESCRIPTION
### Description
<!--- Add something that describes the pull request here --->
Adds a sanity check for invalid script parameters given to getScriptFromName(String script), i.e. it's not ```example.sk```, it's not ```example```. If something like ```spigot.yml``` were to be given to the function, it would return null

---
**Target Minecraft Versions:**     Any
**Requirements:**     None
**Related Issues:**     https://github.com/SkriptLang/Skript/issues/2103