### PR TITLE
new RelativeLocationFunction

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/DefaultFunctions.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultFunctions.java
@@ -319,6 +319,21 @@ public class DefaultFunctions {
 				.examples("location(0, 128, 0)", "location(player's x-coordinate, player's y-coordinate + 5, player's z-coordinate, player's world, 0, 90)")
 				.since("2.2"));
 		
+		Functions.registerFunction(new JavaFunction<Location>("relative", new Parameter[] {
+			new Parameter<>("location", Classes.getExactClassInfo(Location.class), true, null),
+			new Parameter<>("x", numberClass, true, null),
+			new Parameter<>("y", numberClass, true, null),
+			new Parameter<>("z", numberClass, true, null)
+		}, Classes.getExactClassInfo(Location.class), true) {
+			@Override
+			public Location[] execute(FunctionEvent e, Object[][] params) {
+				return new Location[] {((Location)params[0][0]).add(((Number) params[1][0]).doubleValue(),
+					((Number) params[2][0]).doubleValue(), ((Number) params[3][0]).doubleValue())};
+			}
+		}.description("Creates a location from a relative position in correlation to the input location.")
+			.examples("relative({loc}, 1, 0, -1)", "relative(location of player, -10, 0, 10")
+			.since("INSERT VERSION"));
+		
 		Functions.registerFunction(new JavaFunction<Date>("date", new Parameter[] {
 				new Parameter<>("year", numberClass, true, null), new Parameter<>("month", numberClass, true, null), new Parameter<>("day", numberClass, true, null),
 				new Parameter<>("hour", numberClass, true, new SimpleLiteral<Number>(0, true)), new Parameter<>("minute", numberClass, true, new SimpleLiteral<Number>(0, true)), new Parameter<>("second", numberClass, true, new SimpleLiteral<Number>(0, true)), new Parameter<>("millisecond", numberClass, true, new SimpleLiteral<Number>(0, true)),


### PR DESCRIPTION
### Description
Adds a new function to get a location relative to the input location.
ex:
```vb
relative(location of player, 0, 0, 1)
```
would return a location 1 block south of the player

This solves the issue where people have to get a location, save it to a variable, and then manipulate the x, y, z coords of said location. Cuts down a lot of the work.

---
**Target Minecraft Versions:**  any
**Requirements:** none
**Related Issues:**  none
