### PR TITLE
BlocksWithin - fix issue with bound being smaller than expected

### DIFF
--- a/src/main/java/ch/njol/skript/util/AABB.java
+++ b/src/main/java/ch/njol/skript/util/AABB.java
@@ -48,8 +48,8 @@ public class AABB implements Iterable<Block> {
 		if (l1.getWorld() != l2.getWorld())
 			throw new IllegalArgumentException("Locations must be in the same world");
 		world = l1.getWorld();
-		lowerBound = new Vector(Math.min(l1.getX(), l2.getX()), Math.min(l1.getY(), l2.getY()), Math.min(l1.getZ(), l2.getZ()));
-		upperBound = new Vector(Math.max(l1.getX(), l2.getX()), Math.max(l1.getY(), l2.getY()), Math.max(l1.getZ(), l2.getZ()));
+		lowerBound = new Vector(Math.min(l1.getBlockX(), l2.getBlockX()), Math.min(l1.getBlockY(), l2.getBlockY()), Math.min(l1.getBlockZ(), l2.getBlockZ()));
+		upperBound = new Vector(Math.max(l1.getBlockX(), l2.getBlockX()), Math.max(l1.getBlockY(), l2.getBlockY()), Math.max(l1.getBlockZ(), l2.getBlockZ()));
 	}
 	
 	public AABB(final Block b1, final Block b2) {
@@ -109,9 +109,9 @@ public class AABB implements Iterable<Block> {
 			private final int minX = Math2.ceilI(lowerBound.getX() - Skript.EPSILON),
 					minY = Math2.ceilI(lowerBound.getY() - Skript.EPSILON),
 					minZ = Math2.ceilI(lowerBound.getZ() - Skript.EPSILON);
-			private final int maxX = Math2.floorI(upperBound.getX() + Skript.EPSILON) - 1,
-					maxY = Math2.floorI(upperBound.getY() + Skript.EPSILON) - 1,
-					maxZ = Math2.floorI(upperBound.getZ() + Skript.EPSILON) - 1;
+			private final int maxX = Math2.floorI(upperBound.getX() + Skript.EPSILON),
+					maxY = Math2.floorI(upperBound.getY() + Skript.EPSILON),
+					maxZ = Math2.floorI(upperBound.getZ() + Skript.EPSILON);
 			
 			private int x = minX - 1,// next() increases x by one immediately
 					y = minY,


### PR DESCRIPTION
### Description
This PR aims to fix an issue with the `blocks within` expression, where the bounding box is smaller than expected.
This was due to the AABB class shrinking when it shouldn't be

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #3615 
