### PR TITLE
ExprSubstring - fix an error with `start` being null

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprSubstring.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSubstring.java
@@ -105,7 +105,7 @@ public class ExprSubstring extends SimpleExpression<String> {
 	@Override
 	@SuppressWarnings("null")
 	public boolean isSingle() {
-		return string.isSingle() && start.isSingle();
+		return string.isSingle() && (start == null || start.isSingle());
 	}
 	
 	@Override


### PR DESCRIPTION
### Description
This PR aims to fix an issue with ExprSubstring throwing an error

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #3585 
