### PR TITLE
Apply new line (`%nr%`) in item lore correctly

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprItemWithLore.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprItemWithLore.java
@@ -19,6 +19,8 @@
 package ch.njol.skript.expressions;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.bukkit.event.Event;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -62,10 +64,13 @@ public class ExprItemWithLore extends PropertyExpression<ItemType, ItemType> {
 
 	@Override
 	protected ItemType[] get(Event e, ItemType[] source) {
-		String[] lore = this.lore.getArray(e);
+		List<String> lore = Arrays.stream(this.lore.getArray(e))
+			.flatMap(l -> Arrays.stream(l.split("\n").clone()))
+			.collect(Collectors.toList());
+
 		return get(source, item -> {
 			ItemMeta meta = item.getItemMeta();
-			meta.setLore(Arrays.asList(lore));
+			meta.setLore(lore);
 			item.setItemMeta(meta);
 			return item;
 		});

--- a/src/main/java/ch/njol/skript/expressions/ExprItemWithLore.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprItemWithLore.java
@@ -64,7 +64,7 @@ public class ExprItemWithLore extends PropertyExpression<ItemType, ItemType> {
 
 	@Override
 	protected ItemType[] get(Event e, ItemType[] source) {
-		List<String> lore = Arrays.stream(this.lore.getArray(e))
+		List<String> lore = this.lore.stream(e)
 			.flatMap(l -> Arrays.stream(l.split("\n")))
 			.collect(Collectors.toList());
 

--- a/src/main/java/ch/njol/skript/expressions/ExprItemWithLore.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprItemWithLore.java
@@ -65,7 +65,7 @@ public class ExprItemWithLore extends PropertyExpression<ItemType, ItemType> {
 	@Override
 	protected ItemType[] get(Event e, ItemType[] source) {
 		List<String> lore = Arrays.stream(this.lore.getArray(e))
-			.flatMap(l -> Arrays.stream(l.split("\n").clone()))
+			.flatMap(l -> Arrays.stream(l.split("\n")))
 			.collect(Collectors.toList());
 
 		return get(source, item -> {

--- a/src/test/skript/tests/syntaxes/expressions/ExprItemWithLore.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprItemWithLore.sk
@@ -1,6 +1,6 @@
 test "item with lore as one string without newline":
-	set {_i1} to 1 of stone with lore "one line"
-	assert the line 1 of lore of {_i1} is "has correct first line"
+	set {_i1} to 1 of stone with lore "first line"
+	assert the line 1 of lore of {_i1} is "first line" with "has correct first line"
 
 test "item with lore as multiple string without newline":
 	set {_i2} to 1 of stone with lore "first line" and "second line"

--- a/src/test/skript/tests/syntaxes/expressions/ExprItemWithLore.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprItemWithLore.sk
@@ -1,0 +1,19 @@
+test "item with lore as one string without newline":
+	set {_i1} to 1 of stone with lore "one line"
+	assert the line 1 of lore of {_i1} is "has correct first line"
+
+test "item with lore as multiple string without newline":
+	set {_i2} to 1 of stone with lore "first line" and "second line"
+	assert the line 1 of lore of {_i2} is "first line" with "has correct first line"
+	assert the line 2 of lore of {_i2} is "second line" with "has correct second line"
+
+test "item with lore as one string with newline":
+	set {_i3} to 1 of stone with lore "first line%nl%second line"
+	assert the line 1 of lore of {_i3} is "first line" with "has correct first line"
+	assert the line 2 of lore of {_i3} is "second line" with "has correct second line"
+
+test "item with lore as multiple string with newline":
+	set {_i4} to 1 of stone with lore "first line%nl%second line" and "third line"
+	assert the line 1 of lore of {_i4} is "first line" with "has correct first line"
+	assert the line 2 of lore of {_i4} is "second line" with "has correct second line"
+	assert the line 3 of lore of {_i4} is "third line" with "has correct third line"


### PR DESCRIPTION
### Description
Apply new line (`%nr%`) in item lore. It seems that #2505 forgot this.

e.g.
`1 of stone with lore "first line%nl%second line"`

[The test case](https://github.com/SkriptLang/Skript/pull/3636/files#diff-840322c377d70914e2d9a5072c844f83cbf7155c5ba9b3caaa60ee37d3b4cf5a) describes the behavior well.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #3544.
