### PR TITLE
ExprOffTool - fix an issue with bucket event and offhand actually returning main hand

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprOffTool.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprOffTool.java
@@ -64,7 +64,7 @@ public class ExprOffTool extends ExprTool {
 					} else if (e instanceof PlayerBucketEvent && ((PlayerBucketEvent) e).getPlayer() == p) {
 						final PlayerInventory i = ((PlayerBucketEvent) e).getPlayer().getInventory();
 						assert i != null;
-						return new InventorySlot(i, ((PlayerBucketEvent) e).getPlayer().getInventory().getHeldItemSlot()) {
+						return new InventorySlot(i, 40) { // 40 = offhand slot
 							@Override
 							@Nullable
 							public ItemStack getItem() {


### PR DESCRIPTION
### Description
This PR aims to fix an issue with getting the offhand tool in a bucket event. It is returning the main hand, when it should be returning the offhand.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #3584 
