### PR TITLE
ExprBlockData - fix link for types (classes)

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprBlockData.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBlockData.java
@@ -32,7 +32,7 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
 
 @Name("Block Data")
-@Description("Get the <a href='types.html#blockdata'>block data</a> associated with a block. This data can also be used to set blocks.")
+@Description("Get the <a href='classes.html#blockdata'>block data</a> associated with a block. This data can also be used to set blocks.")
 @Examples({"set {data} to block data of target block",
 	"set block at player to {data}"})
 @RequiredPlugins("Minecraft 1.13+")


### PR DESCRIPTION
### Description
When I created this expression, I type the wrong link (I think I copied it from another expression, which I guess that one was wrong)

---
**Target Minecraft Versions:** all
**Requirements:** none
**Related Issues:** none
