### PR TITLE
Fix conditionals with inline conditions or exit section effects

### DIFF
--- a/src/main/java/ch/njol/skript/sections/SecConditional.java
+++ b/src/main/java/ch/njol/skript/sections/SecConditional.java
@@ -74,6 +74,7 @@ public class SecConditional extends Section {
 
 			// Change event if using 'parse if'
 			if (parseIf) {
+				//noinspection unchecked
 				parser.setCurrentEvents(new Class[]{SkriptParseEvent.class});
 				parser.setCurrentEventName("parse");
 				parser.setCurrentSkriptEvent(null);
@@ -145,25 +146,39 @@ public class SecConditional extends Section {
 		return true;
 	}
 
+	@Override
+	@Nullable
+	public TriggerItem getNext() {
+		return getSkippedNext();
+	}
+
+	@Nullable
+	public TriggerItem getNormalNext() {
+		return super.getNext();
+	}
+
 	@Nullable
 	@Override
 	protected TriggerItem walk(Event e) {
 		if (parseIf && !parseIfPassed) {
-			return getNext();
+			return getNormalNext();
 		} else if (type == ConditionalType.ELSE || parseIf || condition.check(e)) {
+			TriggerItem skippedNext = getSkippedNext();
+			setNext(skippedNext);
+
 			if (last != null)
-				last.setNext(getSkippedNext());
-			return first != null ? first : getSkippedNext();
+				last.setNext(skippedNext);
+			return first != null ? first : skippedNext;
 		} else {
-			return getNext();
+			return getNormalNext();
 		}
 	}
 
 	@Nullable
 	private TriggerItem getSkippedNext() {
-		TriggerItem next = getNext();
+		TriggerItem next = getNormalNext();
 		while (next instanceof SecConditional && ((SecConditional) next).type != ConditionalType.IF)
-			next = next.getNext();
+			next = ((SecConditional) next).getNormalNext();
 		return next;
 	}
 

--- a/src/test/skript/tests/syntaxes/sections/SecConditional.sk
+++ b/src/test/skript/tests/syntaxes/sections/SecConditional.sk
@@ -11,3 +11,22 @@ test "SecConditional - ParseIf":
 	else:
 		#this code in this section SHOULD be parsed but should NOT be ran
 		assert 10 = 1 with "ParseIf/Else section was parsed and failed"
+
+test "SecConditional":
+	set {_b} to true
+	if 1 is 1:
+		delete {_b}
+		1 = 2
+	else if 1 = 1:
+		assert 1 = 2 with "conditional failed ##1"
+	else:
+		assert 1 = 2 with "conditional failed ##2"
+	if {_b} is set:
+		assert 1 = 2 with "conditional failed ##3"
+
+	if 1 = 2:
+		assert 1 = 2 with "conditional failed ##4"
+	else if 1 = 1:
+		exit 1 section
+	else:
+		assert 1 = 2 with "conditional failed ##5"


### PR DESCRIPTION
### Description
Fixes a bug with code such as 
```
command /test:
	trigger:
		if 1 = 1:
			broadcast "true"
			exit 1 section # or an inline condition that returns false, such as `1 = 2`
		else:
			broadcast "false"
```
broadcasting both true and false.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
