### PR TITLE
Fix EffDoIf with exit effect

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffDoIf.java
+++ b/src/main/java/ch/njol/skript/effects/EffDoIf.java
@@ -71,6 +71,7 @@ public class EffDoIf extends Effect  {
 	@Override
 	public TriggerItem walk(Event e) {
 		if (condition.check(e)) {
+			effect.setParent(getParent());
 			effect.setNext(getNext());
 			return effect;
 		}


### PR DESCRIPTION
### Description
EffDoIf didn't set the parsed effects parent.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #3983
