### PR TITLE
ExprInventoryInfo - remove "owner" to fix a clash with "entity owner"

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprInventoryInfo.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprInventoryInfo.java
@@ -51,8 +51,8 @@ public class ExprInventoryInfo extends SimpleExpression<Object> {
 	
 	static {
 		Skript.registerExpression(ExprInventoryInfo.class, Object.class, ExpressionType.PROPERTY,
-				"(" + HOLDER + "¦(holder|owner)[s]|" + VIEWERS + "¦viewers|" + ROWS + "¦[amount of] rows|" + SLOTS + "¦[amount of] slots)" + " of %inventories%",
-				"%inventories%'[s] (" + HOLDER + "¦(holder|owner)[s]|" + VIEWERS + "¦viewers|" + ROWS + "¦[amount of] rows|" + SLOTS + "¦[amount of] slots)");
+				"(" + HOLDER + "¦holder[s]|" + VIEWERS + "¦viewers|" + ROWS + "¦[amount of] rows|" + SLOTS + "¦[amount of] slots)" + " of %inventories%",
+				"%inventories%'[s] (" + HOLDER + "¦holder[s]|" + VIEWERS + "¦viewers|" + ROWS + "¦[amount of] rows|" + SLOTS + "¦[amount of] slots)");
 	}
 	
 	@SuppressWarnings("null")


### PR DESCRIPTION
### Description
This PR aims to fix an issue with the Inventory (holder|owner) expression clashing with the entity (owner|tamer) expression.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #3344 
