### PR TITLE
add the plugin on spigot

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,6 +9,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - name: Checkout submodules
+      uses: textbook/git-checkout-submodule-action@2.0.0
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,17 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build and run test scripts
+      run: ./gradlew skriptTest


### PR DESCRIPTION
Hello

I ask if there would be a way either to add the plugin on spigot or I propose to do it with the updates fairly regularly

under your authorization of course!

because because not having the resource on spigot pause a problem for certain test for me I am obliged to use a free test server but I cannot update 1.15 because it does not want to add a plugin which is not on spigot which is a shame!

cordially secours_montagne
![Capture d’écran_2020-07-09_20-36-32](https://user-images.githubusercontent.com/66556948/87077781-f186ab00-c223-11ea-986e-1a55e71035ec.png)
