### PR TITLE
english lang - fixes

### DIFF
--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -815,7 +815,7 @@ entities:
 		pattern: <age> cartographer(|1¦s)|(4¦)cartographer (kid(|1¦s)|child(|1¦ren))
 	cleric:
 		name: cleric¦s
-		pattern: <age> cleric(|1¦s)|(4¦)cleric (kid(|1¦s)|child(|1¦ren))
+		pattern: <age> (priest|cleric)(|1¦s)|(4¦)(priest|cleric) (kid(|1¦s)|child(|1¦ren))
 	fisherman:
 		name: fisherman¦s
 		pattern: <age> fisherman(|1¦s)|(4¦)fisherman (kid(|1¦s)|child(|1¦ren))
@@ -845,7 +845,7 @@ entities:
 		pattern: <age> librarian(|1¦s)|(4¦)librarian (kid(|1¦s)|child(|1¦ren))
 	priest:
 		name: priest¦s
-		pattern: <age> priest(|1¦s)|(4¦)priest (kid(|1¦s)|child(|1¦ren))
+		pattern: <age> (priest|cleric)(|1¦s)|(4¦)(priest|cleric) (kid(|1¦s)|child(|1¦ren))
 	blacksmith:
 		name: blacksmith¦s
 		pattern: <age> [black]smith(|1¦s)|(4¦)[black]smith (kid(|1¦s)|child(|1¦ren))


### PR DESCRIPTION
### Description
- Match priest/cleric in english.lang file

This changes patterns for priests and clerics to be the same, which allows for using either name on all versions of MC.

This fixes an issue Bensku had with a regression test across all versions (see #2641)

This also creates better compatibility when users are upgrading their server from 1.13.2 and below -> 1.14+ 

I have this PR going to the 2.4 branch, but its not really necessary as a fix in 2.4, but would still be a nice/helpful fix. But if need be I can change it to the master branch. 

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #2641 
