### PR TITLE
Improve Experience Event

### DIFF
--- a/src/main/java/ch/njol/skript/events/EvtExperienceSpawn.java
+++ b/src/main/java/ch/njol/skript/events/EvtExperienceSpawn.java
@@ -18,20 +18,6 @@
  */
 package ch.njol.skript.events;
 
-import java.util.ArrayList;
-import java.util.Collection;
-
-import org.bukkit.Bukkit;
-import org.bukkit.event.Event;
-import org.bukkit.event.EventException;
-import org.bukkit.event.Listener;
-import org.bukkit.event.block.BlockExpEvent;
-import org.bukkit.event.entity.EntityDeathEvent;
-import org.bukkit.event.entity.ExpBottleEvent;
-import org.bukkit.event.player.PlayerFishEvent;
-import org.bukkit.plugin.EventExecutor;
-import org.eclipse.jdt.annotation.Nullable;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptConfig;
 import ch.njol.skript.SkriptEventHandler;
@@ -40,41 +26,65 @@ import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SelfRegisteringSkriptEvent;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.Trigger;
+import ch.njol.skript.registrations.EventValues;
+import ch.njol.skript.util.Experience;
+import ch.njol.skript.util.Getter;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.event.Event;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockExpEvent;
+import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.event.entity.ExpBottleEvent;
+import org.bukkit.event.player.PlayerFishEvent;
+import org.bukkit.plugin.EventExecutor;
+import org.eclipse.jdt.annotation.Nullable;
 
-/**
- * @author Peter Güttinger
- */
+import java.util.ArrayList;
+import java.util.Collection;
+
 public class EvtExperienceSpawn extends SelfRegisteringSkriptEvent {
+
 	static {
-		Skript.registerEvent("Experience Spawn", EvtExperienceSpawn.class, ExperienceSpawnEvent.class, "[e]xp[erience] [orb] spawn", "spawn of [a[n]] [e]xp[erience] [orb]")
+		Skript.registerEvent("Experience Spawn", EvtExperienceSpawn.class, ExperienceSpawnEvent.class,
+				"[e]xp[erience] [orb] spawn",
+				"spawn of [a[n]] [e]xp[erience] [orb]")
 				.description("Called whenever experience is about to spawn. This is a helper event for easily being able to stop xp from spawning, as all you can currently do is cancel the event.",
-						"Please note that it's impossible to detect xp orbs spawned by plugins (including Skript) with Bukkit, thus make sure that you have no such plugins if you don't want any xp orbs to spawn. " +
-								"(Many plugins that only <i>change</i> the experience dropped by blocks or entities will be detected without problems though)")
+						"Please note that it's impossible to detect xp orbs spawned by plugins (including Skript) with Bukkit, thus make sure that you have no such plugins if you don't want any xp orbs to spawn. "
+						+ "(Many plugins that only <i>change</i> the experience dropped by blocks or entities will be detected without problems though)")
 				.examples("on xp spawn:",
-						"	world is \"minigame_world\"",
-						"	cancel event")
+						"\tworld is \"minigame_world\"",
+						"\tcancel event")
 				.since("2.0");
+		EventValues.registerEventValue(ExperienceSpawnEvent.class, Location.class, new Getter<Location, ExperienceSpawnEvent>() {
+			@Override
+			public Location get(ExperienceSpawnEvent e) {
+				return e.getLocation();
+			}
+		}, 0);
+		EventValues.registerEventValue(ExperienceSpawnEvent.class, Experience.class, new Getter<Experience, ExperienceSpawnEvent>() {
+			@Override
+			public Experience get(ExperienceSpawnEvent e) {
+				return new Experience(e.getSpawnedXP());
+			}
+		}, 0);
 	}
 	
 	@Override
-	public boolean init(final Literal<?>[] args, final int matchedPattern, final ParseResult parseResult) {
-		if (!Skript.isRunningMinecraft(1, 4, 5)) {
-			Skript.error("The experience spawn event can only be used in Minecraft 1.4.5 and later");
-			return false;
-		}
+	public boolean init(Literal<?>[] args, int matchedPattern, ParseResult parseResult) {
 		return true;
 	}
-	
-	static Collection<Trigger> triggers = new ArrayList<>();
+
+	private static final Collection<Trigger> triggers = new ArrayList<>();
 	
 	@Override
-	public void register(final Trigger t) {
+	public void register(Trigger t) {
 		triggers.add(t);
 		registerExecutor();
 	}
 	
 	@Override
-	public void unregister(final Trigger t) {
+	public void unregister(Trigger t) {
 		triggers.remove(t);
 	}
 	
@@ -89,56 +99,51 @@ public class EvtExperienceSpawn extends SelfRegisteringSkriptEvent {
 	private static void registerExecutor() {
 		if (registeredExecutor)
 			return;
-		for (final Class<? extends Event> c : new Class[] {BlockExpEvent.class, EntityDeathEvent.class, ExpBottleEvent.class, PlayerFishEvent.class})
+		for (Class<? extends Event> c : new Class[] {BlockExpEvent.class, EntityDeathEvent.class, ExpBottleEvent.class, PlayerFishEvent.class})
 			Bukkit.getPluginManager().registerEvent(c, new Listener() {}, SkriptConfig.defaultEventPriority.value(), executor, Skript.getInstance(), true);
 		registeredExecutor = true;
 	}
 	
-	private final static EventExecutor executor = new EventExecutor() {
-		@SuppressWarnings("null")
-		@Override
-		public void execute(final @Nullable Listener listener, final @Nullable Event e) throws EventException {
-			if (e == null)
+	private static final EventExecutor executor = (listener, e) -> {
+		ExperienceSpawnEvent es;
+		if (e instanceof BlockExpEvent) {
+			es = new ExperienceSpawnEvent(((BlockExpEvent) e).getExpToDrop(), ((BlockExpEvent) e).getBlock().getLocation().add(0.5, 0.5, 0.5));
+		} else if (e instanceof EntityDeathEvent) {
+			es = new ExperienceSpawnEvent(((EntityDeathEvent) e).getDroppedExp(), ((EntityDeathEvent) e).getEntity().getLocation());
+		} else if (e instanceof ExpBottleEvent) {
+			es = new ExperienceSpawnEvent(((ExpBottleEvent) e).getExperience(), ((ExpBottleEvent) e).getEntity().getLocation());
+		} else if (e instanceof PlayerFishEvent) {
+			if (((PlayerFishEvent) e).getState() != PlayerFishEvent.State.CAUGHT_FISH) // There is no EXP
 				return;
-			
-			final ExperienceSpawnEvent es;
-			if (e instanceof BlockExpEvent) {
-				es = new ExperienceSpawnEvent(((BlockExpEvent) e).getExpToDrop(), ((BlockExpEvent) e).getBlock().getLocation().add(0.5, 0.5, 0.5));
-			} else if (e instanceof EntityDeathEvent) {
-				es = new ExperienceSpawnEvent(((EntityDeathEvent) e).getDroppedExp(), ((EntityDeathEvent) e).getEntity().getLocation());
-			} else if (e instanceof ExpBottleEvent) {
-				es = new ExperienceSpawnEvent(((ExpBottleEvent) e).getExperience(), ((ExpBottleEvent) e).getEntity().getLocation());
-			} else if (e instanceof PlayerFishEvent) {
-				es = new ExperienceSpawnEvent(((PlayerFishEvent) e).getExpToDrop(), ((PlayerFishEvent) e).getPlayer().getLocation());
-			} else {
-				assert false;
-				return;
-			}
-			
-			SkriptEventHandler.logEventStart(e);
-			for (final Trigger t : triggers) {
-				SkriptEventHandler.logTriggerStart(t);
-				t.execute(es);
-				SkriptEventHandler.logTriggerEnd(t);
-			}
-			SkriptEventHandler.logEventEnd();
-			
-			if (es.isCancelled())
-				es.setSpawnedXP(0);
-			if (e instanceof BlockExpEvent) {
-				((BlockExpEvent) e).setExpToDrop(es.getSpawnedXP());
-			} else if (e instanceof EntityDeathEvent) {
-				((EntityDeathEvent) e).setDroppedExp(es.getSpawnedXP());
-			} else if (e instanceof ExpBottleEvent) {
-				((ExpBottleEvent) e).setExperience(es.getSpawnedXP());
-			} else if (e instanceof PlayerFishEvent) {
-				((PlayerFishEvent) e).setExpToDrop(es.getSpawnedXP());
-			}
+			es = new ExperienceSpawnEvent(((PlayerFishEvent) e).getExpToDrop(), ((PlayerFishEvent) e).getPlayer().getLocation());
+		} else {
+			assert false;
+			return;
+		}
+
+		SkriptEventHandler.logEventStart(e);
+		for (Trigger t : triggers) {
+			SkriptEventHandler.logTriggerStart(t);
+			t.execute(es);
+			SkriptEventHandler.logTriggerEnd(t);
+		}
+		SkriptEventHandler.logEventEnd();
+
+		if (es.isCancelled())
+			es.setSpawnedXP(0);
+		if (e instanceof BlockExpEvent) {
+			((BlockExpEvent) e).setExpToDrop(es.getSpawnedXP());
+		} else if (e instanceof EntityDeathEvent) {
+			((EntityDeathEvent) e).setDroppedExp(es.getSpawnedXP());
+		} else if (e instanceof ExpBottleEvent) {
+			((ExpBottleEvent) e).setExperience(es.getSpawnedXP());
+		} else if (e instanceof PlayerFishEvent) {
+			((PlayerFishEvent) e).setExpToDrop(es.getSpawnedXP());
 		}
 	};
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(@Nullable Event e, boolean debug) {
 		return "experience spawn";
 	}
 	

--- a/src/main/java/ch/njol/skript/events/bukkit/ExperienceSpawnEvent.java
+++ b/src/main/java/ch/njol/skript/events/bukkit/ExperienceSpawnEvent.java
@@ -23,51 +23,28 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
-import ch.njol.skript.registrations.EventValues;
-import ch.njol.skript.util.Experience;
-import ch.njol.skript.util.Getter;
-
-/**
- * @author Peter Güttinger
- */
 public class ExperienceSpawnEvent extends Event implements Cancellable {
-	static {
-		EventValues.registerEventValue(ExperienceSpawnEvent.class, Location.class, new Getter<Location, ExperienceSpawnEvent>() {
-			@Override
-			public Location get(final ExperienceSpawnEvent e) {
-				return e.getLocation();
-			}
-		}, 0);
-		EventValues.registerEventValue(ExperienceSpawnEvent.class, Experience.class, new Getter<Experience, ExperienceSpawnEvent>() {
-			@Override
-			public Experience get(final ExperienceSpawnEvent e) {
-				return new Experience(e.getSpawnedXP());
-			}
-		}, 0);
-	}
 	
-	private int xp;
+	private int exp;
+	private final Location location;
+	private boolean cancelled = false;
 	
-	private final Location l;
-	
-	public ExperienceSpawnEvent(final int xp, final Location l) {
-		this.xp = xp;
-		this.l = l;
+	public ExperienceSpawnEvent(int exp, Location location) {
+		this.exp = exp;
+		this.location = location;
 	}
 	
 	public int getSpawnedXP() {
-		return xp;
+		return exp;
 	}
 	
-	public void setSpawnedXP(final int xp) {
-		this.xp = Math.max(0, xp);
+	public void setSpawnedXP(int xp) {
+		this.exp = Math.max(0, xp);
 	}
 	
 	public Location getLocation() {
-		return l;
+		return location;
 	}
-	
-	private boolean cancelled = false;
 	
 	@Override
 	public boolean isCancelled() {


### PR DESCRIPTION
### Description
This PR aims to fix `<none>` values being returned for the experience spawn event, along with the event firing in cases where there would never be EXP spawning (for example, it fired for ALL cases/states of the fish event). I cleaned up `EvtExperienceSpawn` and `ExperienceSpawnEvent`

---
**Target Minecraft Versions:** Any
**Requirements:** None
**Related Issues:** 
- #2915 (fixes)
- #3661 (Not sure if this technically fixes, but these events are also called at the same time so this could just be an unavoidable inconsistency. Applying an event priority to the fish event may be the workaround for the user)
