### PR TITLE
Prepare for 1.16.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ allprojects {
 }
 
 dependencies {
-	implementation 'com.destroystokyo.paper:paper-api:1.15-R0.1-SNAPSHOT'
+	implementation 'com.destroystokyo.paper:paper-api:1.16.1-R0.1-SNAPSHOT'
 	implementation 'org.eclipse.jdt:org.eclipse.jdt.annotation:1.1.0'
 	implementation 'com.google.code.findbugs:findbugs:3.0.1'
 	implementation 'com.sk89q.worldguard:worldguard-legacy:7.0.0-SNAPSHOT'

--- a/src/main/java/ch/njol/skript/bukkitutil/UnresolvedOfflinePlayer.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/UnresolvedOfflinePlayer.java
@@ -25,7 +25,10 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.Statistic;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -175,6 +178,96 @@ public class UnresolvedOfflinePlayer implements OfflinePlayer {
 	@Override
 	public long getLastSeen() {
 		return bukkitOfflinePlayer.getLastSeen();
+	}
+	
+	@Override
+	public void incrementStatistic(Statistic statistic) throws IllegalArgumentException {
+		bukkitOfflinePlayer.incrementStatistic(statistic);
+	}
+	
+	@Override
+	public void decrementStatistic(Statistic statistic) throws IllegalArgumentException {
+		bukkitOfflinePlayer.decrementStatistic(statistic);
+	}
+	
+	@Override
+	public void incrementStatistic(Statistic statistic, int amount) throws IllegalArgumentException {
+		bukkitOfflinePlayer.incrementStatistic(statistic, amount);
+	}
+	
+	@Override
+	public void decrementStatistic(Statistic statistic, int amount) throws IllegalArgumentException {
+		bukkitOfflinePlayer.decrementStatistic(statistic, amount);
+	}
+	
+	@Override
+	public void setStatistic(Statistic statistic, int newValue) throws IllegalArgumentException {
+		bukkitOfflinePlayer.setStatistic(statistic, newValue);
+	}
+	
+	@Override
+	public int getStatistic(Statistic statistic) throws IllegalArgumentException {
+		return bukkitOfflinePlayer.getStatistic(statistic);
+	}
+	
+	@Override
+	public void incrementStatistic(Statistic statistic, Material material) throws IllegalArgumentException {
+		bukkitOfflinePlayer.incrementStatistic(statistic, material);
+	}
+	
+	@Override
+	public void decrementStatistic(Statistic statistic, Material material) throws IllegalArgumentException {
+		bukkitOfflinePlayer.decrementStatistic(statistic, material);
+	}
+	
+	@Override
+	public int getStatistic(Statistic statistic, Material material) throws IllegalArgumentException {
+		return bukkitOfflinePlayer.getStatistic(statistic, material);
+	}
+	
+	@Override
+	public void incrementStatistic(Statistic statistic, Material material, int amount) throws IllegalArgumentException {
+		bukkitOfflinePlayer.incrementStatistic(statistic, material, amount);
+	}
+	
+	@Override
+	public void decrementStatistic(Statistic statistic, Material material, int amount) throws IllegalArgumentException {
+		bukkitOfflinePlayer.decrementStatistic(statistic, material, amount);
+	}
+	
+	@Override
+	public void setStatistic(Statistic statistic, Material material, int newValue) throws IllegalArgumentException {
+		bukkitOfflinePlayer.setStatistic(statistic, material, newValue);
+	}
+	
+	@Override
+	public void incrementStatistic(Statistic statistic, EntityType entityType) throws IllegalArgumentException {
+	
+	}
+	
+	@Override
+	public void decrementStatistic(Statistic statistic, EntityType entityType) throws IllegalArgumentException {
+		bukkitOfflinePlayer.decrementStatistic(statistic, entityType);
+	}
+	
+	@Override
+	public int getStatistic(Statistic statistic, EntityType entityType) throws IllegalArgumentException {
+		return bukkitOfflinePlayer.getStatistic(statistic, entityType);
+	}
+	
+	@Override
+	public void incrementStatistic(Statistic statistic, EntityType entityType, int amount) throws IllegalArgumentException {
+		bukkitOfflinePlayer.incrementStatistic(statistic, entityType, amount);
+	}
+	
+	@Override
+	public void decrementStatistic(Statistic statistic, EntityType entityType, int amount) {
+		bukkitOfflinePlayer.decrementStatistic(statistic, entityType, amount);
+	}
+	
+	@Override
+	public void setStatistic(Statistic statistic, EntityType entityType, int newValue) {
+		bukkitOfflinePlayer.setStatistic(statistic, entityType, newValue);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/entity/DroppedItemData.java
+++ b/src/main/java/ch/njol/skript/entity/DroppedItemData.java
@@ -82,7 +82,9 @@ public class DroppedItemData extends EntityData<Item> {
 	public void set(final Item entity) {
 		final ItemType t = CollectionUtils.getRandom(types);
 		assert t != null;
-		entity.setItemStack(t.getItem().getRandom());
+		ItemStack stack = t.getItem().getRandom();
+		if (stack != null)
+			entity.setItemStack(stack);
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprItem.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprItem.java
@@ -110,7 +110,7 @@ public class ExprItem extends EventValueExpression<ItemStack> {
 			case RESET:
 				assert false;
 		}
-		if (i != null)
+		if (i != null && is != null)
 			i.setItemStack(is);
 		else if (s != null)
 			s.setItem(is);

--- a/src/main/java/ch/njol/skript/util/BlockStateBlock.java
+++ b/src/main/java/ch/njol/skript/util/BlockStateBlock.java
@@ -35,6 +35,7 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.PistonMoveReaction;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Entity;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.MetadataValue;
 import org.bukkit.plugin.Plugin;
@@ -288,12 +289,27 @@ public class BlockStateBlock implements Block {
 	}
 	
 	@Override
-	public boolean breakNaturally(final ItemStack tool) {
+	public boolean breakNaturally(@Nullable ItemStack tool) {
 		if (delayChanges) {
 			Bukkit.getScheduler().scheduleSyncDelayedTask(Skript.getInstance(), new Runnable() {
 				@Override
 				public void run() {
 					state.getBlock().breakNaturally(tool);
+				}
+			});
+			return true;
+		} else {
+			return false;
+		}
+	}
+	
+	@Override
+	public boolean breakNaturally(ItemStack tool, boolean triggerEffect) {
+		if (delayChanges) {
+			Bukkit.getScheduler().scheduleSyncDelayedTask(Skript.getInstance(), new Runnable() {
+				@Override
+				public void run() {
+					state.getBlock().breakNaturally(tool, triggerEffect);
 				}
 			});
 			return true;
@@ -309,7 +325,13 @@ public class BlockStateBlock implements Block {
 	}
 	
 	@Override
-	public Collection<ItemStack> getDrops(final ItemStack tool) {
+	public Collection<ItemStack> getDrops(@Nullable ItemStack tool) {
+		assert false;
+		return Collections.emptySet();
+	}
+	
+	@Override
+	public Collection<ItemStack> getDrops(ItemStack tool, @Nullable Entity entity) {
 		assert false;
 		return Collections.emptySet();
 	}

--- a/src/main/java/ch/njol/skript/util/DelayedChangeBlock.java
+++ b/src/main/java/ch/njol/skript/util/DelayedChangeBlock.java
@@ -34,6 +34,7 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.PistonMoveReaction;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Entity;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.MetadataValue;
 import org.bukkit.plugin.Plugin;
@@ -288,7 +289,7 @@ public class DelayedChangeBlock implements Block {
 	}
 	
 	@Override
-	public boolean breakNaturally(final ItemStack tool) {
+	public boolean breakNaturally(@Nullable ItemStack tool) {
 		if (newState != null) {
 			return false;
 		} else {
@@ -303,13 +304,33 @@ public class DelayedChangeBlock implements Block {
 	}
 	
 	@Override
+	public boolean breakNaturally(ItemStack tool, boolean triggerEffect) {
+		if (newState != null) {
+			return false;
+		} else {
+			Bukkit.getScheduler().scheduleSyncDelayedTask(Skript.getInstance(), new Runnable() {
+				@Override
+				public void run() {
+					b.breakNaturally(tool, triggerEffect);
+				}
+			});
+			return true;
+		}
+	}
+	
+	@Override
 	public Collection<ItemStack> getDrops() {
 		return b.getDrops();
 	}
 	
 	@Override
-	public Collection<ItemStack> getDrops(final ItemStack tool) {
+	public Collection<ItemStack> getDrops(@Nullable ItemStack tool) {
 		return b.getDrops(tool);
+	}
+	
+	@Override
+	public Collection<ItemStack> getDrops(ItemStack tool, @Nullable Entity entity) {
+		return b.getDrops(tool, entity);
 	}
 	
 	@Nullable

--- a/src/main/java/ch/njol/skript/util/slot/DroppedItemSlot.java
+++ b/src/main/java/ch/njol/skript/util/slot/DroppedItemSlot.java
@@ -45,6 +45,7 @@ public class DroppedItemSlot extends Slot {
 
 	@Override
 	public void setItem(@Nullable ItemStack item) {
+		assert item != null;
 		entity.setItemStack(item);
 	}
 


### PR DESCRIPTION
### Description
This PR prepares Skript for 1.16

There were some changes to the Bukkit/Paper APIs in 1.16, and we had to implement a few new things. 
Also some changes to some Nullable/NonNull parameters.
I did my best to implement everything, but my main goal was just to get this to build against the 1.16.1 API.

I would appreciate some feedback on this. How to clean it up, how to make things better. I'm all ears!

---
**Target Minecraft Versions:** (target is to build on 1.16, but work on all versions)
**Requirements:** none
**Related Issues:** none
