### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ dependencies {
 
 An example of the version tag would be ```dev37c```.
 
-> Note: If Gradle isn't able to resolve Skript's dependencies, just [disable the resolution of transitive dependencies](https://docs.gradle.org/current/userguide/managing_transitive_dependencies.html#sub:disabling_resolution_transitive_dependencies) for Skript in your project.
+> Note: If Gradle isn't able to resolve Skript's dependencies, just [disable the resolution of transitive dependencies](https://docs.gradle.org/current/userguide/resolution_rules.html#sec:disabling_resolution_transitive_dependencies) for Skript in your project.
 
 Or, if you use Maven:
 ```


### PR DESCRIPTION
### Description
This pull request just fixes a broken link about Gradle in the README.