### PR TITLE
PandaData Fixes

### DIFF
--- a/src/main/java/ch/njol/skript/entity/PandaData.java
+++ b/src/main/java/ch/njol/skript/entity/PandaData.java
@@ -61,18 +61,24 @@ public class PandaData extends EntityData<Panda> {
 	public void set(Panda entity) {
 		Gene gen = mainGene;
 		if (gen == null)
-			gen = Gene.values()[ThreadLocalRandom.current().nextInt()];
+			gen = Gene.values()[ThreadLocalRandom.current().nextInt(0, 7)];
 		entity.setMainGene(gen);
 		entity.setHiddenGene(hiddenGene != null ? hiddenGene : gen);
 	}
 	
 	@Override
 	protected boolean match(Panda entity) {
-		if (hiddenGene != null)
-			return mainGene == entity.getMainGene() && hiddenGene == entity.getHiddenGene();
-		else
-			return mainGene == entity.getMainGene();
-		
+		if (hiddenGene != null) {
+			if(mainGene != null)
+				return mainGene == entity.getMainGene() && hiddenGene == entity.getHiddenGene();
+			else
+				return hiddenGene == entity.getHiddenGene();
+		} else {
+			if(mainGene != null)
+				return mainGene == entity.getMainGene();
+			else
+				return true;
+		}
 	}
 	
 	@Override


### PR DESCRIPTION
### Description

Fixes an issue where ThreadLocalRandom generates a random number out of bounds of the Gene array, and also fixes the comparison issue for pandas by adding more checks to match()

(Note: Making separate issues for Cats and Pandas since the causes are different)

---
**Target Minecraft Versions:**     Any MC version with Pandas
**Requirements:**     None
**Related Issues:**     #2440
