### PR TITLE
Add Number of Characters Expression

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprNumberOfCharacters.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNumberOfCharacters.java
@@ -1,0 +1,107 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.expressions;
+
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+
+@Name("Number of Characters")
+@Description("The number of uppercase, lowercase, or digit characters in a string.")
+@Examples({"#Simple Chat Filter",
+			"on chat:",
+			"\tif number of uppercase chars in message / length of message > 0.5",
+			"\t\tcancel event",
+			"\t\tsend \"<red>Your message has to many caps!\" to player"})
+@Since("INSERT VERSION")
+public class ExprNumberOfCharacters extends SimpleExpression<Number> {
+
+	static {
+		Skript.registerExpression(ExprNumberOfCharacters.class, Number.class, ExpressionType.SIMPLE,
+				"number of upper[ ]case char(acters|s) in %string%",
+				"number of lower[ ]case char(acters|s) in %string%",
+				"number of digit char(acters|s) in %string%");
+	}
+
+	private int pattern = 0;
+
+	@SuppressWarnings("null")
+	private Expression<String> expr;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		pattern = matchedPattern;
+		expr = (Expression<String>) exprs[0];
+		return true;
+	}
+
+	@Override
+	@SuppressWarnings("null")
+	@Nullable
+	protected Number[] get(Event e) {
+		String str = expr.getSingle(e);
+		int size = 0;
+		if (pattern == 0) {
+			for (int i = 0; i < str.length(); i++) {
+				if (Character.isUpperCase(str.charAt(i))) size++;
+			}
+		} else if (pattern == 1) {
+			for (int i = 0; i < str.length(); i++) {
+				if (Character.isLowerCase(str.charAt(i))) size++;
+			}
+		} else {
+			for (int i = 0; i < str.length(); i++) {
+				if (Character.isDigit(str.charAt(i))) size++;
+			}
+		}
+		return new Number[]{size};
+	}
+	
+	@Override
+	public boolean isSingle() {
+		return true;
+	}
+
+	@Override
+	public Class<? extends Number> getReturnType() {
+		return Number.class;
+	}
+
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		if (pattern == 0) {
+			return "number of uppercase characters";
+		} else if (pattern == 1) {
+			return "number of lowercase characters";
+		}
+		return "number of digits";
+	}
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprNumberOfCharacters.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNumberOfCharacters.java
@@ -70,16 +70,16 @@ public class ExprNumberOfCharacters extends SimpleExpression<Number> {
 		String str = expr.getSingle(e);
 		int size = 0;
 		if (pattern == 0) {
-			for (int i = 0; i < str.length(); i++) {
-				if (Character.isUpperCase(str.charAt(i))) size++;
+			for (int c : (Iterable<Integer>) str.codePoints()::iterator) {
+				if (Character.isUpperCase(c)) size++;
 			}
 		} else if (pattern == 1) {
-			for (int i = 0; i < str.length(); i++) {
-				if (Character.isLowerCase(str.charAt(i))) size++;
+			for (int c : (Iterable<Integer>) str.codePoints()::iterator) {
+				if (Character.isLowerCase(c)) size++;
 			}
 		} else {
-			for (int i = 0; i < str.length(); i++) {
-				if (Character.isDigit(str.charAt(i))) size++;
+			for (int c : (Iterable<Integer>) str.codePoints()::iterator) {
+				if (Character.isDigit(c)) size++;
 			}
 		}
 		return new Number[]{size};

--- a/src/test/skript/tests/syntaxes/expressions/ExprNumberOfCharacters.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprNumberOfCharacters.sk
@@ -1,0 +1,4 @@
+test "number of characters":
+	assert number of uppercase chars in "TESTing123" = 4 with "number of uppercase chars failed"
+	assert number of lowercase characters in "TESTing123" = 3 with "number of lowercase characters failed"
+	assert number of digit characters in "TESTing123" = 3 with "number of digit characters failed"


### PR DESCRIPTION
### Description
Adds an expression to get the number of uppercase, lowercase, or digit characters in a string.
I used this expression a lot when I had skUtilities, and figured it'd be useful to have in vanilla Skript.

---
**Target Minecraft Versions:**     Any
**Requirements:**     None
**Related Issues:**     None (I think)