### PR TITLE
new ExprClientViewDistance expression

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprClientViewDistance.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprClientViewDistance.java
@@ -31,7 +31,8 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
 
 @Name("View Distance of Client")
-@Description("The view distance of the client. Can not be changed")
+@Description("The view distance of the client. Can not be changed. " +
+	"This differs from the server side view distance of player as this will retrieve the view distance the player has set on their client.")
 @Examples({"set {_clientView} to the client view distance of player", "set view distance of player to client view distance of player"})
 @RequiredPlugins("1.13.2+")
 @Since("INSERT VERSION")

--- a/src/main/java/ch/njol/skript/expressions/ExprClientViewDistance.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprClientViewDistance.java
@@ -20,7 +20,6 @@
 package ch.njol.skript.expressions;
 
 import org.bukkit.entity.Player;
-import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
@@ -29,58 +28,35 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.RequiredPlugins;
 import ch.njol.skript.doc.Since;
-import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
-import ch.njol.skript.lang.util.SimpleExpression;
-import ch.njol.util.Kleenean;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
 
 @Name("View Distance of Client")
 @Description("The view distance of the client. (Can not be changed)")
 @Examples({"set {_clientView} to the client view distance of player", "set view distance of player to client view distance of player"})
 @RequiredPlugins("1.13.2+")
 @Since("INSERT VERSION")
-public class ExprClientViewDistance extends SimpleExpression<Number> {
+public class ExprClientViewDistance extends SimplePropertyExpression<Player, Number> {
 	
 	static {
 		if (Skript.methodExists(Player.class, "getClientViewDistance")) {
-			Skript.registerExpression(ExprClientViewDistance.class, Number.class, ExpressionType.PROPERTY,
-				"[the] client view distance of %player%");
+			register(ExprClientViewDistance.class, Number.class, "client view distance", "player");
 		}
 	}
 	
-	@SuppressWarnings("null")
-	private Expression<Player> player;
-	
-	@SuppressWarnings({"unchecked", "null"})
-	@Override
-	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
-		player = (Expression<Player>) exprs[0];
-		return true;
-	}
-	
-	@Override
 	@Nullable
-	protected Number[] get(Event e) {
-		final Player player = this.player.getSingle(e);
-		if (player == null)
-			return new Number[0];
-		return new Number[] {player.getClientViewDistance()};
+	@Override
+	public Number convert(Player player) {
+		return player.getClientViewDistance();
 	}
 	
 	@Override
-	public boolean isSingle() {
-		return true;
+	protected String getPropertyName() {
+		return "client view distance";
 	}
 	
 	@Override
 	public Class<? extends Number> getReturnType() {
 		return Number.class;
-	}
-	
-	@Override
-	public String toString(@Nullable Event e, boolean d) {
-		return "client view distance of " + player.toString(e, d);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprClientViewDistance.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprClientViewDistance.java
@@ -39,7 +39,7 @@ public class ExprClientViewDistance extends SimplePropertyExpression<Player, Num
 	
 	static {
 		if (Skript.methodExists(Player.class, "getClientViewDistance")) {
-			register(ExprClientViewDistance.class, Number.class, "client view distance", "player");
+			register(ExprClientViewDistance.class, Number.class, "client view distance[s]", "players");
 		}
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprClientViewDistance.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprClientViewDistance.java
@@ -31,7 +31,7 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
 
 @Name("View Distance of Client")
-@Description("The view distance of the client. (Can not be changed)")
+@Description("The view distance of the client. Can not be changed")
 @Examples({"set {_clientView} to the client view distance of player", "set view distance of player to client view distance of player"})
 @RequiredPlugins("1.13.2+")
 @Since("INSERT VERSION")

--- a/src/main/java/ch/njol/skript/expressions/ExprClientViewDistance.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprClientViewDistance.java
@@ -1,0 +1,86 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.expressions;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.RequiredPlugins;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+
+@Name("View Distance of Client")
+@Description("The view distance of the client. (Can not be changed)")
+@Examples({"set {_clientView} to the client view distance of player", "set view distance of player to client view distance of player"})
+@RequiredPlugins("1.13.2+")
+@Since("INSERT VERSION")
+public class ExprClientViewDistance extends SimpleExpression<Number> {
+	
+	static {
+		if (Skript.methodExists(Player.class, "getClientViewDistance")) {
+			Skript.registerExpression(ExprClientViewDistance.class, Number.class, ExpressionType.PROPERTY,
+				"[the] client view distance of %player%");
+		}
+	}
+	
+	@SuppressWarnings("null")
+	private Expression<Player> player;
+	
+	@SuppressWarnings({"unchecked", "null"})
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		player = (Expression<Player>) exprs[0];
+		return true;
+	}
+	
+	@Override
+	@Nullable
+	protected Number[] get(Event e) {
+		final Player player = this.player.getSingle(e);
+		if (player == null)
+			return new Number[0];
+		return new Number[] {player.getClientViewDistance()};
+	}
+	
+	@Override
+	public boolean isSingle() {
+		return true;
+	}
+	
+	@Override
+	public Class<? extends Number> getReturnType() {
+		return Number.class;
+	}
+	
+	@Override
+	public String toString(@Nullable Event e, boolean d) {
+		return "client view distance of " + player.toString(e, d);
+	}
+	
+}


### PR DESCRIPTION
### Description
This expression adds the option to grab the view distance from the player's client. 
This can be used hand in hand with the player view distance expression, or you know, just for funnies to see how far a player's client view distance is set.

This may also be handy when doing certain effects for players, making sure they can actually see them. 

---
**Target Minecraft Versions:** 1.13.2+
**Requirements:** Spigot 1.13.2+
**Related Issues:** none
