### PR TITLE
Fix incorrect ending dash with ExprRawName

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/AliasesProvider.java
+++ b/src/main/java/ch/njol/skript/aliases/AliasesProvider.java
@@ -95,11 +95,11 @@ public class AliasesProvider {
 		
 		@Nullable
 		public String insertId(@Nullable String inserted) {
-			if (id == null) // Inserting to nothing
-				return inserted;
-			if (inserted == null)
+			if (inserted == null) // Nothing to insert
 				return id;
 			inserted = inserted.substring(0, inserted.length() - 1); // Strip out -
+			if (id == null) // Inserting to nothing
+				return inserted;
 			
 			String id = this.id;
 			assert id != null;


### PR DESCRIPTION
### Description
This PR aims to fix the linked issue by stripping the ending dash slightly earlier (if the string to insert is not null, it will try to strip it basically).

---
**Target Minecraft Versions:** None
**Requirements:** None
**Related Issues:** #4160
