### PR TITLE
Re-set local variables after async teleporation

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffTeleport.java
+++ b/src/main/java/ch/njol/skript/effects/EffTeleport.java
@@ -88,12 +88,18 @@ public class EffTeleport extends Effect {
 			return null;
 		}
 		
-		//This will either fetch the chunk instantly if on spigot or already loaded or fetch it async if on paper.
+		Object localVars = Variables.removeLocals(e);
+		
+		// This will either fetch the chunk instantly if on spigot or already loaded or fetch it async if on paper.
 		PaperLib.getChunkAtAsync(loc).thenAccept(chunk -> {
 			// The following is now on the main thread
 			for (final Entity entity : entityArray) {
 				entity.teleport(getSafeLocation(loc));
 			}
+
+			// Re-set local variables
+			if (localVars != null)
+				Variables.setLocalVariables(e, localVars);
 			
 			// Continue the rest of the trigger if there is one
 			continueWalk(next, e);


### PR DESCRIPTION
### Description
This saves and then re-sets local variables after the teleportation. I think I did everything right (I haven't actually worked with async effects before), but if there is anything else I should change reviews are very appreciated. This seemed to fix the issue when I tested it.

---
**Target Minecraft Versions:** All
**Requirements:** None
**Related Issues:** #3605 
