### PR TITLE
Fix EvtEntity event-location

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -406,6 +406,13 @@ public final class BukkitEventValues {
 				return e.getEntity().getWorld();
 			}
 		}, 0);
+		EventValues.registerEventValue(EntityEvent.class, Location.class, new Getter<Location, EntityEvent>() {
+			@Override
+			@Nullable
+			public Location get(final EntityEvent e) {
+				return e.getEntity().getLocation();
+			}
+		}, 0);
 		// EntityDamageEvent
 		EventValues.registerEventValue(EntityDamageEvent.class, DamageCause.class, new Getter<DamageCause, EntityDamageEvent>() {
 			@Override


### PR DESCRIPTION
### Description
This fixes the CCE thrown by using event-location in EvtSpawn.
It seemed to be a result of the event change in #3427.

I had no issues during testing. I also made sure ExprSpawnReason was still working right, since the event changed, and I had no issues with it. It just returns null if it is a non-living entity

---
**Target Minecraft Versions:** Any
**Requirements:** None
**Related Issues:** #3622 
