### PR TITLE
ExpressionInfo - fix an issue with a previous change that has broken …

### DIFF
--- a/src/main/java/ch/njol/skript/lang/ExpressionInfo.java
+++ b/src/main/java/ch/njol/skript/lang/ExpressionInfo.java
@@ -18,12 +18,19 @@
  */
 package ch.njol.skript.lang;
 
+import org.eclipse.jdt.annotation.Nullable;
+
 public class ExpressionInfo<E extends Expression<T>, T> extends SyntaxElementInfo<E> {
 	
 	public Class<T> returnType;
+	@Nullable
 	public ExpressionType expressionType;
 	
-	public ExpressionInfo(final String[] patterns, final Class<T> returnType, final Class<E> c, final String originClassPath, ExpressionType expressionType) throws IllegalArgumentException {
+	public ExpressionInfo(final String[] patterns, final Class<T> returnType, final Class<E> c, final String originClassPath) throws IllegalArgumentException {
+		this(patterns, returnType, c, originClassPath, null);
+	}
+	
+	public ExpressionInfo(final String[] patterns, final Class<T> returnType, final Class<E> c, final String originClassPath, @Nullable ExpressionType expressionType) throws IllegalArgumentException {
 		super(patterns, c, originClassPath);
 		this.returnType = returnType;
 		this.expressionType = expressionType;
@@ -41,6 +48,7 @@ public class ExpressionInfo<E extends Expression<T>, T> extends SyntaxElementInf
 	 * Get the type of this expression.
 	 * @return The type of this Expression
 	 */
+	@Nullable
 	public ExpressionType getExpressionType() {
 		return expressionType;
 	}


### PR DESCRIPTION
### Description
This PR aims to fix an issue with the recent API changes to ExpressionInfo that has broken a couple of addons.
Adding back in the original constructor.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #3624 
