### PR TITLE
Make message and broadcast effects accept objects

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffBroadcast.java
+++ b/src/main/java/ch/njol/skript/effects/EffBroadcast.java
@@ -18,6 +18,8 @@
  */
 package ch.njol.skript.effects;
 
+import ch.njol.skript.registrations.Classes;
+import ch.njol.skript.util.LiteralUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -41,39 +43,43 @@ import ch.njol.util.Kleenean;
 		"message to all players instead of broadcasting it."})
 @Examples({"broadcast \"Welcome %player% to the server!\"",
 		"broadcast \"Woah! It's a message!\""})
-@Since("1.0")
+@Since("1.0, INSERT VERSION (broadcasting objects)")
 public class EffBroadcast extends Effect {
+
 	static {
-		Skript.registerEffect(EffBroadcast.class, "broadcast %strings% [(to|in) %-worlds%]");
+		Skript.registerEffect(EffBroadcast.class, "broadcast %objects% [(to|in) %-worlds%]");
 	}
-	
-	@SuppressWarnings("null")
-	private Expression<String> messages;
+
+	@SuppressWarnings("NotNullFieldNotInitialized")
+	private Expression<?> messages;
 	@Nullable
 	private Expression<World> worlds;
-	
-	@SuppressWarnings({"unchecked", "null"})
+
+	@SuppressWarnings("unchecked")
 	@Override
-	public boolean init(final Expression<?>[] vars, final int matchedPattern, final Kleenean isDelayed, final ParseResult parser) {
-		messages = (Expression<String>) vars[0];
-		worlds = (Expression<World>) vars[1];
-		return true;
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parser) {
+		messages = LiteralUtils.defendExpression(exprs[0]);
+		worlds = (Expression<World>) exprs[1];
+		return LiteralUtils.canInitSafely(messages);
 	}
 	
 	@Override
-	public void execute(final Event e) {
-		for (final String m : messages.getArray(e)) {
-			final Expression<World> worlds = this.worlds;
+	public void execute(Event e) {
+		World[] worlds = this.worlds != null ? this.worlds.getArray(e) : null;
+
+		for (Object object : messages.getArray(e)) {
+			String string = object instanceof String ? (String) object : Classes.toString(object);
+
 			if (worlds == null) {
 				// not Bukkit.broadcastMessage to ignore permissions
-				for (final Player p : PlayerUtils.getOnlinePlayers()) {
-					p.sendMessage(m);
+				for (Player player : PlayerUtils.getOnlinePlayers()) {
+					player.sendMessage(string);
 				}
-				Bukkit.getConsoleSender().sendMessage(m);
+				Bukkit.getConsoleSender().sendMessage(string);
 			} else {
-				for (final World w : worlds.getArray(e)) {
-					for (final Player p : w.getPlayers()) {
-						p.sendMessage(m);
+				for (World w : worlds) {
+					for (Player player : w.getPlayers()) {
+						player.sendMessage(string);
 					}
 				}
 			}
@@ -81,8 +87,7 @@ public class EffBroadcast extends Effect {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		final Expression<World> worlds = this.worlds;
+	public String toString(@Nullable Event e, boolean debug) {
 		return "broadcast " + messages.toString(e, debug) + (worlds == null ? "" : " to " + worlds.toString(e, debug));
 	}
 	

--- a/src/main/java/ch/njol/skript/effects/EffMessage.java
+++ b/src/main/java/ch/njol/skript/effects/EffMessage.java
@@ -18,8 +18,13 @@
  */
 package ch.njol.skript.effects;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 
+import ch.njol.skript.registrations.Classes;
+import ch.njol.skript.util.LiteralUtils;
+import ch.njol.skript.util.chat.MessageComponent;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
@@ -58,7 +63,7 @@ import net.md_5.bungee.api.chat.TextComponent;
 		"\tcancel event",
 		"\tsend \"[%player%] >> %message%\" to all players from player"})
 @RequiredPlugins("Minecraft 1.16.4+ for optional sender")
-@Since("1.0, 2.2-dev26 (advanced features), 2.5.2 (optional sender)")
+@Since("1.0, 2.2-dev26 (advanced features), 2.5.2 (optional sender), INSERT VERSION (sending objects)")
 public class EffMessage extends Effect {
 	
 	private static final boolean SUPPORTS_SENDER = Skript.classExists("org.bukkit.command.CommandSender$Spigot") &&
@@ -66,21 +71,21 @@ public class EffMessage extends Effect {
 	
 	static {
 		if (SUPPORTS_SENDER)
-			Skript.registerEffect(EffMessage.class, "(message|send [message[s]]) %strings% [to %commandsenders%] [from %-player%]");
+			Skript.registerEffect(EffMessage.class, "(message|send [message[s]]) %objects% [to %commandsenders%] [from %-player%]");
 		else
-			Skript.registerEffect(EffMessage.class, "(message|send [message[s]]) %strings% [to %commandsenders%]");
+			Skript.registerEffect(EffMessage.class, "(message|send [message[s]]) %objects% [to %commandsenders%]");
 	}
 
-	@SuppressWarnings("null")
-	private Expression<? extends String>[] messages;
+	@SuppressWarnings("NotNullFieldNotInitialized")
+	private Expression<?>[] messages;
 
 	/**
 	 * Used for {@link EffMessage#toString(Event, boolean)}
 	 */
-	@SuppressWarnings("null")
-	private Expression<String> messageExpr;
+	@SuppressWarnings("NotNullFieldNotInitialized")
+	private Expression<?> messageExpr;
 
-	@SuppressWarnings("null")
+	@SuppressWarnings("NotNullFieldNotInitialized")
 	private Expression<CommandSender> recipients;
 	
 	@Nullable
@@ -88,41 +93,54 @@ public class EffMessage extends Effect {
 	
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
-	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parser) {
-		messages = exprs[0] instanceof ExpressionList ? ((ExpressionList<String>) exprs[0]).getExpressions() : new Expression[] {exprs[0]};
-		messageExpr = (Expression<String>) exprs[0];
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parser) {
+		messageExpr = LiteralUtils.defendExpression(exprs[0]);
+
+		messages = messageExpr instanceof ExpressionList ?
+			((ExpressionList<?>) messageExpr).getExpressions() : new Expression[] {messageExpr};
 		recipients = (Expression<CommandSender>) exprs[1];
 		if (SUPPORTS_SENDER)
 			sender = (Expression<Player>) exprs[2];
-		return true;
+		return LiteralUtils.canInitSafely(messageExpr);
 	}
 
 	@Override
-	protected void execute(final Event e) {
+	protected void execute(Event e) {
 		Player sender = this.sender != null ? this.sender.getSingle(e) : null;
-		for (Expression<? extends String> message : messages) {
-			for (CommandSender receiver : recipients.getArray(e)) {
+
+		CommandSender[] commandSenders = recipients.getArray(e);
+
+		for (Expression<?> message : messages) {
+
+			Object[] messageArray = null;
+			List<MessageComponent> messageComponents = null;
+
+			for (CommandSender receiver : commandSenders) {
+				if (receiver instanceof Player && message instanceof VariableString) {
+					if (messageComponents == null)
+						messageComponents = ((VariableString) message).getMessageComponents(e);
+				} else {
+					if (messageArray == null)
+						messageArray = message.getArray(e);
+				}
+
 				if (receiver instanceof Player) { // Can use JSON formatting
 					if (message instanceof VariableString) { // Process formatting that is safe
-						sendMessage((Player) receiver, sender, BungeeConverter
-							.convert(((VariableString) message).getMessageComponents(e)));
+						sendMessage((Player) receiver, sender,
+							BungeeConverter.convert(messageComponents)
+						);
 					} else if (message instanceof ExprColoured && ((ExprColoured) message).isUnsafeFormat()) { // Manually marked as trusted
-						for (String string : message.getArray(e)) {
-							assert string != null;
-							sendMessage((Player) receiver, sender, BungeeConverter
-								.convert(ChatMessages.parse(string)));
+						for (Object object : messageArray) {
+							sendMessage((Player) receiver, sender, BungeeConverter.convert(ChatMessages.parse((String) object)));
 						}
 					} else { // It is just a string, no idea if it comes from a trusted source -> don't parse anything
-						for (String string : message.getArray(e)) {
-							assert string != null;
-							assert string != null;
-							sendMessage((Player) receiver, sender, new TextComponent(string));
+						for (Object object : messageArray) {
+							sendMessage((Player) receiver, sender, new TextComponent(toString(object)));
 						}
 					}
 				} else { // Not a player, send plain text with legacy formatting
-					for (String string : message.getArray(e)) {
-						assert string != null;
-						receiver.sendMessage(string);
+					for (Object object : messageArray) {
+						receiver.sendMessage(toString(object));
 					}
 				}
 			}
@@ -136,8 +154,12 @@ public class EffMessage extends Effect {
 			receiver.spigot().sendMessage(components);
 	}
 
+	private String toString(Object object) {
+		return object instanceof String ? (String) object : Classes.toString(object);
+	}
+
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(@Nullable Event e, boolean debug) {
 		return "send " + messageExpr.toString(e, debug) + " to " + recipients.toString(e, debug) +
 			(sender != null ? " from " + sender.toString(e, debug) : "");
 	}

--- a/src/main/java/ch/njol/skript/lang/VariableString.java
+++ b/src/main/java/ch/njol/skript/lang/VariableString.java
@@ -506,8 +506,8 @@ public class VariableString implements Expression<String> {
 				
 				// Convert it to plain text
 				String text = null;
-				if (o instanceof ExprColoured) { // Special case: user wants to process formatting
-					String unformatted = ((ExprColoured) o).getSingle(e);
+				if (o instanceof ExprColoured && ((ExprColoured) o).isUnsafeFormat()) { // Special case: user wants to process formatting
+					String unformatted = Classes.toString(((ExprColoured) o).getArray(e), true, mode);
 					if (unformatted != null) {
 						message.addAll(ChatMessages.parse(unformatted));
 					}


### PR DESCRIPTION
### Description
Makes `EffMessage` and `EffBroadcast` accept objects to broadcast, instead of just strings. 
Also makes it so the effects don't call any of the expressions getters multiple times (which is what the ugly code at the start of the second loop in `EffMessage#execute` is for):
```
function doStuff() :: text:
	broadcast "func called"
	return "test"

command /test:
	trigger:
		add sender to {_l::*}
		add sender to {_l::*}
		send "Result: %doStuff()%" to {_l::*}
```
will now only call `doStuff` once, used to be twice.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #3164
