### PR TITLE
Fix Java 12 compatibility

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -1053,8 +1053,13 @@ public final class Skript extends JavaPlugin implements Listener {
 					Thread.sleep(10000);
 				} catch (final InterruptedException e) {}
 				try {
-					final Field modifiers = Field.class.getDeclaredField("modifiers");
-					modifiers.setAccessible(true);
+					Field modifiers = null;
+					try {
+						modifiers = Field.class.getDeclaredField("modifiers");
+					} catch (final NoSuchFieldException ignored) { /* ignored */ }
+					if (modifiers != null) {
+						modifiers.setAccessible(true);
+					}
 					final JarFile jar = new JarFile(getFile());
 					try {
 						for (final JarEntry e : new EnumerationIterable<>(jar.entries())) {
@@ -1063,11 +1068,13 @@ public final class Skript extends JavaPlugin implements Listener {
 									final Class<?> c = Class.forName(e.getName().replace('/', '.').substring(0, e.getName().length() - ".class".length()), false, getClassLoader());
 									for (final Field f : c.getDeclaredFields()) {
 										if (Modifier.isStatic(f.getModifiers()) && !f.getType().isPrimitive()) {
-											if (Modifier.isFinal(f.getModifiers())) {
+											if (Modifier.isFinal(f.getModifiers()) && modifiers != null) {
 												modifiers.setInt(f, f.getModifiers() & ~Modifier.FINAL);
 											}
-											f.setAccessible(true);
-											f.set(null, null);
+											if (!Modifier.isFinal(f.getModifiers())) {
+												f.setAccessible(true);
+												f.set(null, null);
+											}
 										}
 									}
 								} catch (final Throwable ex) {


### PR DESCRIPTION
### Description
Fixes this error:

```
[22:02:47 WARN]: java.lang.NoSuchFieldException: modifiers
[22:02:47 WARN]:        at java.base/java.lang.Class.getDeclaredField(Class.java:2569)
[22:02:47 WARN]:        at ch.njol.skript.Skript$4.run(Skript.java:1056)
[22:02:47 WARN]:        at java.base/java.lang.Thread.run(Thread.java:832)
```

The Field#modifiers field was removed on Java 12.

The eror happens on Java 12+ only and the stacktrace is only printed when Skript#testing returns true (i.e -ea/-enableassertions), but it should be fixed anyway.

By "fix", it just ignores the error. The behaviour is not same as on Java < 12. Can't find a better alternative rn, but probably there is.

Not tested on Java 11 but it would give a illegal access warning with or without this fix anyway. Perhaps unsetting static final fields should be removed altogether as most of them are constants? Don't know. The whole workaround may also be unnecessary, is this memory leak thing still exists on recent MC versions?

---
**Target Minecraft Versions:** any<!-- 'any' means all supported versions -->
**Requirements:** none<!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** none<!-- Links to related issues -->
