### PR TITLE
ExprFinalDamage - Fix returning getDamage instead of getFinalDamage

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprFinalDamage.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFinalDamage.java
@@ -64,7 +64,7 @@ public class ExprFinalDamage extends SimpleExpression<Double> {
 	protected Double[] get(final Event e) {
 		if (!(e instanceof EntityDamageEvent))
 			return new Double[0];
-		return new Double[] {HealthUtils.getDamage((EntityDamageEvent) e)};
+		return new Double[] {HealthUtils.getFinalDamage((EntityDamageEvent) e)};
 	}
 	
 	@Override


### PR DESCRIPTION
### Description
It was recently brought to my attention that `final damage` was not returning correctly. 
This fixes that issue.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:**  none that I can find
