### PR TITLE
Fix return type of some list expressions

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprReversedList.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprReversedList.java
@@ -18,10 +18,12 @@
  */
 package ch.njol.skript.expressions;
 
+import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import ch.njol.skript.util.LiteralUtils;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -46,22 +48,23 @@ public class ExprReversedList extends SimpleExpression<Object> {
 		Skript.registerExpression(ExprReversedList.class, Object.class, ExpressionType.COMBINED, "reversed %objects%");
 	}
 
-	@SuppressWarnings("null")
+	@SuppressWarnings("NotNullFieldNotInitialized")
 	private Expression<?> list;
 
 	@Override
-	@SuppressWarnings({"null", "unchecked"})
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
-		list = exprs[0].getConvertedExpression(Object.class);
-		return list != null;
+		list = LiteralUtils.defendExpression(exprs[0]);
+		return LiteralUtils.canInitSafely(list);
 	}
 
 	@Override
 	@Nullable
 	protected Object[] get(Event e) {
-		List<Object> reversed = Arrays.asList(list.getAll(e).clone());
+		Object[] inputArray = list.getArray(e).clone();
+		List<?> reversed = Arrays.asList(inputArray);
 		Collections.reverse(reversed);
-		return reversed.toArray();
+		Object[] array = (Object[]) Array.newInstance(getReturnType(), inputArray.length);
+		return reversed.toArray(array);
 	}
 
 	@Override
@@ -71,7 +74,7 @@ public class ExprReversedList extends SimpleExpression<Object> {
 
 	@Override
 	public Class<?> getReturnType() {
-		return Object.class;
+		return list.getReturnType();
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprReversedList.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprReversedList.java
@@ -18,15 +18,6 @@
  */
 package ch.njol.skript.expressions;
 
-import java.lang.reflect.Array;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
-import ch.njol.skript.util.LiteralUtils;
-import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -34,9 +25,17 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.skript.util.LiteralUtils;
 import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 @Name("Reversed List")
 @Description("Reverses given list.")
@@ -52,7 +51,7 @@ public class ExprReversedList extends SimpleExpression<Object> {
 	private Expression<?> list;
 
 	@Override
-	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		list = LiteralUtils.defendExpression(exprs[0]);
 		return LiteralUtils.canInitSafely(list);
 	}
@@ -61,10 +60,19 @@ public class ExprReversedList extends SimpleExpression<Object> {
 	@Nullable
 	protected Object[] get(Event e) {
 		Object[] inputArray = list.getArray(e).clone();
-		List<?> reversed = Arrays.asList(inputArray);
-		Collections.reverse(reversed);
 		Object[] array = (Object[]) Array.newInstance(getReturnType(), inputArray.length);
-		return reversed.toArray(array);
+		System.arraycopy(inputArray, 0, array, 0, inputArray.length);
+		reverse(array);
+		return array;
+	}
+
+	private void reverse(Object[] array) {
+		for (int i = 0; i < array.length / 2; i++) {
+			Object temp = array[i];
+			int reverse = array.length - i - 1;
+			array[i] = array[reverse];
+			array[reverse] = temp;
+		}
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprShuffledList.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprShuffledList.java
@@ -18,10 +18,12 @@
  */
 package ch.njol.skript.expressions;
 
+import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import ch.njol.skript.util.LiteralUtils;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -46,33 +48,29 @@ public class ExprShuffledList extends SimpleExpression<Object> {
 		Skript.registerExpression(ExprShuffledList.class, Object.class, ExpressionType.COMBINED, "shuffled %objects%");
 	}
 
-	@SuppressWarnings("null")
+	@SuppressWarnings("NotNullFieldNotInitialized")
 	private Expression<?> list;
 
 	@Override
-	@SuppressWarnings({"null", "unchecked"})
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		list = exprs[0].getConvertedExpression(Object.class);
-		return list != null;
+		list = LiteralUtils.defendExpression(exprs[0]);
+		return LiteralUtils.canInitSafely(list);
 	}
 
 	@Override
 	@Nullable
 	protected Object[] get(Event e) {
-		Object[] origin = list.getAll(e);
-		List<Object> shuffled = Arrays.asList(origin.clone()); // Not yet shuffled...
-		
-		try {
-			Collections.shuffle(shuffled);
-		} catch (IllegalArgumentException ex) { // In case elements are not comparable
-			Skript.error("Tried to sort a list, but some objects are not comparable!");
-		}
-		return shuffled.toArray();
+		Object[] origin = list.getAll(e).clone();
+		List<Object> shuffled = Arrays.asList(origin); // Not yet shuffled...
+		Collections.shuffle(shuffled);
+
+		Object[] array = (Object[]) Array.newInstance(getReturnType(), origin.length);
+		return shuffled.toArray(array);
 	}
 
 	@Override
 	public Class<? extends Object> getReturnType() {
-		return Object.class;
+		return list.getReturnType();
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprShuffledList.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprShuffledList.java
@@ -60,7 +60,7 @@ public class ExprShuffledList extends SimpleExpression<Object> {
 	@Override
 	@Nullable
 	protected Object[] get(Event e) {
-		Object[] origin = list.getAll(e).clone();
+		Object[] origin = list.getArray(e).clone();
 		List<Object> shuffled = Arrays.asList(origin); // Not yet shuffled...
 		Collections.shuffle(shuffled);
 

--- a/src/main/java/ch/njol/skript/expressions/ExprSortedList.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSortedList.java
@@ -60,7 +60,7 @@ public class ExprSortedList extends SimpleExpression<Object> {
 	@Override
 	@Nullable
 	protected Object[] get(Event e) {
-		Object[] unsorted = list.getAll(e);
+		Object[] unsorted = list.getArray(e);
 		Object[] sorted = (Object[]) Array.newInstance(getReturnType(), unsorted.length); // Not yet sorted...
 		
 		for (int i = 0; i < sorted.length; i++) {

--- a/src/main/java/ch/njol/skript/expressions/ExprSortedList.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSortedList.java
@@ -18,8 +18,10 @@
  */
 package ch.njol.skript.expressions;
 
+import java.lang.reflect.Array;
 import java.util.Arrays;
 
+import ch.njol.skript.util.LiteralUtils;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -46,21 +48,20 @@ public class ExprSortedList extends SimpleExpression<Object> {
 		Skript.registerExpression(ExprSortedList.class, Object.class, ExpressionType.COMBINED, "sorted %objects%");
 	}
 
-	@SuppressWarnings("null")
+	@SuppressWarnings("NotNullFieldNotInitialized")
 	private Expression<?> list;
 
 	@Override
-	@SuppressWarnings({"null", "unchecked"})
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		list = exprs[0].getConvertedExpression(Object.class);
-		return list != null;
+		list = LiteralUtils.defendExpression(exprs[0]);
+		return LiteralUtils.canInitSafely(list);
 	}
 
 	@Override
 	@Nullable
 	protected Object[] get(Event e) {
 		Object[] unsorted = list.getAll(e);
-		Object[] sorted = new Object[unsorted.length]; // Not yet sorted...
+		Object[] sorted = (Object[]) Array.newInstance(getReturnType(), unsorted.length); // Not yet sorted...
 		
 		for (int i = 0; i < sorted.length; i++) {
 			Object value = unsorted[i];
@@ -87,8 +88,8 @@ public class ExprSortedList extends SimpleExpression<Object> {
 	}
 
 	@Override
-	public Class<? extends Object> getReturnType() {
-		return Object.class;
+	public Class<?> getReturnType() {
+		return list.getReturnType();
 	}
 
 	@Override


### PR DESCRIPTION
### Description
Fixes the return type of some list expressions: `ExprSortedList`, `ExprShuffledList`, `ExprReversedList`.

All 3 loops in this code don't parse without this PR (with error `loop-value is not a text`):
```
command /test:
	trigger:
		set {_l::*} to 5 times
		loop reversed indices of {_l::*}:
			set {_i} to (loop-value) parsed as integer
			message "%loop-value% ; %{_i}%"
		loop shuffled indices of {_l::*}:
			set {_i} to (loop-value) parsed as integer
			message "%loop-value% ; %{_i}%"
		loop sorted indices of {_l::*}:
			set {_i} to (loop-value) parsed as integer
			message "%loop-value% ; %{_i}%"
		
```

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #3492
