### PR TITLE
Apply potion effects without adding onto current duration

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffPotion.java
+++ b/src/main/java/ch/njol/skript/effects/EffPotion.java
@@ -57,7 +57,7 @@ public class EffPotion extends Effect {
 	}
 	
 	private final static int DEFAULT_DURATION = 15 * 20; // 15 seconds, same as EffPoison
-	private int mark;
+	private boolean replaceExisting;
 	
 	@SuppressWarnings("null")
 	private Expression<PotionEffectType> potions;
@@ -75,7 +75,7 @@ public class EffPotion extends Effect {
 	@Override
 	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
 		apply = matchedPattern < 3;
-		this.mark = parseResult.mark;
+		replaceExisting = parseResult.mark == 1;
 		if (apply) {
 			potions = (Expression<PotionEffectType>) exprs[0];
 			tier = (Expression<Number>) exprs[1];
@@ -134,7 +134,9 @@ public class EffPotion extends Effect {
 		for (final LivingEntity en : entities.getArray(e)) {
 			for (final PotionEffectType t : ts) {
 				int duration = d;
-				if (mark != 1) {
+				if (replaceExisting) {
+					en.addPotionEffect(new PotionEffect(t, duration, a, ambient, particles), true);
+				} else {
 					if (en.hasPotionEffect(t)) {
 						for (final PotionEffect eff : en.getActivePotionEffects()) {
 							if (eff.getType() == t) {
@@ -144,7 +146,6 @@ public class EffPotion extends Effect {
 						}
 					}
 				}
-				en.addPotionEffect(new PotionEffect(t, duration, a, ambient, particles), true);
 			}
 		}
 	}

--- a/src/main/java/ch/njol/skript/effects/EffPotion.java
+++ b/src/main/java/ch/njol/skript/effects/EffPotion.java
@@ -45,18 +45,19 @@ import ch.njol.util.Kleenean;
 		"remove haste from the victim",
 		"on join:",
 		"	apply potion of strength of tier {strength.%player%} to the player for 999 days"})
-@Since("2.0, 2.2-dev27 (ambient and particle-less potion effects)")
+@Since("2.0, 2.2-dev27 (ambient and particle-less potion effects), INSERT VERSION (replacing existing effect)")
 public class EffPotion extends Effect {
 	static {
 		Skript.registerEffect(EffPotion.class,
-				"apply [potion of] %potioneffecttypes% [potion] [[[of] tier] %-number%] to %livingentities% [for %-timespan%]",
-				"apply ambient [potion of] %potioneffecttypes% [potion] [[[of] tier] %-number%] to %livingentities% [for %-timespan%]",
-				"apply [potion of] %potioneffecttypes% [potion] [[[of] tier] %-number%] without [any] particles to %livingentities% [for %-timespan%]"
+				"apply [potion of] %potioneffecttypes% [potion] [[[of] tier] %-number%] to %livingentities% [for %-timespan%] [(1¦replacing [the] existing effect)]",
+				"apply ambient [potion of] %potioneffecttypes% [potion] [[[of] tier] %-number%] to %livingentities% [for %-timespan%] [(1¦replacing [the] existing effect)]",
+				"apply [potion of] %potioneffecttypes% [potion] [[[of] tier] %-number%] without [any] particles to %livingentities% [for %-timespan%] [(1¦replacing [the] existing effect)]"
 				//, "apply %itemtypes% to %livingentities%"
 				/*,"remove %potioneffecttypes% from %livingentities%"*/);
 	}
 	
 	private final static int DEFAULT_DURATION = 15 * 20; // 15 seconds, same as EffPoison
+	private int mark;
 	
 	@SuppressWarnings("null")
 	private Expression<PotionEffectType> potions;
@@ -74,6 +75,7 @@ public class EffPotion extends Effect {
 	@Override
 	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
 		apply = matchedPattern < 3;
+		this.mark = parseResult.mark;
 		if (apply) {
 			potions = (Expression<PotionEffectType>) exprs[0];
 			tier = (Expression<Number>) exprs[1];
@@ -132,11 +134,13 @@ public class EffPotion extends Effect {
 		for (final LivingEntity en : entities.getArray(e)) {
 			for (final PotionEffectType t : ts) {
 				int duration = d;
-				if (en.hasPotionEffect(t)) {
-					for (final PotionEffect eff : en.getActivePotionEffects()) {
-						if (eff.getType() == t) {
-							duration += eff.getDuration();
-							break;
+				if (mark != 1) {
+					if (en.hasPotionEffect(t)) {
+						for (final PotionEffect eff : en.getActivePotionEffects()) {
+							if (eff.getType() == t) {
+								duration += eff.getDuration();
+								break;
+							}
 						}
 					}
 				}

--- a/src/main/java/ch/njol/skript/effects/EffPotion.java
+++ b/src/main/java/ch/njol/skript/effects/EffPotion.java
@@ -134,9 +134,7 @@ public class EffPotion extends Effect {
 		for (final LivingEntity en : entities.getArray(e)) {
 			for (final PotionEffectType t : ts) {
 				int duration = d;
-				if (replaceExisting) {
-					en.addPotionEffect(new PotionEffect(t, duration, a, ambient, particles), true);
-				} else {
+				if (!replaceExisting) {
 					if (en.hasPotionEffect(t)) {
 						for (final PotionEffect eff : en.getActivePotionEffects()) {
 							if (eff.getType() == t) {
@@ -146,6 +144,7 @@ public class EffPotion extends Effect {
 						}
 					}
 				}
+				en.addPotionEffect(new PotionEffect(t, duration, a, ambient, particles), true);
 			}
 		}
 	}


### PR DESCRIPTION
### Description
This PR adds in what is described in #2598. The syntax may be able to be improved and I'm open to any suggestions. I have not really made any changes in Skript's code before, so please let me know if I'm doing anything wrong :)

I built these changes and they worked perfectly when I tested them.

I was thinking we could also add in a test for the entire effect but I was not 100% sure on how to do it properly.

---
**Target Minecraft Versions:**     Any
**Requirements:**     None
**Related Issues:**     #2598 
