### PR TITLE
plugin.yml - fix soft-depend -> softdepend

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -57,7 +57,7 @@ commands:
         permission: skript.admin
         usage: /skript help
 
-soft-depend: [SQLibrary, Vault, WorldGuard, Residence, PreciousStones]
+softdepend: [SQLibrary, Vault, WorldGuard, Residence, PreciousStones]
 
 permissions:
     skript.*:


### PR DESCRIPTION
### Description
This PR aims to fix an issue with the soft depends in the plugin.yml.
When the plugin loads I saw this warning:
```
[12:27:44 WARN]: [Skript] Loaded class net.milkbowl.vault.economy.Economy from Vault v1.7.3-b131 
which is not a depend, softdepend or loadbefore of this plugin.
```
Well, clearly Vault is a soft depend, then I realized it should be `softdepend` not `soft-depend`

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
