### PR TITLE
Add automatic module name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,7 @@ tasks.withType(ShadowJar) {
 	manifest {
 		attributes(
 			'Name': 'ch/njol/skript',
+			'Automatic-Module-Name': 'ch.njol.skript',
 			'Sealed': 'true'
 		)
 	}
@@ -202,6 +203,7 @@ task githubRelease(type: ShadowJar) {
 	manifest {
 		attributes(
 			'Name': 'ch/njol/skript',
+			'Automatic-Module-Name': 'ch.njol.skript',
 			'Sealed': 'true'
 		)
 	}
@@ -237,6 +239,7 @@ task spigotRelease(type: ShadowJar) {
 	manifest {
 		attributes(
 			'Name': 'ch/njol/skript',
+			'Automatic-Module-Name': 'ch.njol.skript',
 			'Sealed': 'true'
 		)
 	}
@@ -268,6 +271,7 @@ task nightlyRelease(type: ShadowJar) {
 	manifest {
 		attributes(
 			'Name': 'ch/njol/skript',
+			'Automatic-Module-Name': 'ch.njol.skript',
 			'Sealed': 'true'
 		)
 	}


### PR DESCRIPTION
### Description
Adds an automatic module name, that is, used as module name when Skript is on the modulepath on Java 9+.

If the jar is not modular (does not contain module-info.class) and does not have a `Automatic-Module-Name` entry on META-INF/MANIFEST.MF, then the module name is determined by file name.

Publishing non modular artifacts (not containing module-info.class) that also doesn't contain `Automatic-Module-Name` to any repository and using them as libraries on projects is discouraged, and will most likely cause a warning to be thrown.

The filename based module name is normally `Skript` on releases published in GitHub Releases, but people can alter them and name it whatever they want.

Adding an `Automatic-Module-Name` _will_ break the current _modular_ projects that requiring Skript via its module name derived from file name (i.e. `requires Skript;` in module-info.java), because in this PR I used `ch.njol.skript` as module name, so the correct code should be `requires ch.njol.skript;` after this PR. We can do `Automatic-Module-Name: Skript` to not break anything and just make it not dependant on file name, but for naming conventions it should be `ch.njol.skript`.

Note that, this will not change anything on < Java 9 or even Java 9+, on non modular projects.

---
**Target Minecraft Versions:** any<!-- 'any' means all supported versions -->
**Requirements:** none<!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** none<!-- Links to related issues -->
