### PR TITLE
HealthUtils - update

### DIFF
--- a/src/test/skript/tests/misc/2584-HealthUtils - update.sk
+++ b/src/test/skript/tests/misc/2584-HealthUtils - update.sk
@@ -1,0 +1,8 @@
+on test "health utils update":
+	spawn a pig at spawn of world "world"
+	set {_pig} to last spawned pig
+	set max health of {_pig} to 20
+	set health of {_pig} to 20
+	assert max health of {_pig} = 20 with "pig failed to set max health to 20: Max health of pig = %max health of {_pig}%"
+	assert health of {_pig} = 20 with "pig failed to set health to 20: Health of pig = %health of {_pig}%"
+	delete last spawned pig


### PR DESCRIPTION
### Description
- Removed some really old code that was used before MC 1.6 (prior to MC 1.6, the damageable classes methods used ints, 1.6 introduced using doubles. The reflection methods were introduced by Njol years ago to help handle the difference. Since we don't support below 1.9.4 they are most definitely not needed)
- Updated the java doc notes
- Updated to use attributes to make this class more future proof in the event the deprecated Damageable#getMaxHealth and Damageable#setMaxHealth methods are removed in future Spigot releases
- I have tested this on both 1.9.4 and 1.14.4, everything works swimmingly.


---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none

### Special Note:
This file was using CRLF, I wanted to switch it to LF but figured the PR would be hard to see what was changed.
If this is to be approved and you guys so choose, I can easily switch it to LF and push before merging.
