### PR TITLE
InfoCommand - add server version, skript version and installed addons

### DIFF
--- a/src/main/java/ch/njol/skript/SkriptCommand.java
+++ b/src/main/java/ch/njol/skript/SkriptCommand.java
@@ -30,6 +30,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.PluginDescriptionFile;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.ScriptLoader.ScriptInfo;
@@ -332,6 +333,14 @@ public class SkriptCommand implements CommandExecutor {
 			} else if (args[0].equalsIgnoreCase("info")) {
 				info(sender, "info.aliases");
 				info(sender, "info.documentation");
+				info(sender, "info.server", Bukkit.getVersion());
+				info(sender, "info.version", Skript.getVersion());
+				info(sender, "info.addons");
+				for (SkriptAddon addon : Skript.getAddons()) {
+					PluginDescriptionFile desc = addon.plugin.getDescription();
+					String web = desc.getWebsite();
+					Skript.info(sender, " - " + desc.getFullName() + (web != null ? " (" + web + ")" : ""));
+				}
 			} else if (args[0].equalsIgnoreCase("help")) {
 				skriptCommandHelp.showHelp(sender);
 			} else if (args[0].equalsIgnoreCase("gen-docs")) {

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -136,6 +136,9 @@ skript command:
 	info:
 		aliases: Skript's aliases can be found here: <aqua>https://github.com/SkriptLang/skript-aliases
 		documentation: Skript's documentation can be found here: <aqua>https://skriptlang.github.io/Skript
+		version: Skript Version: <aqua>%s
+		server: Server Version: <aqua>%s
+		addons: Installed Skript Addons:
 
 # -- Updater --
 updater:


### PR DESCRIPTION
### Description
This PR adds server version, skript version and installed addons to the `/skript info` command.

Quite often when people request help, they give us very little info. We may say to them "Which version is your server and/or Skript?" ... they reply "latest", same with addons. 
By adding this additional info, a user can quickly see the details of their server, skript and which addons they currently have installed.

### Example:
<img width="932" alt="Screen Shot 2020-05-14 at 2 19 14 PM" src="https://user-images.githubusercontent.com/20008482/81987094-e7627a80-95ed-11ea-940f-253a7c7d562d.png">


---
**Target Minecraft Versions:**  any
**Requirements:** none
**Related Issues:**  #2970 
