### PR TITLE
Fix example script errors

### DIFF
--- a/src/main/resources/scripts/item command.sk
+++ b/src/main/resources/scripts/item command.sk
@@ -30,7 +30,7 @@ command /item <items>:
 					message "<red>%loop-item%<reset> is blacklisted and thus cannot be spawned"
 
 # This version of the command checks whether the player has permission to spawn the desired item.
-# A player needs the "skript.give.<ID>" permission to spawn an item of the desired type
+# A player needs the "skript.give.<type of item>" permission to spawn an item of the desired type
 # and the permission "skript.give.enchanted" to spawn enchanted items.
 command /item2 <items>:
 	description: Give yourself some items
@@ -44,10 +44,10 @@ command /item2 <items>:
 				if player does not have the permission "skript.give.enchanted":
 					message "You don't have permission to spawn enchanted items!"
 					stop
-			if player has permission "skript.give.%ID of loop-item%":
+			if player has permission "skript.give.%type of loop-item%":
 				give loop-item to player
 			else:
-				message "You don't have permission to spawn <red>%loop-item%<reset>!"
+				message "You don't have permission to spawn <red>%loop-item%<reset>! (skript.give.%type of loop-item%)"
 
 
 command /give <item types> to <player>:
@@ -57,8 +57,8 @@ command /give <item types> to <player>:
 	trigger:
 		send "Giving %argument 1% to %argument 2%" to player
 		loop argument 1:
-			if player has permission "skript.give.%ID of loop-item%":
+			if player has permission "skript.give.%type of loop-item%":
 				give loop-item to argument 2
 				send "You recieved %loop-item% from %player%" to argument 2
 			else:
-				message "<red>You don't have permission to give away free <red>%loop-item%<reset>!"
+				message "<red>You don't have permission to give away free <red>%loop-item%<reset>! (skript.give.%type of loop-item%)"


### PR DESCRIPTION
### Description
IDs were removed on 1.13+, replace it with type instead. Fixes these errors:

```
[22:01:32 ERROR]: [Skript] Items do not have numeric ids on Minecraft 1.13 or newer. (item command.sk, line 47: if player has permission "skript.give.%ID of loop-item%":')
[22:01:33 ERROR]: [Skript] Items do not have numeric ids on Minecraft 1.13 or newer. (item command.sk, line 60: if player has permission "skript.give.%ID of loop-item%":')
[22:01:33 ERROR]: [Skript] 'else' has to be placed just after an 'if' or 'else if' section (item command.sk, line 63: else:')
```

Note that this not perfect, i.e cobblestone would require skript.give.cobblestone block permission instead of just cobblestone.

So I added the required permission too to the no permission message. If there is a better alternative to type of expression, let me know and I'll change it.

---
**Target Minecraft Versions:** any<!-- 'any' means all supported versions -->
**Requirements:** none<!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** none<!-- Links to related issues -->
