### PR TITLE
Show right amount of loaded commands after reload

### DIFF
--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -637,8 +637,8 @@ final public class ScriptLoader {
 						if (c != null) {
 							commands.add(c);
 							i.commandNames.add(c.getName()); // For tab completion
+							i.commands++;
 						}
-						i.commands++;
 						
 						deleteCurrentEvent();
 						
@@ -650,8 +650,8 @@ final public class ScriptLoader {
 						final Function<?> func = Functions.loadFunction(node);
 						if (func != null) {
 							functions.add(func);
+							i.functions++;
 						}
-						i.functions++;
 						
 						deleteCurrentEvent();
 						


### PR DESCRIPTION
### Description
Skript displays the wrong amount of commands (and functions, if that was displayed) when reloading all scripts (or when reloading a specific script with log verbosity 'high'). Example:
```
command [[[[[[:
	trigger:
		stop
command [[[[[[:
	trigger:
		stop
command [[[[[[:
	trigger:
		stop
command [[[[[[:
	trigger:
		stop
command [[[[[[:
	trigger:
		stop
```
![image](https://user-images.githubusercontent.com/29547183/105746920-5c899c00-5f40-11eb-827e-75a7957d7724.png)

---
**Target Minecraft Versions:** any
**Requirements:** nony
**Related Issues:** none
