### PR TITLE
ExprItemWithEnchant - new

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
@@ -195,13 +195,10 @@ public class SkriptClasses {
 				.name("Item Type")
 				.description("An item type is an alias, e.g. 'a pickaxe', 'all plants', etc., and can result in different items when added to an inventory, " +
 						"and unlike <a href='#itemstack'>items</a> they are well suited for checking whether an inventory contains a certain item or whether a certain item is of a certain type.",
-						"An item type can also have one or more <a href='#enchantmenttype'>enchantments</a> with or without a specific level defined, " +
-								"and can optionally start with 'all' or 'every' to make this item type represent <i>all</i> types that the alias represents, including data ranges.")
-				.usage("<code>[&lt;number&gt; [of]] [all/every] &lt;alias&gt; [of &lt;enchantment&gt; [&lt;level&gt;] [,/and &lt;more enchantments...&gt;]]</code>")
+						"An item type can optionally start with 'all' or 'every' to make this item type represent <i>all</i> types that the alias represents, including data ranges.")
+				.usage("<code>[&lt;number&gt; [of]] [all/every] &lt;alias&gt;]</code>")
 				.examples("give 4 torches to the player",
 						"add all slabs to the inventory of the block",
-						"player's tool is a diamond sword of sharpness",
-						"remove a pickaxes of fortune 4 from {stored items::*}",
 						"set {_item} to 10 of every upside-down stair",
 						"block is dirt or farmland")
 				.since("1.0")
@@ -232,17 +229,6 @@ public class SkriptClasses {
 						// TODO this is missing information
 						for (final ItemData d : t.getTypes()) {
 							b.append("," + d.getType());
-						}
-						final EnchantmentType[] enchs = t.getEnchantmentTypes();
-						if (enchs != null) {
-							b.append("|");
-							for (final EnchantmentType ench : enchs) {
-								Enchantment e = ench.getType();
-								if (e == null)
-									continue;
-								b.append("#" + EnchantmentUtils.getKey(e));
-								b.append(":" + ench.getLevel());
-							}
 						}
 						return "" + b.toString();
 					}

--- a/src/main/java/ch/njol/skript/expressions/ExprItemWithEnchant.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprItemWithEnchant.java
@@ -1,0 +1,87 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.expressions;
+
+
+import org.bukkit.Bukkit;
+import org.bukkit.event.Event;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.PropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.util.EnchantmentType;
+import ch.njol.util.Kleenean;
+
+@Name("Item with Enchantments")
+@Description("Returns the given item type with the specified enchantments added to it.")
+@Examples({"give player a diamond sword of sharpness 2", "give player 1 of {_item} with sharpness and mending"})
+@Since("INSERT VERSION")
+public class ExprItemWithEnchant extends PropertyExpression<ItemType, ItemType> {
+	
+	static {
+		Skript.registerExpression(ExprItemWithEnchant.class, ItemType.class, ExpressionType.PROPERTY,
+			"%itemtype% (of|with) %enchantmenttypes%");
+	}
+	
+	@SuppressWarnings("null")
+	private Expression<EnchantmentType> enchants;
+	
+	@SuppressWarnings({"unchecked", "null"})
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		setExpr((Expression<ItemType>) exprs[0]);
+		enchants = (Expression<EnchantmentType>) exprs[1];
+		return true;
+	}
+	
+	@SuppressWarnings("null")
+	@Override
+	protected ItemType[] get(Event e, ItemType[] source) {
+		EnchantmentType[] enchants = this.enchants.getArray(e);
+		return get(source, item -> {
+			ItemMeta meta = item.getItemMeta();
+			for (EnchantmentType enchant : enchants) {
+				meta.addEnchant(enchant.getType(), enchant.getLevel(), true);
+			}
+			item.setItemMeta(meta);
+			return item;
+		});
+	}
+	
+	@Override
+	public Class<? extends ItemType> getReturnType() {
+		return ItemType.class;
+	}
+	
+	@Override
+	public String toString(@Nullable Event e, boolean d) {
+		return getExpr().toString(e, d) + " with enchantment " + enchants.toString(e, d);
+	}
+	
+}


### PR DESCRIPTION
### Description
Add a new expression for item types with enchantments

The main purpose of this PR is to fix an issue with parsing item types with enchantments when the item type is in a variable, ex:
```vb
set {_i} to diamond sword
give player 1 of {_i} or sharpness 3
```
This would result in an error and the item would not work. I believe this was due to an internal parsing of item types where there was an option for enchantments, rather than an expression to add enchantments.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #1836 
