### PR TITLE
Give line numbers to command and function triggers

### DIFF
--- a/src/main/java/ch/njol/skript/command/Commands.java
+++ b/src/main/java/ch/njol/skript/command/Commands.java
@@ -488,11 +488,12 @@ public abstract class Commands {
 		}
 		
 		Commands.currentArguments = currentArguments;
-		final ScriptCommand c;
+		ScriptCommand c;
 		try {
-			c = new ScriptCommand(config, command, "" + pattern.toString(), currentArguments, description, usage,
+			c = new ScriptCommand(config, command, pattern.toString(), currentArguments, description, usage,
 					aliases, permission, permissionMessage, cooldown, cooldownMessage, cooldownBypass, cooldownStorage,
 					executableBy, ScriptLoader.loadItems(trigger));
+			c.trigger.setLineNumber(node.getLine());
 		} finally {
 			Commands.currentArguments = null;
 		}
@@ -502,7 +503,6 @@ public abstract class Commands {
 		
 		if (Skript.logVeryHigh() && !Skript.debug())
 			Skript.info("registered command " + desc);
-		currentArguments = null;
 		return c;
 	}
 	

--- a/src/main/java/ch/njol/skript/lang/function/ScriptFunction.java
+++ b/src/main/java/ch/njol/skript/lang/function/ScriptFunction.java
@@ -45,6 +45,7 @@ public class ScriptFunction<T> extends Function<T> {
 				new SimpleEvent(),
 				ScriptLoader.loadItems(node)
 			);
+			trigger.setLineNumber(node.getLine());
 		} finally {
 			Functions.currentFunction = null;
 		}


### PR DESCRIPTION
### Description
Sets the line number fields of the triggers of functions and commands.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #2336 (partially)
