### PR TITLE
Rework the contains condition

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondContains.java
+++ b/src/main/java/ch/njol/skript/conditions/CondContains.java
@@ -34,146 +34,131 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionList;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.skript.lang.function.ExprFunctionCall;
 import ch.njol.skript.lang.Variable;
-import ch.njol.skript.log.ParseLogHandler;
-import ch.njol.skript.log.SkriptLogger;
 import ch.njol.skript.registrations.Comparators;
-import ch.njol.skript.registrations.Converters;
 import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
 import ch.njol.util.StringUtils;
 
-/**
- * @author Peter Güttinger
- */
 @Name("Contains")
-@Description("Checks whether an inventory contains the given item, a text contains another piece of text, or a list of objects (e.g. a {list variable::*}) contains another object.")
+@Description("Checks whether an inventory contains an item, a text contains another piece of text, " +
+		"or a list (e.g. {list variable::*} or 'drops') contains another object.")
 @Examples({"block contains 20 cobblestone",
-		"player has 4 flint and 2 iron ingots"})
+		"player has 4 flint and 2 iron ingots",
+		"{list::*} contains 5"})
 @Since("1.0")
 public class CondContains extends Condition {
-	
+
 	static {
 		Skript.registerCondition(CondContains.class,
-				"%inventories% ha(s|ve) %itemtypes% [in [(the[ir]|his|her|its)] inventory]",
+				"%inventories% (has|have) %itemtypes% [in [(the[ir]|his|her|its)] inventory]",
+				"%inventories% (doesn't|does not|do not|don't) have %itemtypes% [in [(the[ir]|his|her|its)] inventory]",
 				"%inventories/strings/objects% contain[s] %itemtypes/strings/objects%",
-				"%inventories% do[es](n't| not) have %itemtypes% [in [(the[ir]|his|her|its)] inventory]",
-				"%inventories/strings/objects% do[es](n't| not) contain %itemtypes/strings/objects%");
+				"%inventories/strings/objects% (doesn't|does not|do not|don't) contain %itemtypes/strings/objects%",
+				"[the] list [of] %objects% (doesn't|does not|do not|don't) contain %objects%", // comes before 'contains' because of a parser bug
+				"[the] list [of] %objects% contain[s] %objects%",
+				"(all|1¦any|2¦none) of %strings% contain[s] %strings%");
 	}
-	
+
 	@SuppressWarnings("null")
 	private Expression<?> containers;
 	@SuppressWarnings("null")
 	private Expression<?> items;
-	
-	@SuppressWarnings({"unchecked", "null", "unused"})
+	private boolean isListCheck, isStringCheck, isAnyNoneOf;
+
+	@SuppressWarnings({"null", "unchecked"})
 	@Override
-	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parser) {
-		containers = exprs[0].getConvertedExpression(Object.class);
-		if (containers == null)
-			return false;
-		if (!(containers instanceof Variable) && !String.class.isAssignableFrom(containers.getReturnType()) && !Inventory.class.isAssignableFrom(containers.getReturnType())
-				&& !containers.getReturnType().equals(Object.class)) {
-			final ParseLogHandler h = SkriptLogger.startParseLogHandler();
-			try {
-				Expression<?> c = containers.getConvertedExpression(String.class);
-				if (c == null)
-					c = containers.getConvertedExpression(Inventory.class);
-				if (c == null) {
-					h.printError();
-					return false;
-				}
-				containers = c;
-				h.printLog();
-			} finally {
-				h.stop();
-			}
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		containers = exprs[0];
+		items = exprs[1];
+		isAnyNoneOf = parseResult.mark == 1 || parseResult.mark == 2;
+		isListCheck = matchedPattern == 4 || matchedPattern == 5;
+		isStringCheck = matchedPattern == 6;
+
+		if (!isListCheck && !(containers instanceof Variable) && containers.getReturnType() != Inventory.class &&
+				containers.getReturnType() != String.class && containers.getReturnType() != Object.class) {
+			Expression<?> converted = containers.getConvertedExpression(Inventory.class);
+			if (converted == null)
+				converted = containers.getConvertedExpression(String.class);
+			if (converted != null)
+				containers = converted;
 		}
-		items = exprs[1].getConvertedExpression(Object.class);
-		if (items == null)
-			return false;
-		setNegated(matchedPattern >= 2);
+
+		setNegated(matchedPattern == 1 || matchedPattern == 3 || matchedPattern == 4 || parseResult.mark == 2);
 		return true;
 	}
-	
+
 	@Override
-	public boolean check(final Event e) {
-		boolean caseSensitive = SkriptConfig.caseSensitive.value();
-		
-		// Special case for listr variables and functions that return them
-		if ((containers instanceof Variable || containers instanceof ExprFunctionCall)
-				&& !containers.isSingle()) {
-			for (Object value : containers.getAll(e)) {
-				for (Object searched : items.getAll(e)) {
-					if (Relation.EQUAL.is(Comparators.compare(searched, value))) {
-						return !isNegated();
+	public boolean check(Event e) {
+		// List contains checks
+		if (!isListCheck && !isStringCheck) {
+			if (containers instanceof ExpressionList) {
+				// It should be list check if the expression list contains
+				// an expression that doesn't return an inventory or a string
+				for (Expression<?> expr : ((ExpressionList<?>) containers).getExpressions()) {
+					Class<?> returnType = expr.getReturnType();
+					if (returnType != Inventory.class && returnType != String.class && returnType != Object.class) {
+						isListCheck = true;
+						break;
 					}
 				}
+			} else if (containers.getReturnType() != Inventory.class && containers.getReturnType() != String.class &&
+					!containers.isSingle()) {
+				isListCheck = true;
+			}
+		}
+		if (isListCheck) {
+			Object[] containersAll = containers.getAll(e);
+			if (containersAll.length == 0) // not actually needed, but avoids further loops
+				return isNegated();
+			return items.check(e, (Checker<Object>) item -> {
+				for (Object container : containers.getAll(e)) {
+					if (Relation.EQUAL.is(Comparators.compare(container, item)))
+						return true;
+				}
+				return false;
+			}, isNegated());
+		}
+
+		boolean caseSensitive = SkriptConfig.caseSensitive.value();
+
+		// 'any/none of texts contains' checks
+		if (isAnyNoneOf) {
+			for (Object container : containers.getAll(e)) {
+				String str = (String) container;
+				assert str != null;
+				if (items.check(e, (Checker<Object>) type ->
+						type instanceof String && StringUtils.contains(str, (String) type, caseSensitive)))
+					return !isNegated();
 			}
 			return isNegated();
 		}
-		
-		return containers.check(e,
-				(Checker<Object>) container -> {
-					if (container instanceof Inventory) {
-						final Inventory invi = (Inventory) container;
-						return items.check(e, (Checker<Object>) type -> {
-							if (type instanceof ItemType)
-								return ((ItemType) type).isContainedIn(invi);
-							else if (type instanceof ItemStack)
-								return invi.contains((ItemStack) type);
-							else return false;
-						});
-					} else if (container instanceof String) {
-						final String s = (String) container;
-						return items.check(e,
-								(Checker<Object>) type -> {
-									if (type instanceof Variable) {
-										@SuppressWarnings("unchecked")
-										String toFind = ((Variable<String>) type).getSingle(e);
-										if (toFind != null)
-											return StringUtils.contains(s, toFind, caseSensitive);
-									}
-									return type instanceof String && StringUtils.contains(s, (String) type, caseSensitive);
-								});
-					} else { // Ok, so we have a variable...
-						Object val = container instanceof Variable
-								? ((Variable<?>) container).getSingle(e) : container;
-						
-						Inventory invi = Converters.convert(val, Inventory.class);
-						if (invi != null) {
-							return items.check(e, (Checker<Object>) type -> {
-								if (type instanceof ItemType)
-									return ((ItemType) type).isContainedIn(invi);
-								else if (type instanceof ItemStack)
-									return invi.contains((ItemStack) type);
-								else return false;
-							});
-						}
-						
-						String s = Converters.convert(val, String.class);
-						if (s != null) {
-							return items.check(e,
-									(Checker<Object>) type -> {
-										if (type instanceof Variable) {
-											@SuppressWarnings("unchecked")
-											String toFind = ((Variable<String>) type).getSingle(e);
-											if (toFind != null)
-												return StringUtils.contains(s, toFind, caseSensitive);
-										}
-										return type instanceof String && StringUtils.contains(s, (String) type, caseSensitive);
-									});
-						}
-					}
+
+		// Inventory/string contains checks
+		return containers.check(e, (Checker<Object>) container -> {
+			if (container instanceof Inventory) {
+				Inventory inv = (Inventory) container;
+				return items.check(e, (Checker<Object>) type -> {
+					if (type instanceof ItemType)
+						return ((ItemType) type).isContainedIn(inv);
+					if (type instanceof ItemStack)
+						return inv.contains((ItemStack) type);
 					return false;
-				}, isNegated());
+				});
+			} else if (container instanceof String) {
+				String str = (String) container;
+				return items.check(e, (Checker<Object>) type ->
+					type instanceof String && StringUtils.contains(str, (String) type, caseSensitive));
+			}
+			return false;
+		}, isNegated());
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(@Nullable Event e, boolean debug) {
 		return containers.toString(e, debug) + (isNegated() ? " doesn't contain " : " contains ") + items.toString(e, debug);
 	}
-	
+
 }


### PR DESCRIPTION
### Description
This PR reworks CondContains to make it more stable:
- Cleaned up its code
  - Removed much unnecessary codes
- Fixed some issues
- Added more features
- After the last changes, it wasn't supporting lists like `contains 1 and 2` or `contains 1 or 2`, this is fixed

Here are some codes (effect commands) i used to test:
https://gist.github.com/Blueyescat/eadf558783dd7aa57d7255a069e7d449
*all of them works as expected*

**Current syntaxes:**
```autohotkey
%inventories% (has|have) %itemtypes% [in [(the[ir]|his|her|its)] inventory]
%inventories% (doesn't|does not|do not|don't) have %itemtypes% [in [(the[ir]|his|her|its)] inventory]
%inventories/strings/objects% contain[s] %itemtypes/strings/objects%
%inventories/strings/objects% (doesn't|does not|do not|don't) contain %itemtypes/strings/objects%
[the] list [of] %objects% (doesn't|does not|do not|don't) contain %objects%
[the] list [of] %objects% contain[s] %objects%
(all|1¦any|2¦none) of %strings% contain[s] %strings%
```

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #1404, #1838 and #2122
