### PR TITLE
Feature/sounds add namespace support

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondIsOccluding.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsOccluding.java
@@ -14,8 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
  *
- *
- * Copyright 2011-2017 Peter Güttinger and contributors
+ * Copyright Peter Güttinger, SkriptLang team and contributors
  */
 package ch.njol.skript.conditions;
 

--- a/src/main/java/ch/njol/skript/effects/EffPlaySound.java
+++ b/src/main/java/ch/njol/skript/effects/EffPlaySound.java
@@ -55,7 +55,7 @@ import ch.njol.util.Kleenean;
 public class EffPlaySound extends Effect {
 
 	private static final boolean SOUND_CATEGORIES_EXIST = Skript.classExists("org.bukkit.SoundCategory");
-	private static final Pattern SOUND_VALID_PATTERN = Pattern.compile("[a-z0-9\\/._-]+"); // Minecraft only accepts these characters 
+	private static final Pattern SOUND_VALID_PATTERN = Pattern.compile("[a-z0-9\\/:._-]+"); // Minecraft only accepts these characters
 	
 	static {
 		if (SOUND_CATEGORIES_EXIST) {


### PR DESCRIPTION
### Description
This PR aims to add support for ":" in sound strings, which adds support for namespaces
Also, while I was in there I updated the header of CondIsOccluding (wouldn't build)

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #3404 
