### PR TITLE
VillagerData - fix

### DIFF
--- a/src/main/java/ch/njol/skript/entity/VillagerData.java
+++ b/src/main/java/ch/njol/skript/entity/VillagerData.java
@@ -55,10 +55,10 @@ public class VillagerData extends EntityData<Villager> {
 		
 		if (Skript.isRunningMinecraft(1, 14)) {
 			EntityData.register(VillagerData.class, "villager", Villager.class, 0,
-					"villager", "armorer", "butcher", "cartographer",
+					"villager", "normal", "armorer", "butcher", "cartographer",
 					"cleric", "farmer", "fisherman", "fletcher",
 					"leatherworker", "librarian", "mason", "nitwit",
-					"normal", "shepherd", "toolsmith", "weaponsmith");
+					"shepherd", "toolsmith", "weaponsmith");
 			professions = Arrays.asList(Profession.values());
 		} else if (Skript.isRunningMinecraft(1, 10)) { // Post 1.10: Not all professions go for villagers
 			EntityData.register(VillagerData.class, "villager", Villager.class, 0,

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -806,7 +806,7 @@ entities:
 		pattern: <age> villager(|1¦s)|(4¦)[villager] (kid(|1¦s)|child(|1¦ren))
 	normal:
 		name: villager¦s
-		pattern: <age> villager(|1¦s)|(4¦)[villager] (kid(|1¦s)|child(|1¦ren))
+		pattern: <age> [unemployed] villager(|1¦s)|(4¦)[[unemployed] villager] (kid(|1¦s)|child(|1¦ren))
 	armorer:
 		name: armorer¦s
 		pattern: <age> armorer(|1¦s)|(4¦)armorer (kid(|1¦s)|child(|1¦ren))


### PR DESCRIPTION
### Description
- Fix an issue with the ordering of villager professions
The issue was comparisons for villager types were not working, ie:
```vb
command /test:
    trigger:
        if target entity is a cleric:
            send "CLERIC"
        else:
            send "NO?!?!"
```
The villager types would not match.

In the BukkitAPI, the NONE profession is listed after NITWIT:
![Screen Shot 2019-11-05 at 1 51 20 PM](https://user-images.githubusercontent.com/20008482/68249299-650c5480-ffd3-11e9-80e9-bc569ca3f2dc.png)

but when actually printing out the values it appears that NONE is registered first (ergo it's 0 in the list)
ie:
```
[13:44:00 INFO]: Val: NONE
[13:44:00 INFO]: Val: ARMORER
[13:44:00 INFO]: Val: BUTCHER
[13:44:00 INFO]: Val: CARTOGRAPHER
[13:44:00 INFO]: Val: CLERIC
[13:44:00 INFO]: Val: FARMER
[13:44:00 INFO]: Val: FISHERMAN
[13:44:00 INFO]: Val: FLETCHER
[13:44:00 INFO]: Val: LEATHERWORKER
[13:44:00 INFO]: Val: LIBRARIAN
[13:44:00 INFO]: Val: MASON
[13:44:00 INFO]: Val: NITWIT
[13:44:00 INFO]: Val: SHEPHERD
[13:44:00 INFO]: Val: TOOLSMITH
[13:44:00 INFO]: Val: WEAPONSMITH
```


Additionally in the lang file, I added an option for "unemployed" to be able to compare a villager entity to an "unemployed villager"

---
**Target Minecraft Versions:** 1.14+
**Requirements:** none
**Related Issues:** #2625
