### PR TITLE
BukkitEventValues - add PlayerItemDamageEvent item value

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -677,10 +677,10 @@ public final class BukkitEventValues {
 			}
 		}, 0);
 		// PlayerItemDamageEvent
-		EventValues.registerEventValue(PlayerItemDamageEvent.class, ItemStack.class, new Getter<ItemStack, PlayerItemDamageEvent>() {
+		EventValues.registerEventValue(PlayerItemDamageEvent.class, ItemType.class, new Getter<ItemType, PlayerItemDamageEvent>() {
 			@Override
-			public ItemStack get(PlayerItemDamageEvent event) {
-				return event.getItem();
+			public ItemType get(PlayerItemDamageEvent event) {
+				return new ItemType(event.getItem());
 			}
 		}, 0);
 		

--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -89,6 +89,7 @@ import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemBreakEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
+import org.bukkit.event.player.PlayerItemDamageEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.event.player.PlayerRiptideEvent;
@@ -673,6 +674,13 @@ public final class BukkitEventValues {
 			@Nullable
 			public Block get(final PlayerMoveEvent e) {
 				return EvtMoveOn.getBlock(e);
+			}
+		}, 0);
+		// PlayerItemDamageEvent
+		EventValues.registerEventValue(PlayerItemDamageEvent.class, ItemStack.class, new Getter<ItemStack, PlayerItemDamageEvent>() {
+			@Override
+			public ItemStack get(PlayerItemDamageEvent event) {
+				return event.getItem();
 			}
 		}, 0);
 		


### PR DESCRIPTION
### Description
This PR fixes an issue with the item damage event missing an event-item value

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #2895 
