### PR TITLE
ExprRawName - fix an error from the toString method

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprRawName.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprRawName.java
@@ -78,8 +78,7 @@ public class ExprRawName extends SimpleExpression<String> {
 	@SuppressWarnings("null")
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
-		String[] strs = get(e);
-		if (strs == null) return "";
-		return Arrays.toString(strs);
+		return "minecraft name of " + types.toString(e, debug);
 	}
+	
 }


### PR DESCRIPTION
### Description
This PR aims to fix an NPE error when using this expression in a string, ie:
```vb
send "%minecraft name of player's tool%"
```
should return
```
[02:49:08 WARN]: [Skript] minecraft name of the tool of the player is already a text, so you should not put it in one (e.g. minecraft name of the tool of the player instead of "%minecraft name of the tool of the player%") (test.sk, line 6: send "%minecraft name of player's tool%"')
```
but instead its throwing an error.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
