### PR TITLE
BukkitClasses - fix some misplaced patterns for some classes

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -1389,7 +1389,7 @@ public class BukkitClasses {
 				.user("teleport ?(cause|reason|type)s?")
 				.name("Teleport Cause")
 				.description("The teleport cause in a <a href='events.html#teleport'>teleport</a> event.")
-				.examples(teleportCauses.getAllNames())
+				.usage(teleportCauses.getAllNames())
 				.since("2.2-dev35")
 				.parser(new Parser<TeleportCause>() {
 					@Override
@@ -1421,7 +1421,7 @@ public class BukkitClasses {
 				.user("spawn(ing)? ?reasons?")
 				.name("Spawn Reason")
 				.description("The spawn reason in a <a href='events.html#spawn'>spawn</a> event.")
-				.examples(spawnReasons.getAllNames())
+				.usage(spawnReasons.getAllNames())
 				.since("2.3")
 				.parser(new Parser<SpawnReason>() {
 					@Override
@@ -1490,7 +1490,7 @@ public class BukkitClasses {
 				.name("Firework Type")
 				.description("The type of a <a href='#fireworkeffect'>fireworkeffect</a>.")
 				.defaultExpression(new EventValueExpression<>(FireworkEffect.Type.class))
-				.examples(fireworktypes.getAllNames())
+				.usage(fireworktypes.getAllNames())
 				.since("2.4")
 				.documentationId("FireworkType")
 				.parser(new Parser<FireworkEffect.Type>() {
@@ -1557,7 +1557,7 @@ public class BukkitClasses {
 				.user("difficult(y|ies)")
 				.name("Difficulty")
 				.description("The difficulty of a <a href='#world'>world</a>.")
-				.examples(difficulties.getAllNames())
+				.usage(difficulties.getAllNames())
 				.since("2.3")
 				.parser(new Parser<Difficulty>() {
 					@Override
@@ -1589,7 +1589,7 @@ public class BukkitClasses {
 				.user("resource ?pack ?states?")
 				.name("Resource Pack State")
 				.description("The state in a <a href='events.html#resource_pack_request_action'>resource pack request response</a> event.")
-				.examples(resourcePackStates.getAllNames())
+				.usage(resourcePackStates.getAllNames())
 				.since("2.4")
 				.parser(new Parser<Status>() {
 					@Override
@@ -1623,7 +1623,7 @@ public class BukkitClasses {
 					.name("Sound Category")
 					.description("The category of a sound, they are used for sound options of Minecraft. " +
 							"See the <a href='effects.html#EffPlaySound'>play sound</a> and <a href='effects.html#EffStopSound'>stop sound</a> effects.")
-					.examples(soundCategories.getAllNames())
+					.usage(soundCategories.getAllNames())
 					.since("2.4")
 					.requiredPlugins("Minecraft 1.11 or newer")
 					.parser(new Parser<SoundCategory>() {
@@ -1658,7 +1658,7 @@ public class BukkitClasses {
 					.name("Gene")
 					.description("Represents a Panda's main or hidden gene. " +
 							"See <a href='https://minecraft.gamepedia.com/Panda#Genetics'>genetics</a> for more info.")
-					.examples(genes.getAllNames())
+					.usage(genes.getAllNames())
 					.since("2.4")
 					.requiredPlugins("Minecraft 1.14 or newer")
 					.parser(new Parser<Gene>() {
@@ -1691,7 +1691,7 @@ public class BukkitClasses {
 					.user("cat ?(type|race)s?")
 					.name("Cat Type")
 					.description("Represents the race/type of a cat entity.")
-					.examples(races.getAllNames())
+					.usage(races.getAllNames())
 					.since("2.4")
 					.requiredPlugins("Minecraft 1.14 or newer")
 					.documentationId("CatType")


### PR DESCRIPTION
### Description
This PR fixes some misplaced patterns for some classes.
In some classes the patterns were put in the description section rather than the usage section.
This brings some continuity between the classes

#### Before:
![](https://i.imgur.com/V5gT9Yf.png)

#### After
![](https://i.imgur.com/5vPUfIv.png)

---
**Target Minecraft Versions:** all
**Requirements:** none
**Related Issues:** none
