### PR TITLE
Update function references when the function definition is reloaded

### DIFF
--- a/src/main/java/ch/njol/skript/lang/function/FunctionReference.java
+++ b/src/main/java/ch/njol/skript/lang/function/FunctionReference.java
@@ -113,6 +113,7 @@ public class FunctionReference<T> {
 	 */
 	@SuppressWarnings("unchecked")
 	public boolean validateFunction(boolean first) {
+		function = null;
 		SkriptLogger.setNode(node);
 		Skript.debug("Validating function " + functionName);
 		final Signature<?> sign = Functions.getSignature(functionName);


### PR DESCRIPTION
### Description
This change sets `function` to `null` when the `FunctionReference` is validated (this happens when the function definition is (re)loaded). Since `FunctionReference#execute` sets `function` to the appropriate `Function`, this change will cause the `FunctionReference` to reference the new `Function` when the functions definition is reloaded.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #3660 
