### PR TITLE
SecConditional - add `parse if` option

### DIFF
--- a/src/main/java/ch/njol/skript/events/bukkit/SkriptParseEvent.java
+++ b/src/main/java/ch/njol/skript/events/bukkit/SkriptParseEvent.java
@@ -1,0 +1,40 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.events.bukkit;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Internally used for parsing `parse if` sections
+ */
+public class SkriptParseEvent extends Event {
+
+	private final static HandlerList handlers = new HandlerList();
+
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+
+}

--- a/src/main/java/ch/njol/skript/sections/SecConditional.java
+++ b/src/main/java/ch/njol/skript/sections/SecConditional.java
@@ -52,6 +52,7 @@ public class SecConditional extends Section {
 	private ConditionalType type;
 	private Condition condition;
 	private boolean parseIf;
+	private boolean parseIfPassed;
 
 	private Kleenean hasDelayAfter;
 
@@ -109,6 +110,7 @@ public class SecConditional extends Section {
 			if (!condition.check(new SkriptParseEvent())) {
 				return true;
 			}
+			parseIfPassed = true;
 		}
 
 		Kleenean hadDelayBefore = getParser().getHasDelayBefore();
@@ -146,7 +148,9 @@ public class SecConditional extends Section {
 	@Nullable
 	@Override
 	protected TriggerItem walk(Event e) {
-		if (type == ConditionalType.ELSE || condition.check(e)) {
+		if (parseIf && !parseIfPassed) {
+			return getNext();
+		} else if (type == ConditionalType.ELSE || parseIf || condition.check(e)) {
 			if (last != null)
 				last.setNext(getSkippedNext());
 			return first != null ? first : getSkippedNext();

--- a/src/main/java/ch/njol/skript/sections/SecConditional.java
+++ b/src/main/java/ch/njol/skript/sections/SecConditional.java
@@ -90,10 +90,11 @@ public class SecConditional extends Section {
 				if (!condition.check(null)) {
 					return true;
 				}
-			} catch (NullPointerException ignore) {
+			} catch (NullPointerException | IllegalArgumentException ignore) {
 				String expr = parseResult.regexes.get(0).group();
 				String e = matchedPattern == 1 ? "else " : "";
 				Skript.error("Condition '" + expr + "' can't be used with '" + e + "parse if': " + condition);
+				return false;
 			}
 		}
 

--- a/src/main/java/ch/njol/skript/sections/SecConditional.java
+++ b/src/main/java/ch/njol/skript/sections/SecConditional.java
@@ -49,7 +49,6 @@ public class SecConditional extends Section {
 	private ConditionalType type;
 	private Condition condition;
 	private boolean parseIf;
-	private boolean parseIfPassed;
 
 	private Kleenean hasDelayAfter;
 
@@ -91,7 +90,6 @@ public class SecConditional extends Section {
 				if (!condition.check(null)) {
 					return true;
 				}
-				parseIfPassed = true;
 			} catch (NullPointerException ignore) {
 				String expr = parseResult.regexes.get(0).group();
 				String e = matchedPattern == 1 ? "else " : "";
@@ -134,7 +132,7 @@ public class SecConditional extends Section {
 	@Nullable
 	@Override
 	protected TriggerItem walk(Event e) {
-		if (type == ConditionalType.ELSE || (parseIf && parseIfPassed) || condition.check(e)) {
+		if (type == ConditionalType.ELSE || condition.check(e)) {
 			if (last != null)
 				last.setNext(getSkippedNext());
 			return first != null ? first : getSkippedNext();

--- a/src/main/java/ch/njol/skript/sections/SecConditional.java
+++ b/src/main/java/ch/njol/skript/sections/SecConditional.java
@@ -38,7 +38,7 @@ public class SecConditional extends Section {
 	static {
 		Skript.registerSection(SecConditional.class,
 			"else",
-			"else (|1¦parse) if <.+>",
+			"else [(1¦parse)] if <.+>",
 			"[(1¦parse if|2¦if)] <.+>");
 	}
 
@@ -49,6 +49,7 @@ public class SecConditional extends Section {
 	private ConditionalType type;
 	private Condition condition;
 	private boolean parseIf;
+	private boolean parseIfPassed;
 
 	private Kleenean hasDelayAfter;
 
@@ -90,6 +91,7 @@ public class SecConditional extends Section {
 				if (!condition.check(null)) {
 					return true;
 				}
+				parseIfPassed = true;
 			} catch (NullPointerException ignore) {
 				String expr = parseResult.regexes.get(0).group();
 				String e = matchedPattern == 1 ? "else " : "";
@@ -132,7 +134,7 @@ public class SecConditional extends Section {
 	@Nullable
 	@Override
 	protected TriggerItem walk(Event e) {
-		if (type == ConditionalType.ELSE || condition.check(e)) {
+		if (type == ConditionalType.ELSE || (parseIf && parseIfPassed) || condition.check(e)) {
 			if (last != null)
 				last.setNext(getSkippedNext());
 			return first != null ? first : getSkippedNext();

--- a/src/test/skript/tests/syntaxes/sections/SecConditional.sk
+++ b/src/test/skript/tests/syntaxes/sections/SecConditional.sk
@@ -1,0 +1,13 @@
+test "SecConditional - ParseIf":
+	parse if plugin "LaDeDa-LeFakePlugin" is enabled:
+		#this code in this section should NOT be parsed
+		floopidy flopidy flernindurf
+		assert 10 = 1 with "ParseIf section was parsed and failed"
+
+	parse if plugin "Skript" is enabled:
+		#this code in this should SHOULD be parsed
+		set {_a} to 10 # I mean.. what else do you put here, amirite?
+
+	else:
+		#this code in this section SHOULD be parsed but should NOT be ran
+		assert 10 = 1 with "ParseIf/Else section was parsed and failed"

--- a/src/test/skript/tests/syntaxes/sections/SecConditional.sk
+++ b/src/test/skript/tests/syntaxes/sections/SecConditional.sk
@@ -4,7 +4,7 @@ test "SecConditional - ParseIf":
 		floopidy flopidy flernindurf
 		assert 10 = 1 with "ParseIf section was parsed and failed"
 
-	parse if plugin "Skript" is enabled:
+	else parse if plugin "Skript" is enabled:
 		#this code in this should SHOULD be parsed
 		set {_a} to 10 # I mean.. what else do you put here, amirite?
 


### PR DESCRIPTION
### Description
This PR aims to add a `parse if` condition.
The goal of this is stop code from being parsed in a section if the condition is not true.
This can be useful when using different addons with a script, and only wanting to load code if the addon is actually loaded, otherwise this code would throw a bunch of errors on you.

Example code:
```vb
on load:
	parse if plugin "SkBee" is enabled:
		this fake code SHOULD error

	else parse if plugin "SomeFakePlugin" is enabled:
		this fake code should NOT error
```
Output:
```
> sk reload test
[14:12:48 INFO]: [Skript] Reloading test.sk...
[14:12:48 ERROR]: Can't understand this condition/effect: this fake code SHOULD error (test.sk, line 6: this fake code SHOULD error')
[14:12:48 INFO]: [Skript] Encountered 1 error while reloading test.sk!
```

Because SkBee is loaded on my server, the code below is parsed (and in this case errors cause its not real code)
The second plugin is fake/not loaded, therefor the section does not parse, and no errors.


---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:**  #2037 and #1449
