### PR TITLE
Fix teleport effect async

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffTeleport.java
+++ b/src/main/java/ch/njol/skript/effects/EffTeleport.java
@@ -45,7 +45,7 @@ import org.eclipse.jdt.annotation.Nullable;
 @Description({"Teleport an entity to a specific location. ",
 		"This effect is delayed by default on Paper, meaning certain syntax such as the return effect for functions cannot be used after this effect.",
 		"The keyword 'force' indicates this effect will not be delayed, ",
-		"which may cause lag spikes or server crashes when using this effect to teleport players to unloaded chunks."})
+		"which may cause lag spikes or server crashes when using this effect to teleport entities to unloaded chunks."})
 @Examples({"teleport the player to {homes.%player%}",
 		"teleport the attacker to the victim"})
 @Since("1.0")

--- a/src/main/java/ch/njol/skript/effects/EffTeleport.java
+++ b/src/main/java/ch/njol/skript/effects/EffTeleport.java
@@ -18,16 +18,6 @@
  */
 package ch.njol.skript.effects;
 
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
-import org.bukkit.entity.Entity;
-import org.bukkit.event.Event;
-import org.bukkit.event.player.PlayerMoveEvent;
-import org.bukkit.event.player.PlayerRespawnEvent;
-import org.eclipse.jdt.annotation.Nullable;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -43,6 +33,13 @@ import ch.njol.skript.util.Direction;
 import ch.njol.skript.variables.Variables;
 import ch.njol.util.Kleenean;
 import io.papermc.lib.PaperLib;
+import io.papermc.lib.environments.PaperEnvironment;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Event;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerRespawnEvent;
+import org.eclipse.jdt.annotation.Nullable;
 
 @Name("Teleport")
 @Description("Teleport an entity to a specific location.")
@@ -51,20 +48,28 @@ import io.papermc.lib.PaperLib;
 @Since("1.0")
 public class EffTeleport extends Effect {
 
+	private static final boolean CAN_RUN_ASYNC = PaperLib.getEnvironment() instanceof PaperEnvironment;
+
 	static {
-		Skript.registerEffect(EffTeleport.class, "teleport %entities% (to|%direction%) %location%");
+		Skript.registerEffect(EffTeleport.class, "[(1¦force)] teleport %entities% (to|%direction%) %location%");
 	}
 
-	@SuppressWarnings("null")
+	@SuppressWarnings("NotNullFieldNotInitialized")
 	private Expression<Entity> entities;
-	@SuppressWarnings("null")
+	@SuppressWarnings("NotNullFieldNotInitialized")
 	private Expression<Location> location;
+
+	private boolean isAsync;
 
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
-	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parser) {
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		entities = (Expression<Entity>) exprs[0];
 		location = Direction.combine((Expression<? extends Direction>) exprs[1], (Expression<? extends Location>) exprs[2]);
+		isAsync = CAN_RUN_ASYNC && parseResult.mark == 0;
+
+		if (isAsync)
+			getParser().setHasDelayBefore(Kleenean.UNKNOWN); // UNKNOWN because it isn't async if the chunk is already loaded.
 		return true;
 	}
 	
@@ -72,36 +77,46 @@ public class EffTeleport extends Effect {
 	@Override
 	protected TriggerItem walk(Event e) {
 		debug(e, true);
+
 		TriggerItem next = getNext();
+
 		boolean delayed = Delay.isDelayed(e);
+		
+		Location loc = location.getSingle(e);
+		if (loc == null)
+			return next;
+
+		Entity[] entityArray = entities.getArray(e); // We have to fetch this before possible async execution to avoid async local variable access.
+		if (entityArray.length == 0)
+			return next;
+
+		if (!delayed) {
+			if (e instanceof PlayerRespawnEvent && entityArray.length == 1 && entityArray[0].equals(((PlayerRespawnEvent) e).getPlayer())) {
+				((PlayerRespawnEvent) e).setRespawnLocation(loc);
+				return next;
+			}
+
+			if (e instanceof PlayerMoveEvent && entityArray.length == 1 && entityArray[0].equals(((PlayerMoveEvent) e).getPlayer())) {
+				((PlayerMoveEvent) e).setTo(loc);
+				return next;
+			}
+		}
+
+		if (!isAsync) {
+			for (Entity entity : entityArray) {
+				entity.teleport(loc);
+			}
+			return next;
+		}
+
 		Delay.addDelayedEvent(e);
-		
-		final Location loc = location.getSingle(e);
-		final Entity[] entityArray = entities.getArray(e); // We have to fetch this before possible async execution to avoid async local variable access.
-		
-		final boolean respawnEvent = !delayed && e instanceof PlayerRespawnEvent && entityArray.length == 1 && entityArray[0].equals(((PlayerRespawnEvent) e).getPlayer());
-		final boolean moveEvent = !delayed && e instanceof PlayerMoveEvent && entityArray.length == 1 && entityArray[0].equals(((PlayerMoveEvent) e).getPlayer());
-		
-		if (respawnEvent && loc != null) {
-			((PlayerRespawnEvent) e).setRespawnLocation(getSafeLocation(loc));
-		}
-		
-		if (moveEvent && loc != null) {
-			((PlayerMoveEvent) e).setTo(getSafeLocation(loc));
-		}
-		
-		if ((respawnEvent || moveEvent) || loc == null) {
-			continueWalk(next, e);
-			return null;
-		}
-		
 		Object localVars = Variables.removeLocals(e);
 		
-		// This will either fetch the chunk instantly if on spigot or already loaded or fetch it async if on paper.
+		// This will either fetch the chunk instantly if on Spigot or already loaded or fetch it async if on Paper.
 		PaperLib.getChunkAtAsync(loc).thenAccept(chunk -> {
 			// The following is now on the main thread
-			for (final Entity entity : entityArray) {
-				entity.teleport(getSafeLocation(loc));
+			for (Entity entity : entityArray) {
+				entity.teleport(loc);
 			}
 
 			// Re-set local variables
@@ -109,47 +124,30 @@ public class EffTeleport extends Effect {
 				Variables.setLocalVariables(e, localVars);
 			
 			// Continue the rest of the trigger if there is one
-			continueWalk(next, e);
+			Object timing = null;
+			if (next != null) {
+				if (SkriptTimings.enabled()) {
+					Trigger trigger = getTrigger();
+					if (trigger != null) {
+						timing = SkriptTimings.start(trigger.getDebugLabel());
+					}
+				}
+
+				TriggerItem.walk(next, e);
+			}
+			Variables.removeLocals(e); // Clean up local vars, we may be exiting now
+			SkriptTimings.stop(timing);
 		});
 		return null;
 	}
-	
-	private void continueWalk(@Nullable TriggerItem next, Event e) {
-		Object timing = null;
-		if (next != null) {
-			if (SkriptTimings.enabled()) {
-				Trigger trigger = getTrigger();
-				if (trigger != null) {
-					timing = SkriptTimings.start(trigger.getDebugLabel());
-				}
-			}
-			
-			TriggerItem.walk(next, e);
-		}
-		Variables.removeLocals(e); // Clean up local vars, we may be exiting now
-		SkriptTimings.stop(timing);
-	}
-	
-	private Location getSafeLocation(Location loc) {
-		Location toLoc = loc;
-		if (Math.abs(toLoc.getX() - toLoc.getBlockX() - 0.5) < Skript.EPSILON && Math.abs(toLoc.getZ() - toLoc.getBlockZ() - 0.5) < Skript.EPSILON) {
-			final Block on = toLoc.getBlock().getRelative(BlockFace.DOWN);
-			if (on.getType() != Material.AIR) {
-				toLoc = toLoc.clone();
-				// TODO 1.13 block height stuff
-				//to.setY(on.getY() + Utils.getBlockHeight(on.getTypeId(), on.getData()));
-			}
-		}
-		return toLoc;
-	}
-	
+
 	@Override
-	protected void execute(final Event e) {
+	protected void execute(Event e) {
 		// Nothing needs to happen here, we're executing in walk
 	}
 
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(@Nullable Event e, boolean debug) {
 		return "teleport " + entities.toString(e, debug) + " to " + location.toString(e, debug);
 	}
 

--- a/src/main/java/ch/njol/skript/effects/EffTeleport.java
+++ b/src/main/java/ch/njol/skript/effects/EffTeleport.java
@@ -42,7 +42,10 @@ import org.bukkit.event.player.PlayerRespawnEvent;
 import org.eclipse.jdt.annotation.Nullable;
 
 @Name("Teleport")
-@Description("Teleport an entity to a specific location.")
+@Description({"Teleport an entity to a specific location. ",
+		"This effect is delayed by default on Paper, meaning certain syntax such as the return effect for functions cannot be used after this effect.",
+		"The keyword 'force' indicates this effect will not be delayed, ",
+		"which may cause lag spikes or server crashes when using this effect to teleport players to unloaded chunks."})
 @Examples({"teleport the player to {homes.%player%}",
 		"teleport the attacker to the victim"})
 @Since("1.0")


### PR DESCRIPTION
### Description
Makes EffTeleport properly mark a trigger as delayed during parsing (if applicable), and adds an optional 'force' keyword to make the teleport synchronous.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #3816
