### PR TITLE
ExprNumbers bugfixes and decimal iterator revamp

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprNumbers.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNumbers.java
@@ -97,14 +97,13 @@ public class ExprNumbers extends SimpleExpression<Number> {
 				list.add((long) low + i);
 			}
 		} else if (mode == 2) {
-			final double amount = f.doubleValue() - s.doubleValue() + 1;
 			
-			final String[] split = s.toString().split("\\.");
+			final String[] split = (reverse ? f : s).toString().split("\\.");
 			final int numberAccuracy = SkriptConfig.numberAccuracy.value();
-			int precision = Math.min(split.length > 1 ? split[1].length() : numberAccuracy, numberAccuracy);
+			int precision = Math.min(split.length > 1 ? split[1].length() : 0, numberAccuracy);
 			
 			final double multiplier = Math.pow(10, precision);
-			for (int i = (int) (s.doubleValue() * multiplier); i <= f.doubleValue() * multiplier; i++) {
+			for (int i = (int) Math.ceil(s.doubleValue() * multiplier); i <= Math.floor(f.doubleValue() * multiplier); i++) {
 				list.add((i / multiplier));
 			}
 		}
@@ -148,25 +147,29 @@ public class ExprNumbers extends SimpleExpression<Number> {
 			};
 		} else {
 			return new Iterator<Number>() {
-				final double start = starting.doubleValue();
+				final double min = starting.doubleValue();
 				final double max = finish.doubleValue();
-				final String[] split = starting.toString().split("\\.");
-				final int precision = split.length > 0 ? split[1].length() : 0;
-			
+				
+				final String[] split = (reverse ? finish : starting).toString().split("\\.");
+				final int numberAccuracy = SkriptConfig.numberAccuracy.value();
+				final int precision = Math.min(split.length > 1 ? split[1].length() : 0, numberAccuracy);
 				final double multiplier = Math.pow(10, precision);
-				int current = reverse ? (int) (max * multiplier - 1) : (int) (start * multiplier);
+				
+				final int intMax = (int) Math.floor(max * multiplier);
+				final int intMin = (int) Math.ceil (min * multiplier);
+				int current = reverse ? intMax : intMin;
 				
 				@Override
 				public boolean hasNext() {
-					return reverse ? current > start : current < max * multiplier;
+					return reverse ? (current >= intMin) : (current <= intMax);
 				}
 				
 				@Override
 				public Number next() {
 					if (!hasNext())
 						throw new NoSuchElementException();
-					double value = start + current / multiplier;
-					current = reverse ? current - 1 : current + 1;
+					double value = current / multiplier;
+					current += reverse ? -1 : 1;
 					return value;
 				}
 			};


### PR DESCRIPTION
### Description
Completely revamped decimals between's iterator to fix an issue, also made some changes to fix rounding errors and always choose the first number's decimal precision (regardless of which is larger).

---
**Target Minecraft Versions:** any
**Related Issues:** #3494 
