### PR TITLE
Fix EffReplace escaping characters when not needed

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffReplace.java
+++ b/src/main/java/ch/njol/skript/effects/EffReplace.java
@@ -106,7 +106,7 @@ public class EffReplace extends Effect {
 				for (int x = 0; x < haystack.length; x++)
 					for (final Object n : needles) {
 						assert n != null;
-						haystack[x] = StringUtils.replace((String)haystack[x], (String)n, Matcher.quoteReplacement((String)replacement), caseSensitive);
+						haystack[x] = StringUtils.replace((String) haystack[x], (String) n, (String) replacement, caseSensitive);
 					}
 			}
 			this.haystack.change(e, haystack, ChangeMode.SET);

--- a/src/main/java/ch/njol/util/StringUtils.java
+++ b/src/main/java/ch/njol/util/StringUtils.java
@@ -402,7 +402,7 @@ public abstract class StringUtils {
 	public static String replace(final String haystack, final String needle, final String replacement, final boolean caseSensitive) {
 		if (caseSensitive)
 			return "" + haystack.replace(needle, replacement);
-		return "" + haystack.replaceAll("(?ui)" + Pattern.quote(needle), replacement);
+		return "" + haystack.replaceAll("(?ui)" + Pattern.quote(needle), Matcher.quoteReplacement(replacement));
 	}
 	
 	public static String replaceFirst(final String haystack, final String needle, final String replacement, final boolean caseSensitive) {


### PR DESCRIPTION
### Description
Update `EffReplace` and `StringUtils` so it only escapes the replacement string if needed, which is only if the replacement is done with regex, which is only done if case sensitivity is disabled.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #1226
