### PR TITLE
BukkitEventValues - add event-value for target in ItemMergeEvent

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -1063,7 +1063,6 @@ public final class BukkitEventValues {
 			}
 		}, 0);
 		//ItemMergeEvent
-		//TODO there is also e.getTarget() two entities involved in this event, currently can be worked around currently with `on item merge of (insert target itemtype)`
 		EventValues.registerEventValue(ItemMergeEvent.class, Item.class, new Getter<Item, ItemMergeEvent>() {
 			@Override
 			@Nullable
@@ -1071,6 +1070,13 @@ public final class BukkitEventValues {
 				return e.getEntity();
 			}
 		}, 0);
+		EventValues.registerEventValue(ItemMergeEvent.class, Item.class, new Getter<Item, ItemMergeEvent>() {
+			@Override
+			@Nullable
+			public Item get(ItemMergeEvent e) {
+				return e.getTarget();
+			}
+		}, 1);
 		EventValues.registerEventValue(ItemMergeEvent.class, ItemType.class, new Getter<ItemType, ItemMergeEvent>() {
 			@Override
 			@Nullable

--- a/src/main/java/ch/njol/skript/events/EvtItem.java
+++ b/src/main/java/ch/njol/skript/events/EvtItem.java
@@ -113,7 +113,8 @@ public class EvtItem extends SkriptEvent {
 					 	"	cancel event")
 				.since("2.2-dev35");
 		Skript.registerEvent("Item Merge", EvtItem.class, ItemMergeEvent.class, "(item[ ][stack]|[item] %-itemtypes%) merg(e|ing)", "item[ ][stack] merg(e|ing) [[of] %-itemtypes%]")
-				.description("Called when dropped items merge into a single stack.")
+				.description("Called when dropped items merge into a single stack. event-entity will be the entity which is trying to merge, " +
+						"and future event-entity will be the entity which is being merged into.")
 				.examples("on item merge of gold blocks:",
 					 	"	cancel event")
 				.since("2.2-dev35");


### PR DESCRIPTION
### Description
This PR aims to resolve an issue with the ItemMergeEvent, allow the user to grab the target entity (the entity in which the item is merging into)
I set it up as a future event-entity and it works quite well ... yay!

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
