### PR TITLE
SkriptError - add addon version

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -1583,7 +1583,7 @@ public final class Skript extends JavaPlugin implements Listener {
 					logEx("Here is full list of them:");
 					StringBuilder pluginsMessage = new StringBuilder();
 					for (PluginDescriptionFile desc : pluginPackages.values()) {
-						pluginsMessage.append(desc.getName());
+						pluginsMessage.append(desc.getName()).append("-").append(desc.getVersion());
 						String website = desc.getWebsite();
 						if (website != null && !website.isEmpty()) // Add website if found
 							pluginsMessage.append(" (").append(desc.getWebsite()).append(")");

--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -1583,7 +1583,7 @@ public final class Skript extends JavaPlugin implements Listener {
 					logEx("Here is full list of them:");
 					StringBuilder pluginsMessage = new StringBuilder();
 					for (PluginDescriptionFile desc : pluginPackages.values()) {
-						pluginsMessage.append(desc.getFullName());
+						pluginsMessage.append(desc.getName()).append("-").append(desc.getVersion());
 						String website = desc.getWebsite();
 						if (website != null && !website.isEmpty()) // Add website if found
 							pluginsMessage.append(" (").append(desc.getWebsite()).append(")");

--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -1583,7 +1583,7 @@ public final class Skript extends JavaPlugin implements Listener {
 					logEx("Here is full list of them:");
 					StringBuilder pluginsMessage = new StringBuilder();
 					for (PluginDescriptionFile desc : pluginPackages.values()) {
-						pluginsMessage.append(desc.getName()).append("-").append(desc.getVersion());
+						pluginsMessage.append(desc.getFullName());
 						String website = desc.getWebsite();
 						if (website != null && !website.isEmpty()) // Add website if found
 							pluginsMessage.append(" (").append(desc.getWebsite()).append(")");


### PR DESCRIPTION
### Description
This PR is to add the version of the addons to Skript's sever error messages.

Many times when helping people, they will send a stack trace error. Often times these errors are created by addons, but seeing something like this:
```
[14:13:50 ERROR]: #!#! Here is full list of them:
[14:13:50 ERROR]: #!#! skript-mirror (https://github.com/btk5h/skript-mirror) TuSKe (github.com/Tuke-Nuke/TuSKe) SK-NBeeT (https://github.com/ShaneBeee/Sk-NBeeT) 
```
...is not helpful, as we have no clue which versions of the addons the user is using. Quite often we ask "Which version of Tuske are you using", reply: "latest" or "newest" and more often than not, they are **not** using the "latest" or "newest" version of said addon.

Simply adding the version to the error, we can cut down on asking which version of the addon they are using, ex:
```
[14:06:49 ERROR]: #!#! Here is full list of them:
[14:06:49 ERROR]: #!#! skript-mirror-2.0.0-SNAPSHOT (https://github.com/btk5h/skript-mirror) TuSKe-1.8.2-Pikachu-Patch-3 (github.com/Tuke-Nuke/TuSKe) SK-NBeeT-2.7.2 (https://github.com/ShaneBeee/Sk-NBeeT) 
```
Now by being able to see the version of the addon they are using, we can offer better/quicker support, such as "You should update skript-mirror to 2.0.0" or "You should use Pikachu's patch of Tuske"

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
