### PR TITLE
Fix chat color stuff with expressions

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffMessage.java
+++ b/src/main/java/ch/njol/skript/effects/EffMessage.java
@@ -18,7 +18,6 @@
  */
 package ch.njol.skript.effects;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
@@ -46,7 +45,6 @@ import ch.njol.skript.util.chat.BungeeConverter;
 import ch.njol.skript.util.chat.ChatMessages;
 import ch.njol.util.Kleenean;
 import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.api.chat.TextComponent;
 
 @Name("Message")
 @Description({"Sends a message to the given player. Only styles written",
@@ -135,7 +133,8 @@ public class EffMessage extends Effect {
 						}
 					} else { // It is just a string, no idea if it comes from a trusted source -> don't parse anything
 						for (Object object : messageArray) {
-							sendMessage((Player) receiver, sender, new TextComponent(toString(object)));
+							List<MessageComponent> components = ChatMessages.fromParsedString(toString(object));
+							sendMessage((Player) receiver, sender, BungeeConverter.convert(components));
 						}
 					}
 				} else { // Not a player, send plain text with legacy formatting

--- a/src/main/java/ch/njol/skript/lang/VariableString.java
+++ b/src/main/java/ch/njol/skript/lang/VariableString.java
@@ -516,26 +516,27 @@ public class VariableString implements Expression<String> {
 					continue;
 				} else if (o instanceof Expression<?>) {
 					text = Classes.toString(((Expression<?>) o).getArray(e), true, mode);
-				} else {
-					assert false;
 				}
 				
 				assert text != null;
-				MessageComponent plain = ChatMessages.plainText(text);
+				List<MessageComponent> components = ChatMessages.fromParsedString(text);
 				if (!message.isEmpty()) { // Copy styles from previous component
-					ChatMessages.copyStyles(message.get(message.size() - 1), plain);
-				} else if (Utils.HEX_SUPPORTED && text.contains("§x")) { // Try to parse hex colors
-					int start = text.lastIndexOf("§x");
-					if (start + 14 < text.length()) {
-						String replace = text.substring(start + 2, start + 14);
-						plain.color = Utils.parseHexColor(replace.replace("&", "").replace("§", ""));
-						plain.text = text.replace("§x" + replace, "");
+					int startSize = message.size();
+					for (int i = 0; i < components.size(); i++) {
+						MessageComponent plain = components.get(i);
+						ChatMessages.copyStyles(message.get(startSize + i - 1), plain);
+						message.add(plain);
 					}
+				} else {
+					message.addAll(components);
 				}
-				message.add(plain);
 			} else {
-				message.add(component);
-				previous = component;
+				MessageComponent componentCopy = component.copy();
+				if (!message.isEmpty()) { // Copy styles from previous component
+					ChatMessages.copyStyles(message.get(message.size() - 1), componentCopy);
+				}
+				message.add(componentCopy);
+				previous = componentCopy;
 			}
 		}
 		

--- a/src/main/java/ch/njol/skript/util/chat/ChatMessages.java
+++ b/src/main/java/ch/njol/skript/util/chat/ChatMessages.java
@@ -409,6 +409,80 @@ public class ChatMessages {
 	public static MessageComponent[] parseToArray(String msg) {
 		return parse(msg).toArray(new MessageComponent[0]);
 	}
+
+	/**
+	 * Parses a string that may only contain colour codes using the '§' character to a list of components.
+	 */
+	public static List<MessageComponent> fromParsedString(String msg) {
+		char[] chars = msg.toCharArray();
+
+		List<MessageComponent> components = new ArrayList<>();
+		MessageComponent current = new MessageComponent();
+		components.add(current);
+		StringBuilder curStr = new StringBuilder();
+
+		for (int i = 0; i < chars.length; i++) {
+			char c = chars[i];
+			ChatCode code;
+			String param = "";
+
+			if (c == '§') {
+				// Corner case: this is last character, so we cannot get next
+				if (i == chars.length - 1) {
+					curStr.append(c);
+					continue;
+				}
+
+				char color = chars[i + 1];
+
+				boolean tryHex = Utils.HEX_SUPPORTED && color == 'x';
+				ChatColor chatColor = null;
+				if (tryHex && i + 14 < chars.length) { // Try to parse hex "&x&1&2&3&4&5&6"
+					chatColor = Utils.parseHexColor(msg.substring(i + 2, i + 14).replace("&", "").replace("§", ""));
+					tryHex = chatColor != null;
+				}
+
+				if (color >= colorChars.length) { // Invalid Unicode color character
+					curStr.append(c);
+					continue;
+				}
+				code = colorChars[color];
+				if (code == null && !tryHex) {
+					curStr.append(c).append(color); // Invalid formatting char, plain append
+				} else {
+					String text = curStr.toString();
+					curStr = new StringBuilder();
+					current.text = text;
+
+					MessageComponent old = current;
+					current = new MessageComponent();
+
+					components.add(current);
+
+					if (tryHex) { // Set color to hex ChatColor
+						current.color = chatColor;
+						i = i + 12; // Skip past all the tags
+					} else if (code.getColorCode() != null) { // Just update color code
+						current.color = ChatColor.getByChar(code.getColorChar());
+					} else {
+						code.updateComponent(current, param); // Call SkriptChatCode update
+					}
+
+					// Copy styles from old to current if needed
+					copyStyles(old, current);
+				}
+
+				i++; // Skip this and color char
+				continue;
+			}
+
+			curStr.append(c); // Append this char to curStr
+		}
+
+		current.text = curStr.toString();
+
+		return components;
+	}
 	
 	public static String toJson(String msg) {
 		ComponentList componentList = new ComponentList(parse(msg));

--- a/src/main/java/ch/njol/skript/util/chat/MessageComponent.java
+++ b/src/main/java/ch/njol/skript/util/chat/MessageComponent.java
@@ -91,14 +91,12 @@ public class MessageComponent {
 	public String font;
 	
 	public static class ClickEvent {
-		
 		public ClickEvent(ClickEvent.Action action, String value) {
 			this.action = action;
 			this.value = value;
 		}
 		
-		public static enum Action  {
-			
+		public enum Action  {
 			open_url,
 			
 			run_command,
@@ -121,7 +119,6 @@ public class MessageComponent {
 	}
 	
 	public static class HoverEvent {
-		
 		public HoverEvent(HoverEvent.Action action, String value) {
 			this.action = action;
 			this.value = value;
@@ -154,10 +151,27 @@ public class MessageComponent {
 	public HoverEvent hoverEvent;
 	
 	public static class BooleanSerializer implements JsonSerializer<Boolean> {
-
 		@Override
 		public @Nullable JsonElement serialize(@Nullable Boolean src, @Nullable Type typeOfSrc, @Nullable JsonSerializationContext context) {
 			return src ? new JsonPrimitive(true) : null;
 		}
 	}
+
+	public MessageComponent copy() {
+		MessageComponent messageComponent = new MessageComponent();
+		messageComponent.text = this.text;
+		messageComponent.reset = this.reset;
+		messageComponent.bold = this.bold;
+		messageComponent.italic = this.italic;
+		messageComponent.underlined = this.underlined;
+		messageComponent.strikethrough = this.strikethrough;
+		messageComponent.obfuscated = this.obfuscated;
+		messageComponent.color = this.color;
+		messageComponent.insertion = this.insertion;
+		messageComponent.clickEvent = this.clickEvent;
+		messageComponent.font = this.font;
+		messageComponent.hoverEvent = this.hoverEvent;
+		return messageComponent;
+	}
+
 }


### PR DESCRIPTION
### Description
Fixed chat color issues by creating ChatMessage.fromParsedString, which only turns color codes with '§' into MessageComponents.
Also copies over color codes from previous components properly.
```
command /test:
	trigger:
		set {_x} to "&bCB"
		message "&aABC %{_x}% AAA"
		message formatted "&aABC %{_x}% AAA"
		message colored "&aABC %{_x}% AAA"
		message "&aABC %{_x}% &eAAA"
		
		message "<##00ff00>A"
		message colored "<##00ff00>A"
		set {_value} to "<##00ff00>A"
		message {_value}
		message formatted {_value}
		message colored {_value}
		message uncolored {_value}
```
![image](https://user-images.githubusercontent.com/29547183/129450729-74c7223b-4a30-48be-b5e1-3ca2f0f2e33a.png)

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #2319, #4276
