### PR TITLE
Fix ExprXOf converting

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprXOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprXOf.java
@@ -31,6 +31,7 @@ import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemStack;
 import org.eclipse.jdt.annotation.Nullable;
@@ -45,6 +46,7 @@ public class ExprXOf extends PropertyExpression<Object, Object> {
 		Skript.registerExpression(ExprXOf.class, Object.class, ExpressionType.PATTERN_MATCHES_EVERYTHING, "%number% of %itemstacks/itemtypes/entitytype%");
 	}
 
+	@SuppressWarnings("NotNullFieldNotInitialized")
 	private Expression<Number> amount;
 
 	@Override
@@ -77,6 +79,26 @@ public class ExprXOf extends PropertyExpression<Object, Object> {
 				return t;
 			}
 		});
+	}
+
+	@Override
+	@Nullable
+	@SuppressWarnings("unchecked")
+	public <R> Expression<? extends R> getConvertedExpression(Class<R>... to) {
+		if (CollectionUtils.containsSuperclass(to, getReturnType()))
+			return (Expression<? extends R>) this;
+
+		if (!CollectionUtils.containsAnySuperclass(to, ItemStack.class, ItemType.class, EntityType.class))
+			return null;
+
+		Expression<? extends R> converted = getExpr().getConvertedExpression(to);
+		if (converted == null)
+			return null;
+
+		ExprXOf exprXOf = new ExprXOf();
+		exprXOf.setExpr(converted);
+		exprXOf.amount = amount;
+		return (Expression<? extends R>) exprXOf;
 	}
 
 	@Override

--- a/src/test/skript/tests/syntaxes/expressions/ExprXOf.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprXOf.sk
@@ -1,0 +1,7 @@
+test "X of":
+	set {_x} to 5
+	assert 1 of {_x} is not set with "incorrect type failed"
+	set {_y} to "zombie" parsed as entitytype
+	assert 2 of {_y} is 2 zombie with "entity type amount failed"
+	set {_z} to stone
+	assert 2 of {_z} is 2 stone with "item failed"


### PR DESCRIPTION
### Description
In #4261, I removed the getConvertedExpression method from ExprXOf, but this turned out to be a bad change, as seen in #4296. This PR adds back the method, buts limits the classes argument to only the types that ExprXOf can accept. 

I also added a test.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4296, #4261
