### PR TITLE
Add Hex Color Support

### DIFF
--- a/docs/text.html
+++ b/docs/text.html
@@ -112,19 +112,8 @@ Here's a table of all colors, including both Skript names and color codes:
 </table>
 
 In Minecraft 1.16, support was added for 6-digit hexadecimal colors to specify custom colors other than the 16 default color codes.
-A new tag was added to allow usage of these colors:
-<table>
-  <tr>
-    <td>Name</td>
-    <td>Alternative Names</td>
-    <td>Description</td>
-  </tr>
-  <tr>
-    <td>color</td>
-    <td>c, hex</td>
-    <td>Sets the color of the message based on a 6-digit hexadecimal color</td>
-  </tr>
-</table>
+A new tag can be used to format with these colors. The tag looks like "<#hex code>".<br>
+Here's what the tag would look like when used in a script: send "<#123456>Hey %player%!" to player<br><br>
 
 For information not related to Skript, see
 <a href="https://minecraft.gamepedia.com/Formatting_codes#Color_codes">Minecraft

--- a/docs/text.html
+++ b/docs/text.html
@@ -110,11 +110,12 @@ Here's a table of all colors, including both Skript names and color codes:
     <td></td>
   </tr>
 </table>
-
+<p>
 In Minecraft 1.16, support was added for 6-digit hexadecimal colors to specify custom colors other than the 16 default color codes.
-A new tag can be used to format with these colors. The tag looks like "<#hex code>".<br>
-Here's what the tag would look like when used in a script: send "<#123456>Hey %player%!" to player<br><br>
-
+A new tag can be used to format with these colors. The tag looks like this: <code><#hex code></code>.
+<br>
+Here's what the tag would look like when used in a script: <code>send "<#123456>Hey %player%!" to player</code>
+<p>
 For information not related to Skript, see
 <a href="https://minecraft.gamepedia.com/Formatting_codes#Color_codes">Minecraft
 Wiki page</a> concerning colors.

--- a/docs/text.html
+++ b/docs/text.html
@@ -110,6 +110,22 @@ Here's a table of all colors, including both Skript names and color codes:
     <td></td>
   </tr>
 </table>
+
+In Minecraft 1.16, support was added for 6-digit hexadecimal colors to specify custom colors other than the 16 default color codes.
+A new tag was added to allow usage of these colors:
+<table>
+  <tr>
+    <td>Name</td>
+    <td>Alternative Names</td>
+    <td>Description</td>
+  </tr>
+  <tr>
+    <td>color</td>
+    <td>c, hex</td>
+    <td>Sets the color of the message based on a 6-digit hexadecimal color</td>
+  </tr>
+</table>
+
 For information not related to Skript, see
 <a href="https://minecraft.gamepedia.com/Formatting_codes#Color_codes">Minecraft
 Wiki page</a> concerning colors.

--- a/src/main/java/ch/njol/skript/effects/EffActionBar.java
+++ b/src/main/java/ch/njol/skript/effects/EffActionBar.java
@@ -31,10 +31,12 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.VariableString;
 import ch.njol.skript.util.chat.BungeeConverter;
 import ch.njol.skript.util.chat.ChatMessages;
 import ch.njol.util.Kleenean;
 import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 
 @Name("Action Bar")
@@ -66,9 +68,14 @@ public class EffActionBar extends Effect {
 	protected void execute(final Event e) {
 		String msg = message.getSingle(e);
 		assert msg != null;
-		for (Player player : recipients.getArray(e)) {
-			player.spigot().sendMessage(ChatMessageType.ACTION_BAR, BungeeConverter.convert(ChatMessages.parseToArray(msg)));
+		BaseComponent[] components;
+		if (message instanceof VariableString) {
+			components = BungeeConverter.convert(((VariableString) message).getMessageComponents(e));
+		} else {
+			components = BungeeConverter.convert(ChatMessages.parseToArray(msg));
 		}
+		for (Player player : recipients.getArray(e))
+			player.spigot().sendMessage(ChatMessageType.ACTION_BAR, components);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/effects/EffActionBar.java
+++ b/src/main/java/ch/njol/skript/effects/EffActionBar.java
@@ -31,13 +31,11 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
-import ch.njol.skript.lang.VariableString;
 import ch.njol.skript.util.chat.BungeeConverter;
 import ch.njol.skript.util.chat.ChatMessages;
 import ch.njol.util.Kleenean;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.api.chat.TextComponent;
 
 @Name("Action Bar")
 @Description("Sends an action bar message to the given player(s).")
@@ -68,12 +66,7 @@ public class EffActionBar extends Effect {
 	protected void execute(final Event e) {
 		String msg = message.getSingle(e);
 		assert msg != null;
-		BaseComponent[] components;
-		if (message instanceof VariableString) {
-			components = BungeeConverter.convert(((VariableString) message).getMessageComponents(e));
-		} else {
-			components = BungeeConverter.convert(ChatMessages.parseToArray(msg));
-		}
+		BaseComponent[] components = BungeeConverter.convert(ChatMessages.parseToArray(msg));
 		for (Player player : recipients.getArray(e))
 			player.spigot().sendMessage(ChatMessageType.ACTION_BAR, components);
 	}

--- a/src/main/java/ch/njol/skript/util/Utils.java
+++ b/src/main/java/ch/njol/skript/util/Utils.java
@@ -52,7 +52,6 @@ import ch.njol.skript.entity.EntityData;
 import ch.njol.skript.localization.Language;
 import ch.njol.skript.localization.LanguageChangeListener;
 import ch.njol.skript.registrations.Classes;
-import ch.njol.skript.util.chat.ChatMessages;
 import ch.njol.util.Callback;
 import ch.njol.util.NonNullPair;
 import ch.njol.util.Pair;
@@ -485,7 +484,7 @@ public abstract class Utils {
 	final static ChatColor[] styles = {ChatColor.BOLD, ChatColor.ITALIC, ChatColor.STRIKETHROUGH, ChatColor.UNDERLINE, ChatColor.MAGIC, ChatColor.RESET};
 	final static Map<String, String> chat = new HashMap<>();
 	final static Map<String, String> englishChat = new HashMap<>();
-	final static boolean HEX_SUPPORTED = Skript.isRunningMinecraft(1, 16);
+	public final static boolean HEX_SUPPORTED = Skript.isRunningMinecraft(1, 16);
 	static {
 		Language.addListener(new LanguageChangeListener() {
 			@Override
@@ -497,13 +496,6 @@ public abstract class Utils {
 						chat.put(s.toLowerCase(), style.toString());
 						if (english)
 							englishChat.put(s.toLowerCase(), style.toString());
-					}
-				}
-				if (HEX_SUPPORTED) { // Register "color" tag into chat map
-					for (final String s : Language.getList("chat styles.color")) {
-						chat.put(s.toLowerCase(), "color");
-						if (english)
-							englishChat.put(s.toLowerCase(), "color");
 					}
 				}
 			}
@@ -540,13 +532,10 @@ public abstract class Utils {
 				final String f = chat.get(tag);
 				if (f != null)
 					return f;
-				if (HEX_SUPPORTED && tag.contains(":")) { // Check for parsing hex colors
-					final String[] parts = tag.split(":", 2);
-					if (parts.length == 2 && chat.get(parts[0]).equals("color")) {
-						ChatColor chatColor = ChatMessages.parseHexColor(parts[1]);
-						if (chatColor != null)
-							return chatColor.toString();
-					}
+				if (HEX_SUPPORTED && tag.startsWith("#")) { // Check for parsing hex colors
+					ChatColor chatColor = parseHexColor(tag);
+					if (chatColor != null)
+						return chatColor.toString();
 				}
 				return "" + m.group();
 			}
@@ -576,13 +565,10 @@ public abstract class Utils {
 				final String f = englishChat.get(tag);
 				if (f != null)
 					return f;
-				if (HEX_SUPPORTED && tag.contains(":")) { // Check for parsing hex colors
-					final String[] parts = tag.split(":", 2);
-					if (parts.length == 2 && englishChat.get(parts[0]).equals("color")) {
-						ChatColor chatColor = ChatMessages.parseHexColor(parts[1]);
-						if (chatColor != null)
-							return chatColor.toString();
-					}
+				if (HEX_SUPPORTED && tag.startsWith("#")) { // Check for parsing hex colors
+					ChatColor chatColor = parseHexColor(tag);
+					if (chatColor != null)
+						return chatColor.toString();
 				}
 				return "" + m.group();
 			}
@@ -590,6 +576,24 @@ public abstract class Utils {
 		assert m != null;
 		m = ChatColor.translateAlternateColorCodes('&', "" + m);
 		return "" + m;
+	}
+	
+	/**
+	 * Tries to get a {@link ChatColor} from the given string.
+	 * @param hex The hex code to parse.
+	 * @return The ChatColor, or null if it couldn't be parsed.
+	 */
+	@SuppressWarnings("null")
+	@Nullable
+	public static ChatColor parseHexColor(String hex) {
+		hex = hex.replace("#", "");
+		if (hex.length() < 6)
+			return null;
+		try {
+			return ChatColor.of('#' + hex.substring(0, 6));
+		} catch (IllegalArgumentException e) {
+			return null;
+		}
 	}
 	
 	/**

--- a/src/main/java/ch/njol/skript/util/chat/BungeeConverter.java
+++ b/src/main/java/ch/njol/skript/util/chat/BungeeConverter.java
@@ -45,8 +45,8 @@ public class BungeeConverter {
 		base.setUnderlined(origin.underlined);
 		base.setStrikethrough(origin.strikethrough);
 		base.setObfuscated(origin.obfuscated);
-		if (origin.color != null) // TODO this is crappy way to copy *color* over...
-			base.setColor(ChatColor.getByChar(SkriptChatCode.valueOf(origin.color).getColorChar()));
+		if (origin.color != null)
+			base.setColor(origin.color);
 		/*
 		 * This method doesn't exist on normal spigot 1.8
 		 * and it's not worth working around since people affected

--- a/src/main/java/ch/njol/skript/util/chat/BungeeConverter.java
+++ b/src/main/java/ch/njol/skript/util/chat/BungeeConverter.java
@@ -22,6 +22,7 @@ package ch.njol.skript.util.chat;
 import java.util.List;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.util.Utils;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
@@ -60,7 +61,7 @@ public class BungeeConverter {
 			base.setClickEvent(new ClickEvent(ClickEvent.Action.valueOf(origin.clickEvent.action.spigotName), origin.clickEvent.value));
 		if (origin.hoverEvent != null)
 			base.setHoverEvent(new HoverEvent(HoverEvent.Action.valueOf(origin.hoverEvent.action.spigotName),
-					new BaseComponent[] {new TextComponent(origin.hoverEvent.value)})); // WAIT WHAT?!?
+					convert(ChatMessages.parse(origin.hoverEvent.value)))); // Parse color (and possibly hex codes) here
 		
 		return base;
 	}

--- a/src/main/java/ch/njol/skript/util/chat/ChatMessages.java
+++ b/src/main/java/ch/njol/skript/util/chat/ChatMessages.java
@@ -251,8 +251,7 @@ public class ChatMessages {
 					ChatColor chatColor = null;
 					if (tryHex) {
 						chatColor = Utils.parseHexColor(name);
-						if (chatColor == null)
-							tryHex = false;
+						tryHex = chatColor != null;
 					}
 					
 					code = codes.get(name);
@@ -299,8 +298,7 @@ public class ChatMessages {
 				ChatColor chatColor = null;
 				if (tryHex && i + 14 < chars.length) { // Try to parse hex "&x&1&2&3&4&5&6"
 					chatColor = Utils.parseHexColor(msg.substring(i + 2, i + 14).replace("&", "").replace("§", ""));
-					if (chatColor == null)
-						tryHex = false;
+					tryHex = chatColor != null;
 				}
 				
 				if (color >= colorChars.length) { // Invalid Unicode color character

--- a/src/main/java/ch/njol/skript/util/chat/ChatMessages.java
+++ b/src/main/java/ch/njol/skript/util/chat/ChatMessages.java
@@ -56,6 +56,7 @@ import ch.njol.skript.localization.Message;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.registrations.Converters;
 import ch.njol.yggdrasil.Fields;
+import net.md_5.bungee.api.ChatColor;
 
 /**
  * Handles parsing chat messages.
@@ -113,6 +114,8 @@ public class ChatMessages {
 				Skript.debug("Parsing message style lang files");
 				for (SkriptChatCode code : SkriptChatCode.values()) {
 					assert code != null;
+					if (code == SkriptChatCode.color && !Skript.isRunningMinecraft(1, 16)) // Don't register "color" tag for versions below 1.16
+						continue;
 					registerChatCode(code);
 				}
 				
@@ -257,7 +260,7 @@ public class ChatMessages {
 						components.add(current);
 						
 						if (code.getColorCode() != null) { // Just update color code
-							current.color = code.getColorCode();
+							current.color = ChatColor.getByChar(code.getColorChar());
 						} else {
 							assert param != null;
 							code.updateComponent(current, param); // Call SkriptChatCode update
@@ -300,7 +303,7 @@ public class ChatMessages {
 					components.add(current);
 					
 					if (code.getColorCode() != null) // Just update color code
-						current.color = code.getColorCode();
+						current.color = ChatColor.getByChar(code.getColorChar());
 					else
 						code.updateComponent(current, param); // Call SkriptChatCode update
 					
@@ -506,5 +509,23 @@ public class ChatMessages {
 		plain = plain.replace("<", "").replace(">", "").replace("§", "").replace("&", "");
 		assert plain != null;
 		return plain;
+	}
+
+	/**
+	 * Tries to get a {@link ChatColor} from the given string.
+	 * @param hex The hex code to parse.
+	 * @return The ChatColor, or null if it couldn't be parsed.
+	 */
+	@SuppressWarnings("null")
+	@Nullable
+	public static ChatColor parseHexColor(String hex) {
+		hex = hex.replace("#", "");
+		if (hex.length() < 6)
+			return null;
+		try {
+			return ChatColor.of('#' + hex.substring(0, 6));
+		} catch (IllegalArgumentException e) {
+			return null;
+		}
 	}
 }

--- a/src/main/java/ch/njol/skript/util/chat/ChatMessages.java
+++ b/src/main/java/ch/njol/skript/util/chat/ChatMessages.java
@@ -529,6 +529,8 @@ public class ChatMessages {
 		String plain = sb.toString();
 		
 		// To be extra safe, strip <, >, § and &; protects against bugs in parser
+		if (Utils.HEX_SUPPORTED) // Strip '§x'
+			plain = plain.replace("§x", "");
 		plain = plain.replace("<", "").replace(">", "").replace("§", "").replace("&", "");
 		assert plain != null;
 		return plain;

--- a/src/main/java/ch/njol/skript/util/chat/MessageComponent.java
+++ b/src/main/java/ch/njol/skript/util/chat/MessageComponent.java
@@ -31,6 +31,8 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
+import net.md_5.bungee.api.ChatColor;
+
 /**
  * Component for chat messages. This can be serialized with GSON and then
  * sent to client.
@@ -73,7 +75,7 @@ public class MessageComponent {
 	/**
 	 * Color of this text. Defaults to reseting it.
 	 */
-	public @Nullable String color;
+	public @Nullable ChatColor color;
 	
 	/**
 	 * Value of this, if present, will appended on what player is currently

--- a/src/main/java/ch/njol/skript/util/chat/SkriptChatCode.java
+++ b/src/main/java/ch/njol/skript/util/chat/SkriptChatCode.java
@@ -136,7 +136,7 @@ public enum SkriptChatCode implements ChatCode {
 		public void updateComponent(MessageComponent component, String param) {
 			// TODO component based codes must be supported
 			// Especially since 1.13 might break the old ones completely...
-			HoverEvent e = new HoverEvent(HoverEvent.Action.show_text, Utils.replaceChatStyles(param));
+			HoverEvent e = new HoverEvent(HoverEvent.Action.show_text, param);
 			component.hoverEvent = e;
 		}
 	},

--- a/src/main/java/ch/njol/skript/util/chat/SkriptChatCode.java
+++ b/src/main/java/ch/njol/skript/util/chat/SkriptChatCode.java
@@ -26,7 +26,6 @@ import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.lang.VariableString;
 import ch.njol.skript.util.chat.MessageComponent.*;
-import net.md_5.bungee.api.ChatColor;
 
 /**
  * Chat codes that come with Skript by default.
@@ -60,16 +59,6 @@ public enum SkriptChatCode implements ChatCode {
 	white("white", 'f'),
 	
 	// Formatting
-	
-	color {
-		@SuppressWarnings("null")
-		@Override
-		public void updateComponent(MessageComponent component, String param) {
-			ChatColor color = ChatMessages.parseHexColor(param);
-			if (color != null)
-				component.color = color;
-		}
-	},
 	
 	bold {
 		@Override

--- a/src/main/java/ch/njol/skript/util/chat/SkriptChatCode.java
+++ b/src/main/java/ch/njol/skript/util/chat/SkriptChatCode.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.lang.VariableString;
 import ch.njol.skript.util.chat.MessageComponent.*;
+import net.md_5.bungee.api.ChatColor;
 
 /**
  * Chat codes that come with Skript by default.
@@ -59,6 +60,16 @@ public enum SkriptChatCode implements ChatCode {
 	white("white", 'f'),
 	
 	// Formatting
+	
+	color {
+		@SuppressWarnings("null")
+		@Override
+		public void updateComponent(MessageComponent component, String param) {
+			ChatColor color = ChatMessages.parseHexColor(param);
+			if (color != null)
+				component.color = color;
+		}
+	},
 	
 	bold {
 		@Override

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -524,6 +524,7 @@ colors:
 
 # -- Chat Styles --
 chat styles:
+	color: color, c, hex
 	bold: bold, b
 	italic: italic, italics, i
 	strikethrough: strikethrough, strike, s

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -524,7 +524,6 @@ colors:
 
 # -- Chat Styles --
 chat styles:
-	color: color, c, hex
 	bold: bold, b
 	italic: italic, italics, i
 	strikethrough: strikethrough, strike, s


### PR DESCRIPTION
### Description
This is a remake of #3078, which I had to close because the conflicts had gotten too complicated for me to fix.
This PR adds hex color support to Skript through a new "color" tag. I have updated the documentation appropriately. Unlike #3078, the tag *should* work everywhere now. I had to make some changes to EffActionBar for colors to work properly there.

This is kind of outside of this PR, but Skript doesn't allow you to do:
`
send title "<RED>Hello %player%!"
`
"RED" must be in lowercase. I'm not sure if this is intentional or not though.
The cause is: https://github.com/SkriptLang/Skript/blob/558e9c64a5024781427c36aa12d808b2cce8ea22/src/main/java/ch/njol/skript/util/Utils.java#L526 in that the string isn't converted to lowercase ("RED" doesn't exist in the map, but "red" does).

---
**Target Minecraft Versions:**     1.16+
**Requirements:**     1.16+
**Related Issues:**     Fixes #3106 
