### PR TITLE
Fix no user in experience class info

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
@@ -759,6 +759,7 @@ public class SkriptClasses {
 				}));
 		
 		Classes.registerClass(new ClassInfo<>(Experience.class, "experience")
+				.user("experience ?(points?)?")
 				.name("Experience")
 				.description("Experience points. Please note that Bukkit only allows to give XP, but not remove XP from players. " +
 						"You can however change a player's <a href='../expressions.html#ExprLevel'>level</a> and <a href='../expressions/#ExprLevelProgress'>level progress</a> freely.")


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
This pull request fixes the `experience` class info having no user.
I tested the changes, and everything works.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** N/A <!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** #3265 <!-- Links to related issues -->
