### PR TITLE
Fix CSV storage not using the right temporary file

### DIFF
--- a/src/main/java/ch/njol/skript/variables/FlatFileStorage.java
+++ b/src/main/java/ch/njol/skript/variables/FlatFileStorage.java
@@ -374,7 +374,7 @@ public class FlatFileStorage extends VariablesStorage {
 							return;
 						}
 					}
-					final File tempFile = new File(Skript.getInstance().getDataFolder(), "variables.csv.temp");
+					File tempFile = new File(file.getParentFile(), file.getName() + ".temp");
 					PrintWriter pw = null;
 					try {
 						pw = new PrintWriter(tempFile, "UTF-8");


### PR DESCRIPTION
### Description
Fixes FlatFileStorage not writing to the right temporary file, always using `variables.csv.temp` instead of `<file>.temp`

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4398
