### PR TITLE
EffColorItems - fix

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffColorItems.java
+++ b/src/main/java/ch/njol/skript/effects/EffColorItems.java
@@ -151,7 +151,6 @@ public class EffColorItems extends Effect {
 				}
 			}
 		}
-		this.items.change(e, items, ChangeMode.SET);
 	}
 	
 	@Override


### PR DESCRIPTION
### Description
This fixes an issue with the dye effect throwing errors in console.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #2623
