### PR TITLE
[Docs] Fix dark gray color names

### DIFF
--- a/docs/text.html
+++ b/docs/text.html
@@ -126,8 +126,8 @@
               height: 10px;
             "></td>
             <td>§8</td>
-            <td>grey</td>
-            <td>light grey, gray, light gray, silver</td>
+            <td>dark grey</td>
+            <td>dark gray</td>
         </tr>
         <tr>
             <td style="


### PR DESCRIPTION
Looks like someone accidentally pasted light gray names into dark gray row.