### PR TITLE
Charge Creeper Effect and Condition

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondIsCharged.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsCharged.java
@@ -1,0 +1,54 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.conditions;
+
+import org.bukkit.entity.Creeper;
+import org.bukkit.entity.LivingEntity;
+
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+
+@Name("Is Charged")
+@Description("Checks if a creeper is charged (powered).")
+@Examples({"if the last spawned creeper is charged:",
+			"\tbroadcast a charged creeper is at %location of last spawned creeper%"})
+@Since("INSERT VERSION")
+public class CondIsCharged extends PropertyCondition<LivingEntity> {
+	
+	static {
+		register(CondIsCharged.class, "(charged|powered)", "livingentities");
+	}
+	
+	@Override
+	public boolean check(final LivingEntity e) {
+		if (e instanceof Creeper)
+			return ((Creeper) e).isPowered();
+		return false;
+	}
+	
+	@Override
+	protected String getPropertyName() {
+		return "charged";
+	}
+	
+}

--- a/src/main/java/ch/njol/skript/conditions/CondIsCharged.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsCharged.java
@@ -31,7 +31,7 @@ import ch.njol.skript.doc.Since;
 @Name("Is Charged")
 @Description("Checks if a creeper is charged (powered).")
 @Examples({"if the last spawned creeper is charged:",
-			"\tbroadcast a charged creeper is at %location of last spawned creeper%"})
+			"\tbroadcast \"A charged creeper is at %location of last spawned creeper%\""})
 @Since("INSERT VERSION")
 public class CondIsCharged extends PropertyCondition<LivingEntity> {
 	

--- a/src/main/java/ch/njol/skript/effects/EffChargeCreeper.java
+++ b/src/main/java/ch/njol/skript/effects/EffChargeCreeper.java
@@ -1,0 +1,75 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+
+import org.bukkit.entity.Creeper;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+@Name("Charge Creeper")
+@Description("Charges or uncharges a creeper. A creeper is charged when it has been struck by lightning.")
+@Examples({"on spawn of creeper:", 
+			"\tcharge the event-entity"})
+@Since("INSERT VERSION")
+public class EffChargeCreeper extends Effect {
+
+	static {
+		Skript.registerEffect(EffChargeCreeper.class,
+				"make %livingentities% [a[n]] (charged|powered|1¦((un|non[-])charged|(un|non[-])powered)) [creeper[s]]",
+				"(charge|power|1¦(uncharge|unpower)) %livingentities%");
+	}
+
+	@SuppressWarnings("null")
+	private Expression<LivingEntity> entities;
+
+	private boolean charge;
+
+	@SuppressWarnings({"unchecked", "null"})
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		entities = (Expression<LivingEntity>) exprs[0];
+		charge = parseResult.mark != 1;
+		return true;
+	}
+
+	@Override
+	protected void execute(Event e) {
+		for (LivingEntity le : entities.getArray(e)) {
+			if (le instanceof Creeper)
+				((Creeper) le).setPowered(charge);
+		}
+	}
+
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		return "make " + entities.toString(e, debug) + (charge == true ? " charged" : " not charged");
+	}
+}

--- a/src/test/skript/tests/syntaxes/effects/EffChargeCreeper.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffChargeCreeper.sk
@@ -1,0 +1,8 @@
+test "charge creeper effect/condition":
+	spawn a creeper at spawn of world "world"
+	assert last spawned creeper is not charged with "spawning a normal creeper shouldn't spawn a charged one"
+	charge the last spawned creeper
+	assert last spawned creeper is charged with "a creeper should be charged after it is set as charged"
+	uncharge the last spawned creeper
+	assert last spawned creeper is not charged with "uncharging a charged creeper should uncharge it"
+	delete last spawned creeper


### PR DESCRIPTION
### Description
This PR adds an effect which allows the user to charge or uncharge a creeper. There is also a condition to check whether or not a creeper is charged.

---
**Target Minecraft Versions:**     Any
**Requirements:**     None
**Related Issues:**     None
