### PR TITLE
Change Assertion in ExpressionList

### DIFF
--- a/src/main/java/ch/njol/skript/lang/ExpressionList.java
+++ b/src/main/java/ch/njol/skript/lang/ExpressionList.java
@@ -56,7 +56,7 @@ public class ExpressionList<T> implements Expression<T> {
 	}
 	
 	protected ExpressionList(final Expression<? extends T>[] expressions, final Class<T> returnType, final boolean and, final @Nullable ExpressionList<?> source) {
-		assert expressions != null && expressions.length > 1;
+		assert expressions != null;
 		this.expressions = expressions;
 		this.returnType = returnType;
 		this.and = and;


### PR DESCRIPTION
### Description
This PR removes the assertion that the length of an ExpressionList is greater than one.
In my PersistentData PR, I need to be able to use an ExpressionList with just one value. While it works fine in-game, the test does not work. This change shouldn't break anything.

---
**Target Minecraft Versions:**     N/A
**Requirements:**     N/A
**Related Issues:**     #2837 
