### PR TITLE
Fix Gradle building

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,8 +9,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Checkout submodules
-      uses: textbook/git-checkout-submodule-action@2.0.0
+      with:
+        submodules: recursive
     - name: Set up JDK 16
       uses: actions/setup-java@v1
       with:

--- a/src/main/java/ch/njol/skript/util/BlockStateBlock.java
+++ b/src/main/java/ch/njol/skript/util/BlockStateBlock.java
@@ -278,7 +278,12 @@ public class BlockStateBlock implements Block {
 	public boolean isSolid() {
 		return state.getBlock().isSolid();
 	}
-	
+
+	@Override
+	public boolean isCollidable() {
+		return state.getBlock().isCollidable();
+	}
+
 	@Override
 	public double getTemperature() {
 		return state.getBlock().getTemperature();

--- a/src/main/java/ch/njol/skript/util/DelayedChangeBlock.java
+++ b/src/main/java/ch/njol/skript/util/DelayedChangeBlock.java
@@ -278,7 +278,12 @@ public class DelayedChangeBlock implements Block {
 	public boolean isSolid() {
 		return b.isSolid();
 	}
-	
+
+	@Override
+	public boolean isCollidable() {
+		return b.isCollidable();
+	}
+
 	@Override
 	public double getTemperature() {
 		return b.getTemperature();


### PR DESCRIPTION
### Description
Updates Skript's classes that implement Block.
Also updates the workflow, as https://github.com/textbook/git-checkout-submodule-action has been archived, so now it uses actions/checkout with the submodules: recursive option

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
