### PR TITLE
Fix default value, filter input, metadata, relational variable, ternary incorrectly converting

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprDefaultValue.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDefaultValue.java
@@ -49,6 +49,7 @@ public class ExprDefaultValue<T> extends SimpleExpression<T> {
 	}
 
 	private final ExprDefaultValue<?> source;
+	private final Class<? extends T>[] types;
 	private final Class<T> superType;
 	@Nullable
 	private Expression<Object> first;
@@ -67,6 +68,7 @@ public class ExprDefaultValue<T> extends SimpleExpression<T> {
 			this.first = source.first;
 			this.second = source.second;
 		}
+		this.types = types;
 		this.superType = (Class<T>) Utils.getSuperType(types);
 	}
 
@@ -83,7 +85,7 @@ public class ExprDefaultValue<T> extends SimpleExpression<T> {
 		Object[] first = this.first.getArray(e);
 		Object values[] = first.length != 0 ? first : second.getArray(e);
 		try {
-			return Converters.convertStrictly(values, superType);
+			return Converters.convertArray(values, types, superType);
 		} catch (ClassCastException e1) {
 			return (T[]) Array.newInstance(superType, 0);
 		}

--- a/src/main/java/ch/njol/skript/expressions/ExprFilter.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFilter.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
 
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 
 import com.google.common.collect.Iterators;
 import ch.njol.skript.Skript;
@@ -55,6 +56,7 @@ import ch.njol.util.coll.iterator.ArrayIterator;
 @SuppressWarnings({"null", "unchecked"})
 public class ExprFilter extends SimpleExpression<Object> {
 
+	@Nullable
 	private static ExprFilter parsing;
 
 	static {
@@ -68,6 +70,7 @@ public class ExprFilter extends SimpleExpression<Object> {
 	private String rawCond;
 	private Expression<Object> objects;
 
+	@Nullable
 	public static ExprFilter getParsing() {
 		return parsing;
 	}
@@ -163,16 +166,20 @@ public class ExprFilter extends SimpleExpression<Object> {
 			);
 		}
 
-		private ExprInput<?> source;
-		private Class<T> superType;
+		@Nullable
+		private final ExprInput<?> source;
+		private final Class<? extends T>[] types;
+		private final Class<T> superType;
+		@SuppressWarnings("NotNullFieldNotInitialized")
 		private ExprFilter parent;
+		@Nullable
 		private ClassInfo<?> inputType;
 
-	public ExprInput() {
+		public ExprInput() {
 			this(null, (Class<? extends T>) Object.class);
 		}
 
-		public ExprInput(ExprInput<?> source, Class<? extends T>... types) {
+		public ExprInput(@Nullable ExprInput<?> source, Class<? extends T>... types) {
 			this.source = source;
 			if (source != null) {
 				this.parent = source.parent;
@@ -181,6 +188,7 @@ public class ExprFilter extends SimpleExpression<Object> {
 				parent.addChild(this);
 			}
 
+			this.types = types;
 			this.superType = (Class<T>) Utils.getSuperType(types);
 		}
 
@@ -204,7 +212,7 @@ public class ExprFilter extends SimpleExpression<Object> {
 			}
 
 			try {
-				return Converters.convertStrictly(new Object[]{current}, superType);
+				return Converters.convertArray(new Object[]{current}, types, superType);
 			} catch (ClassCastException e1) {
 				return (T[]) Array.newInstance(superType, 0);
 			}
@@ -229,6 +237,7 @@ public class ExprFilter extends SimpleExpression<Object> {
 			return superType;
 		}
 
+		@Nullable
 		private ClassInfo<?> getClassInfo() {
 			return inputType;
 		}

--- a/src/main/java/ch/njol/skript/expressions/ExprMetadata.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprMetadata.java
@@ -65,6 +65,7 @@ public class ExprMetadata<T> extends SimpleExpression<T> {
 	private Expression<String> values;
 	@Nullable
 	private Expression<Metadatable> holders;
+	private Class<? extends T>[] types;
 	private Class<T> superType;
 
 	public ExprMetadata() {
@@ -77,6 +78,7 @@ public class ExprMetadata<T> extends SimpleExpression<T> {
 			this.values = source.values;
 			this.holders = source.holders;
 		}
+		this.types = types;
 		this.superType = (Class<T>) Utils.getSuperType(types);
 	}
 
@@ -99,7 +101,7 @@ public class ExprMetadata<T> extends SimpleExpression<T> {
 			}
 		}
 		try {
-			return Converters.convertStrictly(values.toArray(), superType);
+			return Converters.convertArray(values.toArray(), types, superType);
 		} catch (ClassCastException e1) {
 			return (T[]) Array.newInstance(superType, 0);
 		}

--- a/src/main/java/ch/njol/skript/expressions/ExprRelationalVariable.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprRelationalVariable.java
@@ -77,6 +77,7 @@ public class ExprRelationalVariable<T> extends SimpleExpression<T> {
 	private Expression<Object> holders;
 
 	private ExprRelationalVariable<?> source;
+	private Class<? extends T>[] types;
 	private Class<T> superType;
 
 	public ExprRelationalVariable() {
@@ -89,6 +90,7 @@ public class ExprRelationalVariable<T> extends SimpleExpression<T> {
 			this.variables = source.variables;
 			this.holders = source.holders;
 		}
+		this.types = types;
 		this.superType = (Class<T>) Utils.getSuperType(types);
 	}
 
@@ -124,7 +126,7 @@ public class ExprRelationalVariable<T> extends SimpleExpression<T> {
 			}
 		}
 		try {
-			return Converters.convertStrictly(values.toArray(), superType);
+			return Converters.convertArray(values.toArray(), types, superType);
 		} catch (ClassCastException ex) {
 			return (T[]) Array.newInstance(superType, 0);
 		}

--- a/src/main/java/ch/njol/skript/expressions/ExprTernary.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTernary.java
@@ -52,6 +52,7 @@ public class ExprTernary<T> extends SimpleExpression<T> {
 
 	private final ExprTernary<?> source;
 	private final Class<T> superType;
+	private final Class<? extends T>[] types;
 	@Nullable
 	private Expression<Object> ifTrue;
 	@Nullable
@@ -72,6 +73,7 @@ public class ExprTernary<T> extends SimpleExpression<T> {
 			this.ifFalse = source.ifFalse;
 			this.condition = source.condition;
 		}
+		this.types = types;
 		this.superType = (Class<T>) Utils.getSuperType(types);
 	}
 
@@ -93,7 +95,7 @@ public class ExprTernary<T> extends SimpleExpression<T> {
 	protected T[] get(Event e) {
 		Object[] values = condition.check(e) ? ifTrue.getArray(e) : ifFalse.getArray(e);
 		try {
-			return Converters.convertStrictly(values, superType);
+			return Converters.convertArray(values, types, superType);
 		} catch (ClassCastException e1) {
 			return (T[]) Array.newInstance(superType, 0);
 		}


### PR DESCRIPTION
### Description
The expressions in the title were converting incorrectly, because they were only storing the supertype of the given classes to convert to, instead of the classes themselves. If the classes were, for example, ItemStack and ItemType, the stored supertype would be Object, which would match any returned object, e.g. InventorySlot, even if that class doesn't match the given types.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #3905
