### PR TITLE
Rework EffPotion

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/DefaultConverters.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultConverters.java
@@ -34,6 +34,8 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -353,5 +355,11 @@ public class DefaultConverters {
 				}
 			});
 		}
+
+		// PotionEffectType -> PotionEffect (300 ticks = 15 seconds default duration)
+		Converters.registerConverter(PotionEffectType.class, PotionEffect.class,
+			potionEffectType -> new PotionEffect(potionEffectType, 300, 0, false, true)
+		);
+
 	}
 }


### PR DESCRIPTION
### Description
This PR makes changes to EffPotion to have it follow vanilla behavior. This was done by reworking the whole thing to only use the PotionEffect class that Skript now supports (as of 2.5.2 iirc)

I added two new syntax options to EffPotionEffect as well. This allows users to create PotionEffects from syntax such as `swiftness 2`

I also added a converter that converts PotionEffectTypes into PotionEffects. This allows a user to do something like:
`apply speed to player for 5 seconds`

There are still some changes to be made, so I am opening this as a draft.
It is worth nothing that the default duration from the /effect command is 30 seconds, so we should probably change that internally too.

NOTE: This PR contains breaking syntax changes. It should be merged in a future version, such as 2.6.1 or even as far as 2.7 (that can be decided).

---
**Target Minecraft Versions:** Any
**Requirements:** None
**Related Issues:** #4178 
