### PR TITLE
EffBan - add an optional time span to temp ban a player

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffBan.java
+++ b/src/main/java/ch/njol/skript/effects/EffBan.java
@@ -87,7 +87,15 @@ public class EffBan extends Effect {
 	protected void execute(final Event e) {
 		final String reason = this.reason != null ? this.reason.getSingle(e) : null; // don't check for null, just ignore an invalid reason
 		Timespan ts = this.expires != null ? this.expires.getSingle(e) : null;
-		final Date expires = ts != null ? new Date(System.currentTimeMillis() + ts.getMilliSeconds()) : null;
+		Date expires = null;
+		if (this.expires != null) {
+			if (ts != null)
+				expires = new Date(System.currentTimeMillis() + ts.getMilliSeconds());
+			else {
+				Skript.error("Could not temp ban " + players.toString(e, true) + " for: " + this.expires.toString(e, true));
+				return;
+			}
+		}
 		final String source = "Skript ban effect";
 		for (final Object o : players.getArray(e)) {
 			if (o instanceof Player) {

--- a/src/main/java/ch/njol/skript/effects/EffBan.java
+++ b/src/main/java/ch/njol/skript/effects/EffBan.java
@@ -86,8 +86,7 @@ public class EffBan extends Effect {
 	@Override
 	protected void execute(final Event e) {
 		final String reason = this.reason != null ? this.reason.getSingle(e) : null; // don't check for null, just ignore an invalid reason
-		Timespan ts = this.expires != null ? this.expires.getSingle(e) : null;
-		final Date expires = ts != null ? new Date(System.currentTimeMillis() + ts.getMilliSeconds()) : null;
+		final Date expires = this.expires != null ? new Date(System.currentTimeMillis() + this.expires.getSingle(e).getMilliSeconds()) : null;
 		final String source = "Skript ban effect";
 		for (final Object o : players.getArray(e)) {
 			if (o instanceof Player) {

--- a/src/main/java/ch/njol/skript/effects/EffBan.java
+++ b/src/main/java/ch/njol/skript/effects/EffBan.java
@@ -86,7 +86,8 @@ public class EffBan extends Effect {
 	@Override
 	protected void execute(final Event e) {
 		final String reason = this.reason != null ? this.reason.getSingle(e) : null; // don't check for null, just ignore an invalid reason
-		final Date expires = this.expires != null ? new Date(System.currentTimeMillis() + this.expires.getSingle(e).getMilliSeconds()) : null;
+		Timespan ts = this.expires != null ? this.expires.getSingle(e) : null;
+		final Date expires = ts != null ? new Date(System.currentTimeMillis() + ts.getMilliSeconds()) : null;
 		final String source = "Skript ban effect";
 		for (final Object o : players.getArray(e)) {
 			if (o instanceof Player) {

--- a/src/main/java/ch/njol/skript/effects/EffBan.java
+++ b/src/main/java/ch/njol/skript/effects/EffBan.java
@@ -38,32 +38,35 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.util.Timespan;
 import ch.njol.util.Kleenean;
 
 /**
  * @author Peter Güttinger
  */
 @Name("Ban")
-@Description({"Bans/unbans a player or an IP address.",
-		"Starting with Skript 2.1.1 and Bukkit 1.7.2 R0.4, one can also ban players with a reason.",
-		"Note that banning a player will not kick them from the server. You may use the <a href='effects.html#EffKick'>kick effect</a> if you wish so."})
+@Description({"Bans/unbans a player or an IP address. Option values for ban reason and temp ban time span.",
+	"Note that banning a player will not kick them from the server. You may use the <a href='effects.html#EffKick'>kick effect</a> if you wish so."})
 @Examples({"unban player",
-		"ban \"127.0.0.1\"",
-		"IP-ban the player because \"he is an idiot\""})
-@Since("1.4, 2.1.1 (ban reason)")
+	"ban \"127.0.0.1\"",
+	"IP-ban the player because \"he is an idiot\"",
+	"ban player due to \"inappropriate language\" for 2 days"})
+@Since("1.4, 2.1.1 (ban reason), INSERT VERSION (timespan)")
 public class EffBan extends Effect {
 	
 	static {
 		Skript.registerEffect(EffBan.class,
-				"ban %strings/offlineplayers% [(by reason of|because [of]|on account of|due to) %-string%]", "unban %strings/offlineplayers%",
-				"ban %players% by IP [(by reason of|because [of]|on account of|due to) %-string%]", "unban %players% by IP",
-				"IP(-| )ban %players% [(by reason of|because [of]|on account of|due to) %-string%]", "(IP(-| )unban|un[-]IP[-]ban) %players%");
+			"ban %strings/offlineplayers% [(by reason of|because [of]|on account of|due to) %-string%] [for %-timespan%]", "unban %strings/offlineplayers%",
+			"ban %players% by IP [(by reason of|because [of]|on account of|due to) %-string%] [for %-timespan%]", "unban %players% by IP",
+			"IP(-| )ban %players% [(by reason of|because [of]|on account of|due to) %-string%] [for %-timespan%]", "(IP(-| )unban|un[-]IP[-]ban) %players%");
 	}
 	
 	@SuppressWarnings("null")
 	private Expression<?> players;
 	@Nullable
 	private Expression<String> reason;
+	@Nullable
+	private Expression<Timespan> expires;
 	
 	private boolean ban;
 	private boolean ipBan;
@@ -73,15 +76,17 @@ public class EffBan extends Effect {
 	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
 		players = exprs[0];
 		reason = exprs.length > 1 ? (Expression<String>) exprs[1] : null;
+		expires = exprs.length > 1 ? (Expression<Timespan>) exprs[2] : null;
 		ban = matchedPattern % 2 == 0;
 		ipBan = matchedPattern >= 2;
 		return true;
 	}
 	
+	@SuppressWarnings("null")
 	@Override
 	protected void execute(final Event e) {
 		final String reason = this.reason != null ? this.reason.getSingle(e) : null; // don't check for null, just ignore an invalid reason
-		final Date expires = null;
+		final Date expires = this.expires != null ? new Date(System.currentTimeMillis() + this.expires.getSingle(e).getMilliSeconds()) : null;
 		final String source = "Skript ban effect";
 		for (final Object o : players.getArray(e)) {
 			if (o instanceof Player) {
@@ -125,7 +130,8 @@ public class EffBan extends Effect {
 	
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
-		return (ipBan ? "IP-" : "") + (ban ? "" : "un") + "ban " + players.toString(e, debug) + (reason != null ? " on account of " + reason.toString(e, debug) : "");
+		return (ipBan ? "IP-" : "") + (ban ? "" : "un") + "ban " + players.toString(e, debug) +
+			(reason != null ? " on account of " + reason.toString(e, debug) : "") + (expires != null ? " for " + expires.toString(e, debug) : "");
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffBan.java
+++ b/src/main/java/ch/njol/skript/effects/EffBan.java
@@ -46,6 +46,7 @@ import ch.njol.util.Kleenean;
  */
 @Name("Ban")
 @Description({"Bans/unbans a player or an IP address. Option values for ban reason and temp ban time span.",
+	"Note that if the timespan is not set, or if the value of the timespan is <none>, it will permanently ban the player.",
 	"Note that banning a player will not kick them from the server. You may use the <a href='effects.html#EffKick'>kick effect</a> if you wish so."})
 @Examples({"unban player",
 	"ban \"127.0.0.1\"",
@@ -87,15 +88,7 @@ public class EffBan extends Effect {
 	protected void execute(final Event e) {
 		final String reason = this.reason != null ? this.reason.getSingle(e) : null; // don't check for null, just ignore an invalid reason
 		Timespan ts = this.expires != null ? this.expires.getSingle(e) : null;
-		Date expires = null;
-		if (this.expires != null) {
-			if (ts != null)
-				expires = new Date(System.currentTimeMillis() + ts.getMilliSeconds());
-			else {
-				Skript.error("Could not temp ban " + players.toString(e, true) + " for: " + this.expires.toString(e, true));
-				return;
-			}
-		}
+		final Date expires = ts != null ? new Date(System.currentTimeMillis() + ts.getMilliSeconds()) : null;
 		final String source = "Skript ban effect";
 		for (final Object o : players.getArray(e)) {
 			if (o instanceof Player) {


### PR DESCRIPTION
### Description
This PR adds an option time span to the ban effect to allow users to temp ban players.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #2667 

Special note:
I tried to do a test for this one, but for true testing I need to do a wait. The testing environment appears to ignore waits in testing. 
