### PR TITLE
Move CondMinecraftVersion from tests.runner -> conditions

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondMinecraftVersion.java
+++ b/src/main/java/ch/njol/skript/conditions/CondMinecraftVersion.java
@@ -35,12 +35,13 @@ import ch.njol.util.Kleenean;
 
 @Name("Running Minecraft")
 @Description("Checks if current Minecraft version is given version or newer.")
-@Examples("running minecraft \"1.14\"")
+@Examples({"running minecraft \"1.14\"", "if not running minecraft \"1.16.1\":"})
 @Since("2.5")
 public class CondMinecraftVersion extends Condition {
 	
 	static {
-		Skript.registerCondition(CondMinecraftVersion.class, "running minecraft %string%");
+		Skript.registerCondition(CondMinecraftVersion.class,
+			"[the] [server] [(is|1¦([is] not|isn't))] running [minecraft] [version] %string%");
 	}
 
 	@SuppressWarnings("null")
@@ -50,18 +51,19 @@ public class CondMinecraftVersion extends Condition {
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		version = (Expression<String>) exprs[0];
+		setNegated(parseResult.mark == 1);
 		return true;
 	}
 	
 	@Override
 	public boolean check(Event e) {
 		String ver = version.getSingle(e);
-		return ver != null ? Skript.isRunningMinecraft(new Version(ver)) : false;
+		return ver != null ? Skript.isRunningMinecraft(new Version(ver)) ^ isNegated() : false;
 	}
 	
 	@Override
 	public String toString(@Nullable Event e, boolean debug) {
-		return "is running minecraft " + version.toString(e, debug);
+		return "is" + (isNegated() ? " not" : "")  + " running minecraft " + version.toString(e, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondMinecraftVersion.java
+++ b/src/main/java/ch/njol/skript/conditions/CondMinecraftVersion.java
@@ -17,7 +17,7 @@
  *
  * Copyright 2011-2017 Peter Güttinger and contributors
  */
-package ch.njol.skript.tests.runner;
+package ch.njol.skript.conditions;
 
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;


### PR DESCRIPTION
### Description
This PR movies the CondMinecraftVersion condition from the test environment to Skript, allowing anyone to use it.
This could be useful for someone who is creating a script with cross version support

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
