### PR TITLE
Handle cancellation of ServerCommandEvent properly

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -1388,7 +1388,7 @@ public final class Skript extends JavaPlugin implements Listener {
 			} else {
 				final ServerCommandEvent e = new ServerCommandEvent(sender, command);
 				Bukkit.getPluginManager().callEvent(e);
-				if (e.getCommand().isEmpty())
+				if (e.getCommand().isEmpty() || e.isCancelled())
 					return false;
 				return Bukkit.dispatchCommand(e.getSender(), e.getCommand());
 			}

--- a/src/main/java/ch/njol/skript/SkriptEventHandler.java
+++ b/src/main/java/ch/njol/skript/SkriptEventHandler.java
@@ -136,7 +136,7 @@ public abstract class SkriptEventHandler {
 		
 		if (e instanceof Cancellable && ((Cancellable) e).isCancelled() && !listenCancelled.contains(e.getClass()) &&
 				!(e instanceof PlayerInteractEvent && (((PlayerInteractEvent) e).getAction() == Action.LEFT_CLICK_AIR || ((PlayerInteractEvent) e).getAction() == Action.RIGHT_CLICK_AIR) && ((PlayerInteractEvent) e).useItemInHand() != Result.DENY)
-				|| e instanceof ServerCommandEvent && ((ServerCommandEvent) e).getCommand().isEmpty()) {
+				|| e instanceof ServerCommandEvent && (((ServerCommandEvent) e).getCommand().isEmpty() || ((ServerCommandEvent) e).isCancelled())) {
 			if (Skript.logVeryHigh())
 				Skript.info(" -x- was cancelled");
 			return;

--- a/src/main/java/ch/njol/skript/command/Commands.java
+++ b/src/main/java/ch/njol/skript/command/Commands.java
@@ -169,7 +169,7 @@ public abstract class Commands {
 		@SuppressWarnings("null")
 		@EventHandler(priority = EventPriority.HIGHEST)
 		public void onServerCommand(final ServerCommandEvent e) {
-			if (e.getCommand() == null || e.getCommand().isEmpty())
+			if (e.getCommand() == null || e.getCommand().isEmpty() || e.isCancelled())
 				return;
 			if (SkriptConfig.enableEffectCommands.value() && e.getCommand().startsWith(SkriptConfig.effectCommandToken.value())) {
 				if (handleEffectCommand(e.getSender(), e.getCommand())) {


### PR DESCRIPTION
### Description
The ServerCommandEvent was made Cancellable somewhere between 1.8 and 1.8.8 but not respected on Skript

Since EffCancelEvent checks for Cancellable as interface, it worked, but some other places on Skript checked manually that if ServerCommandEvent is cancelled by determining if the command is empty or not.

Related Spigot commit:
https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/commits/c31fcfe3a19c4ee597df75e750af1542ac020b92

---
**Target Minecraft Versions:** any<!-- 'any' means all supported versions -->
**Requirements:** none<!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** none<!-- Links to related issues -->
