### PR TITLE
BukkitClasses - reformat Block's toString to include more helpful info

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -219,7 +219,7 @@ public class BukkitClasses {
 					
 					@Override
 					public String toString(final Block b, final int flags) {
-						return ItemType.toString(b, flags);
+						return BlockUtils.blockToString(b, flags);
 					}
 					
 					@Override

--- a/src/main/java/ch/njol/skript/util/BlockUtils.java
+++ b/src/main/java/ch/njol/skript/util/BlockUtils.java
@@ -20,6 +20,7 @@ package ch.njol.skript.util;
 
 import java.util.Arrays;
 
+import ch.njol.skript.aliases.ItemType;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -113,6 +114,30 @@ public abstract class BlockUtils {
 		} catch (IllegalArgumentException ignore) {
 			return null;
 		}
+	}
+
+	/**
+	 * Get the string version of a block, including type and location.
+	 * ex: 'stone' at 1.5, 1.5, 1.5 in world 'world'
+	 *
+	 * @param block Block to get string of
+	 * @param flags
+	 * @return String version of block
+	 */
+	@Nullable
+	public static String blockToString(Block block, int flags) {
+		String type = ItemType.toString(block, flags);
+		Location location = getLocation(block);
+		if (location == null) {
+			return null;
+		}
+
+		double x = location.getX();
+		double y = location.getY();
+		double z = location.getZ();
+		String world = location.getWorld().getName();
+
+		return String.format("'%s' at %s, %s, %s in world '%s'", type, x, y, z, world);
 	}
 	
 }


### PR DESCRIPTION
### Description
This PR aims to reformat a block's toString() method, to include more info.
See #3315 for the discussion.

I know it was up in the air whether or not a world should be included, and its potential to be too verbose, I included it, as users may have block stored in variables, and this just prints a more accurate accounting of the block.

Ex code:
```vb
on load:
	set {_b} to block at location(-910, 12, -234, world "world")
	send "Block: %{_b}%" to console
```
Output:
```
Block: 'raw andesite' at -909.5, 12.5, -233.5 in world 'world'
```

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #3315 
