### PR TITLE
Remove reloading difference async and sync loading

### DIFF
--- a/src/main/java/ch/njol/skript/SkriptCommand.java
+++ b/src/main/java/ch/njol/skript/SkriptCommand.java
@@ -127,18 +127,16 @@ public class SkriptCommand implements CommandExecutor {
 					SkriptConfig.load();
 					Aliases.clear();
 					Aliases.load();
-					
-					if (!ScriptLoader.isAsync())
-						ScriptLoader.disableScripts();
+
+					ScriptLoader.disableScripts();
 					
 					ScriptLoader.loadScripts(logHandler)
 						.thenAccept(unused ->
 							reloaded(sender, logHandler, "config, aliases and scripts"));
 				} else if (args[1].equalsIgnoreCase("scripts")) {
 					reloading(sender, "scripts");
-					
-					if (!ScriptLoader.isAsync())
-						ScriptLoader.disableScripts();
+
+					ScriptLoader.disableScripts();
 					
 					ScriptLoader.loadScripts(logHandler)
 						.thenAccept(unused ->


### PR DESCRIPTION
### Description
The issue in #4246 happens because async reloading is different from normal reloading. In normal reloading, the script is first unloaded, then it is loaded. In async reloading, the script is first loaded, then the old version is unloaded. 

This behaviour was chosen because the server does not halt during async reloading and having the script unload first would mean there is a timeframe where the script is not running, and apparently this was unwanted behaviour.

In this PR I changed the async reloading behaviour, so that it unloads scripts first, then loads them (same as sync reloading).
This fixes the issue, but the disadvantage of this is that during script reloading commands or functions in the reloading scripts aren't available.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4246
