### PR TITLE
Entity Tameable - NEW

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondIsTameable.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsTameable.java
@@ -1,0 +1,53 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.conditions;
+
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Tameable;
+
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+
+@Name("Is Tameable")
+@Description("Check if an entity is tameable.")
+@Examples({"on damage:",
+	"\tif victim is tameable:",
+	"\t\tcancel event"})
+@Since("INSERT VERSION")
+public class CondIsTameable extends PropertyCondition<LivingEntity> {
+	
+	static {
+		register(CondIsTameable.class, "tameable", "livingentities");
+	}
+	
+	@Override
+	public boolean check(LivingEntity entity) {
+		return entity instanceof Tameable;
+	}
+	
+	@Override
+	protected String getPropertyName() {
+		return "tameable";
+	}
+	
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprEntityTamer.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntityTamer.java
@@ -31,9 +31,6 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
-import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 
 @Name("Entity Owner")
@@ -46,13 +43,6 @@ public class ExprEntityTamer extends SimplePropertyExpression<LivingEntity, Offl
 	
 	static {
 		register(ExprEntityTamer.class, OfflinePlayer.class, "(owner|tamer)", "livingentities");
-	}
-	
-	@SuppressWarnings({"unchecked", "null"})
-	@Override
-	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parser) {
-		setExpr((Expression<LivingEntity>) exprs[0]);
-		return true;
 	}
 	
 	@Nullable

--- a/src/main/java/ch/njol/skript/expressions/ExprEntityTamer.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntityTamer.java
@@ -1,0 +1,111 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.expressions;
+
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Tameable;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.PropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.util.Getter;
+import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
+
+@Name("Entity Owner")
+@Description("The owner of a tameable entity, such as a horse or wolf.")
+@Examples({"set owner of target entity to player",
+	"delete owner of target entity",
+	"set {_t} to uuid of tamer of target entity"})
+@Since("INSERT VERSION")
+public class ExprEntityTamer extends PropertyExpression<LivingEntity, OfflinePlayer> {
+	
+	static {
+		register(ExprEntityTamer.class, OfflinePlayer.class, "(owner|tamer)", "livingentities");
+	}
+	
+	@SuppressWarnings({"unchecked", "null"})
+	@Override
+	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parser) {
+		setExpr((Expression<LivingEntity>) exprs[0]);
+		return true;
+	}
+	
+	@Override
+	protected OfflinePlayer[] get(Event e, LivingEntity[] source) {
+		return get(source, new Getter<OfflinePlayer, LivingEntity>() {
+			@Nullable
+			@Override
+			public OfflinePlayer get(LivingEntity entity) {
+				if (entity instanceof Tameable && ((Tameable) entity).isTamed()) {
+					return ((OfflinePlayer) ((Tameable) entity).getOwner());
+				}
+				return null;
+			}
+		});
+	}
+	
+	@Nullable
+	@Override
+	public Class<?>[] acceptChange(ChangeMode mode) {
+		if (mode == ChangeMode.SET || mode == ChangeMode.DELETE)
+			return CollectionUtils.array(OfflinePlayer.class);
+		return null;
+	}
+	
+	@Override
+	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+		OfflinePlayer player = delta == null ? null : ((OfflinePlayer) delta[0]);
+		switch (mode) {
+			case SET:
+				for (LivingEntity entity : getExpr().getAll(e)) {
+					if (!(entity instanceof Tameable))
+						continue;
+					((Tameable) entity).setOwner(player);
+				}
+				break;
+			case DELETE:
+				for (LivingEntity entity : getExpr().getAll(e)) {
+					if (!(entity instanceof Tameable))
+						continue;
+					((Tameable) entity).setOwner(null);
+				}
+		}
+	}
+	
+	@Override
+	public Class<? extends OfflinePlayer> getReturnType() {
+		return OfflinePlayer.class;
+	}
+	
+	@Override
+	public String toString(@Nullable Event e, boolean d) {
+		return "owner of " + getExpr().toString(e, d);
+	}
+	
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprEntityTamer.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntityTamer.java
@@ -65,7 +65,7 @@ public class ExprEntityTamer extends PropertyExpression<LivingEntity, OfflinePla
 				if (entity instanceof Tameable) {
 					Tameable t = ((Tameable) entity);
 					if (t.isTamed())
-					return (OfflinePlayer) t.getOwner();
+						return (OfflinePlayer) t.getOwner();
 				}
 				return null;
 			}

--- a/src/main/java/ch/njol/skript/expressions/ExprEntityTamer.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntityTamer.java
@@ -62,8 +62,10 @@ public class ExprEntityTamer extends PropertyExpression<LivingEntity, OfflinePla
 			@Nullable
 			@Override
 			public OfflinePlayer get(LivingEntity entity) {
-				if (entity instanceof Tameable && ((Tameable) entity).isTamed()) {
-					return ((OfflinePlayer) ((Tameable) entity).getOwner());
+				if (entity instanceof Tameable) {
+					Tameable t = ((Tameable) entity);
+					if (t.isTamed())
+					return (OfflinePlayer) t.getOwner();
 				}
 				return null;
 			}

--- a/src/test/skript/tests/syntaxes/expressions/ExprEntityTamer.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprEntityTamer.sk
@@ -1,0 +1,6 @@
+test "entity tamer expression/condition":
+	spawn a wolf at spawn of world "world"
+	#assert last spawned entity is tameable with "entity is tameable condition not passing, last spawned wolf is not tameable"
+	set owner of last spawned wolf to "Notch" parsed as offline player
+	assert "%owner of last spawned wolf%" = "Notch" with "Owner of last spawned wolf was not set"
+	delete last spawned wolf

--- a/src/test/skript/tests/syntaxes/expressions/ExprEntityTamer.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprEntityTamer.sk
@@ -1,6 +1,6 @@
 test "entity tamer expression/condition":
 	spawn a wolf at spawn of world "world"
-	#assert last spawned entity is tameable with "entity is tameable condition not passing, last spawned wolf is not tameable"
+	assert last spawned entity is tameable with "entity is tameable condition not passing, last spawned wolf is not tameable"
 	set owner of last spawned wolf to "Notch" parsed as offline player
 	assert "%owner of last spawned wolf%" = "Notch" with "Owner of last spawned wolf was not set"
 	delete last spawned wolf


### PR DESCRIPTION
### Description
This PR adds a new expression to get/set the owner/tamer of an entity (such as a horse or wolf) as well as a new condition to check if an entity is tameable.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
