### PR TITLE
Add summon as an alias to the spawn effect

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffSpawn.java
+++ b/src/main/java/ch/njol/skript/effects/EffSpawn.java
@@ -48,8 +48,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class EffSpawn extends Effect {
 	static {
 		Skript.registerEffect(EffSpawn.class,
-				"spawn %entitytypes% [%directions% %locations%]",
-				"spawn %number% of %entitytypes% [%directions% %locations%]");
+				"(spawn|summon) %entitytypes% [%directions% %locations%]",
+				"(spawn|summon) %number% of %entitytypes% [%directions% %locations%]");
 	}
 	
 	@SuppressWarnings("null")


### PR DESCRIPTION
### Description
<!--- Add something that describes the pull request here --->
Simple change that just adds ```summon``` as an alias to the ```spawn``` effect. I added this since I found it odd that Skript doesn't already have this (since it mostly follows Minecraft nomenclature as much as possible), and Minecraft by default spawns mobs in via ```/summon``` and not ```/spawn```

---
**Target Minecraft Versions:**  Any
**Requirements:**     None
**Related Issues:**     None
