### PR TITLE
Create temporary aliases for missing materials

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/Aliases.java
+++ b/src/main/java/ch/njol/skript/aliases/Aliases.java
@@ -33,7 +33,9 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
@@ -407,6 +409,22 @@ public abstract class Aliases {
 		}
 	}
 	
+	/**
+	 * Temporarily create an alias for a material which may not have an alias yet.
+	 */
+	private static void loadMissingAliases() {
+		if (!Skript.classExists("org.bukkit.NamespacedKey"))
+			return;
+		for (Material material : Material.values()) {
+			if (!provider.hasAliasForMaterial(material)) {
+				NamespacedKey key = material.getKey();
+				String name = key.getKey().replace("_", " ");
+				parser.loadAlias(name + "¦s", key.toString());
+				Skript.debug(ChatColor.YELLOW + "Creating temporary alias for: " + key.toString());
+			}
+		}
+	}
+	
 	private static void loadInternal() throws IOException {
 		Path dataFolder = Skript.getInstance().getDataFolder().toPath();
 		
@@ -429,6 +447,7 @@ public abstract class Aliases {
 					Path aliasesPath = zipFs.getPath("/", "aliases-english");
 					assert aliasesPath != null;
 					loadDirectory(aliasesPath);
+					loadMissingAliases();
 				}
 			} catch (URISyntaxException e) {
 				assert false;

--- a/src/main/java/ch/njol/skript/aliases/Aliases.java
+++ b/src/main/java/ch/njol/skript/aliases/Aliases.java
@@ -413,7 +413,7 @@ public abstract class Aliases {
 	 * Temporarily create an alias for a material which may not have an alias yet.
 	 */
 	private static void loadMissingAliases() {
-		if (!Skript.classExists("org.bukkit.NamespacedKey"))
+		if (!Skript.methodExists(Material.class, "getKey"))
 			return;
 		for (Material material : Material.values()) {
 			if (!provider.hasAliasForMaterial(material)) {

--- a/src/main/java/ch/njol/skript/aliases/AliasesProvider.java
+++ b/src/main/java/ch/njol/skript/aliases/AliasesProvider.java
@@ -55,6 +55,11 @@ public class AliasesProvider {
 	private final Map<String, ItemType> aliases;
 	
 	/**
+	 * All materials that are currently loaded by this provider.
+	 */
+	private final List<Material> materials;
+	
+	/**
 	 * Tags are in JSON format. We may need GSON when merging tags
 	 * (which might be done if variations are used).
 	 */
@@ -167,6 +172,7 @@ public class AliasesProvider {
 		this.aliases = new HashMap<>(expectedCount);
 		this.variations = new HashMap<>(expectedCount / 20);
 		this.aliasesMap = new AliasesMap();
+		this.materials = new ArrayList<>();
 		
 		this.gson = new Gson();
 	}
@@ -260,6 +266,8 @@ public class AliasesProvider {
 			if (material == null) { // If server doesn't recognize id, do not proceed
 				throw new InvalidMinecraftIdException(id);
 			}
+			if (!materials.contains(material))
+				materials.add(material);
 			
 			// Hacky: get related entity from block states
 			String entityName = blockStates.remove("relatedEntity");
@@ -377,6 +385,15 @@ public class AliasesProvider {
 
 	public int getAliasCount() {
 		return aliases.size();
+	}
+	
+	/**
+	 * Check if this provider has an alias for the given material.
+	 * @param material Material to check alias for
+	 * @return True if this material has an alias
+	 */
+	public boolean hasAliasForMaterial(Material material) {
+		return materials.contains(material);
 	}
 
 }


### PR DESCRIPTION
### Description
This PR aims to create temporary aliases for missing materials. This will help future proof Skript during future Minecraft releases. 
A small example was the release of Minecraft 1.16. When Spigot was released, we had to try to rush a release on Skript to have aliases available to users. The main problem here was these aliases were added to Skript 2.5-alpha versions. 
Users who wish to stay on a stable release (ie: 2.4.1 at the time) would not have access to these new aliases. 
With this change, and the introduction to BlockData recently, Skript users will not have to wait for a Skript update to use the new aliases. 
This gives us more time to write/test new aliases for Skript, without having to worry about pushing out an update right away. 

### Notes:
- I included `¦s` as a temporary plural variant of each alias. Clearly this will NOT be perfect with some items which have a different plural spelling, but at least it helps with the main ones until we have time to write out the correct aliases for a release.
- In the `Aliases#loadMissingAliases()` method, Im checking for the existence of `Material#getKey()`. This is due to the fact that these temp aliases will only ever be needed for future versions of Minecraft.
- The debug message I made yellow, to stand out when we DO write aliases in the future and need to find out which ones are missing if we just so happen to miss one.

### Example:
I removed a couple aliases to test, here is an example of how it would look in console during debug when an alias is missing:
<img width="860" alt="Screen Shot 2020-07-30 at 6 27 46 PM" src="https://user-images.githubusercontent.com/20008482/88990301-78aec800-d292-11ea-86e8-45db84ce18db.png">


---
**Target Minecraft Versions:** the future
**Requirements:** none
**Related Issues:** none
