### PR TITLE
Fix Firework Flickering

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprFireworkEffect.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFireworkEffect.java
@@ -51,7 +51,7 @@ public class ExprFireworkEffect extends SimpleExpression<FireworkEffect> {
 	@SuppressWarnings({"null", "unchecked"})
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		flicker = parseResult.mark == 2 && parseResult.mark > 3;
+		flicker = parseResult.mark == 2 || parseResult.mark > 3;
 		trail = parseResult.mark >= 3;
 		hasFade = matchedPattern == 1;
 		type = (Expression<FireworkEffect.Type>) exprs[0];


### PR DESCRIPTION
### Description

Fixes FireworkEffect from not properly detecting the ``flicker`` effect... Old code tested for the parse result mark being equal to 2 **and** greater than 3?

---
**Target Minecraft Versions:**     Any
**Requirements:**     None
**Related Issues:**     #2229
