### PR TITLE
Add Expression#stream(Event)

### DIFF
--- a/src/main/java/ch/njol/skript/lang/Expression.java
+++ b/src/main/java/ch/njol/skript/lang/Expression.java
@@ -21,11 +21,13 @@ package ch.njol.skript.lang;
 
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.stream.Stream;
 
 import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemStack;
 import org.eclipse.jdt.annotation.Nullable;
 
+import com.google.common.collect.Streams;
 import ch.njol.skript.ScriptLoader;
 import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
@@ -85,6 +87,20 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	 * @return An array of all possible values of this expression for the given event which must neither be null nor contain nulls, and which must not be an internal array.
 	 */
 	public T[] getAll(final Event e);
+	
+	/**
+	 * Gets a non-null stream of this expression's values
+	 *
+	 * @param e The event
+	 * @return A non-null stream of this expression's values
+	 */
+	default public Stream<? extends T> stream(final Event e) {
+		Iterator<? extends T> iter = iterator(e);
+		if (iter == null) {
+			return Stream.empty();
+		}
+		return Streams.stream(iter);
+	}
 	
 	/**
 	 * @return true if this expression will ever only return one value at most, false if it can return multiple values.


### PR DESCRIPTION
### Description
Allows generation of a `Stream` for any `Expression`. Allows for prettier stream usage:
```
Stream.of(expr.getArray(e))
   .map(Something::get)
   .forEach(Terminal::operation);
```
vs
```
expr.stream(e)
    .map(Something::get)
    .forEach(Terminal::operation);
```

I chose to use `Expression#iterator(Event)` rather than `Expression#getArray(Event)` as `Stream`s may be limited to a certain number of elements, therefore it makes sense to use the `Expression`'s `Iterator` so that streams of intensive expressions with custom `Iterator`s (like the blocks one) take advantage of the same performance boost.


---
**Target Minecraft Versions:**     Any
**Requirements:**     None
**Related Issues:**     None
