### PR TITLE
Fix the comparison issues

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -1393,13 +1393,14 @@ public class BukkitClasses {
 				.since("2.2-dev35")
 				.parser(new Parser<TeleportCause>() {
 					@Override
-					public String toString(TeleportCause teleportCause, int flags) {
-						return teleportCauses.toString(teleportCause, flags);
+					@Nullable
+					public TeleportCause parse(String input, ParseContext context) {
+						return teleportCauses.parse(input);
 					}
 					
 					@Override
-					public boolean canParse(ParseContext context) {
-						return false;
+					public String toString(TeleportCause teleportCause, int flags) {
+						return teleportCauses.toString(teleportCause, flags);
 					}
 					
 					@SuppressWarnings("null")
@@ -1424,13 +1425,14 @@ public class BukkitClasses {
 				.since("2.3")
 				.parser(new Parser<SpawnReason>() {
 					@Override
-					public String toString(SpawnReason spawnReason, int flags) {
-						return spawnReasons.toString(spawnReason, flags);
+					@Nullable
+					public SpawnReason parse(String input, ParseContext context) {
+						return spawnReasons.parse(input);
 					}
 					
 					@Override
-					public boolean canParse(ParseContext context) {
-						return false;
+					public String toString(SpawnReason spawnReason, int flags) {
+						return spawnReasons.toString(spawnReason, flags);
 					}
 					
 					@SuppressWarnings("null")

--- a/src/main/java/ch/njol/skript/classes/data/DefaultComparators.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultComparators.java
@@ -268,6 +268,24 @@ public class DefaultComparators {
 	};
 	static {
 		Comparators.registerComparator(EntityData.class, ItemType.class, entityItemComparator);
+		
+		// Entity - ItemType
+		// This skips (entity -> entitydata) == itemtype
+		// It was not working reliably, because there is a converter chain
+		// entity -> player -> inventoryholder -> block that sometimes takes a priority
+		Comparators.registerComparator(Entity.class, ItemType.class, new Comparator<Entity, ItemType>() {
+
+			@Override
+			public Relation compare(Entity entity, ItemType item) {
+				return entityItemComparator.compare(EntityData.fromEntity(entity), item);
+			}
+
+			@Override
+			public boolean supportsOrdering() {
+				return false;
+			}
+			
+		});
 	}
 	
 	static {

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -574,7 +574,7 @@ public class SkriptParser {
 				final Object t = Classes.parse(expr, ci.getC(), context);
 				if (t != null) {
 					log.printLog();
-					return new SimpleLiteral<>(t, false);
+					return new SimpleLiteral<>(t, false, new UnparsedLiteral(expr));
 				}
 			}
 			log.printError();

--- a/src/main/java/ch/njol/skript/lang/UnparsedLiteral.java
+++ b/src/main/java/ch/njol/skript/lang/UnparsedLiteral.java
@@ -95,7 +95,7 @@ public class UnparsedLiteral implements Literal<Object> {
 				final R r = Classes.parse(data, t, context);
 				if (r != null) {
 					log.printLog();
-					return new SimpleLiteral<R>(r, false);
+					return new SimpleLiteral<>(r, false, this);
 				}
 				log.clear();
 			}

--- a/src/main/java/ch/njol/skript/lang/util/SimpleLiteral.java
+++ b/src/main/java/ch/njol/skript/lang/util/SimpleLiteral.java
@@ -69,14 +69,19 @@ public class SimpleLiteral<T> implements Literal<T>, DefaultExpression<T> {
 		this.isDefault = false;
 	}
 	
-	@SuppressWarnings({"null", "unchecked"})
-	public SimpleLiteral(final T data, final boolean isDefault) {
+	public SimpleLiteral(T data, boolean isDefault) {
+		this(data, isDefault, null);
+	}
+	
+	@SuppressWarnings({"unchecked", "null"})
+	public SimpleLiteral(T data, boolean isDefault, @Nullable UnparsedLiteral source) {
 		assert data != null;
 		this.data = (T[]) Array.newInstance(data.getClass(), 1);
 		this.data[0] = data;
 		c = (Class<T>) data.getClass();
 		and = true;
 		this.isDefault = isDefault;
+		this.source = source;
 	}
 	
 	public SimpleLiteral(final T[] data, final Class<T> to, final boolean and, final @Nullable UnparsedLiteral source) {


### PR DESCRIPTION
### Description
This PR fixes all comparison issues detailed in #2637 and issues linked from it. There were multiple causes for them:

* Literal parsers for types not registered (spawn reason, teleport cause)
* Nonsensical comparator usage (entities, e.g. projectiles)
* Ambiguous literals (some of the damage causes)

The first two were rather easy to fix, even if finding them took a while. The third, however, introduces a major change to CondCompare; it now attempts to parse literals of wrong types again, this time with more type information than SkriptParser has.

All of these changes could cause serious regressions. Testing them automatically is not going to help, because Skript can't (yet?) create mock events for test scripts.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #2637
