### PR TITLE
Fix doubly nested variable parsing

### DIFF
--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -279,9 +279,17 @@ public class SkriptParser {
 		if (varPattern.matcher(expr).matches()) {
 			String variableName = "" + expr.substring(expr.indexOf('{') + 1, expr.lastIndexOf('}'));
 			boolean inExpression = false;
+			int variableDepth = 0;
 			for (char c : variableName.toCharArray()) {
-				if (c == '%')
+				if (c == '%' && variableDepth == 0)
 					inExpression = !inExpression;
+				if (inExpression) {
+					if (c == '{') {
+						variableDepth++;
+					} else if (c == '}')
+						variableDepth--;
+				}
+
 				if (!inExpression && (c == '{' || c == '}'))
 					return null;
 			}

--- a/src/test/skript/tests/regressions/4143-nested-variables-erroring-in-2.6-beta1.sk
+++ b/src/test/skript/tests/regressions/4143-nested-variables-erroring-in-2.6-beta1.sk
@@ -1,0 +1,10 @@
+on load:
+	suppress conflict warnings
+
+test "nested variable parsing":
+	delete {_a}
+	delete {_a%{b}%}
+	delete {_a%{b%{c}%}%}
+	delete {_a%{b%{c%{d}%}%}%}
+	delete {_a%{b%{c%{d%{e}%}%}%}%}
+	delete {_a%{b%{c} + {d}%} + {e%{f} + {g}%}%}


### PR DESCRIPTION
### Description
Update `SkriptParser#parseVariable` to allow doubly nested variables. Also adds a test for them.

This is how this method saw the input (`.` is text, `^` is expression) before this change:
```
{aaa%{bbb%{ccc}%}%}
....^^^^^^.....^^^.
```

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4143
