### PR TITLE
Fix some item comparison issues

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/ItemData.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemData.java
@@ -207,9 +207,11 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 			// Play safe and mark ALL items that may have durability to have it changed
 			itemFlags |= ItemFlags.CHANGED_DURABILITY;
 		}
-		if (stack.hasItemMeta()) {
-			itemFlags |= ItemFlags.CHANGED_TAGS;
-		}
+		// All data made from stacks may have changed tags
+		// We cannot assume that lack of tags indicates that they can be
+		// ignored in comparisons; they may well have been explicitly removed
+		// See issue #2714 for examples of bad things that this causes
+		itemFlags |= ItemFlags.CHANGED_TAGS;
 	}
 	
 	public ItemData(ItemStack stack) {

--- a/src/main/java/ch/njol/skript/aliases/ItemData.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemData.java
@@ -413,28 +413,28 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 		String ourName = first.hasDisplayName() ? first.getDisplayName() : null;
 		String theirName = second.hasDisplayName() ? second.getDisplayName() : null;
 		if (!Objects.equals(ourName, theirName)) {
-			quality = theirName != null ? MatchQuality.SAME_MATERIAL : quality;
+			quality = ourName != null ? MatchQuality.SAME_MATERIAL : quality;
 		}
 		
 		// Lore
 		List<String> ourLore = first.hasLore() ? first.getLore() : null;
 		List<String> theirLore = second.hasLore() ? second.getLore() : null;
 		if (!Objects.equals(ourLore, theirLore)) {
-			quality = theirLore != null ? MatchQuality.SAME_MATERIAL : quality;
+			quality = ourLore != null ? MatchQuality.SAME_MATERIAL : quality;
 		}
 		
 		// Enchantments
 		Map<Enchantment, Integer> ourEnchants = first.getEnchants();
 		Map<Enchantment, Integer> theirEnchants = second.getEnchants();
 		if (!Objects.equals(ourEnchants, theirEnchants)) {
-			quality = !theirEnchants.isEmpty() ? MatchQuality.SAME_MATERIAL : quality;
+			quality = !ourEnchants.isEmpty() ? MatchQuality.SAME_MATERIAL : quality;
 		}
 		
 		// Item flags
 		Set<ItemFlag> ourFlags = first.getItemFlags();
 		Set<ItemFlag> theirFlags = second.getItemFlags();
 		if (!Objects.equals(ourFlags, theirFlags)) {
-			quality = !theirFlags.isEmpty() ? MatchQuality.SAME_MATERIAL : quality;
+			quality = !ourFlags.isEmpty() ? MatchQuality.SAME_MATERIAL : quality;
 		}
 		
 		// Potion data

--- a/src/main/java/ch/njol/skript/aliases/ItemType.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemType.java
@@ -276,25 +276,9 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 	}
 	
 	public boolean isOfType(@Nullable ItemStack item) {
-		// Duplicate code to avoid creating ItemData
-		for (ItemData myType : types) {
-			if (item == null) { // Given item null
-				if (myType.type == Material.AIR)
-					return true; // Both items AIR/null
-			} else if (myType.isAlias) {
-				if (!myType.isOfType(item))
-					continue;
-				return true;
-			} else {
-				return item.isSimilar(myType.stack);
-			}
-		}
-		return false;
-		
-		// Alternative, simpler implementation
-//		if (item == null)
-//			return isOfType(Material.AIR, null);
-//		return isOfType(new ItemData(item));
+		if (item == null)
+			return isOfType(Material.AIR, null);
+		return isOfType(new ItemData(item));
 	}
 	
 	public boolean isOfType(@Nullable BlockState block) {
@@ -312,8 +296,9 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 	
 	public boolean isOfType(ItemData type) {
 		for (final ItemData myType : types) {
-			if (myType.equals(type))
+			if (myType.equals(type)) {
 				return true;
+			}
 		}
 		return false;
 	}


### PR DESCRIPTION
### Description
I fixed a few quirks with item comparisons that caused scripts to remove wrong items in some cases. 

* Missing item meta values (e.g. names) of items in inventories are no longer ignored
  * Previously, removing a named item would also remove unnamed items
  * Instead, removing an unnamed item will (as intended) remove those that do have names
* Items in inventories that fail meta checks are no longer promoted as successful matches
  * Promotion used to be done for items without any meta
  * Lack of meta in items is significant, so this was not safe
  * Promotion is still done for aliases that do not have any tags

Please test this PR for regressions before approving. There might be nasty regressions that I didn't think of.

---
**Target Minecraft Versions:** any, but won't solve comparison issues specific to 1.12 and older versions
**Requirements:** none
**Related Issues:** #2714