### PR TITLE
Fix default block data applying to all placed blocks

### DIFF
--- a/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
@@ -262,7 +262,7 @@ public class NewBlockCompat implements BlockCompat {
 			// Generic block placement
 			if (!placed) {
 				block.setType(type);
-				if (ourValues != null)
+				if (ourValues != null && !ourValues.isDefault())
 					block.setBlockData(ourValues.data, applyPhysics);
 			}
 		}


### PR DESCRIPTION
### Description
So one issue is settings blocks will always default to Bukkit's default block data. 
The issue here is blocks such as fences, it will set a single fence post, and will not connect to blocks next to it. The reason this happens is because Skript sets the default block data.

This PR fixes it by not setting block data if no block data is determined (ie: using an aliases with no option block data properties)
If an alias which is not default is used, then the Block data of said alias will be applied to the set block.

---
**Target Minecraft Versions:**  1.13+
**Requirements:** none
**Related Issues:**  #2292 
