### PR TITLE
ExprTarget - Fix not being able to delete target entity

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprTarget.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTarget.java
@@ -110,7 +110,7 @@ public class ExprTarget extends PropertyExpression<LivingEntity, Entity> {
 	@Override
 	@Nullable
 	public Class<?>[] acceptChange(final ChangeMode mode) {
-		if ((mode == ChangeMode.SET || mode == ChangeMode.DELETE)) {
+		if (mode == ChangeMode.SET || mode == ChangeMode.DELETE) {
 			return CollectionUtils.array(LivingEntity.class);
 		}
 		return super.acceptChange(mode);

--- a/src/main/java/ch/njol/skript/expressions/ExprTarget.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTarget.java
@@ -109,14 +109,14 @@ public class ExprTarget extends PropertyExpression<LivingEntity, Entity> {
 	@Override
 	@Nullable
 	public Class<?>[] acceptChange(final ChangeMode mode) {
-		if (mode == ChangeMode.SET || mode == ChangeMode.DELETE)
+		if (mode == ChangeMode.SET)
 			return CollectionUtils.array(LivingEntity.class);
 		return super.acceptChange(mode);
 	}
 	
 	@Override
 	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
-		if (mode == ChangeMode.SET || mode == ChangeMode.DELETE) {
+		if (mode == ChangeMode.SET) {
 			final LivingEntity target = delta == null ? null : (LivingEntity) delta[0];
 			for (final LivingEntity entity : getExpr().getArray(e)) {
 				if (getTime() >= 0 && e instanceof EntityTargetEvent && entity.equals(((EntityTargetEvent) e).getEntity()) && !Delay.isDelayed(e)) {

--- a/src/main/java/ch/njol/skript/expressions/ExprTarget.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTarget.java
@@ -110,9 +110,8 @@ public class ExprTarget extends PropertyExpression<LivingEntity, Entity> {
 	@Override
 	@Nullable
 	public Class<?>[] acceptChange(final ChangeMode mode) {
-		if (mode == ChangeMode.SET || mode == ChangeMode.DELETE) {
+		if (mode == ChangeMode.SET || mode == ChangeMode.DELETE)
 			return CollectionUtils.array(LivingEntity.class);
-		}
 		return super.acceptChange(mode);
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprTarget.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTarget.java
@@ -19,10 +19,8 @@
  */
 package ch.njol.skript.expressions;
 
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Creature;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
@@ -38,7 +36,6 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.effects.Delay;
 import ch.njol.skript.entity.EntityData;
-import ch.njol.skript.entity.PlayerData;
 import ch.njol.skript.expressions.base.PropertyExpression;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;


### PR DESCRIPTION
### Description
This PR is to fix an issue with deleting a target entity.
When running the code:
```vb
delete target entity of player
```
nothing happens. This fixes that, win win for everyone 👍 

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #2695 
