### PR TITLE
Fix incorrect parsing

### DIFF
--- a/src/main/java/ch/njol/skript/lang/VariableString.java
+++ b/src/main/java/ch/njol/skript/lang/VariableString.java
@@ -591,6 +591,13 @@ public class VariableString implements Expression<String> {
 				MessageComponent plain = ChatMessages.plainText(text);
 				if (!message.isEmpty()) { // Copy styles from previous component
 					ChatMessages.copyStyles(message.get(message.size() - 1), plain);
+				} else if (Utils.HEX_SUPPORTED && text.contains("§x")) { // Try to parse hex colors
+					int start = text.lastIndexOf("§x");
+					if (start + 14 < text.length()) {
+						String replace = text.substring(start + 2, start + 14);
+						plain.color = Utils.parseHexColor(replace.replace("&", "").replace("§", ""));
+						plain.text = text.replace("§x" + replace, "");
+					}
 				}
 				message.add(plain);
 			} else {


### PR DESCRIPTION
### Description
I tracked down this issue down to this section of `VariableString`, where a plain text component is returned.
I'm pretty sure this is safe to do, so it shouldn't cause any issues. I figured grabbing the hex, updating the color, and removing it from the text would be the most efficient way to do this (instead of calling `ChatMessages#parse`).

While `Utils#parseHexColor` may return a null `ChatColor`, I don't think this code will ever run if the hex color is invalid, as `text` won't contain `§x`.

---
**Target Minecraft Versions:** 1.16+
**Requirements:** None
**Related Issues:** #3213 
