### PR TITLE
Altern Numbers Expression

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprNumbers.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNumbers.java
@@ -19,6 +19,7 @@
  */
 package ch.njol.skript.expressions;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -47,7 +48,7 @@ import ch.njol.util.Kleenean;
 @Description({"All numbers between two given numbers, useful for looping.",
 		"Use 'numbers' if your start is not an integer and you want to keep the fractional part of the start number constant, or use 'integers' if you only want to loop integers.",
 		"You may want to use the 'times' expression instead, for instance 'loop 5 times:'"})
-@Examples({"loop numbers from 2.5 to 5.5: # loops 2.5, 3.5, 4.5, 5.5",
+@Examples({"loop numbers from 2.5 to 5.5: # loops 2.5, 2.6, 2.7, ..., 5.4 and 5.5",
 		"loop integers from 2.9 to 5.1: # same as '3 to 5', i.e. loops 3, 4, 5"})
 @Since("1.4.6")
 public class ExprNumbers extends SimpleExpression<Number> {
@@ -81,10 +82,15 @@ public class ExprNumbers extends SimpleExpression<Number> {
 			s = f;
 			f = temp;
 		}
-		final double amount = integer ? Math.floor(f.doubleValue()) - Math.ceil(s.doubleValue()) + 1 : Math.floor(f.doubleValue() - s.doubleValue() + 1);
+		
 		final List<Number> list = new ArrayList<>();
+		
+		
 		final double low = integer ? Math.ceil(s.doubleValue()) : s.doubleValue();
-		for (int i = 0; i < amount; i++) {
+		final BigDecimal decimals = BigDecimal.valueOf(s.doubleValue());
+		final double amount = integer ? Math.floor(f.doubleValue()) - Math.ceil(s.doubleValue()) + 1 : f.doubleValue() - s.doubleValue() + (10 ^ (decimals.scale() * -1));
+		
+		for (int i = 0; i < amount; i+= 10 ^ (decimals.scale() * -1)) {
 			if (integer)
 				list.add((long) low + i);
 			else


### PR DESCRIPTION
This tries to add the feature to this expression blue stated here: https://github.com/SkriptLang/Skript/issues/2601

If the expression wants an integer, it'll always return the right integers as usual, but when it wants numbers, it'll return all the possible numbers between the 2 numbers rounded to the amount of decimals the start value has.

For example:
numbers between 1.2 and 2.3 will return:
1.2, 1.3, 1.4, ..., 2.2 and 2.3

Please say if there's anything wrong.

### Description
<!--- Add something that describes the pull request here --->

---
**Target Minecraft Versions:**     any
**Requirements:**     none
**Related Issues:**     #2601
