### PR TITLE
Fix looping single values

### DIFF
--- a/src/main/java/ch/njol/skript/sections/SecLoop.java
+++ b/src/main/java/ch/njol/skript/sections/SecLoop.java
@@ -74,6 +74,11 @@ public class SecLoop extends Section {
 			expr = new ContainerExpression((Expression<? extends Container<?>>) expr, type.value());
 		}
 
+		if (expr.isSingle()) {
+			Skript.error("Can't loop " + expr + " because it's only a single value.");
+			return false;
+		}
+
 		loadOptionalCode(sectionNode);
 		super.setNext(this);
 

--- a/src/main/java/ch/njol/skript/sections/SecLoop.java
+++ b/src/main/java/ch/njol/skript/sections/SecLoop.java
@@ -75,7 +75,7 @@ public class SecLoop extends Section {
 		}
 
 		if (expr.isSingle()) {
-			Skript.error("Can't loop " + expr + " because it's only a single value.");
+			Skript.error("Can't loop " + expr + " because it's only a single value");
 			return false;
 		}
 


### PR DESCRIPTION
### Description
SecLoop allowed looping single values which caused issues with non-list variables: 
```
loop {_a}:
```
The above code caused a SkriptAPIException.

---
**Target Minecraft Versions:** any
**Requirements:** -
**Related Issues:** -
