### PR TITLE
Fix event listening with subclasses

### DIFF
--- a/src/main/java/ch/njol/skript/SkriptEventHandler.java
+++ b/src/main/java/ch/njol/skript/SkriptEventHandler.java
@@ -96,7 +96,7 @@ public abstract class SkriptEventHandler {
 	
 	private static Iterator<Trigger> getTriggers(Class<? extends Event> event) {
 		return triggers.stream()
-			.filter(pair -> event.equals(pair.getFirst()))
+			.filter(pair -> pair.getFirst().isAssignableFrom(event))
 			.map(NonNullPair::getSecond)
 			.iterator();
 	}


### PR DESCRIPTION
### Description
Fixes events not being called when a subclass of the registered event was called instead of the exact event class.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #3852
