### PR TITLE
AABB - fix an issue with blocks in WG regions also looping blocks 1 outside the region

### DIFF
--- a/src/main/java/ch/njol/skript/util/AABB.java
+++ b/src/main/java/ch/njol/skript/util/AABB.java
@@ -71,7 +71,7 @@ public class AABB implements Iterable<Block> {
 	public AABB(final World w, final Vector v1, final Vector v2) {
 		world = w;
 		lowerBound = new Vector(Math.min(v1.getX(), v2.getX()), Math.min(v1.getY(), v2.getY()), Math.min(v1.getZ(), v2.getZ()));
-		upperBound = new Vector(Math.max(v1.getX(), v2.getX()) + 1, Math.max(v1.getY(), v2.getY()) + 1, Math.max(v1.getZ(), v2.getZ()) + 1);
+		upperBound = new Vector(Math.max(v1.getX(), v2.getX()), Math.max(v1.getY(), v2.getY()), Math.max(v1.getZ(), v2.getZ()));
 	}
 	
 	public AABB(final Chunk c) {


### PR DESCRIPTION
### Description
This PR aims to fix an issue with the blocks in region expression, returning blocks 1 outside of the region.
In a previous change to AABB I broke it, and when I fixed it, I didn't fix the constructor that is used by WG.
This fixes that issue... 3rd times a charm.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #3707 
