### PR TITLE
Clean up book syntaxes

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprBookAuthor.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBookAuthor.java
@@ -19,22 +19,19 @@
  */
 package ch.njol.skript.expressions;
 
-import ch.njol.skript.aliases.Aliases;
+import org.bukkit.event.Event;
+import org.bukkit.inventory.meta.BookMeta;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.eclipse.jdt.annotation.Nullable;
+
 import ch.njol.skript.aliases.ItemType;
-import ch.njol.skript.classes.Changer;
+import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
-import ch.njol.skript.lang.Expression;
 import ch.njol.util.coll.CollectionUtils;
-
-import org.bukkit.Material;
-import org.bukkit.event.Event;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.BookMeta;
-import org.eclipse.jdt.annotation.Nullable;
 
 @Name("Book Author")
 @Description("The author of a book.")
@@ -47,19 +44,40 @@ public class ExprBookAuthor extends SimplePropertyExpression<ItemType, String> {
 		register(ExprBookAuthor.class, String.class, "[book] (author|writer|publisher)", "itemtypes");
 	}
 	
-	private static final ItemType book = Aliases.javaItemType("book with text");
-	
+	@Nullable
 	@Override
-	protected String getPropertyName() {
-		return "author";
+	public String convert(ItemType item) {
+		ItemMeta meta = item.getItemMeta();
+		
+		if (meta instanceof BookMeta)
+			return ((BookMeta) meta).getAuthor();
+		
+		return null;
 	}
 	
 	@Nullable
 	@Override
-	public String convert(ItemType item) {
-		if (!book.isOfType(item.getMaterial()))
-			return null;
-		return ((BookMeta) item.getItemMeta()).getAuthor();
+	public Class<?>[] acceptChange(ChangeMode mode) {
+		if (mode == ChangeMode.SET || mode == ChangeMode.RESET || mode == ChangeMode.DELETE)
+			return CollectionUtils.array(String.class);
+		return null;
+	}
+	
+	@SuppressWarnings("null")
+	@Override
+	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+		ItemType[] items = getExpr().getArray(e);
+		String author = delta == null ? null : (String) delta[0];
+		
+		for (ItemType item : items) {
+			ItemMeta meta = item.getItemMeta();
+			
+			if (!(meta instanceof BookMeta))
+				continue;
+			
+			((BookMeta) meta).setAuthor(author);
+			item.setItemMeta(meta);
+		}
 	}
 	
 	@Override
@@ -67,34 +85,9 @@ public class ExprBookAuthor extends SimplePropertyExpression<ItemType, String> {
 		return String.class;
 	}
 	
-	@Nullable
 	@Override
-	public Class<?>[] acceptChange(Changer.ChangeMode mode) {
-		if (mode == Changer.ChangeMode.SET || mode == Changer.ChangeMode.RESET || mode == Changer.ChangeMode.DELETE)
-			return CollectionUtils.array(String.class);
-		return null;
-	}
-	
-	@SuppressWarnings("null")
-	@Override
-	public void change(Event e, @Nullable Object[] delta, Changer.ChangeMode mode) {
-		ItemStack itemStack = getExpr().getSingle(e).getRandom();
-		if (itemStack == null || !book.isOfType(itemStack))
-			return;
-		BookMeta bookMeta = (BookMeta) itemStack.getItemMeta();
-		switch (mode){
-			case SET:
-				bookMeta.setAuthor(delta == null ? "" : (String) delta[0]);
-				break;
-			case RESET:
-			case DELETE:
-				bookMeta.setAuthor("");
-				break;
-				//$CASES-OMITTED$
-			default:
-				assert false;
-		}
-		itemStack.setItemMeta(bookMeta);
+	protected String getPropertyName() {
+		return "book author";
 	}
 }
 

--- a/src/main/java/ch/njol/skript/expressions/ExprBookPages.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBookPages.java
@@ -19,28 +19,28 @@
  */
 package ch.njol.skript.expressions;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.bukkit.event.Event;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BookMeta;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.eclipse.jdt.annotation.Nullable;
+
 import ch.njol.skript.Skript;
-import ch.njol.skript.aliases.Aliases;
 import ch.njol.skript.aliases.ItemType;
-import ch.njol.skript.classes.Converter;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
-import ch.njol.skript.expressions.base.PropertyExpression;
-import ch.njol.skript.expressions.base.SimplePropertyExpression;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
-import org.bukkit.Material;
-import org.bukkit.event.Event;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.BookMeta;
-import org.eclipse.jdt.annotation.Nullable;
-
-import java.util.List;
 
 @Name("Book Pages")
 @Description("The pages of a book.")
@@ -54,38 +54,58 @@ public class ExprBookPages extends SimpleExpression<String> {
 		Skript.registerExpression(ExprBookPages.class, String.class, ExpressionType.PROPERTY,
 				"[all] [the] [book] (pages|content) of %itemtypes%",
 				"%itemtypes%'s [book] (pages|content)",
-				"[book] page %number% of %itemtypes%", 
-				"%itemtypes%'s [book] page %number%");
+				"[book] page %number% of %itemtypes%",
+				"%itemtypes%'[s] [book] page %number%");
 	}
 	
-	private static final ItemType bookItem = Aliases.javaItemType("book with text");
-	
 	@SuppressWarnings("null")
-	private Expression<ItemType> book;
+	private Expression<ItemType> books;
 	@Nullable
-	private Expression<Number> page;
+	private Expression<Number> page = null;
+	
+	@SuppressWarnings({"unchecked", "null"})
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		books = (Expression<ItemType>) exprs[matchedPattern == 3 ? 1 : 0];
+		
+		if (matchedPattern > 1)
+			page = (Expression<Number>) exprs[matchedPattern ^ 2];
+		return true;
+	}
 	
 	@SuppressWarnings("null")
 	@Nullable
 	@Override
 	protected String[] get(Event e) {
-		ItemStack itemStack = book.getSingle(e).getRandom();
-		if (itemStack == null || !bookItem.isOfType(itemStack))
-			return null;
-		List<String> pages = ((BookMeta) itemStack.getItemMeta()).getPages();
-		if (page != null){
-			Number pageNumber = page.getSingle(e);
-			if (pageNumber == null){
-				return null;
+		ItemType[] items = books.getArray(e);
+		Number n = page != null ? this.page.getSingle(e) : null;
+		List<String> pages = new ArrayList<>();
+		
+		for (ItemType item : items) {
+			ItemMeta meta = item.getItemMeta();
+			
+			if (!(meta instanceof BookMeta))
+				continue;
+			
+			BookMeta book = (BookMeta) meta;
+			
+			if (!book.hasPages())
+				continue;
+			
+			if (n != null) {
+				int p = n.intValue();
+				if (p <= book.getPageCount())
+					pages.add(book.getPage(p));
+			} else {
+				for (int p = 1; p <= book.getPageCount(); p++)
+					pages.add(book.getPage(p));
 			}
-			int page = pageNumber.intValue();
-			if ((page) > pages.size() || page < 1){
-				return null;
-			}
-			return new String[]{pages.get(page - 1)};
-		}else{
-			return pages.toArray(new String[pages.size()]);
 		}
+		
+		if (pages.isEmpty())
+			return null;
+		
+		return pages.toArray(new String[0]);
 	}
 	
 	@Override
@@ -100,23 +120,7 @@ public class ExprBookPages extends SimpleExpression<String> {
 	
 	@Override
 	public String toString(@Nullable Event e, boolean debug) {
-		return "book pages of " + book.toString(e, debug);
-	}
-	
-	@SuppressWarnings({"unchecked", "null"})
-	@Override
-	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
-		if (matchedPattern == 0 || matchedPattern == 1){
-			book = (Expression<ItemType>) exprs[0];
-		}else{
-			if (matchedPattern == 2){
-				page =(Expression<Number>) exprs[0];
-				book = (Expression<ItemType>) exprs[1];
-			}else{
-				book = (Expression<ItemType>) exprs[0];
-				page = (Expression<Number>) exprs[1];
-			}
-		}
-		return true;
+		return (page != null ? "book page " + page.toString(e, debug) + " "
+			: "all the pages of ") + books.toString(e, debug);
 	}
 }


### PR DESCRIPTION
#### Goals
* Clean up the book syntaxes which were somewhat poorly implemented back then.
* Add the missing changers to the pages syntax.

#### Non-goals
* Add component support to the syntaxes, this is targeted for 2.6 (see #3112).
* Add support for the rest of the book meta features.
