### PR TITLE
Fix online players syntax missing 's'

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprOnlinePlayersCount.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprOnlinePlayersCount.java
@@ -51,8 +51,8 @@ public class ExprOnlinePlayersCount extends SimpleExpression<Number> {
 
 	static {
 		Skript.registerExpression(ExprOnlinePlayersCount.class, Number.class, ExpressionType.PROPERTY,
-				"[the] [(1¦(real|default)|2¦(fake|shown|displayed))] [online] players (count|amount|number)",
-				"[the] [(1¦(real|default)|2¦(fake|shown|displayed))] (count|amount|number|size) of [online] players");
+				"[the] [(1¦(real|default)|2¦(fake|shown|displayed))] [online] player[s] (count|amount|number)",
+				"[the] [(1¦(real|default)|2¦(fake|shown|displayed))] (count|amount|number|size) of [online] player[s]");
 	}
 
 	private static final boolean PAPER_EVENT_EXISTS = Skript.classExists("com.destroystokyo.paper.event.server.PaperServerListPingEvent");

--- a/src/main/java/ch/njol/skript/expressions/ExprOnlinePlayersCount.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprOnlinePlayersCount.java
@@ -52,7 +52,7 @@ public class ExprOnlinePlayersCount extends SimpleExpression<Number> {
 	static {
 		Skript.registerExpression(ExprOnlinePlayersCount.class, Number.class, ExpressionType.PROPERTY,
 				"[the] [(1¦(real|default)|2¦(fake|shown|displayed))] [online] players (count|amount|number)",
-				"[the] [(1¦(real|default)|2¦(fake|shown|displayed))] (count|amount|number|size) of online players");
+				"[the] [(1¦(real|default)|2¦(fake|shown|displayed))] (count|amount|number|size) of [online] players");
 	}
 
 	private static final boolean PAPER_EVENT_EXISTS = Skript.classExists("com.destroystokyo.paper.event.server.PaperServerListPingEvent");

--- a/src/main/java/ch/njol/skript/expressions/ExprOnlinePlayersCount.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprOnlinePlayersCount.java
@@ -51,7 +51,7 @@ public class ExprOnlinePlayersCount extends SimpleExpression<Number> {
 
 	static {
 		Skript.registerExpression(ExprOnlinePlayersCount.class, Number.class, ExpressionType.PROPERTY,
-				"[the] [(1¦(real|default)|2¦(fake|shown|displayed))] [online] player (count|amount|number)",
+				"[the] [(1¦(real|default)|2¦(fake|shown|displayed))] [online] players (count|amount|number)",
 				"[the] [(1¦(real|default)|2¦(fake|shown|displayed))] (count|amount|number|size) of online players");
 	}
 


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
This PR aims to fix the syntax of `ExprOnlinePlayersCount` missing an `s` in `players` in the first pattern

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions --> Any
**Requirements:** <!-- Required plugins, Minecraft versions, server software... --> None
**Related Issues:** <!-- Links to related issues -->#4219
