### PR TITLE
Add Head as Alias to Skull

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprSkull.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSkull.java
@@ -60,7 +60,7 @@ import ch.njol.util.Kleenean;
 public class ExprSkull extends SimplePropertyExpression<Object, ItemType> {
 	
 	static {
-		register(ExprSkull.class, ItemType.class, "skull", "offlineplayers");
+		register(ExprSkull.class, ItemType.class, "(head|skull)", "offlineplayers");
 	}
 	
 	private static final ItemType playerSkull = Aliases.javaItemType("player skull");


### PR DESCRIPTION
### Description
<!--- Add something that describes the pull request here --->
https://minecraft.gamepedia.com/Mob_head Player "skulls" are referred to as player heads, and the Skript aliases already support this, so the expression should as well

---
**Target Minecraft Versions:**     Any
**Requirements:**     None
**Related Issues:**     None
