### PR TITLE
Fix drop item effect throwing error

### DIFF
--- a/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
@@ -144,12 +144,12 @@ public class ItemUtils {
 	}
 	
 	/**
-	 * Check if a material is an item that can be held
+	 * Check if a material has an item form that can be held.
 	 *
-	 * @param material Material to check if item
-	 * @return True if material is an item
+	 * @param material Material to check for item form
+	 * @return True if material has an item form
 	 */
-	public static boolean isItem(Material material) {
+	public static boolean hasItemForm(Material material) {
 		if (isItemExists) {
 			return material.isItem();
 		} else {

--- a/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
@@ -37,6 +37,7 @@ public class ItemUtils {
 	private ItemUtils() {} // Not to be instanced
 	
 	private static final boolean damageMeta = Skript.classExists("org.bukkit.inventory.meta.Damageable");
+	private static final boolean isItemExists = Skript.methodExists(Material.class, "isItem"); // Introduced in 1.12.x
 	
 	/**
 	 * Gets damage/durability of an item, or 0 if it does not have damage.
@@ -140,6 +141,20 @@ public class ItemUtils {
 			return is1 == is2;
 		return is1.getType() == is2.getType() && ItemUtils.getDamage(is1) == ItemUtils.getDamage(is2)
 			&& is1.getItemMeta().equals(is2.getItemMeta());
+	}
+	
+	/**
+	 * Check if a material is an item that can be held
+	 *
+	 * @param material Material to check if item
+	 * @return True if material is an item
+	 */
+	public static boolean isItem(Material material) {
+		if (isItemExists) {
+			return material.isItem();
+		} else {
+			return material != Material.AIR;
+		}
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffDrop.java
+++ b/src/main/java/ch/njol/skript/effects/EffDrop.java
@@ -20,14 +20,12 @@
 package ch.njol.skript.effects;
 
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.ExperienceOrb;
 import org.bukkit.entity.Item;
 import org.bukkit.event.Event;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -103,7 +101,7 @@ public class EffDrop extends Effect {
 					if (o instanceof ItemStack)
 						o = new ItemType((ItemStack) o);
 					for (final ItemStack is : ((ItemType) o).getItem().getAll()) {
-						if (ItemUtils.isItem(is.getType())) {
+						if (ItemUtils.hasItemForm(is.getType())) {
 							if (useVelocity) {
 								lastSpawned = l.getWorld().dropItemNaturally(itemDropLoc, is);
 							} else {

--- a/src/main/java/ch/njol/skript/effects/EffDrop.java
+++ b/src/main/java/ch/njol/skript/effects/EffDrop.java
@@ -33,6 +33,7 @@ import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.bukkitutil.ItemUtils;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -102,7 +103,7 @@ public class EffDrop extends Effect {
 					if (o instanceof ItemStack)
 						o = new ItemType((ItemStack) o);
 					for (final ItemStack is : ((ItemType) o).getItem().getAll()) {
-						if (is.getType() != Material.AIR) {
+						if (ItemUtils.isItem(is.getType())) {
 							if (useVelocity) {
 								lastSpawned = l.getWorld().dropItemNaturally(itemDropLoc, is);
 							} else {


### PR DESCRIPTION
### Description
The drop item effect throws a massive error when attempting to drop a material which cannot be an item. 
Bukkit 1.12 added a method Material#isItem, to keep compatibility with 1.9+ I added an ItemUtils method to be able to handle this new method.

---
**Target Minecraft Versions:** all
**Requirements:** none
**Related Issues:**  #2812 
