### PR TITLE
Remove year from license header

### DIFF
--- a/licenseheader.txt
+++ b/licenseheader.txt
@@ -13,5 +13,4 @@
  You should have received a copy of the GNU General Public License
  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
 
-
-Copyright 2011-2017 Peter Güttinger and contributors
+Copyright Peter Güttinger, SkriptLang team and contributors

--- a/src/main/java/ch/njol/skript/PatcherTool.java
+++ b/src/main/java/ch/njol/skript/PatcherTool.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript;
 

--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript;
 

--- a/src/main/java/ch/njol/skript/ServerPlatform.java
+++ b/src/main/java/ch/njol/skript/ServerPlatform.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript;
 

--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript;
 

--- a/src/main/java/ch/njol/skript/SkriptAPIException.java
+++ b/src/main/java/ch/njol/skript/SkriptAPIException.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript;
 

--- a/src/main/java/ch/njol/skript/SkriptAddon.java
+++ b/src/main/java/ch/njol/skript/SkriptAddon.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript;
 

--- a/src/main/java/ch/njol/skript/SkriptCommand.java
+++ b/src/main/java/ch/njol/skript/SkriptCommand.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript;
 

--- a/src/main/java/ch/njol/skript/SkriptConfig.java
+++ b/src/main/java/ch/njol/skript/SkriptConfig.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript;
 

--- a/src/main/java/ch/njol/skript/SkriptEventHandler.java
+++ b/src/main/java/ch/njol/skript/SkriptEventHandler.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript;
 

--- a/src/main/java/ch/njol/skript/SkriptUpdater.java
+++ b/src/main/java/ch/njol/skript/SkriptUpdater.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript;
 

--- a/src/main/java/ch/njol/skript/aliases/Aliases.java
+++ b/src/main/java/ch/njol/skript/aliases/Aliases.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.aliases;
 

--- a/src/main/java/ch/njol/skript/aliases/AliasesMap.java
+++ b/src/main/java/ch/njol/skript/aliases/AliasesMap.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.aliases;
 

--- a/src/main/java/ch/njol/skript/aliases/AliasesParser.java
+++ b/src/main/java/ch/njol/skript/aliases/AliasesParser.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.aliases;
 

--- a/src/main/java/ch/njol/skript/aliases/AliasesProvider.java
+++ b/src/main/java/ch/njol/skript/aliases/AliasesProvider.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.aliases;
 

--- a/src/main/java/ch/njol/skript/aliases/InvalidMinecraftIdException.java
+++ b/src/main/java/ch/njol/skript/aliases/InvalidMinecraftIdException.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.aliases;
 

--- a/src/main/java/ch/njol/skript/aliases/ItemData.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.aliases;
 

--- a/src/main/java/ch/njol/skript/aliases/ItemFlags.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemFlags.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.aliases;
 

--- a/src/main/java/ch/njol/skript/aliases/ItemType.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemType.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.aliases;
 

--- a/src/main/java/ch/njol/skript/aliases/MatchQuality.java
+++ b/src/main/java/ch/njol/skript/aliases/MatchQuality.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.aliases;
 

--- a/src/main/java/ch/njol/skript/aliases/MaterialName.java
+++ b/src/main/java/ch/njol/skript/aliases/MaterialName.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.aliases;
 

--- a/src/main/java/ch/njol/skript/aliases/MaterialRegistry.java
+++ b/src/main/java/ch/njol/skript/aliases/MaterialRegistry.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.aliases;
 

--- a/src/main/java/ch/njol/skript/aliases/ScriptAliases.java
+++ b/src/main/java/ch/njol/skript/aliases/ScriptAliases.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.aliases;
 

--- a/src/main/java/ch/njol/skript/aliases/package-info.java
+++ b/src/main/java/ch/njol/skript/aliases/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * Code related to item aliases.

--- a/src/main/java/ch/njol/skript/bukkitutil/BiomeMappings.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/BiomeMappings.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.bukkitutil;
 

--- a/src/main/java/ch/njol/skript/bukkitutil/BukkitUnsafe.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/BukkitUnsafe.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.bukkitutil;
 

--- a/src/main/java/ch/njol/skript/bukkitutil/ClickEventTracker.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/ClickEventTracker.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.bukkitutil;
 

--- a/src/main/java/ch/njol/skript/bukkitutil/CommandReloader.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/CommandReloader.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.bukkitutil;
 

--- a/src/main/java/ch/njol/skript/bukkitutil/EnchantmentUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/EnchantmentUtils.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.bukkitutil;
 

--- a/src/main/java/ch/njol/skript/bukkitutil/EntityUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/EntityUtils.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.bukkitutil;
 

--- a/src/main/java/ch/njol/skript/bukkitutil/HealthUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/HealthUtils.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.bukkitutil;
 

--- a/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.bukkitutil;
 

--- a/src/main/java/ch/njol/skript/bukkitutil/PassengerUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/PassengerUtils.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.bukkitutil;
 

--- a/src/main/java/ch/njol/skript/bukkitutil/PlayerUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/PlayerUtils.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.bukkitutil;
 

--- a/src/main/java/ch/njol/skript/bukkitutil/ProjectileUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/ProjectileUtils.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.bukkitutil;
 

--- a/src/main/java/ch/njol/skript/bukkitutil/UnresolvedOfflinePlayer.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/UnresolvedOfflinePlayer.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.bukkitutil;
 

--- a/src/main/java/ch/njol/skript/bukkitutil/Workarounds.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/Workarounds.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.bukkitutil;
 

--- a/src/main/java/ch/njol/skript/bukkitutil/block/BlockCompat.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/block/BlockCompat.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.bukkitutil.block;
 

--- a/src/main/java/ch/njol/skript/bukkitutil/block/BlockSetter.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/block/BlockSetter.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.bukkitutil.block;
 

--- a/src/main/java/ch/njol/skript/bukkitutil/block/BlockValues.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/block/BlockValues.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.bukkitutil.block;
 

--- a/src/main/java/ch/njol/skript/bukkitutil/block/MagicBlockCompat.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/block/MagicBlockCompat.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.bukkitutil.block;
 

--- a/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.bukkitutil.block;
 

--- a/src/main/java/ch/njol/skript/bukkitutil/block/package-info.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/block/package-info.java
@@ -14,10 +14,8 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
-
 @NonNullByDefault
 package ch.njol.skript.bukkitutil.block;
 

--- a/src/main/java/ch/njol/skript/bukkitutil/package-info.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * Classes for Bukkit workarounds and support for older versions.

--- a/src/main/java/ch/njol/skript/classes/Arithmetic.java
+++ b/src/main/java/ch/njol/skript/classes/Arithmetic.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.classes;
 

--- a/src/main/java/ch/njol/skript/classes/ChainedConverter.java
+++ b/src/main/java/ch/njol/skript/classes/ChainedConverter.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.classes;
 

--- a/src/main/java/ch/njol/skript/classes/Changer.java
+++ b/src/main/java/ch/njol/skript/classes/Changer.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.classes;
 

--- a/src/main/java/ch/njol/skript/classes/ClassInfo.java
+++ b/src/main/java/ch/njol/skript/classes/ClassInfo.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.classes;
 

--- a/src/main/java/ch/njol/skript/classes/Comparator.java
+++ b/src/main/java/ch/njol/skript/classes/Comparator.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.classes;
 

--- a/src/main/java/ch/njol/skript/classes/ConfigurationSerializer.java
+++ b/src/main/java/ch/njol/skript/classes/ConfigurationSerializer.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.classes;
 

--- a/src/main/java/ch/njol/skript/classes/Converter.java
+++ b/src/main/java/ch/njol/skript/classes/Converter.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.classes;
 

--- a/src/main/java/ch/njol/skript/classes/EnumSerializer.java
+++ b/src/main/java/ch/njol/skript/classes/EnumSerializer.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.classes;
 

--- a/src/main/java/ch/njol/skript/classes/InverseComparator.java
+++ b/src/main/java/ch/njol/skript/classes/InverseComparator.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.classes;
 

--- a/src/main/java/ch/njol/skript/classes/NumberArithmetic.java
+++ b/src/main/java/ch/njol/skript/classes/NumberArithmetic.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.classes;
 

--- a/src/main/java/ch/njol/skript/classes/Parser.java
+++ b/src/main/java/ch/njol/skript/classes/Parser.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.classes;
 

--- a/src/main/java/ch/njol/skript/classes/SerializableChanger.java
+++ b/src/main/java/ch/njol/skript/classes/SerializableChanger.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.classes;
 

--- a/src/main/java/ch/njol/skript/classes/SerializableChecker.java
+++ b/src/main/java/ch/njol/skript/classes/SerializableChecker.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.classes;
 

--- a/src/main/java/ch/njol/skript/classes/SerializableGetter.java
+++ b/src/main/java/ch/njol/skript/classes/SerializableGetter.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.classes;
 

--- a/src/main/java/ch/njol/skript/classes/Serializer.java
+++ b/src/main/java/ch/njol/skript/classes/Serializer.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.classes;
 

--- a/src/main/java/ch/njol/skript/classes/VectorArithmethic.java
+++ b/src/main/java/ch/njol/skript/classes/VectorArithmethic.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.classes;
 

--- a/src/main/java/ch/njol/skript/classes/YggdrasilSerializer.java
+++ b/src/main/java/ch/njol/skript/classes/YggdrasilSerializer.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.classes;
 

--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.classes.data;
 

--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.classes.data;
 

--- a/src/main/java/ch/njol/skript/classes/data/DefaultChangers.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultChangers.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.classes.data;
 

--- a/src/main/java/ch/njol/skript/classes/data/DefaultComparators.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultComparators.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.classes.data;
 

--- a/src/main/java/ch/njol/skript/classes/data/DefaultConverters.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultConverters.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.classes.data;
 

--- a/src/main/java/ch/njol/skript/classes/data/DefaultFunctions.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultFunctions.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.classes.data;
 

--- a/src/main/java/ch/njol/skript/classes/data/JavaClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/JavaClasses.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.classes.data;
 

--- a/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.classes.data;
 

--- a/src/main/java/ch/njol/skript/classes/data/package-info.java
+++ b/src/main/java/ch/njol/skript/classes/data/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * Contains definitions and other data of all types supported by Skript by default.

--- a/src/main/java/ch/njol/skript/classes/package-info.java
+++ b/src/main/java/ch/njol/skript/classes/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * Code related to handling the different types of Java, Skript, and Bukkit.

--- a/src/main/java/ch/njol/skript/command/Argument.java
+++ b/src/main/java/ch/njol/skript/command/Argument.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.command;
 

--- a/src/main/java/ch/njol/skript/command/CommandEvent.java
+++ b/src/main/java/ch/njol/skript/command/CommandEvent.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.command;
 

--- a/src/main/java/ch/njol/skript/command/CommandHelp.java
+++ b/src/main/java/ch/njol/skript/command/CommandHelp.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.command;
 

--- a/src/main/java/ch/njol/skript/command/Commands.java
+++ b/src/main/java/ch/njol/skript/command/Commands.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.command;
 

--- a/src/main/java/ch/njol/skript/command/EffectCommandEvent.java
+++ b/src/main/java/ch/njol/skript/command/EffectCommandEvent.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.command;
 

--- a/src/main/java/ch/njol/skript/command/ScriptCommand.java
+++ b/src/main/java/ch/njol/skript/command/ScriptCommand.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.command;
 

--- a/src/main/java/ch/njol/skript/command/ScriptCommandEvent.java
+++ b/src/main/java/ch/njol/skript/command/ScriptCommandEvent.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.command;
 

--- a/src/main/java/ch/njol/skript/command/package-info.java
+++ b/src/main/java/ch/njol/skript/command/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * Code related to handling commands, either Skript commands or custom script commands.

--- a/src/main/java/ch/njol/skript/conditions/CondAI.java
+++ b/src/main/java/ch/njol/skript/conditions/CondAI.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondAlphanumeric.java
+++ b/src/main/java/ch/njol/skript/conditions/CondAlphanumeric.java
@@ -14,10 +14,8 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
-
 package ch.njol.skript.conditions;
 
 import org.apache.commons.lang.StringUtils;

--- a/src/main/java/ch/njol/skript/conditions/CondCanFly.java
+++ b/src/main/java/ch/njol/skript/conditions/CondCanFly.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondCanHold.java
+++ b/src/main/java/ch/njol/skript/conditions/CondCanHold.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondCanSee.java
+++ b/src/main/java/ch/njol/skript/conditions/CondCanSee.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondCancelled.java
+++ b/src/main/java/ch/njol/skript/conditions/CondCancelled.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondChance.java
+++ b/src/main/java/ch/njol/skript/conditions/CondChance.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondCompare.java
+++ b/src/main/java/ch/njol/skript/conditions/CondCompare.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondContains.java
+++ b/src/main/java/ch/njol/skript/conditions/CondContains.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondDamageCause.java
+++ b/src/main/java/ch/njol/skript/conditions/CondDamageCause.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondDate.java
+++ b/src/main/java/ch/njol/skript/conditions/CondDate.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondHasClientWeather.java
+++ b/src/main/java/ch/njol/skript/conditions/CondHasClientWeather.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondHasCustomModelData.java
+++ b/src/main/java/ch/njol/skript/conditions/CondHasCustomModelData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondHasMetadata.java
+++ b/src/main/java/ch/njol/skript/conditions/CondHasMetadata.java
@@ -1,21 +1,20 @@
 /**
- * This file is part of Skript.
+ *   This file is part of Skript.
  *
- * Skript is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
  *
- * Skript is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondHasRelationalVariable.java
+++ b/src/main/java/ch/njol/skript/conditions/CondHasRelationalVariable.java
@@ -1,23 +1,21 @@
 /**
- * This file is part of Skript.
+ *   This file is part of Skript.
  *
- * Skript is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
  *
- * Skript is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
-
 package ch.njol.skript.conditions;
 
 import org.bukkit.event.Event;

--- a/src/main/java/ch/njol/skript/conditions/CondHasResourcePack.java
+++ b/src/main/java/ch/njol/skript/conditions/CondHasResourcePack.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondHasScoreboardTag.java
+++ b/src/main/java/ch/njol/skript/conditions/CondHasScoreboardTag.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIgnitionProcess.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIgnitionProcess.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIncendiary.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIncendiary.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsAlive.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsAlive.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsBanned.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsBanned.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsBlock.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsBlock.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsBlockRedstonePowered.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsBlockRedstonePowered.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsBlocking.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsBlocking.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsBurning.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsBurning.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsCharged.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsCharged.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsEdible.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsEdible.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsEmpty.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsEmpty.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsEnchanted.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsEnchanted.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsFlammable.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsFlammable.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsFlying.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsFlying.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsInWorld.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsInWorld.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsInvulnerable.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsInvulnerable.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsLoaded.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsLoaded.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsOfType.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsOfType.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsOnGround.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsOnGround.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsOnline.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsOnline.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsPoisoned.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsPoisoned.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsRiding.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsRiding.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsRiptiding.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsRiptiding.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsSet.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsSet.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsSilent.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsSilent.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsSleeping.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsSleeping.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsSlimeChunk.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsSlimeChunk.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsSneaking.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsSneaking.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsSolid.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsSolid.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsSprinting.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsSprinting.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsSwimming.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsSwimming.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsTameable.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsTameable.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsTransparent.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsTransparent.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsWearing.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsWearing.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondItemInHand.java
+++ b/src/main/java/ch/njol/skript/conditions/CondItemInHand.java
@@ -1,5 +1,5 @@
 /**
- * This file is part of Skript.
+ *   This file is part of Skript.
  *
  *  Skript is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondLeashed.java
+++ b/src/main/java/ch/njol/skript/conditions/CondLeashed.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondPermission.java
+++ b/src/main/java/ch/njol/skript/conditions/CondPermission.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondPlayedBefore.java
+++ b/src/main/java/ch/njol/skript/conditions/CondPlayedBefore.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondPvP.java
+++ b/src/main/java/ch/njol/skript/conditions/CondPvP.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondResourcePack.java
+++ b/src/main/java/ch/njol/skript/conditions/CondResourcePack.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondScriptLoaded.java
+++ b/src/main/java/ch/njol/skript/conditions/CondScriptLoaded.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondStartsEndsWith.java
+++ b/src/main/java/ch/njol/skript/conditions/CondStartsEndsWith.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/CondWeather.java
+++ b/src/main/java/ch/njol/skript/conditions/CondWeather.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
+++ b/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions.base;
 

--- a/src/main/java/ch/njol/skript/conditions/base/package-info.java
+++ b/src/main/java/ch/njol/skript/conditions/base/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * @author Peter Güttinger

--- a/src/main/java/ch/njol/skript/conditions/package-info.java
+++ b/src/main/java/ch/njol/skript/conditions/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * Contains the default conditions of Skript.

--- a/src/main/java/ch/njol/skript/config/Config.java
+++ b/src/main/java/ch/njol/skript/config/Config.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.config;
 

--- a/src/main/java/ch/njol/skript/config/ConfigReader.java
+++ b/src/main/java/ch/njol/skript/config/ConfigReader.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.config;
 

--- a/src/main/java/ch/njol/skript/config/EntryNode.java
+++ b/src/main/java/ch/njol/skript/config/EntryNode.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.config;
 

--- a/src/main/java/ch/njol/skript/config/EnumParser.java
+++ b/src/main/java/ch/njol/skript/config/EnumParser.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.config;
 

--- a/src/main/java/ch/njol/skript/config/InvalidNode.java
+++ b/src/main/java/ch/njol/skript/config/InvalidNode.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.config;
 

--- a/src/main/java/ch/njol/skript/config/Node.java
+++ b/src/main/java/ch/njol/skript/config/Node.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.config;
 

--- a/src/main/java/ch/njol/skript/config/NodeMap.java
+++ b/src/main/java/ch/njol/skript/config/NodeMap.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.config;
 

--- a/src/main/java/ch/njol/skript/config/Option.java
+++ b/src/main/java/ch/njol/skript/config/Option.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.config;
 

--- a/src/main/java/ch/njol/skript/config/OptionSection.java
+++ b/src/main/java/ch/njol/skript/config/OptionSection.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.config;
 

--- a/src/main/java/ch/njol/skript/config/SectionNode.java
+++ b/src/main/java/ch/njol/skript/config/SectionNode.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.config;
 

--- a/src/main/java/ch/njol/skript/config/SimpleNode.java
+++ b/src/main/java/ch/njol/skript/config/SimpleNode.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.config;
 

--- a/src/main/java/ch/njol/skript/config/VoidNode.java
+++ b/src/main/java/ch/njol/skript/config/VoidNode.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.config;
 

--- a/src/main/java/ch/njol/skript/config/package-info.java
+++ b/src/main/java/ch/njol/skript/config/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * Code for loading & saving Skript's custom configuration files (actual configs & scripts).

--- a/src/main/java/ch/njol/skript/config/validate/EntryValidator.java
+++ b/src/main/java/ch/njol/skript/config/validate/EntryValidator.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.config.validate;
 

--- a/src/main/java/ch/njol/skript/config/validate/EnumEntryValidator.java
+++ b/src/main/java/ch/njol/skript/config/validate/EnumEntryValidator.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.config.validate;
 

--- a/src/main/java/ch/njol/skript/config/validate/NodeValidator.java
+++ b/src/main/java/ch/njol/skript/config/validate/NodeValidator.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.config.validate;
 

--- a/src/main/java/ch/njol/skript/config/validate/ParsedEntryValidator.java
+++ b/src/main/java/ch/njol/skript/config/validate/ParsedEntryValidator.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.config.validate;
 

--- a/src/main/java/ch/njol/skript/config/validate/SectionValidator.java
+++ b/src/main/java/ch/njol/skript/config/validate/SectionValidator.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.config.validate;
 

--- a/src/main/java/ch/njol/skript/config/validate/package-info.java
+++ b/src/main/java/ch/njol/skript/config/validate/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * @author Peter Güttinger

--- a/src/main/java/ch/njol/skript/doc/Description.java
+++ b/src/main/java/ch/njol/skript/doc/Description.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.doc;
 

--- a/src/main/java/ch/njol/skript/doc/Documentation.java
+++ b/src/main/java/ch/njol/skript/doc/Documentation.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.doc;
 

--- a/src/main/java/ch/njol/skript/doc/DocumentationId.java
+++ b/src/main/java/ch/njol/skript/doc/DocumentationId.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.doc;
 

--- a/src/main/java/ch/njol/skript/doc/Events.java
+++ b/src/main/java/ch/njol/skript/doc/Events.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.doc;
 

--- a/src/main/java/ch/njol/skript/doc/Examples.java
+++ b/src/main/java/ch/njol/skript/doc/Examples.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.doc;
 

--- a/src/main/java/ch/njol/skript/doc/HTMLGenerator.java
+++ b/src/main/java/ch/njol/skript/doc/HTMLGenerator.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.doc;
 

--- a/src/main/java/ch/njol/skript/doc/Name.java
+++ b/src/main/java/ch/njol/skript/doc/Name.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.doc;
 

--- a/src/main/java/ch/njol/skript/doc/NoDoc.java
+++ b/src/main/java/ch/njol/skript/doc/NoDoc.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.doc;
 

--- a/src/main/java/ch/njol/skript/doc/RequiredPlugins.java
+++ b/src/main/java/ch/njol/skript/doc/RequiredPlugins.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.doc;
 

--- a/src/main/java/ch/njol/skript/doc/Since.java
+++ b/src/main/java/ch/njol/skript/doc/Since.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.doc;
 

--- a/src/main/java/ch/njol/skript/doc/package-info.java
+++ b/src/main/java/ch/njol/skript/doc/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * Code related to generation a documentation to be published on a website for example.

--- a/src/main/java/ch/njol/skript/effects/Delay.java
+++ b/src/main/java/ch/njol/skript/effects/Delay.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffActionBar.java
+++ b/src/main/java/ch/njol/skript/effects/EffActionBar.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffBan.java
+++ b/src/main/java/ch/njol/skript/effects/EffBan.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffBreakNaturally.java
+++ b/src/main/java/ch/njol/skript/effects/EffBreakNaturally.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffBroadcast.java
+++ b/src/main/java/ch/njol/skript/effects/EffBroadcast.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffCancelCooldown.java
+++ b/src/main/java/ch/njol/skript/effects/EffCancelCooldown.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffCancelDrops.java
+++ b/src/main/java/ch/njol/skript/effects/EffCancelDrops.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffCancelEvent.java
+++ b/src/main/java/ch/njol/skript/effects/EffCancelEvent.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffChange.java
+++ b/src/main/java/ch/njol/skript/effects/EffChange.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffChargeCreeper.java
+++ b/src/main/java/ch/njol/skript/effects/EffChargeCreeper.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffColorItems.java
+++ b/src/main/java/ch/njol/skript/effects/EffColorItems.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffCommand.java
+++ b/src/main/java/ch/njol/skript/effects/EffCommand.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffConnect.java
+++ b/src/main/java/ch/njol/skript/effects/EffConnect.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffContinue.java
+++ b/src/main/java/ch/njol/skript/effects/EffContinue.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffDoIf.java
+++ b/src/main/java/ch/njol/skript/effects/EffDoIf.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffDrop.java
+++ b/src/main/java/ch/njol/skript/effects/EffDrop.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffEnchant.java
+++ b/src/main/java/ch/njol/skript/effects/EffEnchant.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffEquip.java
+++ b/src/main/java/ch/njol/skript/effects/EffEquip.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffExceptionDebug.java
+++ b/src/main/java/ch/njol/skript/effects/EffExceptionDebug.java
@@ -13,11 +13,9 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * 
- * Copyright 2011-2017 Peter Güttinger and contributors
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
-
 package ch.njol.skript.effects;
 
 import org.bukkit.event.Event;

--- a/src/main/java/ch/njol/skript/effects/EffExit.java
+++ b/src/main/java/ch/njol/skript/effects/EffExit.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffExplodeCreeper.java
+++ b/src/main/java/ch/njol/skript/effects/EffExplodeCreeper.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffExplosion.java
+++ b/src/main/java/ch/njol/skript/effects/EffExplosion.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffFeed.java
+++ b/src/main/java/ch/njol/skript/effects/EffFeed.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffFireworkLaunch.java
+++ b/src/main/java/ch/njol/skript/effects/EffFireworkLaunch.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffHealth.java
+++ b/src/main/java/ch/njol/skript/effects/EffHealth.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffHidePlayerFromServerList.java
+++ b/src/main/java/ch/njol/skript/effects/EffHidePlayerFromServerList.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffIgnite.java
+++ b/src/main/java/ch/njol/skript/effects/EffIgnite.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffIncendiary.java
+++ b/src/main/java/ch/njol/skript/effects/EffIncendiary.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffInvulnerability.java
+++ b/src/main/java/ch/njol/skript/effects/EffInvulnerability.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffKeepInventory.java
+++ b/src/main/java/ch/njol/skript/effects/EffKeepInventory.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffKick.java
+++ b/src/main/java/ch/njol/skript/effects/EffKick.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffKill.java
+++ b/src/main/java/ch/njol/skript/effects/EffKill.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffLeash.java
+++ b/src/main/java/ch/njol/skript/effects/EffLeash.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffLightning.java
+++ b/src/main/java/ch/njol/skript/effects/EffLightning.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffLoadServerIcon.java
+++ b/src/main/java/ch/njol/skript/effects/EffLoadServerIcon.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffLog.java
+++ b/src/main/java/ch/njol/skript/effects/EffLog.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffMakeFly.java
+++ b/src/main/java/ch/njol/skript/effects/EffMakeFly.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffMakeSay.java
+++ b/src/main/java/ch/njol/skript/effects/EffMakeSay.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffMessage.java
+++ b/src/main/java/ch/njol/skript/effects/EffMessage.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffOp.java
+++ b/src/main/java/ch/njol/skript/effects/EffOp.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffOpenInventory.java
+++ b/src/main/java/ch/njol/skript/effects/EffOpenInventory.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffPlaySound.java
+++ b/src/main/java/ch/njol/skript/effects/EffPlaySound.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffPlayerInfoVisibility.java
+++ b/src/main/java/ch/njol/skript/effects/EffPlayerInfoVisibility.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffPlayerVisibility.java
+++ b/src/main/java/ch/njol/skript/effects/EffPlayerVisibility.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffPoison.java
+++ b/src/main/java/ch/njol/skript/effects/EffPoison.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffPotion.java
+++ b/src/main/java/ch/njol/skript/effects/EffPotion.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffPush.java
+++ b/src/main/java/ch/njol/skript/effects/EffPush.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffPvP.java
+++ b/src/main/java/ch/njol/skript/effects/EffPvP.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffReplace.java
+++ b/src/main/java/ch/njol/skript/effects/EffReplace.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffResetTitle.java
+++ b/src/main/java/ch/njol/skript/effects/EffResetTitle.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffRespawn.java
+++ b/src/main/java/ch/njol/skript/effects/EffRespawn.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffReturn.java
+++ b/src/main/java/ch/njol/skript/effects/EffReturn.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffScriptFile.java
+++ b/src/main/java/ch/njol/skript/effects/EffScriptFile.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffSendBlockChange.java
+++ b/src/main/java/ch/njol/skript/effects/EffSendBlockChange.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffSendResourcePack.java
+++ b/src/main/java/ch/njol/skript/effects/EffSendResourcePack.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffSendTitle.java
+++ b/src/main/java/ch/njol/skript/effects/EffSendTitle.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffShear.java
+++ b/src/main/java/ch/njol/skript/effects/EffShear.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffShoot.java
+++ b/src/main/java/ch/njol/skript/effects/EffShoot.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffSilence.java
+++ b/src/main/java/ch/njol/skript/effects/EffSilence.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffSpawn.java
+++ b/src/main/java/ch/njol/skript/effects/EffSpawn.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffStopServer.java
+++ b/src/main/java/ch/njol/skript/effects/EffStopServer.java
@@ -1,21 +1,20 @@
 /**
- * This file is part of Skript.
+ *   This file is part of Skript.
  *
- * Skript is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
  *
- * Skript is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffStopSound.java
+++ b/src/main/java/ch/njol/skript/effects/EffStopSound.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffSuppressWarnings.java
+++ b/src/main/java/ch/njol/skript/effects/EffSuppressWarnings.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffTeleport.java
+++ b/src/main/java/ch/njol/skript/effects/EffTeleport.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffToggle.java
+++ b/src/main/java/ch/njol/skript/effects/EffToggle.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffToggleFlight.java
+++ b/src/main/java/ch/njol/skript/effects/EffToggleFlight.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffTree.java
+++ b/src/main/java/ch/njol/skript/effects/EffTree.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffVectorRotateAroundAnother.java
+++ b/src/main/java/ch/njol/skript/effects/EffVectorRotateAroundAnother.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffVectorRotateXYZ.java
+++ b/src/main/java/ch/njol/skript/effects/EffVectorRotateXYZ.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffVehicle.java
+++ b/src/main/java/ch/njol/skript/effects/EffVehicle.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/EffVisualEffect.java
+++ b/src/main/java/ch/njol/skript/effects/EffVisualEffect.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/IndeterminateDelay.java
+++ b/src/main/java/ch/njol/skript/effects/IndeterminateDelay.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects;
 

--- a/src/main/java/ch/njol/skript/effects/mirre/EffScriptOptionLoops.java
+++ b/src/main/java/ch/njol/skript/effects/mirre/EffScriptOptionLoops.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.effects.mirre;
 

--- a/src/main/java/ch/njol/skript/effects/package-info.java
+++ b/src/main/java/ch/njol/skript/effects/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * Contains the default effects of Skript.

--- a/src/main/java/ch/njol/skript/entity/BeeData.java
+++ b/src/main/java/ch/njol/skript/entity/BeeData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/BoatData.java
+++ b/src/main/java/ch/njol/skript/entity/BoatData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/CatData.java
+++ b/src/main/java/ch/njol/skript/entity/CatData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/CreeperData.java
+++ b/src/main/java/ch/njol/skript/entity/CreeperData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/DroppedItemData.java
+++ b/src/main/java/ch/njol/skript/entity/DroppedItemData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/EndermanData.java
+++ b/src/main/java/ch/njol/skript/entity/EndermanData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/EntityData.java
+++ b/src/main/java/ch/njol/skript/entity/EntityData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/EntityType.java
+++ b/src/main/java/ch/njol/skript/entity/EntityType.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/FallingBlockData.java
+++ b/src/main/java/ch/njol/skript/entity/FallingBlockData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/FishData.java
+++ b/src/main/java/ch/njol/skript/entity/FishData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/FoxData.java
+++ b/src/main/java/ch/njol/skript/entity/FoxData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/GuardianData.java
+++ b/src/main/java/ch/njol/skript/entity/GuardianData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/HorseData.java
+++ b/src/main/java/ch/njol/skript/entity/HorseData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/LlamaData.java
+++ b/src/main/java/ch/njol/skript/entity/LlamaData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/MinecartData.java
+++ b/src/main/java/ch/njol/skript/entity/MinecartData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/MooshroomData.java
+++ b/src/main/java/ch/njol/skript/entity/MooshroomData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/OcelotData.java
+++ b/src/main/java/ch/njol/skript/entity/OcelotData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/PandaData.java
+++ b/src/main/java/ch/njol/skript/entity/PandaData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/ParrotData.java
+++ b/src/main/java/ch/njol/skript/entity/ParrotData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/PigData.java
+++ b/src/main/java/ch/njol/skript/entity/PigData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/PlayerData.java
+++ b/src/main/java/ch/njol/skript/entity/PlayerData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/RabbitData.java
+++ b/src/main/java/ch/njol/skript/entity/RabbitData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/SheepData.java
+++ b/src/main/java/ch/njol/skript/entity/SheepData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/SimpleEntityData.java
+++ b/src/main/java/ch/njol/skript/entity/SimpleEntityData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/SkeletonData.java
+++ b/src/main/java/ch/njol/skript/entity/SkeletonData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/ThrownPotionData.java
+++ b/src/main/java/ch/njol/skript/entity/ThrownPotionData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/TropicalFishData.java
+++ b/src/main/java/ch/njol/skript/entity/TropicalFishData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/VillagerData.java
+++ b/src/main/java/ch/njol/skript/entity/VillagerData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/WolfData.java
+++ b/src/main/java/ch/njol/skript/entity/WolfData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/XpOrbData.java
+++ b/src/main/java/ch/njol/skript/entity/XpOrbData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/ZombieVillagerData.java
+++ b/src/main/java/ch/njol/skript/entity/ZombieVillagerData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.entity;
 

--- a/src/main/java/ch/njol/skript/entity/package-info.java
+++ b/src/main/java/ch/njol/skript/entity/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * Contains definitions of Minecraft's various entity types.

--- a/src/main/java/ch/njol/skript/events/EvtAtTime.java
+++ b/src/main/java/ch/njol/skript/events/EvtAtTime.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/EvtBlock.java
+++ b/src/main/java/ch/njol/skript/events/EvtBlock.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/EvtBookEdit.java
+++ b/src/main/java/ch/njol/skript/events/EvtBookEdit.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/EvtBookSign.java
+++ b/src/main/java/ch/njol/skript/events/EvtBookSign.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/EvtChat.java
+++ b/src/main/java/ch/njol/skript/events/EvtChat.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/EvtClick.java
+++ b/src/main/java/ch/njol/skript/events/EvtClick.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/EvtCommand.java
+++ b/src/main/java/ch/njol/skript/events/EvtCommand.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/EvtDamage.java
+++ b/src/main/java/ch/njol/skript/events/EvtDamage.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/EvtEntity.java
+++ b/src/main/java/ch/njol/skript/events/EvtEntity.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/EvtEntityBlockChange.java
+++ b/src/main/java/ch/njol/skript/events/EvtEntityBlockChange.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/EvtEntityTarget.java
+++ b/src/main/java/ch/njol/skript/events/EvtEntityTarget.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/EvtExperienceSpawn.java
+++ b/src/main/java/ch/njol/skript/events/EvtExperienceSpawn.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/EvtFirework.java
+++ b/src/main/java/ch/njol/skript/events/EvtFirework.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/EvtFirstJoin.java
+++ b/src/main/java/ch/njol/skript/events/EvtFirstJoin.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/EvtGameMode.java
+++ b/src/main/java/ch/njol/skript/events/EvtGameMode.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/EvtGrow.java
+++ b/src/main/java/ch/njol/skript/events/EvtGrow.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/EvtItem.java
+++ b/src/main/java/ch/njol/skript/events/EvtItem.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/EvtLevel.java
+++ b/src/main/java/ch/njol/skript/events/EvtLevel.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/EvtMoveOn.java
+++ b/src/main/java/ch/njol/skript/events/EvtMoveOn.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/EvtPeriodical.java
+++ b/src/main/java/ch/njol/skript/events/EvtPeriodical.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/EvtPlantGrowth.java
+++ b/src/main/java/ch/njol/skript/events/EvtPlantGrowth.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/EvtPressurePlate.java
+++ b/src/main/java/ch/njol/skript/events/EvtPressurePlate.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/EvtResourcePackResponse.java
+++ b/src/main/java/ch/njol/skript/events/EvtResourcePackResponse.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/EvtScript.java
+++ b/src/main/java/ch/njol/skript/events/EvtScript.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/EvtSkript.java
+++ b/src/main/java/ch/njol/skript/events/EvtSkript.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/EvtWeatherChange.java
+++ b/src/main/java/ch/njol/skript/events/EvtWeatherChange.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/SimpleEvents.java
+++ b/src/main/java/ch/njol/skript/events/SimpleEvents.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events;
 

--- a/src/main/java/ch/njol/skript/events/bukkit/ExperienceSpawnEvent.java
+++ b/src/main/java/ch/njol/skript/events/bukkit/ExperienceSpawnEvent.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events.bukkit;
 

--- a/src/main/java/ch/njol/skript/events/bukkit/PreScriptLoadEvent.java
+++ b/src/main/java/ch/njol/skript/events/bukkit/PreScriptLoadEvent.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events.bukkit;
 

--- a/src/main/java/ch/njol/skript/events/bukkit/ScheduledEvent.java
+++ b/src/main/java/ch/njol/skript/events/bukkit/ScheduledEvent.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events.bukkit;
 

--- a/src/main/java/ch/njol/skript/events/bukkit/ScheduledNoWorldEvent.java
+++ b/src/main/java/ch/njol/skript/events/bukkit/ScheduledNoWorldEvent.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events.bukkit;
 

--- a/src/main/java/ch/njol/skript/events/bukkit/ScriptEvent.java
+++ b/src/main/java/ch/njol/skript/events/bukkit/ScriptEvent.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events.bukkit;
 

--- a/src/main/java/ch/njol/skript/events/bukkit/SkriptStartEvent.java
+++ b/src/main/java/ch/njol/skript/events/bukkit/SkriptStartEvent.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events.bukkit;
 

--- a/src/main/java/ch/njol/skript/events/bukkit/SkriptStopEvent.java
+++ b/src/main/java/ch/njol/skript/events/bukkit/SkriptStopEvent.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events.bukkit;
 

--- a/src/main/java/ch/njol/skript/events/bukkit/package-info.java
+++ b/src/main/java/ch/njol/skript/events/bukkit/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * Custom {@link org.bukkit.event.Event Bukkit events}.

--- a/src/main/java/ch/njol/skript/events/package-info.java
+++ b/src/main/java/ch/njol/skript/events/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * Contains the default events of Skript.

--- a/src/main/java/ch/njol/skript/events/util/PlayerChatEventHandler.java
+++ b/src/main/java/ch/njol/skript/events/util/PlayerChatEventHandler.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.events.util;
 

--- a/src/main/java/ch/njol/skript/events/util/package-info.java
+++ b/src/main/java/ch/njol/skript/events/util/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * @author Peter Güttinger

--- a/src/main/java/ch/njol/skript/expressions/ExprAI.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAI.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprAbsorbedBlocks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAbsorbedBlocks.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprAffectedEntities.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAffectedEntities.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprAlphabetList.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAlphabetList.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprAltitude.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAltitude.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprAmount.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAmount.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprAmountOfItems.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAmountOfItems.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprAppliedEnchantments.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAppliedEnchantments.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprArgument.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprArgument.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprArithmetic.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprArithmetic.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprArmorSlot.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprArmorSlot.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprArrowsStuck.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprArrowsStuck.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprAttacked.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAttacked.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprAttacker.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAttacker.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprBed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBed.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprBiome.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBiome.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprBlock.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBlock.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprBlockData.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBlockData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprBlockSphere.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBlockSphere.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprBlocks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBlocks.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprBookAuthor.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBookAuthor.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprBookPages.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBookPages.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprBookTitle.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBookTitle.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprBurnCookTime.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBurnCookTime.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprChatFormat.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprChatFormat.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprChatRecipients.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprChatRecipients.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprChestInventory.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprChestInventory.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprChunk.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprChunk.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprClicked.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprClicked.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprClientViewDistance.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprClientViewDistance.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprCmdCooldownInfo.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCmdCooldownInfo.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprColorOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprColorOf.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprColoured.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprColoured.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprCommand.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCommand.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprCommandSender.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCommandSender.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprCompassTarget.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCompassTarget.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprCoordinate.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCoordinate.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprCreeperMaxFuseTicks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCreeperMaxFuseTicks.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprCursorSlot.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCursorSlot.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprCustomModelData.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCustomModelData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprDamage.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDamage.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprDamageCause.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDamageCause.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprDamagedItem.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDamagedItem.java
@@ -14,10 +14,8 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
-
 package ch.njol.skript.expressions;
 
 import org.bukkit.event.Event;

--- a/src/main/java/ch/njol/skript/expressions/ExprDateAgoLater.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDateAgoLater.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprDefaultValue.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDefaultValue.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprDifference.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDifference.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprDifficulty.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDifficulty.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprDirection.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDirection.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprDistance.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDistance.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprDrops.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDrops.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprDurability.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDurability.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprElement.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprElement.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprEnchantItem.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEnchantItem.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprEnchantingExpCost.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEnchantingExpCost.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprEnchantmentBonus.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEnchantmentBonus.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprEnchantmentExpCosts.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEnchantmentExpCosts.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprEnchantmentLevel.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEnchantmentLevel.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprEnchantmentOffer.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEnchantmentOffer.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprEnchantmentOfferCost.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEnchantmentOfferCost.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprEnchantments.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEnchantments.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprEnderChest.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEnderChest.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprEntities.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntities.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprEntity.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntity.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprEntityAttribute.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntityAttribute.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprEntityTamer.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntityTamer.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprEventCancelled.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEventCancelled.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprEventExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEventExpression.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprExhaustion.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprExhaustion.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprExperience.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprExperience.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprExplodedBlocks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprExplodedBlocks.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprExplosionBlockYield.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprExplosionBlockYield.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprExplosionYield.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprExplosionYield.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprExplosiveYield.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprExplosiveYield.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprEyeLocation.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEyeLocation.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprFacing.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFacing.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprFallDistance.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFallDistance.java
@@ -1,21 +1,20 @@
 /**
- * This file is part of Skript.
+ *   This file is part of Skript.
  *
- * Skript is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
  *
- * Skript is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprFertilizedBlocks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFertilizedBlocks.java
@@ -1,21 +1,20 @@
 /**
- * This file is part of Skript.
+ *   This file is part of Skript.
  *
- * Skript is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
  *
- * Skript is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprFilter.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFilter.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprFinalDamage.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFinalDamage.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprFireworkEffect.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFireworkEffect.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprFlightMode.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFlightMode.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprFoodLevel.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFoodLevel.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprFormatTime.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFormatTime.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprFurnaceSlot.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFurnaceSlot.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprGameMode.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprGameMode.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprGameRule.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprGameRule.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprGlidingState.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprGlidingState.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprGlowing.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprGlowing.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprGravity.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprGravity.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprHash.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHash.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprHealReason.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHealReason.java
@@ -1,21 +1,20 @@
 /**
- * This file is part of Skript.
+ *   This file is part of Skript.
  *
- * Skript is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
  *
- * Skript is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprHealth.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHealth.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprHiddenPlayers.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHiddenPlayers.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprHighestSolidBlock.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHighestSolidBlock.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprHotbarButton.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHotbarButton.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprHotbarSlot.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHotbarSlot.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprHoverList.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHoverList.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprHumidity.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHumidity.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprIP.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprIP.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprIdOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprIdOf.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprIndexOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprIndexOf.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprIndices.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprIndices.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprInventory.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprInventory.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprInventoryAction.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprInventoryAction.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprInventoryInfo.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprInventoryInfo.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprInventorySlot.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprInventorySlot.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprItem.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprItem.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprItemAmount.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprItemAmount.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprItemFrameSlot.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprItemFrameSlot.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprItemWithCustomModelData.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprItemWithCustomModelData.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprItemWithLore.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprItemWithLore.java
@@ -1,21 +1,20 @@
 /**
- * This file is part of Skript.
+ *   This file is part of Skript.
  *
- * Skript is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
  *
- * Skript is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprItems.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprItems.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprItemsIn.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprItemsIn.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprJoinSplit.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprJoinSplit.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprLanguage.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLanguage.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprLastDamageCause.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLastDamageCause.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprLastLoadedServerIcon.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLastLoadedServerIcon.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprLastLoginTime.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLastLoginTime.java
@@ -1,21 +1,20 @@
 /**
- * This file is part of Skript.
+ *   This file is part of Skript.
  *
- * Skript is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
  *
- * Skript is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprLastResourcePackResponse.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLastResourcePackResponse.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprLastSpawnedEntity.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLastSpawnedEntity.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprLeashHolder.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLeashHolder.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprLength.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLength.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprLevel.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLevel.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprLevelProgress.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLevelProgress.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprLightLevel.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLightLevel.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprLocation.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLocation.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprLocationAt.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLocationAt.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprLocationFromVector.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLocationFromVector.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprLocationOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLocationOf.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprLocationVectorOffset.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLocationVectorOffset.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprLoopValue.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLoopValue.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprLore.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLore.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprMOTD.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprMOTD.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprMaxDurability.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprMaxDurability.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprMaxHealth.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprMaxHealth.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprMaxPlayers.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprMaxPlayers.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprMaxStack.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprMaxStack.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprMe.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprMe.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprMessage.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprMessage.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprMetadata.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprMetadata.java
@@ -1,21 +1,20 @@
 /**
- * This file is part of Skript.
+ *   This file is part of Skript.
  *
- * Skript is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
  *
- * Skript is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprName.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprName.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprNamed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNamed.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprNoDamageTicks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNoDamageTicks.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprNow.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNow.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprNumberOfCharacters.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNumberOfCharacters.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprNumbers.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNumbers.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprOffTool.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprOffTool.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprOfflinePlayers.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprOfflinePlayers.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprOnlinePlayersCount.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprOnlinePlayersCount.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprOpenedInventory.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprOpenedInventory.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprParse.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprParse.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprParseError.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprParseError.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprPassenger.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPassenger.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprPermissions.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPermissions.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprPing.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPing.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprPlayerViewDistance.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPlayerViewDistance.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprPlayerWeather.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPlayerWeather.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprPlayerlistHeaderFooter.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPlayerlistHeaderFooter.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprPortal.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPortal.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprPotionEffect.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPotionEffect.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprProtocolVersion.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprProtocolVersion.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprPushedBlocks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPushedBlocks.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprRandom.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprRandom.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprRandomNumber.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprRandomNumber.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprRawName.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprRawName.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprRedstoneBlockPower.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprRedstoneBlockPower.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprRelationalVariable.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprRelationalVariable.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprRemainingAir.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprRemainingAir.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprRespawnLocation.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprRespawnLocation.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprReversedList.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprReversedList.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprRound.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprRound.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprSaturation.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSaturation.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprScoreboardTags.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprScoreboardTags.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprScript.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprScript.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprScripts.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprScripts.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprSeed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSeed.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprServerIcon.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprServerIcon.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprShooter.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprShooter.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprShuffledList.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprShuffledList.java
@@ -1,4 +1,4 @@
-/*
+/**
  *   This file is part of Skript.
  *
  *  Skript is free software: you can redistribute it and/or modify
@@ -13,12 +13,9 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * 
- * Copyright 2011-2017 Peter Güttinger and contributors
- * 
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
-
 package ch.njol.skript.expressions;
 
 import java.util.Arrays;

--- a/src/main/java/ch/njol/skript/expressions/ExprSignText.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSignText.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprSkull.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSkull.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprSlotIndex.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSlotIndex.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprSortedList.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSortedList.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprSpawn.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSpawn.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprSpawnReason.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSpawnReason.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprSpawnerType.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSpawnerType.java
@@ -14,10 +14,8 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
-
 package ch.njol.skript.expressions;
 
 import org.bukkit.Material;

--- a/src/main/java/ch/njol/skript/expressions/ExprSpecialNumber.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSpecialNumber.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprSpectatorTarget.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSpectatorTarget.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprSpeed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSpeed.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprStringCase.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprStringCase.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprSubstring.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSubstring.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprTPS.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTPS.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprTamer.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTamer.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprTarget.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTarget.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprTargetedBlock.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTargetedBlock.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprTeleportCause.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTeleportCause.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprTemperature.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTemperature.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprTernary.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTernary.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprTime.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTime.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprTimePlayed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTimePlayed.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprTimeSince.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTimeSince.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprTimeState.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTimeState.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprTimes.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTimes.java
@@ -1,21 +1,20 @@
 /**
- * This file is part of Skript.
+ *   This file is part of Skript.
  *
- * Skript is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
  *
- * Skript is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprTool.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTool.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprTypeOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTypeOf.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprUUID.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprUUID.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprUnbreakable.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprUnbreakable.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprUnixDate.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprUnixDate.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprUnixTicks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprUnixTicks.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprValue.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprValue.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorAngleBetween.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorAngleBetween.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorArithmetic.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorArithmetic.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorBetweenLocations.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorBetweenLocations.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorCrossProduct.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorCrossProduct.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorCylindrical.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorCylindrical.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorDotProduct.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorDotProduct.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorFromXYZ.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorFromXYZ.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorFromYawAndPitch.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorFromYawAndPitch.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorLength.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorLength.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorNormalize.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorNormalize.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorOfLocation.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorOfLocation.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorRandom.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorRandom.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorSpherical.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorSpherical.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorSquaredLength.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorSquaredLength.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorXYZ.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorXYZ.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorYawPitch.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorYawPitch.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVehicle.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVehicle.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVelocity.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVelocity.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVersion.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVersion.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVersionString.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVersionString.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprWeather.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprWeather.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprWorld.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprWorld.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprWorlds.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprWorlds.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprXOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprXOf.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprYawPitch.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprYawPitch.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/LitAt.java
+++ b/src/main/java/ch/njol/skript/expressions/LitAt.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/LitConsole.java
+++ b/src/main/java/ch/njol/skript/expressions/LitConsole.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/LitNewLine.java
+++ b/src/main/java/ch/njol/skript/expressions/LitNewLine.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions;
 

--- a/src/main/java/ch/njol/skript/expressions/base/EventValueExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/EventValueExpression.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions.base;
 

--- a/src/main/java/ch/njol/skript/expressions/base/PropertyExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/PropertyExpression.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions.base;
 

--- a/src/main/java/ch/njol/skript/expressions/base/SimplePropertyExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/SimplePropertyExpression.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions.base;
 

--- a/src/main/java/ch/njol/skript/expressions/base/WrapperExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/WrapperExpression.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.expressions.base;
 

--- a/src/main/java/ch/njol/skript/expressions/base/package-info.java
+++ b/src/main/java/ch/njol/skript/expressions/base/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * @author Peter Güttinger

--- a/src/main/java/ch/njol/skript/expressions/package-info.java
+++ b/src/main/java/ch/njol/skript/expressions/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * Contains the default expression of Skript.

--- a/src/main/java/ch/njol/skript/hooks/Hook.java
+++ b/src/main/java/ch/njol/skript/hooks/Hook.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.hooks;
 

--- a/src/main/java/ch/njol/skript/hooks/VaultHook.java
+++ b/src/main/java/ch/njol/skript/hooks/VaultHook.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.hooks;
 

--- a/src/main/java/ch/njol/skript/hooks/biomes/BiomeHook.java
+++ b/src/main/java/ch/njol/skript/hooks/biomes/BiomeHook.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.hooks.biomes;
 

--- a/src/main/java/ch/njol/skript/hooks/biomes/BiomeMapUtil.java
+++ b/src/main/java/ch/njol/skript/hooks/biomes/BiomeMapUtil.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.hooks.biomes;
 

--- a/src/main/java/ch/njol/skript/hooks/biomes/package-info.java
+++ b/src/main/java/ch/njol/skript/hooks/biomes/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * @author Peter Güttinger

--- a/src/main/java/ch/njol/skript/hooks/chat/expressions/ExprPrefixSuffix.java
+++ b/src/main/java/ch/njol/skript/hooks/chat/expressions/ExprPrefixSuffix.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.hooks.chat.expressions;
 

--- a/src/main/java/ch/njol/skript/hooks/chat/expressions/package-info.java
+++ b/src/main/java/ch/njol/skript/hooks/chat/expressions/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * @author Peter Güttinger

--- a/src/main/java/ch/njol/skript/hooks/economy/classes/Money.java
+++ b/src/main/java/ch/njol/skript/hooks/economy/classes/Money.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.hooks.economy.classes;
 

--- a/src/main/java/ch/njol/skript/hooks/economy/classes/package-info.java
+++ b/src/main/java/ch/njol/skript/hooks/economy/classes/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * @author Peter Güttinger

--- a/src/main/java/ch/njol/skript/hooks/economy/expressions/ExprBalance.java
+++ b/src/main/java/ch/njol/skript/hooks/economy/expressions/ExprBalance.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.hooks.economy.expressions;
 

--- a/src/main/java/ch/njol/skript/hooks/economy/expressions/package-info.java
+++ b/src/main/java/ch/njol/skript/hooks/economy/expressions/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * @author Peter Güttinger

--- a/src/main/java/ch/njol/skript/hooks/package-info.java
+++ b/src/main/java/ch/njol/skript/hooks/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * Hook interface & implementations for specific plugins.

--- a/src/main/java/ch/njol/skript/hooks/permission/expressions/ExprAllGroups.java
+++ b/src/main/java/ch/njol/skript/hooks/permission/expressions/ExprAllGroups.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.hooks.permission.expressions;
 

--- a/src/main/java/ch/njol/skript/hooks/permission/expressions/ExprGroup.java
+++ b/src/main/java/ch/njol/skript/hooks/permission/expressions/ExprGroup.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.hooks.permission.expressions;
 

--- a/src/main/java/ch/njol/skript/hooks/permission/expressions/package-info.java
+++ b/src/main/java/ch/njol/skript/hooks/permission/expressions/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * @author Peter Güttinger

--- a/src/main/java/ch/njol/skript/hooks/regions/GriefPreventionHook.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/GriefPreventionHook.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.hooks.regions;
 

--- a/src/main/java/ch/njol/skript/hooks/regions/PreciousStonesHook.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/PreciousStonesHook.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.hooks.regions;
 

--- a/src/main/java/ch/njol/skript/hooks/regions/RegionsPlugin.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/RegionsPlugin.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.hooks.regions;
 

--- a/src/main/java/ch/njol/skript/hooks/regions/ResidenceHook.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/ResidenceHook.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.hooks.regions;
 

--- a/src/main/java/ch/njol/skript/hooks/regions/WorldGuardHook.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/WorldGuardHook.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.hooks.regions;
 

--- a/src/main/java/ch/njol/skript/hooks/regions/classes/Region.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/classes/Region.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.hooks.regions.classes;
 

--- a/src/main/java/ch/njol/skript/hooks/regions/classes/package-info.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/classes/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * @author Peter Güttinger

--- a/src/main/java/ch/njol/skript/hooks/regions/conditions/CondCanBuild.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/conditions/CondCanBuild.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.hooks.regions.conditions;
 

--- a/src/main/java/ch/njol/skript/hooks/regions/conditions/CondIsMember.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/conditions/CondIsMember.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.hooks.regions.conditions;
 

--- a/src/main/java/ch/njol/skript/hooks/regions/conditions/CondRegionContains.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/conditions/CondRegionContains.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.hooks.regions.conditions;
 

--- a/src/main/java/ch/njol/skript/hooks/regions/conditions/package-info.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/conditions/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * @author Peter Güttinger

--- a/src/main/java/ch/njol/skript/hooks/regions/events/EvtRegionBorder.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/events/EvtRegionBorder.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.hooks.regions.events;
 

--- a/src/main/java/ch/njol/skript/hooks/regions/events/RegionBorderEvent.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/events/RegionBorderEvent.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.hooks.regions.events;
 

--- a/src/main/java/ch/njol/skript/hooks/regions/events/package-info.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/events/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * @author Peter Güttinger

--- a/src/main/java/ch/njol/skript/hooks/regions/expressions/ExprBlocksInRegion.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/expressions/ExprBlocksInRegion.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.hooks.regions.expressions;
 

--- a/src/main/java/ch/njol/skript/hooks/regions/expressions/ExprMembersOfRegion.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/expressions/ExprMembersOfRegion.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.hooks.regions.expressions;
 

--- a/src/main/java/ch/njol/skript/hooks/regions/expressions/ExprRegion.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/expressions/ExprRegion.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.hooks.regions.expressions;
 

--- a/src/main/java/ch/njol/skript/hooks/regions/expressions/ExprRegionsAt.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/expressions/ExprRegionsAt.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.hooks.regions.expressions;
 

--- a/src/main/java/ch/njol/skript/hooks/regions/expressions/package-info.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/expressions/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * @author Peter Güttinger

--- a/src/main/java/ch/njol/skript/hooks/regions/package-info.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * @author Peter Güttinger

--- a/src/main/java/ch/njol/skript/lang/Condition.java
+++ b/src/main/java/ch/njol/skript/lang/Condition.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/Conditional.java
+++ b/src/main/java/ch/njol/skript/lang/Conditional.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/Debuggable.java
+++ b/src/main/java/ch/njol/skript/lang/Debuggable.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/DefaultExpression.java
+++ b/src/main/java/ch/njol/skript/lang/DefaultExpression.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/Effect.java
+++ b/src/main/java/ch/njol/skript/lang/Effect.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/Expression.java
+++ b/src/main/java/ch/njol/skript/lang/Expression.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/ExpressionInfo.java
+++ b/src/main/java/ch/njol/skript/lang/ExpressionInfo.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/ExpressionList.java
+++ b/src/main/java/ch/njol/skript/lang/ExpressionList.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/ExpressionType.java
+++ b/src/main/java/ch/njol/skript/lang/ExpressionType.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/Literal.java
+++ b/src/main/java/ch/njol/skript/lang/Literal.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/LiteralList.java
+++ b/src/main/java/ch/njol/skript/lang/LiteralList.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/Loop.java
+++ b/src/main/java/ch/njol/skript/lang/Loop.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/ParseContext.java
+++ b/src/main/java/ch/njol/skript/lang/ParseContext.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/SelfRegisteringSkriptEvent.java
+++ b/src/main/java/ch/njol/skript/lang/SelfRegisteringSkriptEvent.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/SkriptEvent.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptEvent.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/SkriptEventInfo.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptEventInfo.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/Statement.java
+++ b/src/main/java/ch/njol/skript/lang/Statement.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/SyntaxElement.java
+++ b/src/main/java/ch/njol/skript/lang/SyntaxElement.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/SyntaxElementInfo.java
+++ b/src/main/java/ch/njol/skript/lang/SyntaxElementInfo.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/Testable.java
+++ b/src/main/java/ch/njol/skript/lang/Testable.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/Trigger.java
+++ b/src/main/java/ch/njol/skript/lang/Trigger.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/TriggerItem.java
+++ b/src/main/java/ch/njol/skript/lang/TriggerItem.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/TriggerSection.java
+++ b/src/main/java/ch/njol/skript/lang/TriggerSection.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/Unit.java
+++ b/src/main/java/ch/njol/skript/lang/Unit.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/UnparsedLiteral.java
+++ b/src/main/java/ch/njol/skript/lang/UnparsedLiteral.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/Variable.java
+++ b/src/main/java/ch/njol/skript/lang/Variable.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/VariableString.java
+++ b/src/main/java/ch/njol/skript/lang/VariableString.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/While.java
+++ b/src/main/java/ch/njol/skript/lang/While.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang;
 

--- a/src/main/java/ch/njol/skript/lang/function/EffFunctionCall.java
+++ b/src/main/java/ch/njol/skript/lang/function/EffFunctionCall.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang.function;
 

--- a/src/main/java/ch/njol/skript/lang/function/ExprFunctionCall.java
+++ b/src/main/java/ch/njol/skript/lang/function/ExprFunctionCall.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang.function;
 

--- a/src/main/java/ch/njol/skript/lang/function/Function.java
+++ b/src/main/java/ch/njol/skript/lang/function/Function.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang.function;
 

--- a/src/main/java/ch/njol/skript/lang/function/FunctionEvent.java
+++ b/src/main/java/ch/njol/skript/lang/function/FunctionEvent.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang.function;
 

--- a/src/main/java/ch/njol/skript/lang/function/FunctionReference.java
+++ b/src/main/java/ch/njol/skript/lang/function/FunctionReference.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang.function;
 

--- a/src/main/java/ch/njol/skript/lang/function/Functions.java
+++ b/src/main/java/ch/njol/skript/lang/function/Functions.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang.function;
 

--- a/src/main/java/ch/njol/skript/lang/function/JavaFunction.java
+++ b/src/main/java/ch/njol/skript/lang/function/JavaFunction.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang.function;
 

--- a/src/main/java/ch/njol/skript/lang/function/Namespace.java
+++ b/src/main/java/ch/njol/skript/lang/function/Namespace.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang.function;
 

--- a/src/main/java/ch/njol/skript/lang/function/Parameter.java
+++ b/src/main/java/ch/njol/skript/lang/function/Parameter.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang.function;
 

--- a/src/main/java/ch/njol/skript/lang/function/ScriptFunction.java
+++ b/src/main/java/ch/njol/skript/lang/function/ScriptFunction.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang.function;
 

--- a/src/main/java/ch/njol/skript/lang/function/Signature.java
+++ b/src/main/java/ch/njol/skript/lang/function/Signature.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang.function;
 

--- a/src/main/java/ch/njol/skript/lang/function/package-info.java
+++ b/src/main/java/ch/njol/skript/lang/function/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * @author Peter Güttinger

--- a/src/main/java/ch/njol/skript/lang/package-info.java
+++ b/src/main/java/ch/njol/skript/lang/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * Contains all code related to parsing scripts.

--- a/src/main/java/ch/njol/skript/lang/parser/LoaderInstance.java
+++ b/src/main/java/ch/njol/skript/lang/parser/LoaderInstance.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang.parser;
 

--- a/src/main/java/ch/njol/skript/lang/parser/ParseLogger.java
+++ b/src/main/java/ch/njol/skript/lang/parser/ParseLogger.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang.parser;
 

--- a/src/main/java/ch/njol/skript/lang/parser/ParserInstance.java
+++ b/src/main/java/ch/njol/skript/lang/parser/ParserInstance.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang.parser;
 

--- a/src/main/java/ch/njol/skript/lang/parser/ParserUtils.java
+++ b/src/main/java/ch/njol/skript/lang/parser/ParserUtils.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang.parser;
 

--- a/src/main/java/ch/njol/skript/lang/parser/ScriptManager.java
+++ b/src/main/java/ch/njol/skript/lang/parser/ScriptManager.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang.parser;
 

--- a/src/main/java/ch/njol/skript/lang/parser/package-info.java
+++ b/src/main/java/ch/njol/skript/lang/parser/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 @NonNullByDefault
 package ch.njol.skript.lang.parser;

--- a/src/main/java/ch/njol/skript/lang/util/ContainerExpression.java
+++ b/src/main/java/ch/njol/skript/lang/util/ContainerExpression.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang.util;
 

--- a/src/main/java/ch/njol/skript/lang/util/ConvertedExpression.java
+++ b/src/main/java/ch/njol/skript/lang/util/ConvertedExpression.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang.util;
 

--- a/src/main/java/ch/njol/skript/lang/util/ConvertedLiteral.java
+++ b/src/main/java/ch/njol/skript/lang/util/ConvertedLiteral.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang.util;
 

--- a/src/main/java/ch/njol/skript/lang/util/SimpleEvent.java
+++ b/src/main/java/ch/njol/skript/lang/util/SimpleEvent.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang.util;
 

--- a/src/main/java/ch/njol/skript/lang/util/SimpleExpression.java
+++ b/src/main/java/ch/njol/skript/lang/util/SimpleExpression.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang.util;
 

--- a/src/main/java/ch/njol/skript/lang/util/SimpleLiteral.java
+++ b/src/main/java/ch/njol/skript/lang/util/SimpleLiteral.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.lang.util;
 

--- a/src/main/java/ch/njol/skript/lang/util/package-info.java
+++ b/src/main/java/ch/njol/skript/lang/util/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * @author Peter Güttinger

--- a/src/main/java/ch/njol/skript/localization/Adjective.java
+++ b/src/main/java/ch/njol/skript/localization/Adjective.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.localization;
 

--- a/src/main/java/ch/njol/skript/localization/ArgsMessage.java
+++ b/src/main/java/ch/njol/skript/localization/ArgsMessage.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.localization;
 

--- a/src/main/java/ch/njol/skript/localization/FormattedMessage.java
+++ b/src/main/java/ch/njol/skript/localization/FormattedMessage.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.localization;
 

--- a/src/main/java/ch/njol/skript/localization/GeneralWords.java
+++ b/src/main/java/ch/njol/skript/localization/GeneralWords.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.localization;
 

--- a/src/main/java/ch/njol/skript/localization/Language.java
+++ b/src/main/java/ch/njol/skript/localization/Language.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.localization;
 

--- a/src/main/java/ch/njol/skript/localization/LanguageChangeListener.java
+++ b/src/main/java/ch/njol/skript/localization/LanguageChangeListener.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.localization;
 

--- a/src/main/java/ch/njol/skript/localization/Message.java
+++ b/src/main/java/ch/njol/skript/localization/Message.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.localization;
 

--- a/src/main/java/ch/njol/skript/localization/Noun.java
+++ b/src/main/java/ch/njol/skript/localization/Noun.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.localization;
 

--- a/src/main/java/ch/njol/skript/localization/PluralizingArgsMessage.java
+++ b/src/main/java/ch/njol/skript/localization/PluralizingArgsMessage.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.localization;
 

--- a/src/main/java/ch/njol/skript/localization/RegexMessage.java
+++ b/src/main/java/ch/njol/skript/localization/RegexMessage.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.localization;
 

--- a/src/main/java/ch/njol/skript/localization/package-info.java
+++ b/src/main/java/ch/njol/skript/localization/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * Localisation code goes here.

--- a/src/main/java/ch/njol/skript/log/BlockingLogHandler.java
+++ b/src/main/java/ch/njol/skript/log/BlockingLogHandler.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.log;
 

--- a/src/main/java/ch/njol/skript/log/BukkitLoggerFilter.java
+++ b/src/main/java/ch/njol/skript/log/BukkitLoggerFilter.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.log;
 

--- a/src/main/java/ch/njol/skript/log/CountingLogHandler.java
+++ b/src/main/java/ch/njol/skript/log/CountingLogHandler.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.log;
 

--- a/src/main/java/ch/njol/skript/log/ErrorDescLogHandler.java
+++ b/src/main/java/ch/njol/skript/log/ErrorDescLogHandler.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.log;
 

--- a/src/main/java/ch/njol/skript/log/ErrorQuality.java
+++ b/src/main/java/ch/njol/skript/log/ErrorQuality.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.log;
 

--- a/src/main/java/ch/njol/skript/log/FilteringLogHandler.java
+++ b/src/main/java/ch/njol/skript/log/FilteringLogHandler.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.log;
 

--- a/src/main/java/ch/njol/skript/log/HandlerList.java
+++ b/src/main/java/ch/njol/skript/log/HandlerList.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.log;
 

--- a/src/main/java/ch/njol/skript/log/LogEntry.java
+++ b/src/main/java/ch/njol/skript/log/LogEntry.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.log;
 

--- a/src/main/java/ch/njol/skript/log/LogHandler.java
+++ b/src/main/java/ch/njol/skript/log/LogHandler.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.log;
 

--- a/src/main/java/ch/njol/skript/log/ParseLogHandler.java
+++ b/src/main/java/ch/njol/skript/log/ParseLogHandler.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.log;
 

--- a/src/main/java/ch/njol/skript/log/RedirectingLogHandler.java
+++ b/src/main/java/ch/njol/skript/log/RedirectingLogHandler.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.log;
 

--- a/src/main/java/ch/njol/skript/log/RetainingLogHandler.java
+++ b/src/main/java/ch/njol/skript/log/RetainingLogHandler.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.log;
 

--- a/src/main/java/ch/njol/skript/log/SkriptLogger.java
+++ b/src/main/java/ch/njol/skript/log/SkriptLogger.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.log;
 

--- a/src/main/java/ch/njol/skript/log/Verbosity.java
+++ b/src/main/java/ch/njol/skript/log/Verbosity.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.log;
 

--- a/src/main/java/ch/njol/skript/log/package-info.java
+++ b/src/main/java/ch/njol/skript/log/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * Code related to logging.

--- a/src/main/java/ch/njol/skript/package-info.java
+++ b/src/main/java/ch/njol/skript/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * The package for the bukkit plugin Skript.

--- a/src/main/java/ch/njol/skript/registrations/Classes.java
+++ b/src/main/java/ch/njol/skript/registrations/Classes.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.registrations;
 

--- a/src/main/java/ch/njol/skript/registrations/Comparators.java
+++ b/src/main/java/ch/njol/skript/registrations/Comparators.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.registrations;
 

--- a/src/main/java/ch/njol/skript/registrations/Converters.java
+++ b/src/main/java/ch/njol/skript/registrations/Converters.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.registrations;
 

--- a/src/main/java/ch/njol/skript/registrations/EventValues.java
+++ b/src/main/java/ch/njol/skript/registrations/EventValues.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.registrations;
 

--- a/src/main/java/ch/njol/skript/registrations/package-info.java
+++ b/src/main/java/ch/njol/skript/registrations/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * Contains classes used for registering new stuff to Skript.

--- a/src/main/java/ch/njol/skript/tests/TestResults.java
+++ b/src/main/java/ch/njol/skript/tests/TestResults.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.tests;
 

--- a/src/main/java/ch/njol/skript/tests/package-info.java
+++ b/src/main/java/ch/njol/skript/tests/package-info.java
@@ -14,10 +14,8 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
-
 /**
  * Support for script-based testing.
  */

--- a/src/main/java/ch/njol/skript/tests/platform/Environment.java
+++ b/src/main/java/ch/njol/skript/tests/platform/Environment.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.tests.platform;
 

--- a/src/main/java/ch/njol/skript/tests/platform/PlatformMain.java
+++ b/src/main/java/ch/njol/skript/tests/platform/PlatformMain.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.tests.platform;
 

--- a/src/main/java/ch/njol/skript/tests/platform/package-info.java
+++ b/src/main/java/ch/njol/skript/tests/platform/package-info.java
@@ -14,10 +14,8 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
-
 /**
  * Support for script-based testing.
  */

--- a/src/main/java/ch/njol/skript/tests/runner/CondMinecraftVersion.java
+++ b/src/main/java/ch/njol/skript/tests/runner/CondMinecraftVersion.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.tests.runner;
 

--- a/src/main/java/ch/njol/skript/tests/runner/EffAssert.java
+++ b/src/main/java/ch/njol/skript/tests/runner/EffAssert.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.tests.runner;
 

--- a/src/main/java/ch/njol/skript/tests/runner/EvtTestCase.java
+++ b/src/main/java/ch/njol/skript/tests/runner/EvtTestCase.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.tests.runner;
 

--- a/src/main/java/ch/njol/skript/tests/runner/SkriptTestEvent.java
+++ b/src/main/java/ch/njol/skript/tests/runner/SkriptTestEvent.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.tests.runner;
 

--- a/src/main/java/ch/njol/skript/tests/runner/TestFunctions.java
+++ b/src/main/java/ch/njol/skript/tests/runner/TestFunctions.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.tests.runner;
 

--- a/src/main/java/ch/njol/skript/tests/runner/TestMode.java
+++ b/src/main/java/ch/njol/skript/tests/runner/TestMode.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.tests.runner;
 

--- a/src/main/java/ch/njol/skript/tests/runner/TestTracker.java
+++ b/src/main/java/ch/njol/skript/tests/runner/TestTracker.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.tests.runner;
 

--- a/src/main/java/ch/njol/skript/tests/runner/package-info.java
+++ b/src/main/java/ch/njol/skript/tests/runner/package-info.java
@@ -14,10 +14,8 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
-
 /**
  * Support for script-based testing.
  */

--- a/src/main/java/ch/njol/skript/timings/SkriptTimings.java
+++ b/src/main/java/ch/njol/skript/timings/SkriptTimings.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.timings;
 

--- a/src/main/java/ch/njol/skript/timings/package-info.java
+++ b/src/main/java/ch/njol/skript/timings/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * Code related to item aliases.

--- a/src/main/java/ch/njol/skript/update/GithubChecker.java
+++ b/src/main/java/ch/njol/skript/update/GithubChecker.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.update;
 

--- a/src/main/java/ch/njol/skript/update/NoUpdateChecker.java
+++ b/src/main/java/ch/njol/skript/update/NoUpdateChecker.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.update;
 

--- a/src/main/java/ch/njol/skript/update/ReleaseChannel.java
+++ b/src/main/java/ch/njol/skript/update/ReleaseChannel.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.update;
 

--- a/src/main/java/ch/njol/skript/update/ReleaseManifest.java
+++ b/src/main/java/ch/njol/skript/update/ReleaseManifest.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.update;
 

--- a/src/main/java/ch/njol/skript/update/ReleaseStatus.java
+++ b/src/main/java/ch/njol/skript/update/ReleaseStatus.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.update;
 

--- a/src/main/java/ch/njol/skript/update/UpdateChecker.java
+++ b/src/main/java/ch/njol/skript/update/UpdateChecker.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.update;
 

--- a/src/main/java/ch/njol/skript/update/UpdateManifest.java
+++ b/src/main/java/ch/njol/skript/update/UpdateManifest.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.update;
 

--- a/src/main/java/ch/njol/skript/update/Updater.java
+++ b/src/main/java/ch/njol/skript/update/Updater.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.update;
 

--- a/src/main/java/ch/njol/skript/update/UpdaterState.java
+++ b/src/main/java/ch/njol/skript/update/UpdaterState.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.update;
 

--- a/src/main/java/ch/njol/skript/update/package-info.java
+++ b/src/main/java/ch/njol/skript/update/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * Code related to item aliases.

--- a/src/main/java/ch/njol/skript/util/AABB.java
+++ b/src/main/java/ch/njol/skript/util/AABB.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/AsyncEffect.java
+++ b/src/main/java/ch/njol/skript/util/AsyncEffect.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/BiomeUtils.java
+++ b/src/main/java/ch/njol/skript/util/BiomeUtils.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/BlockInventoryHolder.java
+++ b/src/main/java/ch/njol/skript/util/BlockInventoryHolder.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/BlockLineIterator.java
+++ b/src/main/java/ch/njol/skript/util/BlockLineIterator.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/BlockSphereIterator.java
+++ b/src/main/java/ch/njol/skript/util/BlockSphereIterator.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/BlockStateBlock.java
+++ b/src/main/java/ch/njol/skript/util/BlockStateBlock.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/BlockUtils.java
+++ b/src/main/java/ch/njol/skript/util/BlockUtils.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/Color.java
+++ b/src/main/java/ch/njol/skript/util/Color.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/ColorRGB.java
+++ b/src/main/java/ch/njol/skript/util/ColorRGB.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/Container.java
+++ b/src/main/java/ch/njol/skript/util/Container.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/DamageCauseUtils.java
+++ b/src/main/java/ch/njol/skript/util/DamageCauseUtils.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/Date.java
+++ b/src/main/java/ch/njol/skript/util/Date.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/DelayedChangeBlock.java
+++ b/src/main/java/ch/njol/skript/util/DelayedChangeBlock.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/Direction.java
+++ b/src/main/java/ch/njol/skript/util/Direction.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/EmptyStacktraceException.java
+++ b/src/main/java/ch/njol/skript/util/EmptyStacktraceException.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/EnchantmentType.java
+++ b/src/main/java/ch/njol/skript/util/EnchantmentType.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/EnumUtils.java
+++ b/src/main/java/ch/njol/skript/util/EnumUtils.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/ExceptionUtils.java
+++ b/src/main/java/ch/njol/skript/util/ExceptionUtils.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/Experience.java
+++ b/src/main/java/ch/njol/skript/util/Experience.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/FileUtils.java
+++ b/src/main/java/ch/njol/skript/util/FileUtils.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/GameruleValue.java
+++ b/src/main/java/ch/njol/skript/util/GameruleValue.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/Getter.java
+++ b/src/main/java/ch/njol/skript/util/Getter.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/InventoryActions.java
+++ b/src/main/java/ch/njol/skript/util/InventoryActions.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/ListVariablePersistentDataType.java
+++ b/src/main/java/ch/njol/skript/util/ListVariablePersistentDataType.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/LiteralUtils.java
+++ b/src/main/java/ch/njol/skript/util/LiteralUtils.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/Patterns.java
+++ b/src/main/java/ch/njol/skript/util/Patterns.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/PersistentDataUtils.java
+++ b/src/main/java/ch/njol/skript/util/PersistentDataUtils.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/PotionEffectUtils.java
+++ b/src/main/java/ch/njol/skript/util/PotionEffectUtils.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/ScriptOptions.java
+++ b/src/main/java/ch/njol/skript/util/ScriptOptions.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /*
 

--- a/src/main/java/ch/njol/skript/util/SingleVariablePersistentDataType.java
+++ b/src/main/java/ch/njol/skript/util/SingleVariablePersistentDataType.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/SkriptColor.java
+++ b/src/main/java/ch/njol/skript/util/SkriptColor.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/Slot.java
+++ b/src/main/java/ch/njol/skript/util/Slot.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/SoundUtils.java
+++ b/src/main/java/ch/njol/skript/util/SoundUtils.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/StringMode.java
+++ b/src/main/java/ch/njol/skript/util/StringMode.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/StructureType.java
+++ b/src/main/java/ch/njol/skript/util/StructureType.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/Task.java
+++ b/src/main/java/ch/njol/skript/util/Task.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/Time.java
+++ b/src/main/java/ch/njol/skript/util/Time.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/Timeperiod.java
+++ b/src/main/java/ch/njol/skript/util/Timeperiod.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/Timespan.java
+++ b/src/main/java/ch/njol/skript/util/Timespan.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/Utils.java
+++ b/src/main/java/ch/njol/skript/util/Utils.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/Version.java
+++ b/src/main/java/ch/njol/skript/util/Version.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/VisualEffect.java
+++ b/src/main/java/ch/njol/skript/util/VisualEffect.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/VisualEffectDummy.java
+++ b/src/main/java/ch/njol/skript/util/VisualEffectDummy.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/WeatherType.java
+++ b/src/main/java/ch/njol/skript/util/WeatherType.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/main/java/ch/njol/skript/util/chat/BungeeConverter.java
+++ b/src/main/java/ch/njol/skript/util/chat/BungeeConverter.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util.chat;
 

--- a/src/main/java/ch/njol/skript/util/chat/ChatCode.java
+++ b/src/main/java/ch/njol/skript/util/chat/ChatCode.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util.chat;
 

--- a/src/main/java/ch/njol/skript/util/chat/ChatMessages.java
+++ b/src/main/java/ch/njol/skript/util/chat/ChatMessages.java
@@ -1,4 +1,4 @@
-/*
+/**
  *   This file is part of Skript.
  *
  *  Skript is free software: you can redistribute it and/or modify
@@ -13,12 +13,9 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * 
- * Copyright 2011-2017 Peter Güttinger and contributors
- * 
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
-
 package ch.njol.skript.util.chat;
 
 import java.util.ArrayList;

--- a/src/main/java/ch/njol/skript/util/chat/LinkParseMode.java
+++ b/src/main/java/ch/njol/skript/util/chat/LinkParseMode.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util.chat;
 

--- a/src/main/java/ch/njol/skript/util/chat/MessageComponent.java
+++ b/src/main/java/ch/njol/skript/util/chat/MessageComponent.java
@@ -1,4 +1,4 @@
-/*
+/**
  *   This file is part of Skript.
  *
  *  Skript is free software: you can redistribute it and/or modify
@@ -13,12 +13,9 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * 
- * Copyright 2011-2017 Peter Güttinger and contributors
- * 
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
-
 package ch.njol.skript.util.chat;
 
 import java.lang.reflect.Type;

--- a/src/main/java/ch/njol/skript/util/chat/SkriptChatCode.java
+++ b/src/main/java/ch/njol/skript/util/chat/SkriptChatCode.java
@@ -1,4 +1,4 @@
-/*
+/**
  *   This file is part of Skript.
  *
  *  Skript is free software: you can redistribute it and/or modify
@@ -13,12 +13,9 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * 
- * Copyright 2011-2017 Peter Güttinger and contributors
- * 
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
-
 package ch.njol.skript.util.chat;
 
 import org.eclipse.jdt.annotation.Nullable;

--- a/src/main/java/ch/njol/skript/util/chat/package-info.java
+++ b/src/main/java/ch/njol/skript/util/chat/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * Various utility classes and methods.

--- a/src/main/java/ch/njol/skript/util/package-info.java
+++ b/src/main/java/ch/njol/skript/util/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * Various utility classes and methods.

--- a/src/main/java/ch/njol/skript/util/slot/CursorSlot.java
+++ b/src/main/java/ch/njol/skript/util/slot/CursorSlot.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util.slot;
 

--- a/src/main/java/ch/njol/skript/util/slot/DroppedItemSlot.java
+++ b/src/main/java/ch/njol/skript/util/slot/DroppedItemSlot.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util.slot;
 

--- a/src/main/java/ch/njol/skript/util/slot/EquipmentSlot.java
+++ b/src/main/java/ch/njol/skript/util/slot/EquipmentSlot.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util.slot;
 

--- a/src/main/java/ch/njol/skript/util/slot/InventorySlot.java
+++ b/src/main/java/ch/njol/skript/util/slot/InventorySlot.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util.slot;
 

--- a/src/main/java/ch/njol/skript/util/slot/ItemFrameSlot.java
+++ b/src/main/java/ch/njol/skript/util/slot/ItemFrameSlot.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util.slot;
 

--- a/src/main/java/ch/njol/skript/util/slot/Slot.java
+++ b/src/main/java/ch/njol/skript/util/slot/Slot.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util.slot;
 

--- a/src/main/java/ch/njol/skript/util/slot/SlotWithIndex.java
+++ b/src/main/java/ch/njol/skript/util/slot/SlotWithIndex.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util.slot;
 

--- a/src/main/java/ch/njol/skript/util/slot/package-info.java
+++ b/src/main/java/ch/njol/skript/util/slot/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * Various utility classes and methods.

--- a/src/main/java/ch/njol/skript/variables/DatabaseStorage.java
+++ b/src/main/java/ch/njol/skript/variables/DatabaseStorage.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.variables;
 

--- a/src/main/java/ch/njol/skript/variables/FlatFileStorage.java
+++ b/src/main/java/ch/njol/skript/variables/FlatFileStorage.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.variables;
 

--- a/src/main/java/ch/njol/skript/variables/SerializedVariable.java
+++ b/src/main/java/ch/njol/skript/variables/SerializedVariable.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.variables;
 

--- a/src/main/java/ch/njol/skript/variables/TypeHints.java
+++ b/src/main/java/ch/njol/skript/variables/TypeHints.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.variables;
 

--- a/src/main/java/ch/njol/skript/variables/Variables.java
+++ b/src/main/java/ch/njol/skript/variables/Variables.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.variables;
 

--- a/src/main/java/ch/njol/skript/variables/VariablesMap.java
+++ b/src/main/java/ch/njol/skript/variables/VariablesMap.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.variables;
 

--- a/src/main/java/ch/njol/skript/variables/VariablesStorage.java
+++ b/src/main/java/ch/njol/skript/variables/VariablesStorage.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.variables;
 

--- a/src/main/java/ch/njol/skript/variables/package-info.java
+++ b/src/main/java/ch/njol/skript/variables/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * Code related to loading, handling, and saving variables. Some code is found in <tt>lang</tt> as well (e.g. in {@link ch.njol.skript.lang.Variable}).

--- a/src/main/java/ch/njol/util/Callback.java
+++ b/src/main/java/ch/njol/util/Callback.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util;
 

--- a/src/main/java/ch/njol/util/CaseInsensitiveString.java
+++ b/src/main/java/ch/njol/util/CaseInsensitiveString.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util;
 

--- a/src/main/java/ch/njol/util/Checker.java
+++ b/src/main/java/ch/njol/util/Checker.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util;
 

--- a/src/main/java/ch/njol/util/Closeable.java
+++ b/src/main/java/ch/njol/util/Closeable.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util;
 

--- a/src/main/java/ch/njol/util/Kleenean.java
+++ b/src/main/java/ch/njol/util/Kleenean.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util;
 

--- a/src/main/java/ch/njol/util/LoggerFilter.java
+++ b/src/main/java/ch/njol/util/LoggerFilter.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util;
 

--- a/src/main/java/ch/njol/util/Math2.java
+++ b/src/main/java/ch/njol/util/Math2.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util;
 

--- a/src/main/java/ch/njol/util/NonNullPair.java
+++ b/src/main/java/ch/njol/util/NonNullPair.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util;
 

--- a/src/main/java/ch/njol/util/NotifyingReference.java
+++ b/src/main/java/ch/njol/util/NotifyingReference.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util;
 

--- a/src/main/java/ch/njol/util/NullableChecker.java
+++ b/src/main/java/ch/njol/util/NullableChecker.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util;
 

--- a/src/main/java/ch/njol/util/Pair.java
+++ b/src/main/java/ch/njol/util/Pair.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util;
 

--- a/src/main/java/ch/njol/util/Predicate.java
+++ b/src/main/java/ch/njol/util/Predicate.java
@@ -14,15 +14,14 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util;
 
 import javax.annotation.Nullable;
 
 /**
- * @author Peter G�ttinger
+ * @author Peter G�ttinger
  *
  */
 public abstract interface Predicate<T> {

--- a/src/main/java/ch/njol/util/Setter.java
+++ b/src/main/java/ch/njol/util/Setter.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util;
 

--- a/src/main/java/ch/njol/util/StringUtils.java
+++ b/src/main/java/ch/njol/util/StringUtils.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util;
 

--- a/src/main/java/ch/njol/util/SynchronizedReference.java
+++ b/src/main/java/ch/njol/util/SynchronizedReference.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util;
 

--- a/src/main/java/ch/njol/util/Validate.java
+++ b/src/main/java/ch/njol/util/Validate.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util;
 

--- a/src/main/java/ch/njol/util/VectorMath.java
+++ b/src/main/java/ch/njol/util/VectorMath.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util;
 

--- a/src/main/java/ch/njol/util/coll/BidiHashMap.java
+++ b/src/main/java/ch/njol/util/coll/BidiHashMap.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util.coll;
 

--- a/src/main/java/ch/njol/util/coll/BidiMap.java
+++ b/src/main/java/ch/njol/util/coll/BidiMap.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util.coll;
 

--- a/src/main/java/ch/njol/util/coll/CollectionUtils.java
+++ b/src/main/java/ch/njol/util/coll/CollectionUtils.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util.coll;
 

--- a/src/main/java/ch/njol/util/coll/CyclicList.java
+++ b/src/main/java/ch/njol/util/coll/CyclicList.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util.coll;
 

--- a/src/main/java/ch/njol/util/coll/ReversedListView.java
+++ b/src/main/java/ch/njol/util/coll/ReversedListView.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util.coll;
 

--- a/src/main/java/ch/njol/util/coll/iterator/ArrayIterator.java
+++ b/src/main/java/ch/njol/util/coll/iterator/ArrayIterator.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util.coll.iterator;
 

--- a/src/main/java/ch/njol/util/coll/iterator/CheckedIterator.java
+++ b/src/main/java/ch/njol/util/coll/iterator/CheckedIterator.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util.coll.iterator;
 

--- a/src/main/java/ch/njol/util/coll/iterator/CombinedIterator.java
+++ b/src/main/java/ch/njol/util/coll/iterator/CombinedIterator.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util.coll.iterator;
 

--- a/src/main/java/ch/njol/util/coll/iterator/EmptyIterable.java
+++ b/src/main/java/ch/njol/util/coll/iterator/EmptyIterable.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util.coll.iterator;
 

--- a/src/main/java/ch/njol/util/coll/iterator/EmptyIterator.java
+++ b/src/main/java/ch/njol/util/coll/iterator/EmptyIterator.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util.coll.iterator;
 

--- a/src/main/java/ch/njol/util/coll/iterator/EnumerationIterable.java
+++ b/src/main/java/ch/njol/util/coll/iterator/EnumerationIterable.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util.coll.iterator;
 

--- a/src/main/java/ch/njol/util/coll/iterator/ImprovedIterator.java
+++ b/src/main/java/ch/njol/util/coll/iterator/ImprovedIterator.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util.coll.iterator;
 

--- a/src/main/java/ch/njol/util/coll/iterator/IteratorIterable.java
+++ b/src/main/java/ch/njol/util/coll/iterator/IteratorIterable.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util.coll.iterator;
 

--- a/src/main/java/ch/njol/util/coll/iterator/ListRangeIterator.java
+++ b/src/main/java/ch/njol/util/coll/iterator/ListRangeIterator.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util.coll.iterator;
 

--- a/src/main/java/ch/njol/util/coll/iterator/NonNullIterator.java
+++ b/src/main/java/ch/njol/util/coll/iterator/NonNullIterator.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util.coll.iterator;
 

--- a/src/main/java/ch/njol/util/coll/iterator/ReversedListIterator.java
+++ b/src/main/java/ch/njol/util/coll/iterator/ReversedListIterator.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util.coll.iterator;
 

--- a/src/main/java/ch/njol/util/coll/iterator/SingleItemIterable.java
+++ b/src/main/java/ch/njol/util/coll/iterator/SingleItemIterable.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util.coll.iterator;
 

--- a/src/main/java/ch/njol/util/coll/iterator/SingleItemIterator.java
+++ b/src/main/java/ch/njol/util/coll/iterator/SingleItemIterator.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util.coll.iterator;
 

--- a/src/main/java/ch/njol/util/coll/iterator/StoppableIterator.java
+++ b/src/main/java/ch/njol/util/coll/iterator/StoppableIterator.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.util.coll.iterator;
 

--- a/src/main/java/ch/njol/util/coll/iterator/package-info.java
+++ b/src/main/java/ch/njol/util/coll/iterator/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * @author Peter Güttinger

--- a/src/main/java/ch/njol/util/coll/package-info.java
+++ b/src/main/java/ch/njol/util/coll/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * @author Peter Güttinger

--- a/src/main/java/ch/njol/util/package-info.java
+++ b/src/main/java/ch/njol/util/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * @author Peter Güttinger

--- a/src/main/java/ch/njol/yggdrasil/ClassResolver.java
+++ b/src/main/java/ch/njol/yggdrasil/ClassResolver.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.yggdrasil;
 

--- a/src/main/java/ch/njol/yggdrasil/DefaultYggdrasilInputStream.java
+++ b/src/main/java/ch/njol/yggdrasil/DefaultYggdrasilInputStream.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.yggdrasil;
 

--- a/src/main/java/ch/njol/yggdrasil/DefaultYggdrasilOutputStream.java
+++ b/src/main/java/ch/njol/yggdrasil/DefaultYggdrasilOutputStream.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.yggdrasil;
 

--- a/src/main/java/ch/njol/yggdrasil/FieldHandler.java
+++ b/src/main/java/ch/njol/yggdrasil/FieldHandler.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.yggdrasil;
 

--- a/src/main/java/ch/njol/yggdrasil/Fields.java
+++ b/src/main/java/ch/njol/yggdrasil/Fields.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.yggdrasil;
 

--- a/src/main/java/ch/njol/yggdrasil/JRESerializer.java
+++ b/src/main/java/ch/njol/yggdrasil/JRESerializer.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.yggdrasil;
 

--- a/src/main/java/ch/njol/yggdrasil/PseudoEnum.java
+++ b/src/main/java/ch/njol/yggdrasil/PseudoEnum.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.yggdrasil;
 

--- a/src/main/java/ch/njol/yggdrasil/SimpleClassResolver.java
+++ b/src/main/java/ch/njol/yggdrasil/SimpleClassResolver.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.yggdrasil;
 

--- a/src/main/java/ch/njol/yggdrasil/Tag.java
+++ b/src/main/java/ch/njol/yggdrasil/Tag.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.yggdrasil;
 

--- a/src/main/java/ch/njol/yggdrasil/Yggdrasil.java
+++ b/src/main/java/ch/njol/yggdrasil/Yggdrasil.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.yggdrasil;
 

--- a/src/main/java/ch/njol/yggdrasil/YggdrasilException.java
+++ b/src/main/java/ch/njol/yggdrasil/YggdrasilException.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.yggdrasil;
 

--- a/src/main/java/ch/njol/yggdrasil/YggdrasilID.java
+++ b/src/main/java/ch/njol/yggdrasil/YggdrasilID.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.yggdrasil;
 

--- a/src/main/java/ch/njol/yggdrasil/YggdrasilInputStream.java
+++ b/src/main/java/ch/njol/yggdrasil/YggdrasilInputStream.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.yggdrasil;
 

--- a/src/main/java/ch/njol/yggdrasil/YggdrasilOutputStream.java
+++ b/src/main/java/ch/njol/yggdrasil/YggdrasilOutputStream.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.yggdrasil;
 

--- a/src/main/java/ch/njol/yggdrasil/YggdrasilSerializable.java
+++ b/src/main/java/ch/njol/yggdrasil/YggdrasilSerializable.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.yggdrasil;
 

--- a/src/main/java/ch/njol/yggdrasil/YggdrasilSerializer.java
+++ b/src/main/java/ch/njol/yggdrasil/YggdrasilSerializer.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.yggdrasil;
 

--- a/src/main/java/ch/njol/yggdrasil/package-info.java
+++ b/src/main/java/ch/njol/yggdrasil/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * @author Peter Güttinger

--- a/src/main/java/ch/njol/yggdrasil/util/JREFieldHandler.java
+++ b/src/main/java/ch/njol/yggdrasil/util/JREFieldHandler.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.yggdrasil.util;
 

--- a/src/main/java/ch/njol/yggdrasil/util/package-info.java
+++ b/src/main/java/ch/njol/yggdrasil/util/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * @author Peter Güttinger

--- a/src/main/java/ch/njol/yggdrasil/xml/YggXMLInputStream.java
+++ b/src/main/java/ch/njol/yggdrasil/xml/YggXMLInputStream.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.yggdrasil.xml;
 

--- a/src/main/java/ch/njol/yggdrasil/xml/YggXMLOutputStream.java
+++ b/src/main/java/ch/njol/yggdrasil/xml/YggXMLOutputStream.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.yggdrasil.xml;
 

--- a/src/main/java/ch/njol/yggdrasil/xml/package-info.java
+++ b/src/main/java/ch/njol/yggdrasil/xml/package-info.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 /**
  * @author Peter Güttinger

--- a/src/main/resources/lang/readme.txt
+++ b/src/main/resources/lang/readme.txt
@@ -14,10 +14,8 @@
      You should have received a copy of the GNU General Public License
      along with Skript.  If not, see <http://www.gnu.org/licenses/>.
 
-
-    Copyright 2011-2017 Peter Güttinger and contributors
+    Copyright Peter Güttinger, SkriptLang team and contributors
 ====
-
 
 = Language Files =
 .lang files are in the same format as all Skript configs & scripts.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -14,8 +14,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Copyright 2011-2017 Peter Güttinger and contributors
+# Copyright Peter Güttinger, SkriptLang team and contributors
 #
 
 

--- a/src/test/java/ch/njol/skript/SkriptTest.java
+++ b/src/test/java/ch/njol/skript/SkriptTest.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript;
 

--- a/src/test/java/ch/njol/skript/aliases/AliasesTest.java
+++ b/src/test/java/ch/njol/skript/aliases/AliasesTest.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.aliases;
 

--- a/src/test/java/ch/njol/skript/config/NodeTest.java
+++ b/src/test/java/ch/njol/skript/config/NodeTest.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.config;
 

--- a/src/test/java/ch/njol/skript/localization/NounTest.java
+++ b/src/test/java/ch/njol/skript/localization/NounTest.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.localization;
 

--- a/src/test/java/ch/njol/skript/localization/RegexMessageTest.java
+++ b/src/test/java/ch/njol/skript/localization/RegexMessageTest.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.localization;
 

--- a/src/test/java/ch/njol/skript/registrations/ClassesTest.java
+++ b/src/test/java/ch/njol/skript/registrations/ClassesTest.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.registrations;
 

--- a/src/test/java/ch/njol/skript/util/UtilsTest.java
+++ b/src/test/java/ch/njol/skript/util/UtilsTest.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.util;
 

--- a/src/test/java/ch/njol/skript/variables/FlatFileStorageTest.java
+++ b/src/test/java/ch/njol/skript/variables/FlatFileStorageTest.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.variables;
 


### PR DESCRIPTION
### Description
Updated the license header to no longer include year (it was never updated).

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none (AFAIK)
