### PR TITLE
Fix/zombiefied name

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 groupid=ch.njol
 name=skript
-version=2.5-beta4
+version=2.5

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -791,7 +791,7 @@ entities:
 		name: non-op¦s
 		pattern: non(-| |)op(|1¦s)
 	zombie pigman:
-		name: (zombie pig¦man¦men|zombified piglin)
+		name: zombie pig¦man¦men|zombified piglin
 		pattern: <age> (zombie pigm(an|1¦en)|zombified piglin(|1¦s))|(4¦)(zombie pigletboy(|1¦s)|zombified piglin (kid(|1¦s)|child(|1¦ren)))
 	sheep:
 		name: sheep


### PR DESCRIPTION
### Description
This PR fixes an issue with the zombie pigman name starting with a parenthesis 

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #3398 
