### PR TITLE
Path Finding

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -110,6 +110,9 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
+
+import com.destroystokyo.paper.event.entity.EntityPathfindEvent;
+
 import org.bukkit.potion.PotionEffectType;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -1009,6 +1012,24 @@ public final class BukkitEventValues {
 				}
 			}, 0);
 		}
+		//EntityPathfindEvent
+		if (Skript.classExists("com.destroystokyo.paper.event.entity.EntityPathfindEvent")) {
+			EventValues.registerEventValue(EntityPathfindEvent.class, Location.class, new Getter<Location, EntityPathfindEvent>() {
+				@Override
+				@Nullable
+				public Location get(EntityPathfindEvent e) {
+					return e.getLoc();
+				}
+			}, 0);
+			EventValues.registerEventValue(EntityPathfindEvent.class, Entity.class, new Getter<Entity, EntityPathfindEvent>() {
+				@Override
+				@Nullable
+				public Entity get(EntityPathfindEvent e) {
+					return e.getEntity();
+				}
+			}, 0);
+		}
+
 
 	}
 }

--- a/src/main/java/ch/njol/skript/events/SimpleEvents.java
+++ b/src/main/java/ch/njol/skript/events/SimpleEvents.java
@@ -93,6 +93,7 @@ import org.bukkit.event.world.WorldUnloadEvent;
 import org.spigotmc.event.entity.EntityDismountEvent;
 import org.spigotmc.event.entity.EntityMountEvent;
 import com.destroystokyo.paper.event.player.PlayerJumpEvent;
+import com.destroystokyo.paper.event.entity.EntityPathfindEvent;
 
 import com.destroystokyo.paper.event.server.PaperServerListPingEvent;
 import ch.njol.skript.Skript;
@@ -516,5 +517,15 @@ public class SimpleEvents {
 							"	cancel event")
 					.since("2.3");
 		}
+		if (Skript.classExists("com.destroystokyo.paper.event.entity.EntityPathfindEvent")) {
+			Skript.registerEvent("Pathfind", SimpleEvent.class, EntityPathfindEvent.class, "[entity] path[ ]find[ing]")
+					.description("Called whenever an entity pathfinds.",
+							"This event requires PaperSpigot.")
+					.examples("on pathfinding:",
+							"	event-entity is zombie",
+							"	cancel event")
+					.since("INSERT VERSION");
+		}
+		
 	}
 }

--- a/src/main/java/ch/njol/skript/events/SimpleEvents.java
+++ b/src/main/java/ch/njol/skript/events/SimpleEvents.java
@@ -519,7 +519,8 @@ public class SimpleEvents {
 		}
 		if (Skript.classExists("com.destroystokyo.paper.event.entity.EntityPathfindEvent")) {
 			Skript.registerEvent("Pathfind", SimpleEvent.class, EntityPathfindEvent.class, "[entity] path[ ]find[ing]")
-					.description("Called whenever an entity decides to start moving to a location.")
+					.description("Called whenever an entity decides to start moving to a location.",
+							"The 'target' expression can be used to determine the pathfinding entity's target")
 					.requiredPlugins("Paper")
 					.examples("on pathfinding:",
 							"	event-entity is zombie",

--- a/src/main/java/ch/njol/skript/events/SimpleEvents.java
+++ b/src/main/java/ch/njol/skript/events/SimpleEvents.java
@@ -519,8 +519,9 @@ public class SimpleEvents {
 		}
 		if (Skript.classExists("com.destroystokyo.paper.event.entity.EntityPathfindEvent")) {
 			Skript.registerEvent("Pathfind", SimpleEvent.class, EntityPathfindEvent.class, "[entity] path[ ]find[ing]")
-					.description("Called whenever an entity pathfinds.",
+					.description("Called whenever an entity decides to start moving to a location.",
 							"This event requires PaperSpigot.")
+					.requiredPlugins("Paper")
 					.examples("on pathfinding:",
 							"	event-entity is zombie",
 							"	cancel event")

--- a/src/main/java/ch/njol/skript/events/SimpleEvents.java
+++ b/src/main/java/ch/njol/skript/events/SimpleEvents.java
@@ -519,8 +519,7 @@ public class SimpleEvents {
 		}
 		if (Skript.classExists("com.destroystokyo.paper.event.entity.EntityPathfindEvent")) {
 			Skript.registerEvent("Pathfind", SimpleEvent.class, EntityPathfindEvent.class, "[entity] path[ ]find[ing]")
-					.description("Called whenever an entity decides to start moving to a location.",
-							"This event requires PaperSpigot.")
+					.description("Called whenever an entity decides to start moving to a location.")
 					.requiredPlugins("Paper")
 					.examples("on pathfinding:",
 							"	event-entity is zombie",


### PR DESCRIPTION
### Description
Adds an event that allows users to grab the entity performing a pathfind, and the entity's target location. Currently, this PR only adds the event, since other plugins like SkQuery and MiSk already have pathfinding effects for use

---
**Target Minecraft Versions:**     Paper versions that have this event
**Requirements:**     Paper
**Related Issues:**     #2334
