### PR TITLE
EvtMove - new player/entity move event

### DIFF
--- a/src/main/java/ch/njol/skript/events/EvtMove.java
+++ b/src/main/java/ch/njol/skript/events/EvtMove.java
@@ -1,0 +1,92 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.events;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.entity.EntityData;
+import ch.njol.skript.lang.Literal;
+import ch.njol.skript.lang.SkriptEvent;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.coll.CollectionUtils;
+import io.papermc.paper.event.entity.EntityMoveEvent;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.Event;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.eclipse.jdt.annotation.Nullable;
+
+public class EvtMove extends SkriptEvent {
+
+	private static final boolean HAS_ENTITY_MOVE = Skript.classExists("io.papermc.paper.event.entity.EntityMoveEvent");
+
+	static {
+		Class<? extends Event>[] events;
+		if (HAS_ENTITY_MOVE)
+			events = CollectionUtils.array(PlayerMoveEvent.class, EntityMoveEvent.class);
+		else
+			events = CollectionUtils.array(PlayerMoveEvent.class);
+
+		Skript.registerEvent("Move", EvtMove.class, events,
+			"(0¦player|1¦%entitydatas%) move")
+			.description("Called when a player or entity moves.",
+				"NOTE: Entity move event will only be called when the entity moves position, not orientation (ie: looking around).",
+				"NOTE: This event can be performance heavy as it is called quite often.",
+				"If you use this event, and later remove it, a server restart is recommend to clear registered events from Skript.")
+		.examples("on player move:",
+			"\tif player does not have permission \"player.can.move\":",
+			"\t\tcancel event",
+			"on skeleton move:",
+			"\tif event-entity is not in world \"world\":",
+			"\t\tkill event-entity")
+		.since("INSERT VERSION");
+	}
+
+	@Nullable
+	private EntityData<?>[] types = null;
+
+	@Override
+	public boolean init(Literal<?>[] args, int matchedPattern, SkriptParser.ParseResult parseResult) {
+		if (HAS_ENTITY_MOVE && parseResult.mark == 1) {
+			types = ((Literal<EntityData<?>>) args[0]).getAll();
+		}
+		return true;
+	}
+
+	@Override
+	public boolean check(Event event) {
+		if (types == null && event instanceof PlayerMoveEvent) {
+			return true;
+		} else if (types != null && HAS_ENTITY_MOVE && event instanceof EntityMoveEvent) {
+			EntityMoveEvent entityEvent = (EntityMoveEvent) event;
+			LivingEntity entity = entityEvent.getEntity();
+			for (EntityData<?> type : types) {
+				if (type.isInstance(entity)) {
+					if (((EntityMoveEvent) event).hasChangedOrientation()) {
+						return true;
+					}
+				}
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		return "null";
+	}
+}

--- a/src/main/java/ch/njol/skript/events/EvtMove.java
+++ b/src/main/java/ch/njol/skript/events/EvtMove.java
@@ -43,7 +43,7 @@ public class EvtMove extends SkriptEvent {
 		else
 			events = CollectionUtils.array(PlayerMoveEvent.class);
 
-		Skript.registerEvent("Move", EvtMove.class, events, "%entitydata% move")
+		Skript.registerEvent("Move", EvtMove.class, events, "%entitydata% (move|walk|step)")
 			.description("Called when a player or entity moves.",
 				"NOTE: Move event will only be called when the entity/player moves position, not orientation (ie: looking around).",
 				"NOTE: These events can be performance heavy as they are called quite often.",
@@ -78,7 +78,6 @@ public class EvtMove extends SkriptEvent {
 		if (isPlayer && event instanceof PlayerMoveEvent) {
 			PlayerMoveEvent playerEvent = (PlayerMoveEvent) event;
 			return moveCheck(playerEvent.getFrom(), playerEvent.getTo());
-
 		} else if (HAS_ENTITY_MOVE && event instanceof EntityMoveEvent) {
 			EntityMoveEvent entityEvent = (EntityMoveEvent) event;
 			if (type.isInstance(entityEvent.getEntity())) {

--- a/src/main/java/ch/njol/skript/events/EvtMove.java
+++ b/src/main/java/ch/njol/skript/events/EvtMove.java
@@ -34,6 +34,10 @@ public class EvtMove extends SkriptEvent {
 
 	private static final boolean HAS_ENTITY_MOVE = Skript.classExists("io.papermc.paper.event.entity.EntityMoveEvent");
 
+	// There was a point the event existed but this method did not
+	private static final boolean HAS_POS_METHOD = HAS_ENTITY_MOVE &&
+		Skript.methodExists(EntityMoveEvent.class, "hasChangedPosition", boolean.class);
+
 	static {
 		Class<? extends Event>[] events;
 		if (HAS_ENTITY_MOVE)
@@ -45,15 +49,16 @@ public class EvtMove extends SkriptEvent {
 			"(0¦player|1¦%entitydatas%) move")
 			.description("Called when a player or entity moves.",
 				"NOTE: Entity move event will only be called when the entity moves position, not orientation (ie: looking around).",
-				"NOTE: This event can be performance heavy as it is called quite often.",
-				"If you use this event, and later remove it, a server restart is recommend to clear registered events from Skript.")
-		.examples("on player move:",
-			"\tif player does not have permission \"player.can.move\":",
-			"\t\tcancel event",
-			"on skeleton move:",
-			"\tif event-entity is not in world \"world\":",
-			"\t\tkill event-entity")
-		.since("INSERT VERSION");
+				"NOTE: These events can be performance heavy as they are called quite often.",
+				"If you use these events, and later remove them, a server restart is recommended to clear registered events from Skript.")
+			.examples("on player move:",
+				"\tif player does not have permission \"player.can.move\":",
+				"\t\tcancel event",
+				"on skeleton move:",
+				"\tif event-entity is not in world \"world\":",
+				"\t\tkill event-entity")
+			.requiredPlugins("Paper 1.16.5+ (for entity move)")
+			.since("INSERT VERSION");
 	}
 
 	@Nullable
@@ -76,7 +81,9 @@ public class EvtMove extends SkriptEvent {
 			LivingEntity entity = entityEvent.getEntity();
 			for (EntityData<?> type : types) {
 				if (type.isInstance(entity)) {
-					if (((EntityMoveEvent) event).hasChangedOrientation()) {
+					if (!HAS_POS_METHOD) {
+						return true;
+					} else if (((EntityMoveEvent) event).hasChangedPosition()) {
 						return true;
 					}
 				}
@@ -87,6 +94,6 @@ public class EvtMove extends SkriptEvent {
 
 	@Override
 	public String toString(@Nullable Event e, boolean debug) {
-		return "null";
+		return (HAS_ENTITY_MOVE && types != null ? types.toString() : "player") + " move";
 	}
 }

--- a/src/main/java/ch/njol/skript/events/EvtMove.java
+++ b/src/main/java/ch/njol/skript/events/EvtMove.java
@@ -22,7 +22,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.entity.EntityData;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptEvent;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.log.ErrorQuality;
 import ch.njol.util.coll.CollectionUtils;
 import io.papermc.paper.event.entity.EntityMoveEvent;
@@ -66,7 +66,7 @@ public class EvtMove extends SkriptEvent {
 	private EntityData<?>[] types = null;
 
 	@Override
-	public boolean init(Literal<?>[] args, int matchedPattern, SkriptParser.ParseResult parseResult) {
+	public boolean init(Literal<?>[] args, int matchedPattern, ParseResult parseResult) {
 		if (parseResult.mark == 1) {
 			if (HAS_ENTITY_MOVE)
 				types = ((Literal<EntityData<?>>) args[0]).getAll();
@@ -82,7 +82,7 @@ public class EvtMove extends SkriptEvent {
 	public boolean check(Event event) {
 		if (types == null && event instanceof PlayerMoveEvent) {
 			return true;
-		} else if (types != null && HAS_ENTITY_MOVE && event instanceof EntityMoveEvent) {
+		} else if (HAS_ENTITY_MOVE && types != null && event instanceof EntityMoveEvent) {
 			EntityMoveEvent entityEvent = (EntityMoveEvent) event;
 			LivingEntity entity = entityEvent.getEntity();
 			for (EntityData<?> type : types) {

--- a/src/main/java/ch/njol/skript/events/EvtMove.java
+++ b/src/main/java/ch/njol/skript/events/EvtMove.java
@@ -23,6 +23,7 @@ import ch.njol.skript.entity.EntityData;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptEvent;
 import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.log.ErrorQuality;
 import ch.njol.util.coll.CollectionUtils;
 import io.papermc.paper.event.entity.EntityMoveEvent;
 import org.bukkit.entity.LivingEntity;
@@ -66,8 +67,13 @@ public class EvtMove extends SkriptEvent {
 
 	@Override
 	public boolean init(Literal<?>[] args, int matchedPattern, SkriptParser.ParseResult parseResult) {
-		if (HAS_ENTITY_MOVE && parseResult.mark == 1) {
-			types = ((Literal<EntityData<?>>) args[0]).getAll();
+		if (parseResult.mark == 1) {
+			if (HAS_ENTITY_MOVE)
+				types = ((Literal<EntityData<?>>) args[0]).getAll();
+			else {
+				Skript.error("Entity move event requires Paper 1.16.5+", ErrorQuality.SEMANTIC_ERROR);
+				return false;
+			}
 		}
 		return true;
 	}
@@ -81,9 +87,7 @@ public class EvtMove extends SkriptEvent {
 			LivingEntity entity = entityEvent.getEntity();
 			for (EntityData<?> type : types) {
 				if (type.isInstance(entity)) {
-					if (!HAS_POS_METHOD) {
-						return true;
-					} else if (((EntityMoveEvent) event).hasChangedPosition()) {
+					if (!HAS_POS_METHOD || entityEvent.hasChangedPosition()) {
 						return true;
 					}
 				}
@@ -96,4 +100,5 @@ public class EvtMove extends SkriptEvent {
 	public String toString(@Nullable Event e, boolean debug) {
 		return (HAS_ENTITY_MOVE && types != null ? types.toString() : "player") + " move";
 	}
+
 }


### PR DESCRIPTION
### Description
This PR introduces the Player move event, along with an entity move event.
In the past it has been discussed to not use these events as they are performance heavy.
Here are a couple reasons I decided to add this:

1) Skript already uses the move event for the "move on" event. So regardless, the performance is going to be hindered by that event.

2) Paper (and I think Spigot too) only calls heavy events like this, if a plugin actually registers an event. 
Skript only registers a listener if a user is using said event. That said, performance will only potentially take a hit to users who use this event. I added cautionary notes in the description of the event to make sure users are clear. This is up to them if they want to use the event or not.

I don't think its in our position to deny users an event strictly because we think it may hurt their server, we should leave that decision in their hands. SkQuery already has this event, which is used by many people. I figured its probably in our best interest to add it.

---
**Target Minecraft Versions:** Paper 1.16.5+ for entity move, any for player move
**Requirements:** Paper 1.16.5+ for entity move, any for player move
**Related Issues:** #716 (added by pickle man) 
