### PR TITLE
Improve public syntax information API 

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -1295,7 +1295,7 @@ public final class Skript extends JavaPlugin implements Listener {
 		if (returnType.isAnnotation() || returnType.isArray() || returnType.isPrimitive())
 			throw new IllegalArgumentException("returnType must be a normal type");
 		String originClassPath = Thread.currentThread().getStackTrace()[2].getClassName();
-		final ExpressionInfo<E, T> info = new ExpressionInfo<>(patterns, returnType, c, originClassPath);
+		final ExpressionInfo<E, T> info = new ExpressionInfo<>(patterns, returnType, c, originClassPath, type);
 		for (int i = type.ordinal() + 1; i < ExpressionType.values().length; i++) {
 			expressionTypesStartIndices[i]++;
 		}

--- a/src/main/java/ch/njol/skript/lang/ExpressionInfo.java
+++ b/src/main/java/ch/njol/skript/lang/ExpressionInfo.java
@@ -21,10 +21,12 @@ package ch.njol.skript.lang;
 public class ExpressionInfo<E extends Expression<T>, T> extends SyntaxElementInfo<E> {
 	
 	public Class<T> returnType;
+	public ExpressionType expressionType;
 	
-	public ExpressionInfo(final String[] patterns, final Class<T> returnType, final Class<E> c, final String originClassPath) throws IllegalArgumentException {
+	public ExpressionInfo(final String[] patterns, final Class<T> returnType, final Class<E> c, final String originClassPath, ExpressionType expressionType) throws IllegalArgumentException {
 		super(patterns, c, originClassPath);
 		this.returnType = returnType;
+		this.expressionType = expressionType;
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/lang/ExpressionInfo.java
+++ b/src/main/java/ch/njol/skript/lang/ExpressionInfo.java
@@ -29,4 +29,19 @@ public class ExpressionInfo<E extends Expression<T>, T> extends SyntaxElementInf
 		this.expressionType = expressionType;
 	}
 	
+	/**
+	 * Get the return type of this expression.
+	 * @return The return type of this Expression
+	 */
+	public Class<T> getReturnType() {
+		return returnType;
+	}
+	
+	/**
+	 * Get the type of this expression.
+	 * @return The type of this Expression
+	 */
+	public ExpressionType getExpressionType() {
+		return expressionType;
+	}
 }

--- a/src/main/java/ch/njol/skript/lang/SyntaxElementInfo.java
+++ b/src/main/java/ch/njol/skript/lang/SyntaxElementInfo.java
@@ -18,6 +18,8 @@
  */
 package ch.njol.skript.lang;
 
+import java.util.Arrays;
+
 /**
  * @author Peter Güttinger
  * @param <E> the syntax element this info is for
@@ -57,7 +59,7 @@ public class SyntaxElementInfo<E extends SyntaxElement> {
 	 * @return Array of Skript patterns for this element
 	 */
 	public String[] getPatterns() {
-		return patterns;
+		return Arrays.copyOf(patterns, patterns.length);
 	}
 	
 	/**

--- a/src/main/java/ch/njol/skript/lang/SyntaxElementInfo.java
+++ b/src/main/java/ch/njol/skript/lang/SyntaxElementInfo.java
@@ -44,4 +44,27 @@ public class SyntaxElementInfo<E extends SyntaxElement> {
 		}
 	}
 	
+	/**
+	 * Get the class that represents this element.
+	 * @return The Class of the element
+	 */
+	public Class<E> getElementClass() {
+		return c;
+	}
+	
+	/**
+	 * Get the patterns of this syntax element.
+	 * @return Array of Skript patterns for this element
+	 */
+	public String[] getPatterns() {
+		return patterns;
+	}
+	
+	/**
+	 * Get the original classpath for this element.
+	 * @return The original ClassPath for this element
+	 */
+	public String getOriginClassPath() {
+		return originClassPath;
+	}
 }

--- a/src/main/java/ch/njol/skript/lang/function/Parameter.java
+++ b/src/main/java/ch/njol/skript/lang/function/Parameter.java
@@ -66,6 +66,10 @@ public final class Parameter<T> {
 		this.single = single;
 	}
 	
+	/**
+	 * Get the Type of this parameter.
+	 * @return Type of the parameter
+	 */
 	public ClassInfo<T> getType() {
 		return type;
 	}
@@ -132,8 +136,30 @@ public final class Parameter<T> {
 		return new Parameter<>(name, type, single, d);
 	}
 	
+	/**
+	 * Get the name of this parameter.
+	 * <p>Will be used as name for the local variable that contains value of it inside function.</p>
+	 * @return Name of this parameter
+	 */
 	public String getName() {
 		return name;
+	}
+	
+	/**
+	 * Get the Expression that will be used to provide the default value of this parameter when the function is called.
+	 * @return Expression that will provide default value of this parameter
+	 */
+	@Nullable
+	public Expression<? extends T> getDefaultExpression() {
+		return def;
+	}
+	
+	/**
+	 * Get whether this parameter takes one or many values.
+	 * @return True if this parameter takes one value, false otherwise
+	 */
+	public boolean isSingleValue() {
+		return single;
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/localization/Language.java
+++ b/src/main/java/ch/njol/skript/localization/Language.java
@@ -62,6 +62,32 @@ public class Language {
 	 */
 	private static String name = "english";
 	
+	/**
+	 * Get if Skript uses the Localized language instead of English.
+	 * @return True if Skript uses the Localized language elements, false otherwise
+	 */
+	public static boolean isUsingLocalizedLanguage() {
+		return useLocal;
+	}
+	
+	/**
+	 * Get elements of the English language of Skript syntax.
+	 * @return A copy of all the elements of the English language
+	 */
+	public static HashMap<String, String> getEnglishLanguage() {
+		return new HashMap<>(english);
+	}
+	
+	/**
+	 * Get elements of the Localized language of Skript syntax.
+	 * @return A copy of all the elements of the Localized language
+	 */
+	@Nullable
+	public static HashMap<String, String> getLocalized() {
+		if (localized != null) return new HashMap<>(localized);
+		return localized;
+	}
+	
 	final static HashMap<String, String> english = new HashMap<>();
 	/**
 	 * May be null.

--- a/src/main/java/ch/njol/skript/localization/Language.java
+++ b/src/main/java/ch/njol/skript/localization/Language.java
@@ -84,7 +84,8 @@ public class Language {
 	 */
 	@Nullable
 	public static HashMap<String, String> getLocalized() {
-		if (localized != null) return new HashMap<>(localized);
+		if (localized != null)
+			return new HashMap<>(localized);
 		return localized;
 	}
 	

--- a/src/main/java/ch/njol/skript/registrations/EventValues.java
+++ b/src/main/java/ch/njol/skript/registrations/EventValues.java
@@ -82,7 +82,8 @@ public class EventValues {
 		@Nullable
 		@SuppressWarnings("null")
 		public Class<? extends E>[] getExcludes() {
-			if (excludes != null) return Arrays.copyOf(excludes, excludes.length);
+			if (excludes != null)
+				return Arrays.copyOf(excludes, excludes.length);
 			return new Class[0];
 		}
 		

--- a/src/main/java/ch/njol/skript/registrations/EventValues.java
+++ b/src/main/java/ch/njol/skript/registrations/EventValues.java
@@ -19,6 +19,7 @@
 package ch.njol.skript.registrations;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.bukkit.event.Event;
@@ -79,8 +80,10 @@ public class EventValues {
 		 * @return The classes of the Excludes associated with this event value
 		 */
 		@Nullable
+		@SuppressWarnings("null")
 		public Class<? extends E>[] getExcludes() {
-			return excludes;
+			if (excludes != null) return Arrays.copyOf(excludes, excludes.length);
+			return new Class[0];
 		}
 		
 		/**

--- a/src/main/java/ch/njol/skript/registrations/EventValues.java
+++ b/src/main/java/ch/njol/skript/registrations/EventValues.java
@@ -56,6 +56,40 @@ public class EventValues {
 			this.excludes = excludes;
 			this.excludeErrorMessage = excludeErrorMessage;
 		}
+		
+		/**
+		 * Get the class that represents the Event.
+		 * @return The class of the Event associated with this event value
+		 */
+		public Class<E> getEventClass() {
+			return event;
+		}
+		
+		/**
+		 * Get the class that represents Value.
+		 * @return The class of the Value associated with this event value
+		 */
+		public Class<T> getValueClass() {
+			return c;
+		}
+		
+		/**
+		 * Get the classes that represent the excluded for this Event value.
+		 * @return The classes of the Excludes associated with this event value
+		 */
+		@Nullable
+		public Class<? extends E>[] getExcludes() {
+			return excludes;
+		}
+		
+		/**
+		 * Get the error message used when encountering an exclude value.
+		 * @return The error message to use when encountering an exclude
+		 */
+		@Nullable
+		public String getExcludeErrorMessage() {
+			return excludeErrorMessage;
+		}
 	}
 	
 	private final static List<EventValueInfo<?, ?>> defaultEventValues = new ArrayList<>(30);

--- a/src/main/java/ch/njol/skript/registrations/EventValues.java
+++ b/src/main/java/ch/njol/skript/registrations/EventValues.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
+import com.google.common.collect.ImmutableList;
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Converter;
 import ch.njol.skript.expressions.base.EventValueExpression;
@@ -95,6 +96,31 @@ public class EventValues {
 	private final static List<EventValueInfo<?, ?>> defaultEventValues = new ArrayList<>(30);
 	private final static List<EventValueInfo<?, ?>> futureEventValues = new ArrayList<>();
 	private final static List<EventValueInfo<?, ?>> pastEventValues = new ArrayList<>();
+	
+	/**
+	 * The past time of an event value. Represented by "past" or "former".
+	 */
+	public static final int TIME_PAST = -1;
+	
+	/**
+	 * The current time of an event value.
+	 */
+	public static final int TIME_NOW = 0;
+	
+	/**
+	 * The future time of an event value.
+	 */
+	public static final int TIME_FUTURE = 1;
+	
+	/**
+	 * Get Event Values list for the specified time
+	 * @param time The time of the event values. One of
+	 * {@link EventValues#TIME_PAST}, {@link EventValues#TIME_NOW} or {@link EventValues#TIME_FUTURE}.
+	 * @return An immutable copy of the event values list for the specified time
+	 */
+	public static List<EventValueInfo<?, ?>> getEventValuesListForTime(int time) {
+		return ImmutableList.copyOf(getEventValuesList(time));
+	}
 	
 	private static List<EventValueInfo<?, ?>> getEventValuesList(int time) {
 		if (time == -1)


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

This PR introduces some changes that will allow documentation extraction tools like ResourceSync(skUnity), [SkriptHubDocsTool](https://github.com/SkriptHub/SkriptHubDocsTool) (Skript Hub) and [DocExtractionTool](https://github.com/SkriptInsight/DocExtractionTool)(SkriptInsight) to have a more consistent API for extracting information. They, and new others will benefit from these changes.

Some of the changes include the following:
 - Store and expose Skript Expression types (The expression order is different depending on the expression's type)
 - Expose Syntax Element information with getters
 - Expose Event Value information with getters
 - Expose Language information with getters
 - Expose Function Parameter information with getters

### Why this change?

When tools need to fetch information from Skript, they have to resort to using Reflection.

https://github.com/SkriptHub/SkriptHubDocsTool/blob/70ae1be649a6797e98e2b108ebaee518d6789f65/src/main/java/net/skripthub/docstool/utils/EventValuesGetter.java#L28-L40

---
**Target Minecraft Versions:** any<!-- 'any' means all supported versions -->
