### PR TITLE
Make `parsed` optional in `parsed as`

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprParse.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprParse.java
@@ -73,7 +73,7 @@ import ch.njol.util.NonNullPair;
 public class ExprParse extends SimpleExpression<Object> {
 	static {
 		Skript.registerExpression(ExprParse.class, Object.class, ExpressionType.COMBINED,
-				"%string% parsed as (%-*classinfo%|\"<.*>\")");
+				"%string% [parsed] as (%-*classinfo%|\"<.*>\")");
 	}
 	
 	@Nullable


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
This PRs aims to make `ExprParse` shorter and easier in most cases to be `[parsed] as` so users can do `set {_p} to "SkriptDev" as offlineplayer`

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions --> any
**Requirements:** <!-- Required plugins, Minecraft versions, server software... --> none
**Related Issues:** <!-- Links to related issues -->
