### PR TITLE
Fix missing piglin zombified entry in language files

### DIFF
--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -1757,6 +1757,7 @@ spawn reasons:
 	village_defense: village defense, golem defense, iron golem defense
 	village_invasion: village invasion, village invading
 	sheared: shear, sheared
+	piglin_zombified: piglin zombified, piglin zombify, piglin zombifying
 
 # -- Difficulties --
 difficulties:

--- a/src/main/resources/lang/korean.lang
+++ b/src/main/resources/lang/korean.lang
@@ -1668,6 +1668,7 @@ spawn reasons:
 	village_defense: village defense, golem defense, iron golem defense
 	village_invasion: village invasion, village invading
 	sheared: shear, sheared
+	piglin_zombified: piglin zombified, piglin zombify, piglin zombifying
 
 # -- Difficulties --
 difficulties:


### PR DESCRIPTION
### Description
Fixes missing piglin zombified entry in language files error when -ea is enabled, and allows using it as a spawn reason in scripts.

Note: This does not update german.lang since it has no spawn reasons section and misses bunch of other keys too, that would be another issue and PR.

---
**Target Minecraft Versions:** any<!-- 'any' means all supported versions -->
**Requirements:** none<!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** #3857<!-- Links to related issues -->
