### PR TITLE
Spawner Type Expression

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprSpawner.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSpawner.java
@@ -28,7 +28,7 @@ import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.classes.Converter;
-import ch.njol.skript.Skript;
+import ch.njol.skript.aliases.Aliases;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -53,7 +53,7 @@ public class ExprSpawner extends SimplePropertyExpression<Block, EntityType> {
 	@Override
 	@Nullable
 	public EntityType convert(final Block b) {
-		if (b.getType() != (Skript.isRunningMinecraft(1, 13) ? Material.SPAWNER : Material.LEGACY_MOB_SPAWNER))
+		if (b.getType() != Aliases.javaItemType("spawner").getMaterial())
 			return null;
 		return toSkriptEntityType(((CreatureSpawner)b.getState()).getSpawnedType());
 	}
@@ -70,7 +70,7 @@ public class ExprSpawner extends SimplePropertyExpression<Block, EntityType> {
 	@Override
 	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
 		for (Block b : getExpr().getArray(e)) {
-			if (b.getType() != (Skript.isRunningMinecraft(1, 13) ? Material.SPAWNER : Material.LEGACY_MOB_SPAWNER))
+			if (b.getType() != Aliases.javaItemType("spawner").getMaterial())
 				continue;
 			CreatureSpawner s = (CreatureSpawner) b.getState();
 			switch (mode) {

--- a/src/main/java/ch/njol/skript/expressions/ExprSpawner.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSpawner.java
@@ -124,7 +124,8 @@ public class ExprSpawner extends SimplePropertyExpression<Block, EntityData> {
 	 */
 	@SuppressWarnings("null")
 	public static EntityData toSkriptEntityData(org.bukkit.entity.EntityType e){
-		return EntityData.parse(e.toString());
+		//Replace underscores with spaces to comply with Skript's Alias format 
+		return EntityData.parse(e.toString().replaceAll("_", " "));
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprSpawner.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSpawner.java
@@ -28,6 +28,7 @@ import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.classes.Converter;
+import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;

--- a/src/main/java/ch/njol/skript/expressions/ExprSpawner.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSpawner.java
@@ -56,7 +56,7 @@ public class ExprSpawner extends SimplePropertyExpression<Block, EntityData> {
 	static {
 		//Cache Bukkit EntityType -> Skript EntityType 
 		for(org.bukkit.entity.EntityType e : org.bukkit.entity.EntityType.values()) {
-			//Replace underscores with spaces to comply with Skript Alias format 
+			//Replace underscores with spaces to comply with Skript's Alias format 
 			CACHE.put(EntityType.parse(e.toString().replaceAll("_", " ")), e);
 		}
 		register(ExprSpawner.class, EntityData.class, "entity type", "blocks");
@@ -108,8 +108,8 @@ public class ExprSpawner extends SimplePropertyExpression<Block, EntityData> {
 	}
 	
 	/**
-	 * Convert from Skript's EntityData to Bukkit's EntityType
-	 * @param e Skript's EntityData
+	 * Convert from Skript's EntityType to Bukkit's EntityType
+	 * @param e Skript's EntityType
 	 * @return Bukkit's EntityType
 	 */
 	@SuppressWarnings({"null"})

--- a/src/main/java/ch/njol/skript/expressions/ExprSpawner.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSpawner.java
@@ -48,18 +48,17 @@ import ch.njol.util.coll.CollectionUtils;
 @Description("Retrieves, sets, or resets the spawner's entity type")
 @Examples({"broadcast \"%spawner's entity type%\""})
 @Since("INSERT VERSION")
-public class ExprSpawner extends SimplePropertyExpression<Block, EntityData> {
+public class ExprSpawnerType extends SimplePropertyExpression<Block, EntityData> {
 	
 	private static final Material MATERIAL_SPAWNER = Aliases.javaItemType("spawner").getMaterial();
 	private static final Map<EntityType, org.bukkit.entity.EntityType> CACHE = new HashMap<EntityType, org.bukkit.entity.EntityType>();
 	
 	static {
-		//Cache Bukkit EntityType -> Skript EntityType 
-		for(org.bukkit.entity.EntityType e : org.bukkit.entity.EntityType.values()) {
-			//Replace underscores with spaces to comply with Skript's Alias format 
-			CACHE.put(EntityType.parse(e.toString().replaceAll("_", " ")), e);
+		// Cache Bukkit EntityType -> Skript EntityType 
+		for (org.bukkit.entity.EntityType e : org.bukkit.entity.EntityType.values()) {
+			CACHE.put(new EntityType(e.getEntityClass(), 1), e);
 		}
-		register(ExprSpawner.class, EntityData.class, "entity type", "blocks");
+		register(ExprSpawnerType.class, EntityData.class, "entity type", "blocks");
 	}
 	
 	@Override
@@ -67,7 +66,7 @@ public class ExprSpawner extends SimplePropertyExpression<Block, EntityData> {
 	public EntityData convert(final Block b) {
 		if (b.getType() != MATERIAL_SPAWNER)
 			return null;
-		return toSkriptEntityData(((CreatureSpawner)b.getState()).getSpawnedType());
+		return toSkriptEntityData(((CreatureSpawner) b.getState()).getSpawnedType());
 	}
 	
 	@Nullable
@@ -93,7 +92,7 @@ public class ExprSpawner extends SimplePropertyExpression<Block, EntityData> {
 					s.setSpawnedType(org.bukkit.entity.EntityType.PIG);
 					break;
 			}
-			s.update(); //Actually trigger the spawner's update 
+			s.update(); // Actually trigger the spawner's update 
 		}
 	}
 	
@@ -113,7 +112,7 @@ public class ExprSpawner extends SimplePropertyExpression<Block, EntityData> {
 	 * @return Bukkit's EntityType
 	 */
 	@SuppressWarnings({"null"})
-	public static org.bukkit.entity.EntityType toBukkitEntityType(EntityType e){
+	private static org.bukkit.entity.EntityType toBukkitEntityType(EntityType e){
 		return CACHE.get(e);
 	}
 	
@@ -123,8 +122,8 @@ public class ExprSpawner extends SimplePropertyExpression<Block, EntityData> {
 	 * @return Skript's EntityData
 	 */
 	@SuppressWarnings("null")
-	public static EntityData toSkriptEntityData(org.bukkit.entity.EntityType e){
-		//Replace underscores with spaces to comply with Skript's Alias format 
+	private static EntityData toSkriptEntityData(org.bukkit.entity.EntityType e){
+		// Replace underscores with spaces to comply with Skript's Alias format 
 		return EntityData.parse(e.toString().replaceAll("_", " "));
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprSpawner.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSpawner.java
@@ -1,0 +1,117 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+
+package ch.njol.skript.expressions;
+
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.CreatureSpawner;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.classes.Converter;
+import ch.njol.skript.classes.Changer;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.entity.EntityType;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
+
+@Name("Spawner Type")
+@Description("Retrieves, sets, or resets the spawner's entitytype")
+@Examples({"broadcast \"%spawner's entitytype%\""})
+@Since("INSERT VERSION")
+public class ExprSpawner extends SimplePropertyExpression<Block, EntityType> {
+	
+	static {
+		register(ExprSpawner.class, EntityType.class, "entitytype", "block");
+	}
+	
+	@Override
+	@Nullable
+	public EntityType convert(final Block b) {
+		if (b.getType() != Material.SPAWNER)
+			return null;
+		return toSkriptEntityType(((CreatureSpawner)b.getState()).getSpawnedType());
+	}
+	
+	@Nullable
+	@Override
+	public Class<?>[] acceptChange(Changer.ChangeMode mode) {
+		if (mode == ChangeMode.SET || mode == ChangeMode.RESET) 
+			return CollectionUtils.array(EntityType.class);
+		return null;
+	}
+	
+	@SuppressWarnings("null")
+	@Override
+	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+		for (Block b : getExpr().getArray(e)) {
+			if (b.getType() != Material.SPAWNER)
+				continue;
+			CreatureSpawner s = (CreatureSpawner) b.getState();
+			switch (mode) {
+				case SET:
+					s.setSpawnedType(toBukkitEntityType((EntityType) delta[0]));
+					break;
+				case RESET:
+					s.setSpawnedType(org.bukkit.entity.EntityType.PIG);
+					break;
+			}
+			s.update(); //Actually trigger the spawner's update 
+		}
+	}
+	
+	@Override
+	public Class<EntityType> getReturnType() {
+		return EntityType.class;
+	}
+	
+	@Override
+	protected String getPropertyName() {
+		return "entitytype";
+	}
+	
+	/**
+	 * Convert from Skript's EntityType to Bukkit's EntityType
+	 * @param e Skript's EntityType
+	 * @return Bukkit's EntityType
+	 */
+	@SuppressWarnings({"null", "deprecation"})
+	public static org.bukkit.entity.EntityType toBukkitEntityType(EntityType e){
+		return org.bukkit.entity.EntityType.fromName(e.toString());
+	}
+	
+	/**
+	 * Convert from Bukkit's EntityType to Skript's EntityType
+	 * @param e Bukkit's EntityType
+	 * @return Skript's EntityType
+	 */
+	@SuppressWarnings("null")
+	public static EntityType toSkriptEntityType(org.bukkit.entity.EntityType e){
+		return EntityType.parse(e.toString());
+	}
+	
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprSpawner.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSpawner.java
@@ -52,7 +52,7 @@ public class ExprSpawner extends SimplePropertyExpression<Block, EntityType> {
 	@Override
 	@Nullable
 	public EntityType convert(final Block b) {
-		if (b.getType() != Material.SPAWNER)
+		if (b.getType() != (Skript.isRunningMinecraft(1, 13) ? Material.SPAWNER : Material.LEGACY_MOB_SPAWNER))
 			return null;
 		return toSkriptEntityType(((CreatureSpawner)b.getState()).getSpawnedType());
 	}
@@ -69,7 +69,7 @@ public class ExprSpawner extends SimplePropertyExpression<Block, EntityType> {
 	@Override
 	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
 		for (Block b : getExpr().getArray(e)) {
-			if (b.getType() != Material.SPAWNER)
+			if (b.getType() != (Skript.isRunningMinecraft(1, 13) ? Material.SPAWNER : Material.LEGACY_MOB_SPAWNER))
 				continue;
 			CreatureSpawner s = (CreatureSpawner) b.getState();
 			switch (mode) {

--- a/src/main/java/ch/njol/skript/expressions/ExprSpawnerType.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSpawnerType.java
@@ -61,8 +61,8 @@ public class ExprSpawnerType extends SimplePropertyExpression<Block, EntityData>
 		for (org.bukkit.entity.EntityType e : org.bukkit.entity.EntityType.values()) {
 			Class<? extends Entity> c = e.getEntityClass();
 			if (c != null) {
-				CACHE.put(new EntityType(e.getEntityClass(), 1), e); // Cache Skript EntityType -> Bukkit EntityType 
-				CACHE_2.put(e, EntityData.fromClass(e.getEntityClass())); // Cache Bukkit EntityType -> Skript EntityData
+				CACHE.put(new EntityType(c, 1), e); // Cache Skript EntityType -> Bukkit EntityType 
+				CACHE_2.put(e, EntityData.fromClass(c)); // Cache Bukkit EntityType -> Skript EntityData
 			}
 		}
 		register(ExprSpawnerType.class, EntityData.class, "(entity|creature) type[s]", "blocks");

--- a/src/main/java/ch/njol/skript/expressions/ExprSpawnerType.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSpawnerType.java
@@ -46,19 +46,22 @@ import ch.njol.util.coll.CollectionUtils;
 
 @Name("Spawner Type")
 @Description("Retrieves, sets, or resets the spawner's entity type")
-@Examples({"broadcast \"%spawner's entity type%\""})
+@Examples({"on right click:",
+		"	if event-block is spawner:",
+		"		send \"Spawner's type is %target block's entity type%\""})
 @Since("INSERT VERSION")
 public class ExprSpawnerType extends SimplePropertyExpression<Block, EntityData> {
 	
 	private static final Material MATERIAL_SPAWNER = Aliases.javaItemType("spawner").getMaterial();
 	private static final Map<EntityType, org.bukkit.entity.EntityType> CACHE = new HashMap<EntityType, org.bukkit.entity.EntityType>();
+	private static final Map<org.bukkit.entity.EntityType, EntityData> CACHE_2 = new HashMap<org.bukkit.entity.EntityType, EntityData>();
 	
 	static {
-		// Cache Bukkit EntityType -> Skript EntityType 
 		for (org.bukkit.entity.EntityType e : org.bukkit.entity.EntityType.values()) {
-			CACHE.put(new EntityType(e.getEntityClass(), 1), e);
+			CACHE.put(new EntityType(e.getEntityClass(), 1), e); // Cache Skript EntityType -> Bukkit EntityType 
+			CACHE_2.put(e, EntityData.fromClass(e.getEntityClass())); // Cache Bukkit EntityType -> Skript EntityData
 		}
-		register(ExprSpawnerType.class, EntityData.class, "entity type", "blocks");
+		register(ExprSpawnerType.class, EntityData.class, "(entity|creature) type[s]", "blocks");
 	}
 	
 	@Override
@@ -123,8 +126,7 @@ public class ExprSpawnerType extends SimplePropertyExpression<Block, EntityData>
 	 */
 	@SuppressWarnings("null")
 	private static EntityData toSkriptEntityData(org.bukkit.entity.EntityType e){
-		// Replace underscores with spaces to comply with Skript's Alias format 
-		return EntityData.parse(e.toString().replaceAll("_", " "));
+		return CACHE_2.get(e);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprSpawnerType.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSpawnerType.java
@@ -58,8 +58,11 @@ public class ExprSpawnerType extends SimplePropertyExpression<Block, EntityData>
 	
 	static {
 		for (org.bukkit.entity.EntityType e : org.bukkit.entity.EntityType.values()) {
-			CACHE.put(new EntityType(e.getEntityClass(), 1), e); // Cache Skript EntityType -> Bukkit EntityType 
-			CACHE_2.put(e, EntityData.fromClass(e.getEntityClass())); // Cache Bukkit EntityType -> Skript EntityData
+			Class<? extends Entity> c = e.getEntityClass();
+			if (c != null) {
+				CACHE.put(new EntityType(e.getEntityClass(), 1), e); // Cache Skript EntityType -> Bukkit EntityType 
+				CACHE_2.put(e, EntityData.fromClass(e.getEntityClass())); // Cache Bukkit EntityType -> Skript EntityData
+			}
 		}
 		register(ExprSpawnerType.class, EntityData.class, "(entity|creature) type[s]", "blocks");
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprSpawnerType.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSpawnerType.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.CreatureSpawner;
+import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 


### PR DESCRIPTION
### Description
Adds an expression that allows for the retrieval, setting, and resetting of spawner blocks' entitytype

Note: I ran into an issue where Skript couldn't properly detect entity types when using Bukkit's ``EntityType.class``, so I just stuck with Skript's ``EntityType.class`` for variable's sake but internally it converts between the two for setting/getting the entity type of the spawner block using the helper functions ``toBukkitEntityType()`` and ``toSkriptEntityType()``

---
**Target Minecraft Versions:**     Any*
**Requirements:**     None
**Related Issues:**     #1186, #2385 