### PR TITLE
No Damage Ticks Expression

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprNoDamageTicks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNoDamageTicks.java
@@ -61,9 +61,9 @@ public class ExprNoDamageTicks extends SimplePropertyExpression<LivingEntity, Nu
 		for (LivingEntity le : getExpr().getArray(e)) {
 			switch (mode) {
 				case ADD:
-					int r = le.getNoDamageTicks() + d;
-					if (r < 0) r = 0;
-					le.setNoDamageTicks(r);
+					int r1 = le.getNoDamageTicks() + d;
+					if (r1 < 0) r1 = 0;
+					le.setNoDamageTicks(r1);
 					break;
 				case SET:
 					le.setNoDamageTicks(d);
@@ -73,9 +73,9 @@ public class ExprNoDamageTicks extends SimplePropertyExpression<LivingEntity, Nu
 					le.setNoDamageTicks(0);
 					break;
 				case REMOVE:
-					int r = le.getNoDamageTicks() - d;
-					if (r < 0) r = 0;
-					le.setNoDamageTicks(r);
+					int r2 = le.getNoDamageTicks() - d;
+					if (r2 < 0) r2 = 0;
+					le.setNoDamageTicks(r2);
 					break;
 				case REMOVE_ALL:
 					assert false;		

--- a/src/main/java/ch/njol/skript/expressions/ExprNoDamageTicks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNoDamageTicks.java
@@ -50,7 +50,7 @@ public class ExprNoDamageTicks extends SimplePropertyExpression<LivingEntity, Nu
 	@Override
 	@Nullable
 	public Class<?>[] acceptChange(final ChangeMode mode) {
-		if (mode == ChangeMode.REMOVE || mode == ChangeMode.REMOVE_ALL)
+		if (mode == ChangeMode.REMOVE_ALL)
 			return null;
 		return CollectionUtils.array(Number.class);
 	}
@@ -71,6 +71,10 @@ public class ExprNoDamageTicks extends SimplePropertyExpression<LivingEntity, Nu
 					le.setNoDamageTicks(0);
 					break;
 				case REMOVE:
+					int r = le.getNoDamageTicks() - d;
+					if (r < 0) r = 0;
+					le.setNoDamageTicks(r);
+					break;
 				case REMOVE_ALL:
 					assert false;		
 			}

--- a/src/main/java/ch/njol/skript/expressions/ExprNoDamageTicks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNoDamageTicks.java
@@ -61,7 +61,9 @@ public class ExprNoDamageTicks extends SimplePropertyExpression<LivingEntity, Nu
 		for (LivingEntity le : getExpr().getArray(e)) {
 			switch (mode) {
 				case ADD:
-					le.setNoDamageTicks(le.getNoDamageTicks() + d);
+					int r = le.getNoDamageTicks() + d;
+					if (r < 0) r = 0;
+					le.setNoDamageTicks(r);
 					break;
 				case SET:
 					le.setNoDamageTicks(d);

--- a/src/main/java/ch/njol/skript/expressions/ExprNoDamageTicks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNoDamageTicks.java
@@ -1,0 +1,90 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.expressions;
+
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.util.coll.CollectionUtils;
+
+@Name("No Damage Ticks")
+@Description("The number of ticks that an entity is invulnerable to damage for.")
+@Examples({"on damage:",
+		"	set victim's invulnerability ticks to 20 #Victim will not take damage for the next second"})
+@Since("INSERT VERSION")
+public class ExprNoDamageTicks extends SimplePropertyExpression<LivingEntity, Number> {
+	
+	static {
+		register(ExprNoDamageTicks.class, Number.class, "(invulnerability|no damage) tick[s]", "livingentities");
+	}
+
+	@Override
+	public Number convert(LivingEntity e) {
+		return e.getNoDamageTicks();
+	}
+	
+	@Override
+	@Nullable
+	public Class<?>[] acceptChange(final ChangeMode mode) {
+		if (mode == ChangeMode.REMOVE || mode == ChangeMode.REMOVE_ALL)
+			return null;
+		return CollectionUtils.array(Number.class);
+	}
+	
+	@Override
+	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+		int d = delta == null ? 0 : ((Number) delta[0]).intValue();
+		for (LivingEntity le : getExpr().getArray(e)) {
+			switch (mode) {
+				case ADD:
+					le.setNoDamageTicks(le.getNoDamageTicks() + d);
+					break;
+				case SET:
+					le.setNoDamageTicks(d);
+					break;
+				case DELETE:
+				case RESET:
+					le.setNoDamageTicks(0);
+					break;
+				case REMOVE:
+				case REMOVE_ALL:
+					assert false;		
+			}
+		}
+	}
+	
+	@Override
+	protected String getPropertyName() {
+		return "no damage ticks";
+	}
+	
+	@Override
+	public Class<Number> getReturnType() {
+		return Number.class;
+	}
+	
+}

--- a/src/test/skript/tests/syntaxes/expressions/ExprNoDamageTicks.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprNoDamageTicks.sk
@@ -1,0 +1,10 @@
+test "no damage ticks":
+	spawn zombie at location(0, 64, 0, world "world")
+	set {_m} to last spawned zombie
+	assert {_m}'s invulnerability ticks is 0 with "entity spawned with no damage ticks"
+	set {_m}'s invulnerability ticks to 25
+	assert {_m}'s invulnerability ticks is 25 with "no damage ticks set failed"
+	add 5 to {_m}'s invulnerability ticks
+	assert {_m}'s invulnerability ticks is 30 with "no damage ticks add failed"
+	delete {_m}'s invulnerability ticks
+	assert {_m}'s invulnerability ticks is 0 with "no damage ticks delete failed"

--- a/src/test/skript/tests/syntaxes/expressions/ExprNoDamageTicks.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprNoDamageTicks.sk
@@ -5,6 +5,14 @@ test "no damage ticks":
 	set {_m}'s invulnerability ticks to 25
 	assert {_m}'s invulnerability ticks is 25 with "no damage ticks set failed"
 	add 5 to {_m}'s invulnerability ticks
-	assert {_m}'s invulnerability ticks is 30 with "no damage ticks add failed"
+	assert {_m}'s invulnerability ticks is 30 with "no damage ticks add ##1 failed"
+	remove 12 from {_m}'s invulnerability ticks
+	assert {_m}'s invulnerability ticks is 18 with "no damage ticks remove ##1 failed"
+	remove 999 from {_m}'s invulnerability ticks
+	assert {_m}'s invulnerability ticks is 0 with "no damage ticks remove ##2 failed"
+	remove -2 from {_m}'s invulnerability ticks
+	assert {_m}'s invulnerability ticks is 2 with "no damage ticks remove ##3 failed"
+	add -1 to {_m}'s invulnerability ticks
+	assert {_m}'s invulnerability ticks is 1 with "no damage ticks add ##2 failed"
 	delete {_m}'s invulnerability ticks
 	assert {_m}'s invulnerability ticks is 0 with "no damage ticks delete failed"


### PR DESCRIPTION
### Description
This PR will allow users to get / modify the "no damage ticks" (aka invulnerability ticks) of living entities. Could be useful in scripts for inducing a cooldown on mob hits or for removing naturally occurring invulnerability ticks.

---
**Target Minecraft Versions:**     Any
**Requirements:**     None
**Related Issues:**     None