### PR TITLE
Fix ExprRespawnLocation expecting a Number

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprRespawnLocation.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprRespawnLocation.java
@@ -91,7 +91,7 @@ public class ExprRespawnLocation extends SimpleExpression<Location> {
 	@Override
 	public Class<?>[] acceptChange(Changer.ChangeMode mode) {
 		if (mode == ChangeMode.SET)
-			return CollectionUtils.array(Number.class);
+			return CollectionUtils.array(Location.class);
 		return null;
 	}
 


### PR DESCRIPTION
### Description
In beta9, ExprRespawnLocation's acceptChange method returns `CollectionUtils.array(Number.class)` even though the expression itself is a location.
![img](https://i.imgur.com/gSb0iZc.png)

---
**Target Minecraft Versions:** Any
**Requirements:** None
**Related Issues:** None (as far as I know)
