### PR TITLE
Update code conventions to require Java 16 for compiling

### DIFF
--- a/code-conventions.md
+++ b/code-conventions.md
@@ -107,10 +107,9 @@ Your comments should look something like these:
 ```
 
 ## Language Features
-* Java 8 source and binary compatibility
-  - JDK 8 must be enough to develop Skript
+* Java 8 source and binary compatibility, even though compiling Skript requires Java 16
   - Users must not need JRE newer than version 8
-* Java 9 and 10 must also work
+* Versions up to and including Java 16 should work too
   - Absolutely no dirty deep reflection hacks
 * It is recommended to make fields final, if they are effectively final
   - Performance impact is be minimal, but it makes code cleaner


### PR DESCRIPTION
### Description
Updates code-conventions.md

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
