### PR TITLE
Fix visual effect issues

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffVisualEffect.java
+++ b/src/main/java/ch/njol/skript/effects/EffVisualEffect.java
@@ -110,7 +110,7 @@ public class EffVisualEffect extends Effect {
 		final Object[] os = where.getArray(e);
 		final Player[] ps = players != null ? players.getArray(e) : null;
 		final Number rad = radius != null ? radius.getSingle(e) : 32; // 32=default particle radius
-		final Number cnt = count != null ? count.getSingle(e) : 0;
+		final Number cnt = count != null ? count.getSingle(e) : 1;
 		assert rad != null;
 		assert cnt != null;
 		for (final Direction d : dirs) {

--- a/src/main/java/ch/njol/skript/effects/EffVisualEffect.java
+++ b/src/main/java/ch/njol/skript/effects/EffVisualEffect.java
@@ -110,7 +110,7 @@ public class EffVisualEffect extends Effect {
 		final Object[] os = where.getArray(e);
 		final Player[] ps = players != null ? players.getArray(e) : null;
 		final Number rad = radius != null ? radius.getSingle(e) : 32; // 32=default particle radius
-		final Number cnt = count != null ? count.getSingle(e) : 1;
+		final Number cnt = count != null ? count.getSingle(e) : 0;
 		assert rad != null;
 		assert cnt != null;
 		for (final Direction d : dirs) {

--- a/src/main/java/ch/njol/skript/util/VisualEffect.java
+++ b/src/main/java/ch/njol/skript/util/VisualEffect.java
@@ -552,7 +552,8 @@ public final class VisualEffect implements SyntaxElement, YggdrasilSerializable 
 				if (ps == null) {
 					// Colored particles must be played one at time; otherwise, colors are broken
 					if (type.isColorable()) {
-						for (int i = 0; i < count; i++) {
+						int c = count == 0 ? 1 : count;
+						for (int i = 0; i < c; i++) {
 							l.getWorld().spawnParticle(particle, l, 1, dX, dY, dZ, speed, pData);
 						}
 					} else {
@@ -561,7 +562,8 @@ public final class VisualEffect implements SyntaxElement, YggdrasilSerializable 
 				} else {
 					for (final Player p : ps) {
 						if (type.isColorable()) {
-							for (int i = 0; i < count; i++) {
+							int c = count == 0 ? 1 : count;
+							for (int i = 0; i < c; i++) {
 								p.spawnParticle(particle, l, 1, dX, dY, dZ, speed, pData);
 							}
 						} else {

--- a/src/main/java/ch/njol/skript/util/VisualEffect.java
+++ b/src/main/java/ch/njol/skript/util/VisualEffect.java
@@ -28,6 +28,7 @@ import org.bukkit.EntityEffect;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Particle;
+import org.bukkit.Particle.DustOptions;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
@@ -61,6 +62,7 @@ public final class VisualEffect implements SyntaxElement, YggdrasilSerializable 
 
 	private final static String LANGUAGE_NODE = "visual effects";
 	static final boolean newEffectData = Skript.classExists("org.bukkit.block.data.BlockData");
+	private static final boolean HAS_REDSTONE_DATA = Skript.isRunningMinecraft(1, 13);
 	
 	public static enum Type implements YggdrasilSerializable {
 		ENDER_SIGNAL(Effect.ENDER_SIGNAL),
@@ -147,6 +149,16 @@ public final class VisualEffect implements SyntaxElement, YggdrasilSerializable 
 			public boolean isColorable() {
 				return true;
 			}
+			
+			@Nullable
+			@Override
+			public Object getData(@Nullable Object raw, Location l) {
+				if (Particle.REDSTONE.getDataType() == DustOptions.class && raw instanceof ParticleOption) {
+					ParticleOption option = (ParticleOption) raw;
+					return new DustOptions(option.color.asBukkitColor(), option.size);
+				}
+				return null;
+			}
 		},
 		SNOWBALL_BREAK(Particle.SNOWBALL),
 		WATER_DRIP(Particle.DRIP_WATER),
@@ -199,6 +211,33 @@ public final class VisualEffect implements SyntaxElement, YggdrasilSerializable 
 			}
 		},
 		BLOCK_DUST(Particle.BLOCK_DUST) {
+			@Override
+			public Object getData(final @Nullable Object raw, final Location l) {
+				if (raw == null)
+					return Material.STONE.getData();
+				else if (raw instanceof ItemType) {
+					if (newEffectData) {
+						ItemStack rand = ((ItemType) raw).getRandom();
+						if (rand == null)
+							return Bukkit.createBlockData(Material.STONE);
+						return Bukkit.createBlockData(rand.getType());
+					} else {
+						ItemStack rand = ((ItemType) raw).getRandom();
+						if (rand == null)
+							return Material.STONE.getData();
+						@SuppressWarnings("deprecation")
+						MaterialData type = rand.getData();
+						assert type != null;
+						return type;
+					}
+				} else {
+					return raw;
+				}
+			}
+		},
+		
+		// 1.10 particles
+		FALLING_DUST("FALLING_DUST") {
 			@Override
 			public Object getData(final @Nullable Object raw, final Location l) {
 				if (raw == null)
@@ -362,13 +401,9 @@ public final class VisualEffect implements SyntaxElement, YggdrasilSerializable 
 							Skript.warning("Missing pattern at '" + (node + ".pattern") + "' in the " + Language.getName() + " language file");
 					} else {
 						types.add(ts[i]);
-						if (ts[i].isColorable())
-							patterns.add(pattern);
-						else {
-							String dVarExpr = Language.get_(LANGUAGE_NODE + ".area_expression");
-							if (dVarExpr == null) dVarExpr = "";
-							patterns.add(pattern + " " + dVarExpr);
-						}
+						String dVarExpr = Language.get_(LANGUAGE_NODE + ".area_expression");
+						if (dVarExpr == null) dVarExpr = "";
+						patterns.add(pattern + " " + dVarExpr);
 					}
 					if (names[i] == null)
 						names[i] = new Noun(node + ".name");
@@ -411,52 +446,53 @@ public final class VisualEffect implements SyntaxElement, YggdrasilSerializable 
 			return false;
 		}
 		
+		int dPos = 0; // Data index
 		if (type.isColorable()) {
-			for (Expression<?> expr : exprs) {
-				if (expr == null) continue;
-				else if (expr.getReturnType().isAssignableFrom(Color.class)) {
-					org.bukkit.Color color = ((Color) expr.getSingle(null)).asBukkitColor();
-					
-					/*
-					 * Colored particles use dX, dY and dZ as RGB values which
-					 * have range from 0 to 1.
-					 * 
-					 * For now, only speed exactly 1 is allowed.
-					 */
-					dX = color.getRed() / 255.0f + 0.00001f;
-					dY = color.getGreen() / 255.0f;
-					dZ = color.getBlue() / 255.0f;
-					speed = 1;
-				} else {
-					Skript.exception("Color not specified for colored particle");
+			if (HAS_REDSTONE_DATA) {
+				Color color = SkriptColor.LIGHT_RED;
+				if (exprs[0] != null) {
+					color = (Color) exprs[0].getSingle(null);
+					dPos++;
+				}
+				data = new ParticleOption(color, 1);
+			} else {
+				for (Expression<?> expr : exprs) {
+					if (expr == null) continue;
+					else if (expr.getReturnType().isAssignableFrom(SkriptColor.class)) {
+						data = expr.getSingle(null);
+					} else {
+						Skript.exception("Color not specified for colored particle");
+						
+					}
 				}
 			}
 		} else {
-			int numberParams = 0;
-			for (Expression<?> expr : exprs) {
-				if (expr.getReturnType() == Long.class || expr.getReturnType() == Integer.class || expr.getReturnType() == Number.class)
-					numberParams++;
-			}
-			
-			int dPos = 0; // Data index
 			Expression<?> expr = exprs[0];
 			if (expr.getReturnType() != Long.class && expr.getReturnType() != Integer.class && expr.getReturnType() != Number.class) {
 				dPos = 1;
 				data = exprs[0].getSingle(null);
 			}
-			
-			if (numberParams == 1) // Only speed
-				speed = ((Number) exprs[dPos].getSingle(null)).floatValue();
-			else if (numberParams == 3) { // Only dX, dY, dZ
-				dX = ((Number) exprs[dPos].getSingle(null)).floatValue();
-				dY = ((Number) exprs[dPos + 1].getSingle(null)).floatValue();
-				dZ = ((Number) exprs[dPos + 2].getSingle(null)).floatValue();
-			} else if (numberParams == 4){ // Both present
-				dX = ((Number) exprs[dPos].getSingle(null)).floatValue();
-				dY = ((Number) exprs[dPos + 1].getSingle(null)).floatValue();
-				dZ = ((Number) exprs[dPos + 2].getSingle(null)).floatValue();
-				speed = ((Number) exprs[dPos + 3].getSingle(null)).floatValue();
+		}
+		
+		int numberParams = 0;
+		if (exprs.length > dPos) {
+			for (int i = dPos; i < exprs.length; i++) {
+				if (exprs[i].getReturnType() == Long.class || exprs[i].getReturnType() == Integer.class || exprs[i].getReturnType() == Number.class)
+					numberParams++;
 			}
+		}
+		
+		if (numberParams == 1) // Only speed
+			speed = ((Number) exprs[dPos].getSingle(null)).floatValue();
+		else if (numberParams == 3) { // Only dX, dY, dZ
+			dX = ((Number) exprs[dPos].getSingle(null)).floatValue();
+			dY = ((Number) exprs[dPos + 1].getSingle(null)).floatValue();
+			dZ = ((Number) exprs[dPos + 2].getSingle(null)).floatValue();
+		} else if (numberParams == 4){ // Both present
+			dX = ((Number) exprs[dPos].getSingle(null)).floatValue();
+			dY = ((Number) exprs[dPos + 1].getSingle(null)).floatValue();
+			dZ = ((Number) exprs[dPos + 2].getSingle(null)).floatValue();
+			speed = ((Number) exprs[dPos + 3].getSingle(null)).floatValue();
 		}
 		
 		return true;
@@ -517,7 +553,7 @@ public final class VisualEffect implements SyntaxElement, YggdrasilSerializable 
 					// Colored particles must be played one at time; otherwise, colors are broken
 					if (type.isColorable()) {
 						for (int i = 0; i < count; i++) {
-							l.getWorld().spawnParticle(particle, l, 0, dX, dY, dZ, speed, pData);
+							l.getWorld().spawnParticle(particle, l, 1, dX, dY, dZ, speed, pData);
 						}
 					} else {
 						l.getWorld().spawnParticle(particle, l, count, dX, dY, dZ, speed, pData);
@@ -526,7 +562,7 @@ public final class VisualEffect implements SyntaxElement, YggdrasilSerializable 
 					for (final Player p : ps) {
 						if (type.isColorable()) {
 							for (int i = 0; i < count; i++) {
-								p.spawnParticle(particle, l, 0, dX, dY, dZ, speed, pData);
+								p.spawnParticle(particle, l, 1, dX, dY, dZ, speed, pData);
 							}
 						} else {
 							p.spawnParticle(particle, l, count, dX, dY, dZ, speed, pData);
@@ -607,6 +643,25 @@ public final class VisualEffect implements SyntaxElement, YggdrasilSerializable 
 			return false;
 		}
 		return true;
+	}
+	
+	static class ParticleOption {
+		
+		Color color;
+		float size;
+		
+		public ParticleOption(Color color, float size) {
+			this.color = color;
+			this.size = size;
+		}
+		
+		@Override
+		public String toString() {
+			return "ParticleOption{" +
+				"color=" + color +
+				", size=" + size +
+				'}';
+		}
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/util/VisualEffect.java
+++ b/src/main/java/ch/njol/skript/util/VisualEffect.java
@@ -657,10 +657,7 @@ public final class VisualEffect implements SyntaxElement, YggdrasilSerializable 
 		
 		@Override
 		public String toString() {
-			return "ParticleOption{" +
-				"color=" + color +
-				", size=" + size +
-				'}';
+			return "ParticleOption{" + "color=" + color + ", size=" + size + '}';
 		}
 	}
 	

--- a/src/main/java/ch/njol/skript/util/VisualEffect.java
+++ b/src/main/java/ch/njol/skript/util/VisualEffect.java
@@ -62,7 +62,7 @@ public final class VisualEffect implements SyntaxElement, YggdrasilSerializable 
 
 	private final static String LANGUAGE_NODE = "visual effects";
 	static final boolean newEffectData = Skript.classExists("org.bukkit.block.data.BlockData");
-	private static final boolean HAS_REDSTONE_DATA = Skript.isRunningMinecraft(1, 13);
+	private static final boolean HAS_REDSTONE_DATA = Skript.classExists("org.bukkit.Particle$DustOptions");
 	
 	public static enum Type implements YggdrasilSerializable {
 		ENDER_SIGNAL(Effect.ENDER_SIGNAL),

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -1491,6 +1491,9 @@ visual effects:
 	block_dust:
 		name: block dust @-
 		pattern: [sprinting] dust of [%itemtype%]
+	falling_dust:
+		name: falling dust @-
+		pattern: falling dust of [%itemtype%]
 	totem:
 		name: totem @-
 		pattern: totem


### PR DESCRIPTION
### Description
This PR aims to fix issues with coloured particles. 
Im not sure why but a lot of the code in the VisualEffect was written in a really odd way, possibly for a really old version of Bukkit API. It appears the offset was being set using the colors' RGB codes?!?! So confusing.

I've spent hours re-writing and testing this. It seems to fix the issues pertaining to colors, as well as some other issues with count, speed and offset.

In VisualEffect I added a subclass ParticleOption. It includes size, which can be used for Redstone dust particles. I tried making size stuff work but I kept failing, so I left the size stuff out for now. Im leaving this class here as it may be useful in the future, and I will attempt to do size stuff again.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #2958, #2740 
