### PR TITLE
SkriptTests - remove vanilla Minecraft GUI console

### DIFF
--- a/src/test/skript/environments/main/paper-1.15.2.json
+++ b/src/test/skript/environments/main/paper-1.15.2.json
@@ -9,6 +9,6 @@
 	"skriptTarget": "plugins/Skript.jar",
 	"commandLine": [
 		"-Dcom.mojang.eula.agree=true",
-		"-jar", "paperclip.jar"
+		"-jar", "paperclip.jar", "--nogui"
 	]
 }


### PR DESCRIPTION
### Description
This PR is to remove the vanilla Minecraft GUI console from the Skript test system, which pops up when you run a server on 1.15.2

I was running tests in the background, the GUI popped up and startled me 🤓 

---
**Target Minecraft Versions:** 1.15.2
**Requirements:** none
**Related Issues:** none
