### PR TITLE
Fix Section parsing NPE

### DIFF
--- a/src/main/java/ch/njol/skript/lang/EffectSection.java
+++ b/src/main/java/ch/njol/skript/lang/EffectSection.java
@@ -56,7 +56,8 @@ public abstract class EffectSection extends Section {
 		SectionContext sectionContext = getParser().getData(SectionContext.class);
 		//noinspection ConstantConditions - For an EffectSection, it may be null
 		hasSection = sectionContext.sectionNode != null;
-		return init(exprs, matchedPattern, isDelayed, parseResult, sectionContext.sectionNode, sectionContext.triggerItems);
+
+		return super.init(exprs, matchedPattern, isDelayed, parseResult);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/lang/Section.java
+++ b/src/main/java/ch/njol/skript/lang/Section.java
@@ -71,7 +71,7 @@ public abstract class Section extends TriggerSection implements SyntaxElement {
 		boolean result = init(exprs, matchedPattern, isDelayed, parseResult, sectionNode, triggerItems);
 
 		// Revert any possible changes to the SectionContext caused by the init method,
-		//  see
+		//  see https://github.com/SkriptLang/Skript/pull/4353
 		sectionContext.sectionNode = sectionNode;
 		sectionContext.triggerItems = triggerItems;
 


### PR DESCRIPTION
### Description
Fixes an issue with section parsing:
when a section's init method changes the SectionContext fields (e.g. by calling `Effect.parse`, as that calls `EffectSection.parse`), and the init method returns false, the next section's init method will be called with the updated values of SectionContext's fields. This could cause an exception like this: https://pastebin.com/3fNtEJ1A

This PR fixes this issue by reverting the SectionContext fields back to their old values after init is called.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
