### PR TITLE
[WIP] Fix - Cond is OP

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondIsOp.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsOp.java
@@ -1,0 +1,50 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.conditions;
+
+import org.bukkit.OfflinePlayer;
+
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+
+@Name("Is Op")
+@Description("Check whether a player is an operator.")
+@Examples({"if player is op:", "if all players are not ops:"})
+@Since("INSERT VERSION")
+public class CondIsOp  extends PropertyCondition<OfflinePlayer> {
+	
+	static {
+		register(CondIsOp.class, PropertyType.BE, "[an] op[erator][s]", "offlineplayers");
+	}
+	
+	@Override
+	public boolean check(OfflinePlayer player) {
+		return player.isOp();
+	}
+	
+	@Override
+	protected String getPropertyName() {
+		return "operator";
+	}
+	
+}


### PR DESCRIPTION
### Description
The point of this PR is to fix an issue with checking OP status of players. 
The main issue in #1037 is that people are checking the OP status as if it were a condition, but in fact, OP is an entity type from the player entity data. The proper way to compare is `if player is an op` rather than `if player is op`, same as you would do `if entity is a skeleton` rather than `if entity is skeleton`.
To fix this issue, I created an actual condition for an OP check. 
Another benefit of this new condition is the fact that there is now a proper doc for `is op` whereas before there really was nothing. I have seen several people ask in the past how to check OP status due to the fact that its not currently documented.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #1037 
