### PR TITLE
Fix issue with Nexus repo + PreciousStones

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,10 +36,6 @@ allprojects {
 		}
 	
 		maven {
-			url 'http://nexus.hc.to/content/repositories/pub_releases'
-		}
-	
-		maven {
 			url 'https://jitpack.io'
 		}
 	
@@ -94,7 +90,7 @@ processResources {
 		"version": System.getenv("SKRIPT_VERSION") == null ? project.property("version") : System.getenv("SKRIPT_VERSION"),
 		'today': "unknown", // Don't leak information about system this was built on
 		"release-flavor": "selfbuilt-unknown", // Note: 'selfbuilt' prefix makes updater report a custom build
-		"release-channel": "nones", // No updates, so anything else wouldn't make sense
+		"release-channel": "none", // No updates, so anything else wouldn't make sense
 		"release-updater": "ch.njol.skript.update.NoUpdateChecker", // Disable update checking
 		"release-source": "",
 		"release-download": "null"

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ processResources {
 		"version": System.getenv("SKRIPT_VERSION") == null ? project.property("version") : System.getenv("SKRIPT_VERSION"),
 		'today': "unknown", // Don't leak information about system this was built on
 		"release-flavor": "selfbuilt-unknown", // Note: 'selfbuilt' prefix makes updater report a custom build
-		"release-channel": "none", // No updates, so anything else wouldn't make sense
+		"release-channel": "nones", // No updates, so anything else wouldn't make sense
 		"release-updater": "ch.njol.skript.update.NoUpdateChecker", // Disable update checking
 		"release-source": "",
 		"release-download": "null"


### PR DESCRIPTION
### Description
So it appears the nexus repo has gone down, which is causing builds to fail with PreciousStones.
For funsies, I took it out just to see what would happened, and the build started working. Goes to show this repo is not needed.

This PR is to fix said issue, so builds will start to build again.

Open for discussion :)

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
