### PR TITLE
Fix combined conditional running on non-first runs

### DIFF
--- a/src/main/java/ch/njol/skript/sections/SecConditional.java
+++ b/src/main/java/ch/njol/skript/sections/SecConditional.java
@@ -164,8 +164,6 @@ public class SecConditional extends Section {
 			return getNormalNext();
 		} else if (type == ConditionalType.ELSE || parseIf || condition.check(e)) {
 			TriggerItem skippedNext = getSkippedNext();
-			setNext(skippedNext);
-
 			if (last != null)
 				last.setNext(skippedNext);
 			return first != null ? first : skippedNext;


### PR DESCRIPTION
### Description
Fixes fallout from #4175: the line `setNext(skippedNext)` was leftover from a previous version of that change, I forgot to remove it before pushing.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4212, https://github.com/SkriptLang/Skript/pull/4162#issuecomment-884731972, #4175
