### PR TITLE
Fix blocks in chunk returning too much

### DIFF
--- a/skript-worldguard6/src/main/java/ch/njol/skript/module/worldguard6/WorldGuard6Hook.java
+++ b/skript-worldguard6/src/main/java/ch/njol/skript/module/worldguard6/WorldGuard6Hook.java
@@ -162,7 +162,7 @@ public class WorldGuard6Hook extends RegionsPlugin<WorldGuardPlugin> {
         @Override
         public Iterator<Block> getBlocks() {
             final BlockVector min = region.getMinimumPoint(), max = region.getMaximumPoint();
-            return new AABB(world, new Vector(min.getBlockX(), min.getBlockY(), min.getBlockZ()), new Vector(max.getBlockX() + 1, max.getBlockY() + 1, max.getBlockZ() + 1)).iterator();
+            return new AABB(world, new Vector(min.getBlockX(), min.getBlockY(), min.getBlockZ()), new Vector(max.getBlockX(), max.getBlockY(), max.getBlockZ())).iterator();
 //          final Iterator<BlockVector2D> iter = region.getPoints().iterator();
 //          if (!iter.hasNext())
 //              return EmptyIterator.get();

--- a/src/main/java/ch/njol/skript/hooks/regions/GriefPreventionHook.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/GriefPreventionHook.java
@@ -183,9 +183,9 @@ public class GriefPreventionHook extends RegionsPlugin<GriefPrevention> {
 			final Location lower = claim.getLesserBoundaryCorner(), upper = claim.getGreaterBoundaryCorner();
 			if (lower == null || upper == null || lower.getWorld() == null || upper.getWorld() == null || lower.getWorld() != upper.getWorld())
 				return EmptyIterator.get();
-			upper.setY(upper.getWorld().getMaxHeight());
-			upper.setX(upper.getBlockX() + 1);
-			upper.setZ(upper.getBlockZ() + 1);
+			upper.setY(upper.getWorld().getMaxHeight() - 1);
+			upper.setX(upper.getBlockX());
+			upper.setZ(upper.getBlockZ());
 			return new AABB(lower, upper).iterator();
 		}
 		

--- a/src/main/java/ch/njol/skript/util/AABB.java
+++ b/src/main/java/ch/njol/skript/util/AABB.java
@@ -57,7 +57,7 @@ public class AABB implements Iterable<Block> {
 			throw new IllegalArgumentException("Blocks must be in the same world");
 		world = b1.getWorld();
 		lowerBound = new Vector(Math.min(b1.getX(), b2.getX()), Math.min(b1.getY(), b2.getY()), Math.min(b1.getZ(), b2.getZ()));
-		upperBound = new Vector(Math.max(b1.getX(), b2.getX()) + 1, Math.max(b1.getY(), b2.getY()) + 1, Math.max(b1.getZ(), b2.getZ()) + 1);
+		upperBound = new Vector(Math.max(b1.getX(), b2.getX()), Math.max(b1.getY(), b2.getY()), Math.max(b1.getZ(), b2.getZ()));
 	}
 	
 	@SuppressWarnings("null")
@@ -65,7 +65,7 @@ public class AABB implements Iterable<Block> {
 		assert rX >= 0 && rY >= 0 && rZ >= 0 : rX + "," + rY + "," + rY;
 		world = center.getWorld();
 		lowerBound = new Vector(center.getX() - rX, Math.max(center.getY() - rY, 0), center.getZ() - rZ);
-		upperBound = new Vector(center.getX() + rX, Math.min(center.getY() + rY, world.getMaxHeight()), center.getZ() + rZ);
+		upperBound = new Vector(center.getX() + rX, Math.min(center.getY() + rY, world.getMaxHeight() - 1), center.getZ() + rZ);
 	}
 	
 	public AABB(final World w, final Vector v1, final Vector v2) {
@@ -77,7 +77,7 @@ public class AABB implements Iterable<Block> {
 	public AABB(final Chunk c) {
 		world = c.getWorld();
 		lowerBound = c.getBlock(0, 0, 0).getLocation().toVector();
-		upperBound = lowerBound.clone().add(new Vector(16, world.getMaxHeight(), 16));
+		upperBound = lowerBound.clone().add(new Vector(15, world.getMaxHeight() - 1, 15));
 	}
 	
 	public boolean contains(final Location l) {


### PR DESCRIPTION
### Description
Changed AABB and classes using it, to not make certain regions extended by 1 block. From some of the constructors in AABB you get the impression upperBound is exclusive (because some constructors add 1 to each vector component), but the implementation indicates is actually inclusive, so these aren't needed. I've also changed the calls to [`World#getMaxHeight()`](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/World.html#getMaxHeight()), because that always returns the 1 above the highest possibly y coord where a block can be found (e.g. 256 instead of 255).

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
