### PR TITLE
Fix reversed arguments in Noun toString method

### DIFF
--- a/src/main/java/ch/njol/skript/localization/Noun.java
+++ b/src/main/java/ch/njol/skript/localization/Noun.java
@@ -387,7 +387,7 @@ public class Noun extends Message {
 	}
 	
 	public static String toString(final String singular, final String plural, final int gender, final int flags) {
-		return getArticleWithSpace(flags, gender) + ((flags & Language.F_PLURAL) != 0 ? plural : singular);
+		return getArticleWithSpace(gender, flags) + ((flags & Language.F_PLURAL) != 0 ? plural : singular);
 	}
 	
 }


### PR DESCRIPTION
### Description
Fixes reversed arguments in Noun's static toString method.

Found automatically by SonarLint. Not sure if it breaks anything, test respectively before merging.

---
**Target Minecraft Versions:** any<!-- 'any' means all supported versions -->
**Requirements:** none<!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** none<!-- Links to related issues -->
