### PR TITLE
Fix villager data for legacy versions

### DIFF
--- a/src/main/java/ch/njol/skript/entity/VillagerData.java
+++ b/src/main/java/ch/njol/skript/entity/VillagerData.java
@@ -69,7 +69,7 @@ public class VillagerData extends EntityData<Villager> {
 			professions = new ArrayList<>();
 			for (Profession prof : Profession.values()) {
 				// We're better off doing stringfying the constants since these don't exist in 1.14
-				if (!prof.toString().equals("NORMAL") || !prof.toString().equals("HUSK"))
+				if (!prof.toString().equals("NORMAL") && !prof.toString().equals("HUSK"))
 					professions.add(prof);
 			}
 		} else { // Pre 1.10: method Profession#isZombie() doesn't exist


### PR DESCRIPTION
### Description
This PR fixes an issue with "last spawned entity" not being set, due to an issue with villager data.

---
**Target Minecraft Versions:**  1.10-1.13.2
**Requirements:**  none
**Related Issues:** #3063 
