### PR TITLE
Cat Comparison Fix

### DIFF
--- a/src/main/java/ch/njol/skript/entity/CatData.java
+++ b/src/main/java/ch/njol/skript/entity/CatData.java
@@ -47,10 +47,8 @@ public class CatData extends EntityData<Cat> {
 	
 	@Override
 	protected boolean init(@Nullable Class<? extends Cat> c, @Nullable Cat cat) {
-		if (cat != null)
-			race = cat.getCatType();
-		race = Cat.Type.TABBY;
-		return false;
+		race = (cat == null) ? Cat.Type.TABBY : cat.getCatType();
+		return true;
 	}
 	
 	@Override


### PR DESCRIPTION
### Description

Fixes the comparison of cats by properly returning true upon initialization of a cat. This PR also cleans up some of the init code with a ternary

(Note: Making separate issues for Cats and Pandas since the causes are different)

---
**Target Minecraft Versions:**     Any MC version with Cats
**Requirements:**     None
**Related Issues:**     #2440