### PR TITLE
Date - expand API for ease of use

### DIFF
--- a/src/main/java/ch/njol/skript/util/Date.java
+++ b/src/main/java/ch/njol/skript/util/Date.java
@@ -19,12 +19,10 @@
  */
 package ch.njol.skript.util;
 
-import java.time.ZoneId;
 import java.util.TimeZone;
 
 import org.eclipse.jdt.annotation.Nullable;
 
-import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptConfig;
 import ch.njol.yggdrasil.YggdrasilSerializable;
 
@@ -67,18 +65,34 @@ public class Date implements Comparable<Date>, YggdrasilSerializable {
 	}
 	
 	/**
+	 * Get the timestamp of this date
+	 *
 	 * @return The timestamp in milliseconds
 	 */
 	public long getTimestamp() {
 		return timestamp;
 	}
 	
-	public void add(final Timespan span) {
+	/**
+	 * Add a {@link Timespan} to this date
+	 *
+	 * @param span Timespan to add
+	 * @return This date with the added timespan
+	 */
+	public Date add(final Timespan span) {
 		timestamp += span.getMilliSeconds();
+		return this;
 	}
 	
-	public void subtract(final Timespan span) {
+	/**
+	 * Subtract a {@link Timespan} from this date
+	 *
+	 * @param span Timespan to subtract
+	 * @return This dat with the subtracted timespan
+	 */
+	public Date subtract(final Timespan span) {
 		timestamp -= span.getMilliSeconds();
+		return this;
 	}
 	
 	@Override
@@ -98,9 +112,7 @@ public class Date implements Comparable<Date>, YggdrasilSerializable {
 		if (!(obj instanceof Date))
 			return false;
 		final Date other = (Date) obj;
-		if (timestamp != other.timestamp)
-			return false;
-		return true;
+		return timestamp == other.timestamp;
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/util/Date.java
+++ b/src/main/java/ch/njol/skript/util/Date.java
@@ -49,6 +49,15 @@ public class Date implements Comparable<Date>, YggdrasilSerializable {
 		this.timestamp = timestamp - offset;
 	}
 	
+	/**
+	 * Get a new Date with the current time
+	 *
+	 * @return New date with the current time
+	 */
+	public static Date now() {
+		return new Date(System.currentTimeMillis());
+	}
+	
 	public Timespan difference(final Date other) {
 		return new Timespan(Math.abs(timestamp - other.timestamp));
 	}
@@ -77,22 +86,38 @@ public class Date implements Comparable<Date>, YggdrasilSerializable {
 	 * Add a {@link Timespan} to this date
 	 *
 	 * @param span Timespan to add
-	 * @return This date with the added timespan
 	 */
-	public Date add(final Timespan span) {
+	public void add(final Timespan span) {
 		timestamp += span.getMilliSeconds();
-		return this;
 	}
 	
 	/**
 	 * Subtract a {@link Timespan} from this date
 	 *
 	 * @param span Timespan to subtract
-	 * @return This date with the subtracted timespan
 	 */
-	public Date subtract(final Timespan span) {
+	public void subtract(final Timespan span) {
 		timestamp -= span.getMilliSeconds();
-		return this;
+	}
+	
+	/**
+	 * Get a new instance of this Date with the added timespan
+	 *
+	 * @param span Timespan to add to this Date
+	 * @return New Date with the added timespan
+	 */
+	public Date plus(Timespan span) {
+		return new Date(timestamp + span.getMilliSeconds());
+	}
+	
+	/**
+	 * Get a new instance of this Date with the subtracted timespan
+	 *
+	 * @param span Timespan to subtract from this Date
+	 * @return New Date with the subtracted timespan
+	 */
+	public Date minus(Timespan span) {
+		return new Date(timestamp - span.getMilliSeconds());
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/util/Date.java
+++ b/src/main/java/ch/njol/skript/util/Date.java
@@ -88,7 +88,7 @@ public class Date implements Comparable<Date>, YggdrasilSerializable {
 	 * Subtract a {@link Timespan} from this date
 	 *
 	 * @param span Timespan to subtract
-	 * @return This dat with the subtracted timespan
+	 * @return This date with the subtracted timespan
 	 */
 	public Date subtract(final Timespan span) {
 		timestamp -= span.getMilliSeconds();


### PR DESCRIPTION
### Description
This PR aims to expand the date a little bit to add some ease of use.
- Add return for plus/minus methods for creating a new instance of the date with the added/subtracted time.
- As suggested by Pikachu, added a Date#now() method, returning a new date at the current time.
- Add some javadoc notes. IntelliJ has some really interesting popups which show java docs on classes/methods you hover over. By adding better java doc notes to some of these methods, end users can easily see what these methods do and are meant for.

I noticed the need for this in #2907 
https://github.com/SkriptLang/Skript/pull/2907/files#r403780753

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
