### PR TITLE
Fix dropping in cancelled death event

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffDrop.java
+++ b/src/main/java/ch/njol/skript/effects/EffDrop.java
@@ -18,17 +18,6 @@
  */
 package ch.njol.skript.effects;
 
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.ExperienceOrb;
-import org.bukkit.entity.Item;
-import org.bukkit.event.Event;
-import org.bukkit.event.entity.EntityDeathEvent;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.util.Vector;
-import org.eclipse.jdt.annotation.Nullable;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.doc.Description;
@@ -41,69 +30,65 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.Direction;
 import ch.njol.skript.util.Experience;
 import ch.njol.util.Kleenean;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.ExperienceOrb;
+import org.bukkit.entity.Item;
+import org.bukkit.event.Event;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Vector;
+import org.eclipse.jdt.annotation.Nullable;
 
-/**
- * @author Peter Güttinger
- */
 @Name("Drop")
 @Description("Drops one or more items.")
 @Examples({"on death of creeper:",
 		"	drop 1 TNT"})
 @Since("1.0")
 public class EffDrop extends Effect {
+
 	static {
-		Skript.registerEffect(EffDrop.class, "drop %itemtypes/experiences% [%directions% %locations%]",
-				"drop %itemtypes/experiences% [%directions% %locations%] without velocity");
+		Skript.registerEffect(EffDrop.class, "drop %itemtypes/experiences% [%directions% %locations%] [(1¦without velocity)]");
 	}
-	
+
 	@Nullable
 	public static Entity lastSpawned = null;
-	
-	@SuppressWarnings("null")
+
+	@SuppressWarnings("NotNullFieldNotInitialized")
 	private Expression<?> drops;
-	@SuppressWarnings("null")
+	@SuppressWarnings("NotNullFieldNotInitialized")
 	private Expression<Location> locations;
-	
-	private boolean useVelocity = true;
-	
-	@SuppressWarnings({"unchecked", "null"})
+
+	private boolean useVelocity;
+
+	@SuppressWarnings("unchecked")
 	@Override
-	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parser) {
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		drops = exprs[0];
 		locations = Direction.combine((Expression<? extends Direction>) exprs[1], (Expression<? extends Location>) exprs[2]);
-		if (matchedPattern == 1) useVelocity = false;
+		useVelocity = parseResult.mark == 0;
 		return true;
 	}
-	
+
 	@Override
-	public void execute(final Event e) {
-		final Object[] os = drops.getArray(e);
-		if (e instanceof EntityDeathEvent && locations.isSingle() && ((EntityDeathEvent) e).getEntity().getLocation().equals(locations.getSingle(e)) && !Delay.isDelayed(e)) {
-			for (final Object o : os) {
-				if (o instanceof Experience) {
-					((EntityDeathEvent) e).setDroppedExp(((EntityDeathEvent) e).getDroppedExp() + ((Experience) o).getXP());
-				} else {
-					((ItemType) o).addTo(((EntityDeathEvent) e).getDrops());
-				}
-			}
-			return;
-		}
-		for (final Location l : locations.getArray(e)) {
-			final Location itemDropLoc = l.clone().subtract(0.5, 0.5, 0.5); // dropItemNaturally adds 0.15 to 0.85 randomly to all coordinates
+	public void execute(Event e) {
+		Object[] os = drops.getArray(e);
+		for (Location l : locations.getArray(e)) {
+			Location itemDropLoc = l.clone().subtract(0.5, 0.5, 0.5); // dropItemNaturally adds 0.15 to 0.85 randomly to all coordinates
 			for (Object o : os) {
 				if (o instanceof Experience) {
-					final ExperienceOrb orb = l.getWorld().spawn(l, ExperienceOrb.class);
+					ExperienceOrb orb = l.getWorld().spawn(l, ExperienceOrb.class);
 					orb.setExperience(((Experience) o).getXP());
 					EffSpawn.lastSpawned = orb;
 				} else {
 					if (o instanceof ItemStack)
 						o = new ItemType((ItemStack) o);
-					for (final ItemStack is : ((ItemType) o).getItem().getAll()) {
+					for (ItemStack is : ((ItemType) o).getItem().getAll()) {
 						if (is.getType() != Material.AIR) {
 							if (useVelocity) {
 								lastSpawned = l.getWorld().dropItemNaturally(itemDropLoc, is);
 							} else {
-								final Item item = l.getWorld().dropItem(l, is);
+								Item item = l.getWorld().dropItem(l, is);
 								item.teleport(l);
 								item.setVelocity(new Vector(0, 0, 0));
 								lastSpawned = item;
@@ -114,10 +99,10 @@ public class EffDrop extends Effect {
 			}
 		}
 	}
-	
+
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(@Nullable Event e, boolean debug) {
 		return "drop " + drops.toString(e, debug) + " " + locations.toString(e, debug);
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/effects/EffDrop.java
+++ b/src/main/java/ch/njol/skript/effects/EffDrop.java
@@ -61,8 +61,8 @@ public class EffDrop extends Effect {
 
 	private boolean useVelocity;
 
-	@SuppressWarnings("unchecked")
 	@Override
+	@SuppressWarnings("unchecked")
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		drops = exprs[0];
 		locations = Direction.combine((Expression<? extends Direction>) exprs[1], (Expression<? extends Location>) exprs[2]);


### PR DESCRIPTION
### Description
Fixes dropping items in a cancelled death event (cancellation is only available on Paper). The code removed was supposed to make item dropping in a death event add it to the event's drops, but this can (and IMO should) be done using the [drops](https://skriptlang.github.io/Skript/expressions.html#ExprDrops) or [experience](https://skriptlang.github.io/Skript/expressions.html#ExprExperience) expression. 

I could've added a condition to make sure the event isn't cancelled, but that would not prevent the bug from happening when the event is cancelled *after* the drop effect is called.

I also cleaned up the file and merged the two patterns, using a parse mark.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4288
