### PR TITLE
Fix spawn eggs for 1.12

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/AliasesProvider.java
+++ b/src/main/java/ch/njol/skript/aliases/AliasesProvider.java
@@ -150,7 +150,7 @@ public class AliasesProvider {
 	}
 	
 	/**
-	 * Contains all variations. {@link #loadVariedAlias} uses this.
+	 * Contains all variations.
 	 */
 	private final Map<String, VariationGroup> variations;
 	
@@ -210,7 +210,7 @@ public class AliasesProvider {
 	}
 	
 	/**
-	 * Name of an alias used by {@link #addAlias(String, String, Map, Map)}
+	 * Name of an alias used by {@link #addAlias(AliasName, String, Map, Map)}
 	 * for registration.
 	 */
 	public static class AliasName {

--- a/src/main/java/ch/njol/skript/aliases/ItemData.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemData.java
@@ -36,11 +36,13 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemFactory;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.inventory.meta.SpawnEggMeta;
 import org.bukkit.potion.PotionData;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -335,7 +337,7 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 			}
 		}
 		
-		/**
+		/*
 		 * Initially, expect exact match. Lower expectations as new differences
 		 * between items are discovered.
 		 */
@@ -434,6 +436,17 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 			PotionData ourPotion = ((PotionMeta) first).getBasePotionData();
 			PotionData theirPotion = ((PotionMeta) second).getBasePotionData();
 			return !Objects.equals(ourPotion, theirPotion) ? MatchQuality.SAME_MATERIAL : quality;
+		}
+		
+		// Only check spawn egg data on 1.12 and below. See issue #3167
+		if (!MaterialRegistry.newMaterials && second instanceof SpawnEggMeta) {
+			if (!(first instanceof SpawnEggMeta)) {
+				return MatchQuality.DIFFERENT; // Second is a spawn egg, first is clearly not
+			}
+			// Compare spawn egg spawned type
+			EntityType ourSpawnedType = ((SpawnEggMeta) first).getSpawnedType();
+			EntityType theirSpawnedType = ((SpawnEggMeta) second).getSpawnedType();
+			return !Objects.equals(ourSpawnedType, theirSpawnedType) ? MatchQuality.SAME_MATERIAL : quality;
 		}
 		
 		return quality;

--- a/src/main/java/ch/njol/skript/aliases/ItemData.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemData.java
@@ -79,6 +79,8 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 	
 	static final MaterialRegistry materialRegistry;
 	
+	private static final boolean SPAWN_EGG_META_EXISTS = Skript.classExists("org.bukkit.inventory.meta.SpawnEggMeta");
+	
 	// Load or create material registry
 	static {
 		Gson gson = new GsonBuilder().serializeNulls().create();
@@ -439,7 +441,7 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 		}
 		
 		// Only check spawn egg data on 1.12 and below. See issue #3167
-		if (!MaterialRegistry.newMaterials && second instanceof SpawnEggMeta) {
+		if (!MaterialRegistry.newMaterials && SPAWN_EGG_META_EXISTS && second instanceof SpawnEggMeta) {
 			if (!(first instanceof SpawnEggMeta)) {
 				return MatchQuality.DIFFERENT; // Second is a spawn egg, first is clearly not
 			}

--- a/src/main/java/ch/njol/skript/aliases/MaterialRegistry.java
+++ b/src/main/java/ch/njol/skript/aliases/MaterialRegistry.java
@@ -32,7 +32,7 @@ import ch.njol.skript.Skript;
  */
 public class MaterialRegistry {
 	
-	public static final boolean newMaterials = Skript.isRunningMinecraft(1, 13);
+	static final boolean newMaterials = Skript.isRunningMinecraft(1, 13);
 	
 	/**
 	 * Loads a material registry from an array of strings. New materials will

--- a/src/main/java/ch/njol/skript/aliases/MaterialRegistry.java
+++ b/src/main/java/ch/njol/skript/aliases/MaterialRegistry.java
@@ -32,7 +32,7 @@ import ch.njol.skript.Skript;
  */
 public class MaterialRegistry {
 	
-	private static final boolean newMaterials = Skript.isRunningMinecraft(1, 13);
+	public static final boolean newMaterials = Skript.isRunningMinecraft(1, 13);
 	
 	/**
 	 * Loads a material registry from an array of strings. New materials will


### PR DESCRIPTION
### Description
Adds a SpawnEggMeta comparison check on 1.12

EDIT: small fixed needed

---
**Target Minecraft Versions:** 1.12
**Requirements:** None
**Related Issues:** #3167 
