### PR TITLE
Improved PortalCreateEvent

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -925,20 +925,6 @@ public final class BukkitEventValues {
 				return e.getWorld();
 			}
 		}, 0);
-		EventValues.registerEventValue(PortalCreateEvent.class, String.class, new Getter<String, PortalCreateEvent>() {
-			@Override
-			@Nullable
-			public String get(final PortalCreateEvent e) {
-				for (BlockState b : e.getBlocks()) { // Gets blocks prior to actual portal creation
-					Material m = b.getType();
-					if (m == Material.OBSIDIAN)
-						return "Nether";
-					else if (m == Material.END_PORTAL_FRAME)
-						return "End";
-				}
-				return null; // Unknown portal type 
-			}
-		}, 0);
 		//PlayerEditBookEvent
 		EventValues.registerEventValue(PlayerEditBookEvent.class, ItemStack.class, new Getter<ItemStack, PlayerEditBookEvent>() {
 			@Override

--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -925,6 +925,20 @@ public final class BukkitEventValues {
 				return e.getWorld();
 			}
 		}, 0);
+		EventValues.registerEventValue(PortalCreateEvent.class, String.class, new Getter<String, PortalCreateEvent>() {
+			@Override
+			@Nullable
+			public String get(final PortalCreateEvent e) {
+				for (BlockState b : e.getBlocks()) { // Gets blocks prior to actual portal creation
+					Material m = b.getType();
+					if (m == Material.OBSIDIAN)
+						return "Nether";
+					else if (m == Material.END_PORTAL_FRAME)
+						return "End";
+				}
+				return null; // Unknown portal type 
+			}
+		}, 0);
 		//PlayerEditBookEvent
 		EventValues.registerEventValue(PlayerEditBookEvent.class, ItemStack.class, new Getter<ItemStack, PlayerEditBookEvent>() {
 			@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprPortal.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPortal.java
@@ -51,7 +51,7 @@ public class ExprPortal extends SimpleExpression<Block> {
 
 	static {
 		Skript.registerExpression(ExprPortal.class, Block.class, ExpressionType.SIMPLE, 
-				"[the] portal's blocks",
+				"[the] portal['s] blocks",
 				"[the] blocks of [the] portal");
 	}
 
@@ -66,10 +66,18 @@ public class ExprPortal extends SimpleExpression<Block> {
 	@Nullable
 	@Override
 	protected Block[] get(Event e) {
-		List<BlockState> blocks = ((PortalCreateEvent) e).getBlocks();
+		List<?> blocks = ((PortalCreateEvent) e).getBlocks();
+		if (Skript.isRunningMinecraft(1, 14)) { // 1.14+ returns List<BlockState> 
+			Block[] arr = new Block[blocks.size()];
+			for(int i = 0; i < blocks.size(); i++) {
+				arr[i] = ((BlockState) blocks.get(i)).getBlock();
+			}
+			return arr;
+		}
+		// 1.13.2 and below returns ArrayList<Block> 
 		Block[] arr = new Block[blocks.size()];
 		for(int i = 0; i < blocks.size(); i++) {
-			arr[i] = blocks.get(i).getBlock();
+			arr[i] = (Block) blocks.get(i);
 		}
 		return arr;
 	}
@@ -77,12 +85,16 @@ public class ExprPortal extends SimpleExpression<Block> {
 	@Nullable
 	@Override
 	public Iterator<Block> iterator(Event e) {
-		List<BlockState> blocks = ((PortalCreateEvent) e).getBlocks();
-		List<Block> list = new ArrayList<>(blocks.size());
-		for(int i = 0; i < blocks.size(); i++) {
-			list.add(i, blocks.get(i).getBlock());
+		List<?> blocks = ((PortalCreateEvent) e).getBlocks();
+		if (Skript.isRunningMinecraft(1, 14)) { // 1.14+ returns List<BlockState> 
+			List<Block> list = new ArrayList<>(blocks.size());
+			for(int i = 0; i < blocks.size(); i++) {
+				list.add(i, ((BlockState) blocks.get(i)).getBlock());
+			}
+			return list.iterator();
 		}
-		return list.iterator();
+		// 1.13.2 and below returns ArrayList<Block> 
+		return (Iterator<Block>) blocks.iterator();
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprPortal.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPortal.java
@@ -1,0 +1,108 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.expressions;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.event.Event;
+import org.bukkit.event.world.PortalCreateEvent;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.ScriptLoader;
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+
+@Name("Portal")
+@Description("The blocks associated with a portal in the portal creation event.")
+@Examples({"on portal creation:",
+		"	loop portal blocks:",
+		"		broadcast \"%loop-block% is part of a portal!\""})
+@Since("INSERT VERSION")
+public class ExprPortal extends SimpleExpression<Block> {
+
+	static {
+		Skript.registerExpression(ExprPortal.class, Block.class, ExpressionType.SIMPLE, 
+				"[the] portal's blocks",
+				"[the] blocks of [the] portal");
+	}
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parser) {
+		if (ScriptLoader.isCurrentEvent(PortalCreateEvent.class))
+			return true;
+		Skript.error("The 'portal' expression may only be used in a portal creation event.");
+		return false;
+	}
+
+	@Nullable
+	@Override
+	protected Block[] get(Event e) {
+		List<BlockState> blocks = ((PortalCreateEvent) e).getBlocks();
+		Block[] arr = new Block[blocks.size()];
+		for(int i = 0; i < blocks.size(); i++) {
+			arr[i] = blocks.get(i).getBlock();
+		}
+		return arr;
+	}
+
+	@Nullable
+	@Override
+	public Iterator<Block> iterator(Event e) {
+		List<BlockState> blocks = ((PortalCreateEvent) e).getBlocks();
+		List<Block> list = new ArrayList<>(blocks.size());
+		for(int i = 0; i < blocks.size(); i++) {
+			list.add(i, blocks.get(i).getBlock());
+		}
+		return list.iterator();
+	}
+
+	@Override
+	public boolean isSingle() {
+		return false;
+	}
+
+	@Override
+	public boolean isDefault() {
+		return true;
+	}
+
+	@Override
+	public Class<Block> getReturnType() {
+		return Block.class;
+	}
+
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		return "the portal blocks";
+	}
+
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprPortal.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPortal.java
@@ -74,11 +74,11 @@ public class ExprPortal extends SimpleExpression<Block> {
 		List<?> blocks = ((PortalCreateEvent) e).getBlocks();
 		if (USING_BLOCKSTATE)
 			return blocks.stream()
-				    .map(block -> ((BlockState) block).getBlock())
-				    .toArray(Block[]::new);
+					.map(block -> ((BlockState) block).getBlock())
+					.toArray(Block[]::new);
 		return blocks.stream()
-			    .map(Block.class::cast)
-			    .toArray(Block[]::new);
+				.map(Block.class::cast)
+				.toArray(Block[]::new);
 	}
 
 	@Nullable

--- a/src/main/java/ch/njol/skript/expressions/ExprPortal.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPortal.java
@@ -48,7 +48,7 @@ import ch.njol.util.Kleenean;
 		"	loop portal blocks:",
 		"		broadcast \"%loop-block% is part of a portal!\""})
 @Since("INSERT VERSION")
-@Events("portal creation")
+@Events("portal_create")
 public class ExprPortal extends SimpleExpression<Block> {
 
 	// 1.14+ returns List<BlockState>, 1.13.2 and below returns ArrayList<Block> 


### PR DESCRIPTION
### Description
Adds a new expression "portal's blocks" / "blocks of portal" to return the portal's blocks via Spigot's PortalCreateEvent.getBlocks() method

---
**Target Minecraft Versions:**     Any (1.9+)
**Requirements:**     None
**Related Issues:**     #576
