### PR TITLE
ExprNamed - fix issue with named items failing

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprNamed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNamed.java
@@ -101,7 +101,7 @@ public class ExprNamed extends PropertyExpression<Object, Object> {
 	
 	@Override
 	public Class<? extends Object> getReturnType() {
-		return getExpr().getReturnType() == ItemType.class ? ItemType.class : Inventory.class;
+		return getExpr().getReturnType() == InventoryType.class ? Inventory.class : ItemType.class;
 	}
 	
 	@Override

--- a/src/test/skript/tests/regressions/3305-named inventory-item.sk
+++ b/src/test/skript/tests/regressions/3305-named inventory-item.sk
@@ -4,3 +4,9 @@ test "named inventory/itemtype":
 
 	set {_h} to hopper inventory named "SENOR HOPPY"
 	assert type of {_h} = hopper inventory with "Inventory type should have been 'hopper inventory'"
+
+	set {a::1} to a diamond sword
+	set {b::1} to {a::1} named "BOB" with lore "LORE1" and "LORE2"
+	assert name of {b::1} = "BOB" with "Name of item should have been 'BOB'"
+	assert 1st line of lore of {b::1} = "LORE1" with "1st line of lore of item should have been 'LORE1'"
+	assert 2nd line of lore of {b::1} = "LORE2" with "2nd line of lore of item should have been 'LORE2'"


### PR DESCRIPTION
### Description
This PR aims to fix an issue with named items throwing errors that they're not ItemTypes. 
This was caused by a previous issue I fixed, when in turn, broke something else.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #3347 
