### PR TITLE
Fix an issue with actions failing on some PRs

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Checkout submodules
       uses: textbook/git-checkout-submodule-action@2.0.0
     - name: Set up JDK 1.8


### PR DESCRIPTION
### Description
There have been a few issues with actions failing. I did some research and saw a few other repos having this issue. Looking thru commits/PRs it appears the fix was to change the checkout v1 to v2

---
**Target Minecraft Versions:** n/a
**Requirements:** none
**Related Issues:** none
