### PR TITLE
🛠 Improve offline player parsing

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -831,7 +831,9 @@ public class BukkitClasses {
 				})
 				.changer(DefaultChangers.playerChanger)
 				.serializeAs(OfflinePlayer.class));
-		
+
+		Pattern uuidPattern = Pattern.compile("(?i)[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}");
+		Pattern playerNamePattern = Pattern.compile("[a-zA-Z0-9_]+");
 		Classes.registerClass(new ClassInfo<>(OfflinePlayer.class, "offlineplayer")
 				.user("offline ?players?")
 				.name("Offline Player")
@@ -844,14 +846,14 @@ public class BukkitClasses {
 				.defaultExpression(new EventValueExpression<>(OfflinePlayer.class))
 				.after("string", "world")
 				.parser(new Parser<OfflinePlayer>() {
-					@SuppressWarnings("deprecation")
 					@Override
 					@Nullable
+					@SuppressWarnings("deprecation")
 					public OfflinePlayer parse(final String s, final ParseContext context) {
 						if (context == ParseContext.COMMAND) {
-							if (s.matches("(?i)[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}"))
+							if (uuidPattern.matcher(s).matches())
 								return Bukkit.getOfflinePlayer(UUID.fromString(s));
-							else if (!s.matches("[a-zA-Z0-9_]+") || s.length() > 16)
+							else if (!playerNamePattern.matcher(s).matches() || s.length() > 16)
 								return null;
 							return Bukkit.getOfflinePlayer(s);
 						}


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
This little PR aims to improve parsing time of offline players by compiling the regex patterns once and not every time they're called (a tiny improvement may help).
*Thanks to @Mr-Darth for this note.*

### Test Results
Code:
```v
on chat:
	set {_i} to System.currentTimeMillis()
	loop 10000 times:
		set {_p} to "0ac0b83a-acb9-4c85-b304-686bd30007c1" parsed as offlineplayer
	set {_i2} to System.currentTimeMillis() - {_i}
	broadcast "&6&lTook %{_i2}% ms"
```
Results:
![image](https://user-images.githubusercontent.com/20037329/137527345-5e2917e1-f611-44a8-8152-7766f15e47d8.png)

**Note:** tests were made after a server restart for more accurate results (as I have found that executing the code multiple times without server restart reached ~ 450ms which might be due to caching or something under the hood)

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->All
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->None
**Related Issues:** <!-- Links to related issues -->None
