### PR TITLE
PatcherTool - fix issue when building on Gradle 6

### DIFF
--- a/src/main/java/ch/njol/skript/PatcherTool.java
+++ b/src/main/java/ch/njol/skript/PatcherTool.java
@@ -68,8 +68,8 @@ public class PatcherTool {
 		}
 		
 		// Open jars and patch target
-		try (FileSystem source = FileSystems.newFileSystem(currentFile, null); 
-				FileSystem target = FileSystems.newFileSystem(patchedFile, null)) {
+		try (FileSystem source = FileSystems.newFileSystem(currentFile, (ClassLoader) null);
+				FileSystem target = FileSystems.newFileSystem(patchedFile, (ClassLoader) null)) {
 			assert source != null;
 			assert target != null;
 			new PatcherTool(source, target).patch(options);


### PR DESCRIPTION
### Description
This PR aims to fix an issue when attempting to build Skript on Gradle 6

Edit: According to my gradle thing, I wasn't actually using gradle 6. But using the gradle buttons in IntelliJ, I was forced to change this class for it to build. Regardless, this will help in the future when we update to Gradle 6. 

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
