### PR TITLE
🚀 Add region `not found` error

### DIFF
--- a/src/main/java/ch/njol/skript/hooks/regions/classes/Region.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/classes/Region.java
@@ -18,16 +18,6 @@
  */
 package ch.njol.skript.hooks.regions.classes;
 
-import java.util.Collection;
-import java.util.Iterator;
-
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.OfflinePlayer;
-import org.bukkit.World;
-import org.bukkit.block.Block;
-import org.eclipse.jdt.annotation.Nullable;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.classes.Parser;
@@ -37,6 +27,15 @@ import ch.njol.skript.lang.ParseContext;
 import ch.njol.skript.lang.VariableString;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.yggdrasil.YggdrasilSerializable.YggdrasilExtendedSerializable;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.eclipse.jdt.annotation.Nullable;
+
+import java.util.Collection;
+import java.util.Iterator;
 
 /**
  * @author Peter Güttinger
@@ -86,6 +85,10 @@ public abstract class Region implements YggdrasilExtendedSerializable {
 								return null;
 							}
 							r = r2;
+						}
+						if (r == null) {
+							Skript.error("Region '" + s + "' could not be found.");
+							return null;
 						}
 						return r;
 					}

--- a/src/main/java/ch/njol/skript/hooks/regions/classes/Region.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/classes/Region.java
@@ -81,13 +81,13 @@ public abstract class Region implements YggdrasilExtendedSerializable {
 							if (r2 == null)
 								continue;
 							if (r != null) {
-								Skript.error("Multiple regions with the name '" + s + "' exist.");
+								Skript.error("Multiple regions with the name '" + s + "' exist");
 								return null;
 							}
 							r = r2;
 						}
 						if (r == null) {
-							Skript.error("Region '" + s + "' could not be found.");
+							Skript.error("Region '" + s + "' could not be found");
 							return null;
 						}
 						return r;


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
This PR aims to fix a long annoying behavior in skript when using an unknown region name it would give another error message.

Before this PR:
![image](https://user-images.githubusercontent.com/20037329/140592679-0a38cfba-dee4-468d-a225-14252c52bfb4.png)

After this PR:
![image](https://user-images.githubusercontent.com/20037329/140592686-914924e2-3630-4b2a-b129-bf64ab84a2c3.png)

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->Any
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->None
**Related Issues:** <!-- Links to related issues --> #2737 (non-fixing but related because the error message wasn't correct)
