### PR TITLE
Fix WorldGuard 6 module not building to right Java version

### DIFF
--- a/skript-worldguard6/build.gradle
+++ b/skript-worldguard6/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'java'
 
+tasks.withType(JavaCompile).configureEach {
+	options.compilerArgs += ["-source", "1.8", "-target", "1.8"]
+}
+
 dependencies {
 	implementation rootProject
 	implementation 'org.eclipse.jdt:org.eclipse.jdt.annotation:2.2.600'


### PR DESCRIPTION
### Description
Fixes the WorldGuard 6 module by adding this code from the main module's build.gradle:
https://github.com/SkriptLang/Skript/blob/6e7eca0d609fdbc8bbb4b1d3fad484f43a45f612/build.gradle#L14-L16

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4211
