### PR TITLE
CondCompare: Is Between Fixes

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondCompare.java
+++ b/src/main/java/ch/njol/skript/conditions/CondCompare.java
@@ -302,21 +302,29 @@ public class CondCompare extends Condition {
 	 * neither a nor b # x and y === a !# x and y && b !# x and y		// nor = and
 	 * neither a nor b # x or y === a !# x or y && b !# x or y			// nor = and
 	 */
-	@SuppressWarnings("unchecked")
 	@Override
+	@SuppressWarnings({"null", "unchecked"})
 	public boolean check(final Event e) {
 		final Expression<?> third = this.third;
 		return first.check(e, (Checker<Object>) o1 ->
 			second.check(e, (Checker<Object>) o2 -> {
 				if (third == null)
 					return relation.is(comp != null ? comp.compare(o1, o2) : Comparators.compare(o1, o2));
-				return third.check(e, (Checker<Object>) o3 ->
-					relation == Relation.NOT_EQUAL ^
-						((Relation.GREATER_OR_EQUAL.is(comp != null ? comp.compare(o1, o2) : Comparators.compare(o1, o2))
-							&& Relation.SMALLER_OR_EQUAL.is(comp != null ? comp.compare(o1, o3) : Comparators.compare(o1, o3)))
-						// Check OPPOSITE (switching o2 / o3)
-						|| (Relation.GREATER_OR_EQUAL.is(comp != null ? comp.compare(o1, o3) : Comparators.compare(o1, o3))
-							&& Relation.SMALLER_OR_EQUAL.is(comp != null ? comp.compare(o1, o2) : Comparators.compare(o1, o2)))));
+				return third.check(e, (Checker<Object>) o3 -> {
+					boolean isBetween;
+					if (comp != null) {
+						isBetween =
+							(Relation.GREATER_OR_EQUAL.is(comp.compare(o1, o2)) && Relation.SMALLER_OR_EQUAL.is(comp.compare(o1, o3)))
+							// Check OPPOSITE (switching o2 / o3)
+							|| (Relation.GREATER_OR_EQUAL.is(comp.compare(o1, o3)) && Relation.SMALLER_OR_EQUAL.is(comp.compare(o1, o2)));
+					} else {
+						isBetween =
+							(Relation.GREATER_OR_EQUAL.is(Comparators.compare(o1, o2)) && Relation.SMALLER_OR_EQUAL.is(Comparators.compare(o1, o3)))
+							// Check OPPOSITE (switching o2 / o3)
+							|| (Relation.GREATER_OR_EQUAL.is(Comparators.compare(o1, o3)) && Relation.SMALLER_OR_EQUAL.is(Comparators.compare(o1, o2)));
+					}
+					return relation == Relation.NOT_EQUAL ^ isBetween;
+				});
 			}
 		), isNegated());
 	}

--- a/src/main/java/ch/njol/skript/conditions/CondCompare.java
+++ b/src/main/java/ch/njol/skript/conditions/CondCompare.java
@@ -306,16 +306,19 @@ public class CondCompare extends Condition {
 	@Override
 	public boolean check(final Event e) {
 		final Expression<?> third = this.third;
-		return first.check(e,
-				(Checker<Object>) o1 -> second.check(e,
-						(Checker<Object>) o2 -> {
-							if (third == null)
-								return relation.is(comp != null ? comp.compare(o1, o2) : Comparators.compare(o1, o2));
-							return third.check(e,
-									(Checker<Object>) o3 -> relation == Relation.NOT_EQUAL ^
-											(Relation.GREATER_OR_EQUAL.is(comp != null ? comp.compare(o1, o2) : Comparators.compare(o1, o2))
-													&& Relation.SMALLER_OR_EQUAL.is(comp != null ? comp.compare(o1, o3) : Comparators.compare(o1, o3))));
-						}), isNegated());
+		return first.check(e, (Checker<Object>) o1 ->
+			second.check(e, (Checker<Object>) o2 -> {
+				if (third == null)
+					return relation.is(comp != null ? comp.compare(o1, o2) : Comparators.compare(o1, o2));
+				return third.check(e, (Checker<Object>) o3 ->
+					relation == Relation.NOT_EQUAL ^
+						((Relation.GREATER_OR_EQUAL.is(comp != null ? comp.compare(o1, o2) : Comparators.compare(o1, o2))
+							&& Relation.SMALLER_OR_EQUAL.is(comp != null ? comp.compare(o1, o3) : Comparators.compare(o1, o3)))
+						// Check OPPOSITE (switching o2 / o3)
+						|| (Relation.GREATER_OR_EQUAL.is(comp != null ? comp.compare(o1, o3) : Comparators.compare(o1, o3))
+							&& Relation.SMALLER_OR_EQUAL.is(comp != null ? comp.compare(o1, o2) : Comparators.compare(o1, o2)))));
+			}
+		), isNegated());
 	}
 	
 	@Override

--- a/src/test/skript/tests/regressions/3111-cond compare is between.sk
+++ b/src/test/skript/tests/regressions/3111-cond compare is between.sk
@@ -1,0 +1,3 @@
+test "cond compare is between":
+	assert 5 is between 1 and 10 with "5 should be between 1 and 10"
+	assert 5 is between 10 and 1 with "5 should be between 10 and 1"


### PR DESCRIPTION
### Description
This fixes #3111 by adding an additional check that **switches** `o2` and `o3` in **Relation** check.

There may be a better way to do this, but I think this is it?

I will probably make some changes to avoid doing that null check multiple times.

---
**Target Minecraft Versions:** None
**Requirements:** None
**Related Issues:** #3111 
