### PR TITLE
Clearer Syntax for CondIsBlocking

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondIsBlocking.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsBlocking.java
@@ -31,7 +31,7 @@ import ch.njol.skript.doc.Since;
  * @author Peter Güttinger
  */
 @Name("Is Blocking")
-@Description("Checks whether a player is blocking with his shield.")
+@Description("Checks whether a player is blocking with their shield.")
 @Examples({"on damage of player:",
 	  	"	victim is blocking",
 	 	"	damage attacker by 0.5 hearts"})

--- a/src/main/java/ch/njol/skript/conditions/CondIsBlocking.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsBlocking.java
@@ -39,7 +39,7 @@ import ch.njol.skript.doc.Since;
 public class CondIsBlocking extends PropertyCondition<Player> {
 	
 	static {
-		register(CondIsBlocking.class, "(blocking|defending)", "players");
+		register(CondIsBlocking.class, "(blocking|defending) [with [a] shield]", "players");
 	}
 	
 	@Override


### PR DESCRIPTION
### Description
Makes it slightly more evident to users that the ``blocking`` conditional is referring to a player shielding, and not anything else.

---
**Target Minecraft Versions:**     Any
**Requirements:**     None
**Related Issues:**     #1578