### PR TITLE
Offline player stuff

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -862,18 +862,18 @@ public class BukkitClasses {
 					}
 					
 					@Override
-					public boolean canParse(final ParseContext context) {
+					public boolean canParse(ParseContext context) {
 						return context == ParseContext.COMMAND;
 					}
 					
 					@Override
-					public String toString(final OfflinePlayer p, final int flags) {
-						return "" + p.getName();
+					public String toString(OfflinePlayer p, int flags) {
+						return p.getName() == null ? p.getUniqueId().toString() : p.getName();
 					}
 					
 					@Override
-					public String toVariableNameString(final OfflinePlayer p) {
-						if (SkriptConfig.usePlayerUUIDsInVariableNames.value())
+					public String toVariableNameString(OfflinePlayer p) {
+						if (SkriptConfig.usePlayerUUIDsInVariableNames.value() || p.getName() == null)
 							return "" + p.getUniqueId();
 						else
 							return "" + p.getName();
@@ -888,10 +888,10 @@ public class BukkitClasses {
 					}
 					
 					@Override
-					public String getDebugMessage(final OfflinePlayer p) {
+					public String getDebugMessage(OfflinePlayer p) {
 						if (p.isOnline())
 							return Classes.getDebugMessage(p.getPlayer());
-						return "" + p.getName();
+						return toString(p, 0);
 					}
 				}).serializer(new Serializer<OfflinePlayer>() {
 					@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprArrowKnockbackStrength.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprArrowKnockbackStrength.java
@@ -45,7 +45,7 @@ public class ExprArrowKnockbackStrength extends SimplePropertyExpression<Project
 	final static boolean abstractArrowExists = Skript.classExists("org.bukkit.entity.AbstractArrow");
 	
 	static {
-		register(ExprArrowKnockbackStrength.class, Number.class, "[the] arrow knockback strength", "projectiles");
+		register(ExprArrowKnockbackStrength.class, Number.class, "arrow knockback strength", "projectiles");
 	}
 	
 	@Nullable

--- a/src/main/java/ch/njol/skript/expressions/ExprName.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprName.java
@@ -27,6 +27,7 @@ import java.util.List;
 import org.bukkit.Bukkit;
 import org.bukkit.GameRule;
 import org.bukkit.Nameable;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.Entity;
@@ -106,7 +107,7 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 
 	static {
 		HAS_GAMERULES = Skript.classExists("org.bukkit.GameRule");
-		register(ExprName.class, String.class, "(1¦name[s]|2¦(display|nick|chat|custom)[ ]name[s])", "players/entities/blocks/itemtypes/inventories/slots"
+		register(ExprName.class, String.class, "(1¦name[s]|2¦(display|nick|chat|custom)[ ]name[s])", "offlineplayers/entities/blocks/itemtypes/inventories/slots"
                 + (HAS_GAMERULES ? "/gamerules" : ""));
 		register(ExprName.class, String.class, "(3¦(player|tab)[ ]list name[s])", "players");
 
@@ -137,12 +138,20 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 	@Override
 	@Nullable
 	public String convert(Object o) {
+		if (o instanceof OfflinePlayer && ((OfflinePlayer) o).isOnline())
+			o = ((OfflinePlayer) o).getPlayer();
+
 		if (o instanceof Player) {
 			switch (mark) {
-				case 1: return ((Player) o).getName();
-				case 2: return ((Player) o).getDisplayName();
-				case 3: return ((Player) o).getPlayerListName();
+				case 1:
+					return ((Player) o).getName();
+				case 2:
+					return ((Player) o).getDisplayName();
+				case 3:
+					return ((Player) o).getPlayerListName();
 			}
+		} else if (o instanceof OfflinePlayer) {
+			return mark == 1 ? ((OfflinePlayer) o).getName() : null;
 		} else if (o instanceof Entity) {
 			return ((Entity) o).getCustomName();
 		} else if (o instanceof Block) {

--- a/src/main/java/ch/njol/skript/expressions/ExprTimePlayed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTimePlayed.java
@@ -18,6 +18,7 @@
  */
 package ch.njol.skript.expressions;
 
+import ch.njol.skript.classes.Changer.ChangeMode;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.Statistic;
 import org.bukkit.entity.Player;
@@ -73,8 +74,8 @@ public class ExprTimePlayed extends SimplePropertyExpression<OfflinePlayer, Time
 	
 	@Nullable
 	@Override
-	public Class<?>[] acceptChange(Changer.ChangeMode mode) {
-		if (mode == Changer.ChangeMode.SET || mode == Changer.ChangeMode.ADD || mode == Changer.ChangeMode.REMOVE) {
+	public Class<?>[] acceptChange(ChangeMode mode) {
+		if (mode == ChangeMode.SET || mode == ChangeMode.ADD || mode == ChangeMode.REMOVE) {
 			return CollectionUtils.array(Timespan.class);
 		} else {
 			return null;
@@ -82,7 +83,7 @@ public class ExprTimePlayed extends SimplePropertyExpression<OfflinePlayer, Time
 	}
 	
 	@Override
-	public void change(Event e, @Nullable Object[] delta, Changer.ChangeMode mode) {
+	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
 		long ticks = ((Timespan) delta[0]).getTicks_i();
 		for (OfflinePlayer offlinePlayer : getExpr().getArray(e)) {
 			long playerTicks = offlinePlayer.getStatistic(TIME_PLAYED);

--- a/src/main/java/ch/njol/skript/expressions/ExprTimePlayed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTimePlayed.java
@@ -18,6 +18,7 @@
  */
 package ch.njol.skript.expressions;
 
+import org.bukkit.OfflinePlayer;
 import org.bukkit.Statistic;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
@@ -44,12 +45,12 @@ import ch.njol.util.coll.CollectionUtils;
 	"\tgive player a diamond sword",
 	"set player's time played to 0 seconds"})
 @Since("2.5")
-public class ExprTimePlayed extends SimplePropertyExpression<Player, Timespan> {
-	
-	private final static Statistic TIME_PLAYED;
+public class ExprTimePlayed extends SimplePropertyExpression<OfflinePlayer, Timespan> {
+
+	private static final Statistic TIME_PLAYED;
 
 	static {
-		register(ExprTimePlayed.class, Timespan.class, "time played", "players");
+		register(ExprTimePlayed.class, Timespan.class, "time played", "offlineplayers");
 		if (Skript.isRunningMinecraft(1, 13)) {
 			TIME_PLAYED = Statistic.PLAY_ONE_MINUTE; // Statistic name is misleading, it's actually measured in ticks
 		} else {
@@ -66,8 +67,8 @@ public class ExprTimePlayed extends SimplePropertyExpression<Player, Timespan> {
 	
 	@Nullable
 	@Override
-	public Timespan convert(Player player) {
-		return Timespan.fromTicks_i(player.getStatistic(TIME_PLAYED));
+	public Timespan convert(OfflinePlayer offlinePlayer) {
+		return Timespan.fromTicks_i(offlinePlayer.getStatistic(TIME_PLAYED));
 	}
 	
 	@Nullable
@@ -82,12 +83,9 @@ public class ExprTimePlayed extends SimplePropertyExpression<Player, Timespan> {
 	
 	@Override
 	public void change(Event e, @Nullable Object[] delta, Changer.ChangeMode mode) {
-		if (delta == null) {
-			return;
-		}
 		long ticks = ((Timespan) delta[0]).getTicks_i();
-		for (Player player : getExpr().getArray(e)) {
-			long playerTicks = player.getStatistic(TIME_PLAYED);
+		for (OfflinePlayer offlinePlayer : getExpr().getArray(e)) {
+			long playerTicks = offlinePlayer.getStatistic(TIME_PLAYED);
 			switch (mode) {
 				case ADD:
 					ticks = playerTicks + ticks;
@@ -96,7 +94,7 @@ public class ExprTimePlayed extends SimplePropertyExpression<Player, Timespan> {
 					ticks = playerTicks - ticks;
 					break;
 			}
-			player.setStatistic(TIME_PLAYED, (int) ticks);
+			offlinePlayer.setStatistic(TIME_PLAYED, (int) ticks);
 		}
 	}
 	


### PR DESCRIPTION
### Description
Changes the string form of offline players, to use their UUID instead of their name when the name isn't available (hasn't joined server before, offline mode etc).
Also made 2 expressions support offline players.
Also fixed a pattern:
![image](https://user-images.githubusercontent.com/29547183/128734715-51ab9086-1011-4f9a-bca7-e42fb09a63fe.png)


---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #2458
