### PR TITLE
Fix expression parse order

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -1303,10 +1303,10 @@ public final class Skript extends JavaPlugin implements Listener {
 			throw new IllegalArgumentException("returnType must be a normal type");
 		String originClassPath = Thread.currentThread().getStackTrace()[2].getClassName();
 		final ExpressionInfo<E, T> info = new ExpressionInfo<>(patterns, returnType, c, originClassPath, type);
-		for (int i = type.ordinal() + 1; i < ExpressionType.values().length; i++) {
+		expressions.add(expressionTypesStartIndices[type.ordinal()], info);
+		for (int i = type.ordinal(); i < ExpressionType.values().length; i++) {
 			expressionTypesStartIndices[i]++;
 		}
-		expressions.add(expressionTypesStartIndices[type.ordinal()], info);
 	}
 	
 	@SuppressWarnings("null")


### PR DESCRIPTION
### Description
The order of the `Skript#expressions` field was partially reversed:
https://pastebin.com/auvMwfnc: `Registered` is the order it was registered, `Detected` is the order of the list after registration. Note that the order of registration shouldn't exactly match the order of the list, as expression with the same `ExpressionType` should be grouped together. Also note that `ExprDamageCause` is registered earlier due to [BukkitClasses#L1302](https://github.com/SkriptLang/Skript/blob/master/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java#L1302).

This is the new result: https://pastebin.com/b41zBNrV

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
