### PR TITLE
ExprBalance - add support for offline player balances

### DIFF
--- a/src/main/java/ch/njol/skript/hooks/economy/expressions/ExprBalance.java
+++ b/src/main/java/ch/njol/skript/hooks/economy/expressions/ExprBalance.java
@@ -41,7 +41,7 @@ import ch.njol.skript.hooks.economy.classes.Money;
 @Examples({"message \"You have %player's money%\" # the currency name will be added automatically",
 		"remove 20$ from the player's balance # replace '$' by whatever currency you use",
 		"add 200 to the player's account # or omit the currency alltogether"})
-@Since("2.0")
+@Since("2.0, INSERT VERSION (offline player support)")
 @RequiredPlugins({"Vault", "a permission plugin that supports Vault"})
 public class ExprBalance extends SimplePropertyExpression<OfflinePlayer, Money> {
 	static {

--- a/src/main/java/ch/njol/skript/hooks/economy/expressions/ExprBalance.java
+++ b/src/main/java/ch/njol/skript/hooks/economy/expressions/ExprBalance.java
@@ -45,7 +45,7 @@ import ch.njol.skript.hooks.economy.classes.Money;
 @RequiredPlugins({"Vault", "a permission plugin that supports Vault"})
 public class ExprBalance extends SimplePropertyExpression<OfflinePlayer, Money> {
 	static {
-		register(ExprBalance.class, Money.class, "(money|balance|[bank] account)", "players");
+		register(ExprBalance.class, Money.class, "(money|balance|[bank] account)", "offlineplayers");
 	}
 	
 	@SuppressWarnings("deprecation")


### PR DESCRIPTION
### Description
This PR aims to add support for offline player balances. Oddly enough this class pretty much already supported it, just the pattern itself didn't.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
