### PR TITLE
Allow asterisks within expressions in lists

### DIFF
--- a/src/main/java/ch/njol/skript/lang/Variable.java
+++ b/src/main/java/ch/njol/skript/lang/Variable.java
@@ -28,6 +28,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -122,7 +124,15 @@ public class Variable<T> implements Expression<T> {
 				Skript.error("A variable's name must neither start nor end with the separator '" + SEPARATOR + "' (error in variable {" + name + "})");
 			return false;
 		} else if (name.contains("*") && (!allowListVariable || name.indexOf("*") != name.length() - 1 || !name.endsWith(SEPARATOR + "*"))) {
-			if (printErrors) {
+			int count = StringUtils.count(name, '*');
+			Matcher m = Pattern.compile("(%(.*?)%)+").matcher(name); // Matches all data within %%
+			while (m.find()) {
+				String g = m.group();
+				count -= g == null ? 0 : StringUtils.count(g, '*');
+			}
+			if (count == 0 || (count == 1 && name.endsWith(SEPARATOR + "*")))
+				return true;
+			else if (printErrors) {
 				if (name.indexOf("*") == 0)
 					Skript.error("[2.0] Local variables now start with an underscore, e.g. {_local variable}. The asterisk is reserved for list variables. (error in variable {" + name + "})");
 				else

--- a/src/main/java/ch/njol/skript/lang/Variable.java
+++ b/src/main/java/ch/njol/skript/lang/Variable.java
@@ -28,8 +28,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.TreeMap;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -124,11 +122,26 @@ public class Variable<T> implements Expression<T> {
 				Skript.error("A variable's name must neither start nor end with the separator '" + SEPARATOR + "' (error in variable {" + name + "})");
 			return false;
 		} else if (name.contains("*") && (!allowListVariable || name.indexOf("*") != name.length() - 1 || !name.endsWith(SEPARATOR + "*"))) {
-			int count = StringUtils.count(name, '*');
-			Matcher m = Pattern.compile("(%(.*?)%)+").matcher(name); // Matches all data within %%
-			while (m.find()) {
-				String g = m.group();
-				count -= g == null ? 0 : StringUtils.count(g, '*');
+			List<Integer> asterisks = new ArrayList<>();
+			List<Integer> percents = new ArrayList<>();
+			for (int i = 0; i < name.length(); i++) {
+				char c = name.charAt(i);
+				if (c == '*')
+					asterisks.add(i);
+				else if (c == '%')
+					percents.add(i);
+			}
+			int count = asterisks.size();
+			int index = 0;
+			for (int i = 0; i < percents.size(); i += 2) {
+				if (index == asterisks.size() || i+1 == percents.size())
+					break;
+				int lb = percents.get(i), ub = percents.get(i+1);
+				System.out.println(lb + " " + ub + " " + asterisks.get(index));
+				while (index < asterisks.size() && lb < asterisks.get(index) && asterisks.get(index) < ub) {
+					count--;
+					index++;
+				}
 			}
 			if (count == 0 || (count == 1 && name.endsWith(SEPARATOR + "*")))
 				return true;

--- a/src/main/java/ch/njol/skript/lang/Variable.java
+++ b/src/main/java/ch/njol/skript/lang/Variable.java
@@ -143,7 +143,7 @@ public class Variable<T> implements Expression<T> {
 					index++;
 				}
 			}
-			if (!(count == 0 || (count == 1 && name.endsWith(SEPARATOR + "*")))){
+			if (!(count == 0 || (count == 1 && name.endsWith(SEPARATOR + "*")))) {
 				if (printErrors) {
 					if (name.indexOf("*") == 0)
 						Skript.error("[2.0] Local variables now start with an underscore, e.g. {_local variable}. The asterisk is reserved for list variables. (error in variable {" + name + "})");

--- a/src/main/java/ch/njol/skript/lang/Variable.java
+++ b/src/main/java/ch/njol/skript/lang/Variable.java
@@ -143,15 +143,15 @@ public class Variable<T> implements Expression<T> {
 					index++;
 				}
 			}
-			if (count == 0 || (count == 1 && name.endsWith(SEPARATOR + "*")))
-				return true;
-			else if (printErrors) {
-				if (name.indexOf("*") == 0)
-					Skript.error("[2.0] Local variables now start with an underscore, e.g. {_local variable}. The asterisk is reserved for list variables. (error in variable {" + name + "})");
-				else
-					Skript.error("A variable's name must not contain any asterisks except at the end after '" + SEPARATOR + "' to denote a list variable, e.g. {variable" + SEPARATOR + "*} (error in variable {" + name + "})");
+			if (!(count == 0 || (count == 1 && name.endsWith(SEPARATOR + "*")))){
+				if (printErrors) {
+					if (name.indexOf("*") == 0)
+						Skript.error("[2.0] Local variables now start with an underscore, e.g. {_local variable}. The asterisk is reserved for list variables. (error in variable {" + name + "})");
+					else
+						Skript.error("A variable's name must not contain any asterisks except at the end after '" + SEPARATOR + "' to denote a list variable, e.g. {variable" + SEPARATOR + "*} (error in variable {" + name + "})");
+				}
+				return false;
 			}
-			return false;
 		} else if (name.contains(SEPARATOR + SEPARATOR)) {
 			if (printErrors)
 				Skript.error("A variable's name must not contain the separator '" + SEPARATOR + "' multiple times in a row (error in variable {" + name + "})");

--- a/src/main/java/ch/njol/skript/lang/Variable.java
+++ b/src/main/java/ch/njol/skript/lang/Variable.java
@@ -134,10 +134,10 @@ public class Variable<T> implements Expression<T> {
 			int count = asterisks.size();
 			int index = 0;
 			for (int i = 0; i < percents.size(); i += 2) {
-				if (index == asterisks.size() || i+1 == percents.size())
+				if (index == asterisks.size() || i+1 == percents.size()) // Out of bounds 
 					break;
 				int lb = percents.get(i), ub = percents.get(i+1);
-				System.out.println(lb + " " + ub + " " + asterisks.get(index));
+				// Continually decrement asterisk count by checking if any asterisks in current range 
 				while (index < asterisks.size() && lb < asterisks.get(index) && asterisks.get(index) < ub) {
 					count--;
 					index++;


### PR DESCRIPTION
### Description
Adds further checks to the Variables class to allow asterisks within expressions in lists since currently it only allows asterisks at the end of a list

Test Code:
```
on click:
	set {test} to 1 #No Error ✓
	set {*test} to 1 #Errors ✓
	set {**test} to 1 #Errors ✓
	set {test*} to 1 #Errors ✓
	set {test:*} to 1 #Errors ✓
	set {test::*} to 1 #No Error ✓
	set {test:::*} to 1 #Errors ✓
	set {test::*::*} to 1 #Errors ✓
	set {test::**::*} to 1 #Errors ✓
	set {test::%2%::*} to 1 #Errors ✓
	set {test::%%::*} to 1 #No Error **?**
	set {test:%%::*} to 1 #Errors ✓
	set {test::%::*} to 1 #Errors ✓
	set {test::&::*} to 1 #No Error ✓
	set {test::%5::*} to 1 #Errors ✓
	set {test::%2*5%::*} to 1 #No Error ✓
	set {test::%2*5%%::*} to 1 #Errors ✓
	set {test::::*} to 1 #Errors ✓
```

Oddly enough, ``set {test::&::*} to 1 #No Error`` is behavior that already occurs prior to my edits. As for ``set {test::%%::*} to 1 #No Error``, I believe the parser is treating it as a single % character, so I'm not too sure if that behavior should be changed for lists

Please feel free to test with additional variables to confirm if my edits are valid, since I might have missed something

---
**Target Minecraft Versions:**     Any
**Requirements:**     None
**Related Issues:**     #2381 