### PR TITLE
Fix ExprRawName isSingle()

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprRawName.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprRawName.java
@@ -68,7 +68,7 @@ public class ExprRawName extends SimpleExpression<String> {
 	
 	@Override
 	public boolean isSingle() {
-		return false;
+		return types.isSingle();
 	}
 	
 	@Override


### PR DESCRIPTION
### Description
This PR fixes the Raw Name expression's isSingle() function return. Currently it always returns false for isSingle() and is not properly checking the Expression variable.

---
**Target Minecraft Versions:**     Any
**Requirements:**     None
**Related Issues:**     None
