### PR TITLE
NewBlockCompat - fix issue with bisected blocks alternatively placing

### DIFF
--- a/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
@@ -197,7 +197,7 @@ public class NewBlockCompat implements BlockCompat {
 				if (Bed.class.isAssignableFrom(dataType)) {
 					Bed data;
 					if (ourValues != null)
-						data = (Bed) ourValues.data;
+						data = (Bed) ourValues.data.clone();
 					else
 						data = (Bed) Bukkit.createBlockData(type);
 					
@@ -229,7 +229,7 @@ public class NewBlockCompat implements BlockCompat {
 				if (Bisected.class.isAssignableFrom(dataType) && !Tag.STAIRS.isTagged(type) && !Tag.TRAPDOORS.isTagged(type)) {
 					Bisected data;
 					if (ourValues != null)
-						data = (Bisected) ourValues.data;
+						data = (Bisected) ourValues.data.clone();
 					else
 						data = (Bisected) Bukkit.createBlockData(type);
 					


### PR DESCRIPTION
### Description
When setting a block to a bisected block (such as a door or bed), it will alternate the bisection.
ie: set a block to a door, it sets correctly. Repeat that task, and it will set at the block below. This is caused by Skript changing the ItemType's ItemData to the opposing bisection, causing blocks to alternate. 
By cloning the original data, we don't have to change it.

---
**Target Minecraft Versions:** 1.13+
**Requirements:** None
**Related Issues:** #2473 
