### PR TITLE
Add documentationId to ClassInfo

### DIFF
--- a/src/main/java/ch/njol/skript/classes/ClassInfo.java
+++ b/src/main/java/ch/njol/skript/classes/ClassInfo.java
@@ -81,6 +81,8 @@ public class ClassInfo<T> implements Debuggable {
 	private String since = null;
 	@Nullable
 	private String[] requiredPlugins = null;
+	@Nullable
+	private String documentationID;
 	
 	/**
 	 * @param c The class
@@ -251,6 +253,20 @@ public class ClassInfo<T> implements Debuggable {
 		return this;
 	}
 	
+	/**
+	 * A non critical ID remapping for ClassInfo.
+	 *
+	 * Only used for Skript's documentation.
+	 *
+	 * @param id
+	 * @return This ClassInfo object
+	 */
+	public ClassInfo<T> documentationID(final String id) {
+		assert this.documentationID == null;
+		this.documentationID = id;
+		return this;
+	}
+	
 	// === GETTERS ===
 	
 	public Class<T> getC() {
@@ -333,6 +349,11 @@ public class ClassInfo<T> implements Debuggable {
 	@Nullable
 	public String getDocName() {
 		return docName;
+	}
+	
+	@Nullable
+	public String getDocumentationID() {
+		return documentationID;
 	}
 	
 	// === ORDERING ===

--- a/src/main/java/ch/njol/skript/classes/ClassInfo.java
+++ b/src/main/java/ch/njol/skript/classes/ClassInfo.java
@@ -82,7 +82,7 @@ public class ClassInfo<T> implements Debuggable {
 	@Nullable
 	private String[] requiredPlugins = null;
 	@Nullable
-	private String documentationID;
+	private String documentationID = null;
 	
 	/**
 	 * @param c The class

--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -1490,6 +1490,7 @@ public class BukkitClasses {
 				.defaultExpression(new EventValueExpression<>(FireworkEffect.Type.class))
 				.examples(fireworktypes.getAllNames())
 				.since("2.4")
+				.documentationID("FireworkType")
 				.parser(new Parser<FireworkEffect.Type>() {
 					@Override
 					@Nullable
@@ -1691,6 +1692,7 @@ public class BukkitClasses {
 					.examples(races.getAllNames())
 					.since("2.4")
 					.requiredPlugins("Minecraft 1.14 or newer")
+					.documentationID("CatType")
 					.parser(new Parser<Cat.Type>() {
 						@Nullable
 						@Override


### PR DESCRIPTION
### Description
Added in documentationID to ClassInfo to help addon authors better document their code using Skript built in annotations. 

This also helps to provide a stable mechanism to fix an issue with the SkriptHubDocsTool where the "SimpleName" for a class such as "FireworkEffect.Type.class" was being returned as just "Type". This addition will give developers a more explicit way to set this info to prevent these conflicts.

---
**Target Minecraft Versions:** Any
**Requirements:** None
**Related Issues:** N/A
