### PR TITLE
ExprHotbarButton - fix doc issue

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprHotbarButton.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHotbarButton.java
@@ -36,7 +36,7 @@ import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 
 @Name("Hotbar Button")
-@Description("The hotbar button clicked in an <a href='events.html#inventory_click>inventory click</a> event.")
+@Description("The hotbar button clicked in an <a href='events.html#inventory_click'>inventory click</a> event.")
 @Examples({"on inventory click:",
 		"	send \"You clicked the hotbar button %hotbar button%!\""})
 @Since("2.5")

--- a/src/main/java/ch/njol/skript/expressions/ExprPlayerlistHeaderFooter.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPlayerlistHeaderFooter.java
@@ -39,7 +39,7 @@ import ch.njol.util.coll.CollectionUtils;
 
 @Name("Player List Header and Footer")
 @Description("The message above and below the player list in the tab menu.")
-@Examples({"set all players tab list header to \"Welcome to the Server!\"",
+@Examples({"set all players' tab list header to \"Welcome to the Server!\"",
 			"send \"%the player's tab list header%\" to player",
 			"reset all players' tab list header"})
 @Since("2.4")


### PR DESCRIPTION
### Description
Fix an issue with the docs of 2 expressions joining (affected hotbar button)

(also fixed a small typo in the player list expression)

**BEFORE**:
![](https://i.imgur.com/C0Z3M5l.png)

**AFTER**:
![](https://i.imgur.com/mXAs9tt.png)

---
**Target Minecraft Versions:**any
**Requirements:**  none
**Related Issues:** none
