### PR TITLE
Fix/EntityData#toString() for some entities

### DIFF
--- a/src/main/java/ch/njol/skript/entity/DroppedItemData.java
+++ b/src/main/java/ch/njol/skript/entity/DroppedItemData.java
@@ -46,6 +46,12 @@ public class DroppedItemData extends EntityData<Item> {
 	@Nullable
 	private ItemType[] types;
 	
+	public DroppedItemData() {}
+	
+	public DroppedItemData(@Nullable ItemType[] types) {
+		this.types = types;
+	}
+	
 	@Override
 	protected boolean init(final Literal<?>[] exprs, final int matchedPattern, final ParseResult parseResult) {
 		if (exprs.length > 0 && exprs[0] != null)
@@ -101,7 +107,7 @@ public class DroppedItemData extends EntityData<Item> {
 	
 	@Override
 	public EntityData getSuperType() {
-		return new DroppedItemData();
+		return new DroppedItemData(types);
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/entity/EndermanData.java
+++ b/src/main/java/ch/njol/skript/entity/EndermanData.java
@@ -54,6 +54,12 @@ public class EndermanData extends EntityData<Enderman> {
 	@Nullable
 	private ItemType[] hand = null;
 	
+	public EndermanData() {}
+	
+	public EndermanData(@Nullable ItemType[] hand) {
+		this.hand = hand;
+	}
+	
 	@SuppressWarnings("unchecked")
 	@Override
 	protected boolean init(final Literal<?>[] exprs, final int matchedPattern, final ParseResult parseResult) {
@@ -194,7 +200,7 @@ public class EndermanData extends EntityData<Enderman> {
 	
 	@Override
 	public EntityData getSuperType() {
-		return new EndermanData();
+		return new EndermanData(hand);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/entity/FallingBlockData.java
+++ b/src/main/java/ch/njol/skript/entity/FallingBlockData.java
@@ -56,6 +56,12 @@ public class FallingBlockData extends EntityData<FallingBlock> {
 	@Nullable
 	private ItemType[] types = null;
 	
+	public FallingBlockData() {}
+	
+	public FallingBlockData(@Nullable ItemType[] types) {
+		this.types = types;
+	}
+	
 	@SuppressWarnings("unchecked")
 	@Override
 	protected boolean init(final Literal<?>[] exprs, final int matchedPattern, final ParseResult parseResult) {
@@ -144,7 +150,7 @@ public class FallingBlockData extends EntityData<FallingBlock> {
 	
 	@Override
 	public EntityData getSuperType() {
-		return new FallingBlockData();
+		return new FallingBlockData(types);
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/entity/FishData.java
+++ b/src/main/java/ch/njol/skript/entity/FishData.java
@@ -43,6 +43,13 @@ public class FishData extends EntityData<Fish> {
 	private boolean wildcard = false;
 	private int pattern = -1;
 	
+	public FishData() {}
+	
+	public FishData(int pattern) {
+		this.pattern = pattern;
+		super.matchedPattern = pattern;
+	}
+	
 	@Override
 	protected boolean init(Literal<?>[] exprs, int matchedPattern, ParseResult parseResult) {
 		if (matchedPattern == 0)
@@ -90,7 +97,7 @@ public class FishData extends EntityData<Fish> {
 
 	@Override
 	public EntityData getSuperType() {
-		return new FishData();
+		return new FishData(pattern);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/entity/FoxData.java
+++ b/src/main/java/ch/njol/skript/entity/FoxData.java
@@ -37,6 +37,13 @@ public class FoxData extends EntityData<Fox> {
 	@Nullable
 	private Type type = null;
 	
+	public FoxData() {}
+	
+	public FoxData(@Nullable Type type) {
+		this.type = type;
+		super.matchedPattern = type == Type.SNOW ? 2 : 1;
+	}
+	
 	@Override
 	protected boolean init(Literal<?>[] exprs, int matchedPattern, ParseResult parseResult) {
 		if (matchedPattern > 0)
@@ -69,7 +76,7 @@ public class FoxData extends EntityData<Fox> {
 	
 	@Override
 	public EntityData getSuperType() {
-		return new FoxData();
+		return new FoxData(type);
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/entity/LlamaData.java
+++ b/src/main/java/ch/njol/skript/entity/LlamaData.java
@@ -46,6 +46,14 @@ public class LlamaData extends EntityData<Llama> {
 	private Color color = null;
 	private boolean isTrader;
 	
+	public LlamaData() {}
+	
+	public LlamaData(@Nullable Color color, boolean isTrader) {
+		this.color = color;
+		this.isTrader = isTrader;
+		super.matchedPattern = (color != null ? (color.ordinal() + 1) : 0) + (isTrader ? 5 : 0);
+	}
+	
 	@Override
 	protected boolean init(Literal<?>[] exprs, int matchedPattern, ParseResult parseResult) {
 		isTrader = TRADER_SUPPORT && matchedPattern > 4;
@@ -62,8 +70,10 @@ public class LlamaData extends EntityData<Llama> {
 	protected boolean init(@Nullable Class<? extends Llama> c, @Nullable Llama llama) {
 		if (TRADER_SUPPORT && c != null)
 			isTrader = c.isAssignableFrom(TraderLlama.class);
-		if (llama != null)
+		if (llama != null) {
 			color = llama.getColor();
+			isTrader = TRADER_SUPPORT && llama instanceof TraderLlama;
+		}
 		return true;
 	}
 	
@@ -92,7 +102,7 @@ public class LlamaData extends EntityData<Llama> {
 	
 	@Override
 	public EntityData getSuperType() {
-		return new LlamaData();
+		return new LlamaData(color, isTrader);
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/entity/MinecartData.java
+++ b/src/main/java/ch/njol/skript/entity/MinecartData.java
@@ -21,13 +21,15 @@ package ch.njol.skript.entity;
 import java.util.ArrayList;
 
 import org.bukkit.entity.Minecart;
+import org.bukkit.entity.minecart.CommandMinecart;
 import org.bukkit.entity.minecart.ExplosiveMinecart;
 import org.bukkit.entity.minecart.HopperMinecart;
+import org.bukkit.entity.minecart.PoweredMinecart;
 import org.bukkit.entity.minecart.RideableMinecart;
 import org.bukkit.entity.minecart.SpawnerMinecart;
+import org.bukkit.entity.minecart.StorageMinecart;
 import org.eclipse.jdt.annotation.Nullable;
 
-import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.Utils;
@@ -41,15 +43,13 @@ public class MinecartData extends EntityData<Minecart> {
 	@SuppressWarnings("null")
 	private static enum MinecartType {
 		ANY(Minecart.class, "minecart"),
-		NORMAL(Skript.classExists("org.bukkit.entity.minecart.RideableMinecart") ? RideableMinecart.class : Minecart.class, "regular minecart"),
-		@SuppressWarnings("unchecked")
-		STORAGE(Skript.classExists("org.bukkit.entity.minecart.StorageMinecart") ? org.bukkit.entity.minecart.StorageMinecart.class : (Class<org.bukkit.entity.minecart.StorageMinecart>) Utils.classForName("org.bukkit.entity.StorageMinecart"), "storage minecart"),
-		@SuppressWarnings("unchecked")
-		POWERED(Skript.classExists("org.bukkit.entity.minecart.PoweredMinecart") ? org.bukkit.entity.minecart.PoweredMinecart.class : (Class<org.bukkit.entity.minecart.StorageMinecart>) Utils.classForName("org.bukkit.entity.PoweredMinecart"), "powered minecart"),
-		// 1.5
-		HOPPER(Skript.classExists("org.bukkit.entity.minecart.HopperMinecart") ? HopperMinecart.class : null, "hopper minecart"),
-		EXPLOSIVE(Skript.classExists("org.bukkit.entity.minecart.ExplosiveMinecart") ? ExplosiveMinecart.class : null, "explosive minecart"),
-		SPAWNER(Skript.classExists("org.bukkit.entity.minecart.SpawnerMinecart") ? SpawnerMinecart.class : null, "spawner minecart");
+		NORMAL(RideableMinecart.class, "regular minecart"),
+		STORAGE(StorageMinecart.class, "storage minecart"),
+		POWERED(PoweredMinecart.class, "powered minecart"),
+		HOPPER(HopperMinecart.class, "hopper minecart"),
+		EXPLOSIVE(ExplosiveMinecart.class, "explosive minecart"),
+		SPAWNER(SpawnerMinecart.class, "spawner minecart"),
+		COMMAND(CommandMinecart.class, "command minecart");
 		
 		@Nullable
 		final Class<? extends Minecart> c;
@@ -88,6 +88,7 @@ public class MinecartData extends EntityData<Minecart> {
 	
 	public MinecartData(final MinecartType type) {
 		this.type = type;
+		this.matchedPattern = type.ordinal();
 	}
 	
 	@SuppressWarnings("null")

--- a/src/main/java/ch/njol/skript/entity/MooshroomData.java
+++ b/src/main/java/ch/njol/skript/entity/MooshroomData.java
@@ -38,6 +38,13 @@ public class MooshroomData extends EntityData<MushroomCow> {
 	@Nullable
 	private Variant variant = null;
 	
+	public MooshroomData() {}
+	
+	public MooshroomData(@Nullable Variant variant) {
+		this.variant = variant;
+		super.matchedPattern = variant == Variant.BROWN ? 2 : 1;
+	}
+	
 	@Override
 	protected boolean init(Literal<?>[] exprs, int matchedPattern, ParseResult parseResult) {
 		if (matchedPattern > 0)
@@ -70,7 +77,7 @@ public class MooshroomData extends EntityData<MushroomCow> {
 	
 	@Override
 	public EntityData getSuperType() {
-		return new MooshroomData();
+		return new MooshroomData(variant);
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/entity/PandaData.java
+++ b/src/main/java/ch/njol/skript/entity/PandaData.java
@@ -27,6 +27,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.localization.Language;
 
 public class PandaData extends EntityData<Panda> {
 	
@@ -37,6 +38,13 @@ public class PandaData extends EntityData<Panda> {
 	
 	@Nullable
 	private Gene mainGene = null, hiddenGene = null;
+	
+	public PandaData() {}
+	
+	public PandaData(@Nullable Gene mainGene, @Nullable Gene hiddenGene) {
+		this.mainGene = mainGene;
+		this.hiddenGene = hiddenGene;
+	}
 	
 	@Override
 	protected boolean init(Literal<?>[] exprs, int matchedPattern, ParseResult parseResult) {
@@ -88,7 +96,7 @@ public class PandaData extends EntityData<Panda> {
 	
 	@Override
 	public EntityData getSuperType() {
-		return new PandaData();
+		return new PandaData(mainGene, hiddenGene);
 	}
 	
 	@Override
@@ -115,4 +123,16 @@ public class PandaData extends EntityData<Panda> {
 		PandaData d = (PandaData) data;
 		return (mainGene == null || mainGene == d.mainGene) && (hiddenGene == null || hiddenGene == d.hiddenGene);
 	}
+	
+	@Override
+	public String toString(int flags) {
+		StringBuilder builder = new StringBuilder();
+		if (mainGene != null)
+			builder.append(Language.getList("genes." + mainGene.name())[0]).append(" ");
+		if (hiddenGene != null && hiddenGene != mainGene)
+			builder.append(Language.getList("genes." + hiddenGene.name())[0]).append(" ");
+		builder.append(Language.get("panda"));
+		return builder.toString();
+	}
+	
 }

--- a/src/main/java/ch/njol/skript/entity/ParrotData.java
+++ b/src/main/java/ch/njol/skript/entity/ParrotData.java
@@ -47,6 +47,13 @@ public class ParrotData extends EntityData<Parrot> {
 	 * we just map enum values to int.
 	 */
 	private int variant;
+	
+	public ParrotData() {}
+	
+	public ParrotData(int variant) {
+		this.variant = variant;
+		super.matchedPattern = variant + 1;
+	}
 
 	@Override
 	protected boolean init(Literal<?>[] exprs, int matchedPattern, ParseResult parseResult) {
@@ -96,7 +103,7 @@ public class ParrotData extends EntityData<Parrot> {
 
 	@Override
 	public EntityData getSuperType() {
-		return new ParrotData();
+		return new ParrotData(variant);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/entity/RabbitData.java
+++ b/src/main/java/ch/njol/skript/entity/RabbitData.java
@@ -36,6 +36,12 @@ public class RabbitData extends EntityData<Rabbit> {
 
     private int type = 0;
     
+    public RabbitData() {}
+    
+    public RabbitData(int type) {
+    	this.type = type;
+    	super.matchedPattern = type;
+	}
 
     @Override
     protected boolean init(Literal<?>[] exprs, int matchedPattern, ParseResult parseResult) {
@@ -68,7 +74,7 @@ public class RabbitData extends EntityData<Rabbit> {
 
     @Override
     public EntityData getSuperType() {
-        return new RabbitData();
+        return new RabbitData(type);
     }
 
     @Override

--- a/src/main/java/ch/njol/skript/entity/VillagerData.java
+++ b/src/main/java/ch/njol/skript/entity/VillagerData.java
@@ -85,6 +85,13 @@ public class VillagerData extends EntityData<Villager> {
 	@Nullable
 	private Profession profession = null;
 	
+	public VillagerData() {}
+	
+	public VillagerData(@Nullable Profession profession) {
+		this.profession = profession;
+		this.matchedPattern = profession != null ? professions.indexOf(profession) + 1 : 0;
+	}
+	
 	@Override
 	protected boolean init(final Literal<?>[] exprs, final int matchedPattern, final ParseResult parseResult) {
 		if (matchedPattern > 0)
@@ -152,7 +159,7 @@ public class VillagerData extends EntityData<Villager> {
 	
 	@Override
 	public EntityData getSuperType() {
-		return new VillagerData();
+		return new VillagerData(profession);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/entity/ZombieVillagerData.java
+++ b/src/main/java/ch/njol/skript/entity/ZombieVillagerData.java
@@ -35,11 +35,13 @@ public class ZombieVillagerData extends EntityData<ZombieVillager> {
 	private final static Villager.Profession[] professions = Villager.Profession.values();
 	
 	static {
-		if (villagerSupport)
+		if (PROFESSION_UPDATE)
+			EntityData.register(ZombieVillagerData.class, "zombie villager", ZombieVillager.class, 0,
+				"zombie villager", "zombie armorer", "zombie butcher", "zombie cartographer", "zombie cleric", "zombie farmer", "zombie fisherman",
+				"zombie fletcher", "zombie leatherworker", "zombie librarian", "zombie mason", "zombie nitwit", "zombie shepherd", "zombie toolsmith", "zombie weaponsmith");
+		else if (villagerSupport)
 			EntityData.register(ZombieVillagerData.class, "zombie villager", ZombieVillager.class, 0,
 					"zombie villager", "zombie farmer", "zombie librarian", "zombie priest", "zombie blacksmith", "zombie butcher", "zombie nitwit");
-		
-		
 	}
 	
 	private Villager.Profession profession = PROFESSION_UPDATE ? Profession.NONE : Profession.valueOf("NORMAL");
@@ -48,6 +50,7 @@ public class ZombieVillagerData extends EntityData<ZombieVillager> {
 	
 	public ZombieVillagerData(Profession prof) {
 		profession = prof;
+		super.matchedPattern = prof.ordinal();
 	}
 
 	@SuppressWarnings("null")
@@ -82,7 +85,7 @@ public class ZombieVillagerData extends EntityData<ZombieVillager> {
 	@SuppressWarnings("null")
 	@Override
 	public void set(final ZombieVillager e) {
-		profession = e.getVillagerProfession();
+		e.setVillagerProfession(profession);
 	}
 	
 	@Override

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -1004,25 +1004,25 @@ entities:
 		name: rabbit¦s
 		pattern: <age> rabbit(|1¦s)|rabbit <age>(|1¦s)
 	brown rabbit:
-		name: rabbit¦s
+		name: brown rabbit¦s
 		pattern: brown <age> rabbit(|1¦s)|brown rabbit <age>(|1¦s)
 	black and white rabbit:
-		name: rabbit¦s
+		name: black and white rabbit¦s
 		pattern: black [and] white <age> rabbit(|1¦s)|black [and] white rabbit <age>(|1¦s)
 	white rabbit:
-		name: rabbit¦s
+		name: white rabbit¦s
 		pattern: white <age> rabbit(|1¦s)|white rabbit <age>(|1¦s)
 	black rabbit:
-		name: rabbit¦s
+		name: black rabbit¦s
 		pattern: black <age> rabbit(|1¦s)|black rabbit <age>(|1¦s)
 	gold rabbit:
-		name: rabbit¦s
+		name: gold rabbit¦s
 		pattern: gold <age> rabbit(|1¦s)|gold rabbit <age>(|1¦s)
 	salt and pepper rabbit:
-		name: rabbit¦s
+		name: salt and pepper rabbit¦s
 		pattern: salt [and] pepper <age> rabbit(|1¦s)|salt [and] pepper rabbit <age>(|1¦s)
 	killer rabbit:
-		name: rabbit¦s
+		name: killer rabbit¦s
 		pattern: killer <age> rabbit(|1¦s)|killer rabbit <age>(|1¦s)
 	fish hook:
 		name: fish hook¦s

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -1075,6 +1075,36 @@ entities:
 	zombie nitwit:
 		name: zombie nitwit¦s
 		pattern: zombie nitwit(|1¦s)
+	zombie armorer:
+		name: zombie armorer¦s
+		pattern: zombie armorer(|1¦s)
+	zombie cartographer:
+		name: zombie cartographer¦s
+		pattern: zombie cartographer(|1¦s)
+	zombie cleric:
+		name: zombie cleric¦s
+		pattern: zombie cleric(|1¦s)
+	zombie fisherman:
+		name: zombie fisher¦man¦men
+		pattern: zombie fisherm(an|1¦en)
+	zombie fletcher:
+		name: zombie fletcher¦s
+		pattern: zombie fletcher(|1¦s)
+	zombie leatherworker:
+		name: zombie leatherworker¦s
+		pattern: zombie leatherworker(|1¦s)
+	zombie mason:
+		name: zombie mason¦s
+		pattern: zombie mason(|1¦s)
+	zombie shepherd:
+		name: zombie shepherd¦s
+		pattern: zombie shepherd(|1¦s)
+	zombie toolsmith:
+		name: zombie toolsmith¦s
+		pattern: zombie toolsmith(|1¦s)
+	zombie weaponsmith:
+		name: zombie weaponsmith¦s
+		pattern: zombie weaponsmith(|1¦s)
 	evoker:
 		name: evoker¦s
 		pattern: evoker(|1¦s)

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -751,6 +751,9 @@ entities:
 	spawner minecart:
 		name: spawner minecart¦s
 		pattern: (monster|mob|) spawner [mine]cart(|1¦s)|[mine]cart(|1¦s) with (monster|mob|) spawner[s]
+	command minecart:
+		name: command minecart¦s
+		pattern: command [mine]cart(|1¦s)|[mine]cart(|1¦s) with command block[s]
 	mooshroom:
 		name: mooshroom¦s
 		pattern: <age> mooshroom(|1¦s)


### PR DESCRIPTION
### Description
This PR aims to fix an issue with EntityData#toString()
Some entities were not returning their full type, ie: minecarts, villagers, foxes, etc. When I started fixed the minecarts I noticed this was an issue with most of the entity datas, so I went thru all of them and fixed them. 
Also fixed some underlying issues, such as missing some zombie villager types.

---
**Target Minecraft Versions:** Any
**Requirements:** None
**Related Issues:** #3456 
