### PR TITLE
Fix entity rabbit comparison

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/DefaultComparators.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultComparators.java
@@ -21,6 +21,7 @@ package ch.njol.skript.classes.data;
 import java.util.Objects;
 
 import ch.njol.skript.aliases.MatchQuality;
+import ch.njol.skript.entity.RabbitData;
 import ch.njol.skript.util.GameruleValue;
 import ch.njol.skript.util.EnchantmentType;
 import ch.njol.skript.util.Experience;
@@ -279,6 +280,8 @@ public class DefaultComparators {
 //				return Relation.get(i.isOfType(Material.SKULL_ITEM.getId(), (short) 1));
 			if (e instanceof BoatData)
 				return Relation.get(((BoatData)e).isOfItemType(i));
+			if (e instanceof RabbitData)
+				return Relation.get(i.isOfType(Material.RABBIT));
 			for (ItemData data : i.getTypes()) {
 				assert data != null;
 				EntityData<?> entity = Aliases.getRelatedEntity(data);


### PR DESCRIPTION
### Description
Skript tried to compare the entity to the rabbit item, so I added rabbit to the EntityData - ItemType comparator

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4040
