### PR TITLE
Add Color Tag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,7 @@ allprojects {
 
 dependencies {
 	implementation 'com.destroystokyo.paper:paper-api:1.15-R0.1-SNAPSHOT'
+	implementation 'net.md-5:bungeecord-chat:1.16-R0.1'
 	implementation 'org.eclipse.jdt:org.eclipse.jdt.annotation:1.1.0'
 	implementation 'com.google.code.findbugs:findbugs:3.0.1'
 	implementation 'com.sk89q.worldguard:worldguard-legacy:7.0.0-SNAPSHOT'

--- a/docs/text.html
+++ b/docs/text.html
@@ -110,6 +110,22 @@ Here's a table of all colors, including both Skript names and color codes:
     <td></td>
   </tr>
 </table>
+
+In Minecraft 1.16, support was added for 6-digit hexadecimal colors to specify custom colors other than the 16 default color codes.
+A new tag was added to allow usage of these colors:
+<table>
+  <tr>
+    <td>Name</td>
+    <td>Alternative Names</td>
+    <td>Description</td>
+  </tr>
+  <tr>
+    <td>color</td>
+    <td>c</td>
+    <td>Sets the color of the message based on a 6-digit hexadecimal color</td>
+  </tr>
+</table>
+
 For information not related to Skript, see
 <a href="https://minecraft.gamepedia.com/Formatting_codes#Color_codes">Minecraft
 Wiki page</a> concerning colors.

--- a/src/main/java/ch/njol/skript/util/chat/BungeeConverter.java
+++ b/src/main/java/ch/njol/skript/util/chat/BungeeConverter.java
@@ -45,8 +45,8 @@ public class BungeeConverter {
 		base.setUnderlined(origin.underlined);
 		base.setStrikethrough(origin.strikethrough);
 		base.setObfuscated(origin.obfuscated);
-		if (origin.color != null) // TODO this is crappy way to copy *color* over...
-			base.setColor(ChatColor.getByChar(SkriptChatCode.valueOf(origin.color).getColorChar()));
+		if (origin.color != null)
+			base.setColor(origin.color);
 		/*
 		 * This method doesn't exist on normal spigot 1.8
 		 * and it's not worth working around since people affected

--- a/src/main/java/ch/njol/skript/util/chat/ChatMessages.java
+++ b/src/main/java/ch/njol/skript/util/chat/ChatMessages.java
@@ -35,6 +35,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
@@ -113,6 +114,8 @@ public class ChatMessages {
 				Skript.debug("Parsing message style lang files");
 				for (SkriptChatCode code : SkriptChatCode.values()) {
 					assert code != null;
+					if (code == SkriptChatCode.color && !Skript.isRunningMinecraft(1, 16))
+						continue;
 					registerChatCode(code);
 				}
 				
@@ -257,7 +260,7 @@ public class ChatMessages {
 						components.add(current);
 						
 						if (code.getColorCode() != null) { // Just update color code
-							current.color = code.getColorCode();
+							current.color = ChatColor.getByChar(code.getColorChar());
 						} else {
 							assert param != null;
 							code.updateComponent(current, param); // Call SkriptChatCode update
@@ -300,7 +303,7 @@ public class ChatMessages {
 					components.add(current);
 					
 					if (code.getColorCode() != null) // Just update color code
-						current.color = code.getColorCode();
+						current.color = ChatColor.getByChar(code.getColorChar());
 					else
 						code.updateComponent(current, param); // Call SkriptChatCode update
 					

--- a/src/main/java/ch/njol/skript/util/chat/MessageComponent.java
+++ b/src/main/java/ch/njol/skript/util/chat/MessageComponent.java
@@ -31,6 +31,8 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
+import net.md_5.bungee.api.ChatColor;
+
 /**
  * Component for chat messages. This can be serialized with GSON and then
  * sent to client.
@@ -73,7 +75,7 @@ public class MessageComponent {
 	/**
 	 * Color of this text. Defaults to reseting it.
 	 */
-	public @Nullable String color;
+	public @Nullable ChatColor color;
 	
 	/**
 	 * Value of this, if present, will appended on what player is currently

--- a/src/main/java/ch/njol/skript/util/chat/SkriptChatCode.java
+++ b/src/main/java/ch/njol/skript/util/chat/SkriptChatCode.java
@@ -22,10 +22,12 @@
 package ch.njol.skript.util.chat;
 
 import ch.njol.skript.util.Utils;
+import ch.njol.skript.util.chat.MessageComponent.*;
+import ch.njol.skript.lang.VariableString;
+
 import org.eclipse.jdt.annotation.Nullable;
 
-import ch.njol.skript.lang.VariableString;
-import ch.njol.skript.util.chat.MessageComponent.*;
+import net.md_5.bungee.api.ChatColor;
 
 /**
  * Chat codes that come with Skript by default.
@@ -59,6 +61,19 @@ public enum SkriptChatCode implements ChatCode {
 	white("white", 'f'),
 	
 	// Formatting
+	
+	color {
+		@SuppressWarnings("null")
+		@Override
+		public void updateComponent(MessageComponent component, String param) {
+			param = param.replace("#", "");
+			if (param.length() < 6)
+				return;
+			try {
+				component.color = ChatColor.of('#' + param.substring(0, 6));
+			} catch (IllegalArgumentException ignored) {}
+		}
+	},
 	
 	bold {
 		@Override

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -512,6 +512,7 @@ colors:
 
 # -- Chat Styles --
 chat styles:
+	color: color, c
 	bold: bold, b
 	italic: italic, italics, i
 	strikethrough: strikethrough, strike, s


### PR DESCRIPTION
### Description
This PR adds support for using custom colors in Minecraft 1.16. It works for chat messages currently, but some changes might be needed.

---
**Target Minecraft Versions:**     1.16
**Requirements:**     None
**Related Issues:**     None?
