### PR TITLE
Add on leave to quit event (#3789)

### DIFF
--- a/src/main/java/ch/njol/skript/events/SimpleEvents.java
+++ b/src/main/java/ch/njol/skript/events/SimpleEvents.java
@@ -307,7 +307,7 @@ public class SimpleEvents {
 				.description("Called when a player uses a nether or end portal. <a href='effects.html#EffCancelEvent'>Cancel the event</a> to prevent the player from teleporting.")
 				.examples("on player portal:")
 				.since("1.0");
-		Skript.registerEvent("Quit", SimpleEvent.class, PlayerQuitEvent.class, "(quit[ting]|disconnect[ing]|log[ ]out|logging out)")
+		Skript.registerEvent("Quit", SimpleEvent.class, PlayerQuitEvent.class, "(quit[ting]|disconnect[ing]|log[ ]out|logging out|leav(e|ing))")
 				.description("Called when a player leaves the server.")
 				.examples("on quit:",
 						"on disconnect:")


### PR DESCRIPTION
### Description
.. as an alternative to quit, disconnect and logout.

Will handle leave, leaving and their variants with "on" prefix. (ScriptLoader adds that, no need to specify here)

Not sure if tests are required for a change like this; not familiar with the testing system but can add one that ensures on quit, on disconnect, on logout and on leave parses successfully (if that is possible).

---
**Target Minecraft Versions:** any<!-- 'any' means all supported versions -->
**Requirements:** none<!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** #3789<!-- Links to related issues -->
