### PR TITLE
EffCancelDrops - fix

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffCancelDrops.java
+++ b/src/main/java/ch/njol/skript/effects/EffCancelDrops.java
@@ -91,7 +91,7 @@ public class EffCancelDrops extends Effect {
 				event.getDrops().clear();
 			if (cancelExps)
 				event.setDroppedExp(0);
-		} else {
+		} else if (e instanceof BlockBreakEvent) {
 			BlockBreakEvent event = (BlockBreakEvent) e;
 			if (cancelItems)
 				event.setDropItems(false);


### PR DESCRIPTION
### Description
- Fix an issue with console throwing errors when doing actions like picking up water.

---
**Target Minecraft Versions:** any
**Requirements:**  none
**Related Issues:** #2645 