### PR TITLE
Add magma to itemtype damage cause comparator

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/DefaultComparators.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultComparators.java
@@ -464,7 +464,7 @@ public class DefaultComparators {
 		ItemType lava = Aliases.javaItemType("lava");
 		Comparators.registerComparator(DamageCause.class, ItemType.class, new Comparator<DamageCause, ItemType>() {
 			@Override
-			public Relation compare(final DamageCause dc, final ItemType t) {
+			public Relation compare(DamageCause dc, ItemType t) {
 				switch (dc) {
 					case FIRE:
 						return Relation.get(t.isOfType(Material.FIRE));
@@ -472,10 +472,13 @@ public class DefaultComparators {
 						return Relation.get(t.equals(lava));
 					case MAGIC:
 						return Relation.get(t.isOfType(Material.POTION));
-						//$CASES-OMITTED$
-					default:
-						return Relation.NOT_EQUAL;
 				}
+				if (Skript.fieldExists(DamageCause.class, "HOT_FLOOR")
+						&& dc.equals(DamageCause.HOT_FLOOR)) {
+					return Relation.get(t.isOfType(Material.MAGMA_BLOCK));
+				}
+
+				return Relation.NOT_EQUAL;
 			}
 			
 			@Override


### PR DESCRIPTION
### Description
Adds magma to the itemtype - damage cause comparator

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4203
