### PR TITLE
Add getExpr to PropertyCondition

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
+++ b/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
@@ -152,7 +152,7 @@ public abstract class PropertyCondition<T> extends Condition implements Checker<
 	}
 	
 	/**
-	 * @return The expression this condition checks the property of
+	 * @return The expression this condition checks the property of.
 	 */
 	public final Expression<? extends T> getExpr() {
 		return expr;

--- a/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
+++ b/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
@@ -151,6 +151,13 @@ public abstract class PropertyCondition<T> extends Condition implements Checker<
 		this.expr = expr;
 	}
 	
+	/**
+	 * @return The expression this condition checks the property of
+	 */
+	public final Expression<? extends T> getExpr() {
+		return expr;
+	}
+	
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
 		return toString(this, getPropertyType(), e, debug, expr, getPropertyName());


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
This PR aims to add a missing method `getExpr` in PropertyCondition class which can be useful in some cases such as overriding `toString` method therefore you can get the expression using this method.

This was supposed to be in another PR with a new condition I was adding `hasLineOfSight` but I found some weird behavior of that condition therefore it requires more testing so I decided to push this small PR.

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->Any
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->None
**Related Issues:** <!-- Links to related issues -->None
