### PR TITLE
Fix stackoverflow error with teleport effect

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffTeleport.java
+++ b/src/main/java/ch/njol/skript/effects/EffTeleport.java
@@ -24,6 +24,7 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
+import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -77,13 +78,19 @@ public class EffTeleport extends Effect {
 		
 		final Location loc = location.getSingle(e);
 		final Entity[] entityArray = entities.getArray(e); // We have to fetch this before possible async execution to avoid async local variable access.
+		
 		final boolean respawnEvent = !delayed && e instanceof PlayerRespawnEvent && entityArray.length == 1 && entityArray[0].equals(((PlayerRespawnEvent) e).getPlayer());
+		final boolean moveEvent = !delayed && e instanceof PlayerMoveEvent && entityArray.length == 1 && entityArray[0].equals(((PlayerMoveEvent) e).getPlayer());
 		
 		if (respawnEvent && loc != null) {
 			((PlayerRespawnEvent) e).setRespawnLocation(getSafeLocation(loc));
 		}
 		
-		if (respawnEvent || loc == null) {
+		if (moveEvent && loc != null) {
+			((PlayerMoveEvent) e).setTo(getSafeLocation(loc));
+		}
+		
+		if ((respawnEvent || moveEvent) || loc == null) {
 			continueWalk(next, e);
 			return null;
 		}


### PR DESCRIPTION
### Description
Teleporting a player in a move event causes a StackOverFlowError since teleportation trigger move event too, and this repeats. The correct way is to use PlayerMoveEvent#setTo instead.

While Skript does not provide a PlayerMoveEvent by default, some add-ons do. This fixes the teleport effect's behaviour on move events.

---
**Target Minecraft Versions:** any<!-- 'any' means all supported versions -->
**Requirements:** none<!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** can't remember but I saw one long time ago<!-- Links to related issues -->
