### PR TITLE
Fix missing cat types in the lang file

### DIFF
--- a/src/main/java/ch/njol/skript/util/VisualEffect.java
+++ b/src/main/java/ch/njol/skript/util/VisualEffect.java
@@ -108,7 +108,7 @@ public final class VisualEffect implements SyntaxElement, YggdrasilSerializable 
 		IRON_GOLEM_SHEATH("IRON_GOLEM_SHEATH", true),
 		TOTEM_RESURRECT("TOTEM_RESURRECT", true),
 		HURT_DROWN("HURT_DROWN", true),
-		HURT_EXPLOSIION("HURT_EXPLOSION", true),
+		HURT_EXPLOSION("HURT_EXPLOSION", true),
 		
 		// Particles
 		FIREWORKS_SPARK(Particle.FIREWORKS_SPARK),

--- a/src/main/java/ch/njol/skript/util/VisualEffect.java
+++ b/src/main/java/ch/njol/skript/util/VisualEffect.java
@@ -108,7 +108,7 @@ public final class VisualEffect implements SyntaxElement, YggdrasilSerializable 
 		IRON_GOLEM_SHEATH("IRON_GOLEM_SHEATH", true),
 		TOTEM_RESURRECT("TOTEM_RESURRECT", true),
 		HURT_DROWN("HURT_DROWN", true),
-		HURT_EXPLOSION("HURT_EXPLOSION", true),
+		HURT_EXPLOSIION("HURT_EXPLOSION", true),
 		
 		// Particles
 		FIREWORKS_SPARK(Particle.FIREWORKS_SPARK),

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -749,7 +749,7 @@ entities:
 		pattern: (wild|untamed) <age> ocelot(|1¦s)
 	cat:
 		name: cat¦s
-		pattern: <age> cat(|1¦s)|tamed <age> ocelot(|1¦s)|(4¦)kitten(|1¦s)
+		pattern: <age> [%-cattype%] cat(|1¦s)|tamed <age> ocelot(|1¦s)|(4¦)[%-cattype%] kitten(|1¦s)
 	painting:
 		name: painting¦s
 		pattern: painting(|1¦s)
@@ -1176,6 +1176,19 @@ entities:
 		name: angry nectar bee¦s
 		pattern: <age> angry bee(|1¦s) with nectar
 
+# -- Cat Types --
+cat types:
+	tabby: tabby
+	black: black
+	red: red
+	siamese: siamese
+	british_shorthair: british shorthair
+	calico: calico
+	persian: persian
+	ragdoll: ragdoll
+	white: white
+	jellie: jellie
+	all_black: all black
 
 # -- Damage Causes --
 damage causes:

--- a/src/test/skript/tests/syntaxes/effects/EffSpawn.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffSpawn.sk
@@ -1,0 +1,13 @@
+test "spawn cats by type" when minecraft version is "1.15.2":
+	delete all cats
+	set {_l} to location of spawn of world "world"
+	spawn 5 all black cats at {_l}
+	assert size of all cats = 5 with "Size of all cats is not 5"
+	assert size of all all black cats = 5 with "Size of all all black cats is not 5"
+	spawn 2 siamese cats at {_l}
+	assert size of all cats = 7 with "Size of all cats is not 7"
+	assert size of all siamese cats = 2 with "Size of all siamese cats is not 2"
+	delete all siamese cats
+	assert size of all cats = 5 with "Size of all cats is not 5 after delete 2 siamese cats"
+	delete all cats
+	assert size of all cats = 0 with "Size of all cats is greater than 0 after all were deleted"


### PR DESCRIPTION
### Description
This PR adds missing cat types to the lang file.
Until this point you could only spawn a cat, but not by type, this fixes that. 

Please ignore the other commits here. I originally planned on doing a bigger PR that fixes a bunch of issues, but decided to split it up.

---
**Target Minecraft Versions:** 1.14+ (when cats were introduced)
**Requirements:** none
**Related Issues:** none
