### PR TITLE
Fix pattern parser confusion.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,10 @@ allprojects {
 		maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
 		maven { url 'https://papermc.io/repo/repository/maven-public/' }
 		maven { url 'https://ci.emc.gs/nexus/content/groups/aikar/' }
+		maven {
+			url 'http://nexus.mrcubee.net/repository/minecraft/'
+			allowInsecureProtocol = true
+		}
 	}
 }
 
@@ -32,6 +36,8 @@ dependencies {
 	implementation group: 'org.eclipse.jdt', name: 'org.eclipse.jdt.annotation', version: '2.2.600'
 	implementation group: 'com.google.code.findbugs', name: 'findbugs', version: '3.0.1'
 	implementation group: 'com.sk89q.worldguard', name: 'worldguard-legacy', version: '7.0.0-SNAPSHOT'
+	shadow group: 'fr.mrcubee.minecraft.library', name: 'plugin-finder', version: '1.0'
+
 	implementation group: 'net.milkbowl.vault', name: 'Vault', version: '1.7.1', {
 		exclude group: 'org.bstats', module: 'bstats-bukkit'
 	}
@@ -78,8 +84,10 @@ tasks.withType(ShadowJar) {
 	]
 	dependencies {
 		include(dependency('io.papermc:paperlib'))
+		include(dependency('fr.mrcubee.minecraft.library:plugin-finder'))
 	}
 	relocate 'io.papermc.lib', 'ch.njol.skript.paperlib'
+	relocate 'fr.mrcubee.finder.plugin', 'ch.njol.skript.finderlib'
 	manifest {
 		attributes(
 			'Name': 'ch/njol/skript',

--- a/src/main/java/ch/njol/skript/expressions/base/PropertyExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/PropertyExpression.java
@@ -18,6 +18,8 @@
  */
 package ch.njol.skript.expressions.base;
 
+import ch.njol.skript.SkriptAddon;
+import fr.mrcubee.finder.plugin.PluginFinder;
 import org.bukkit.event.Event;
 
 import ch.njol.skript.Skript;
@@ -29,6 +31,7 @@ import ch.njol.skript.lang.SyntaxElement;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.skript.registrations.Converters;
 import ch.njol.util.Kleenean;
+import org.bukkit.plugin.Plugin;
 
 /**
  * Represents an expression which represents a property of another one. Remember to set the expression with {@link #setExpr(Expression)} in
@@ -39,17 +42,20 @@ import ch.njol.util.Kleenean;
  * @see #register(Class, Class, String, String)
  */
 public abstract class PropertyExpression<F, T> extends SimpleExpression<T> {
-	
+
 	/**
 	 * Registers an expression as {@link ExpressionType#PROPERTY} with the two default property patterns "property of %types%" and "%types%'[s] property"
-	 * 
+	 *
 	 * @param c
 	 * @param type
 	 * @param property The name of the property
 	 * @param fromType Should be plural but doesn't have to be
 	 */
 	public static <T> void register(final Class<? extends Expression<T>> c, final Class<T> type, final String property, final String fromType) {
-		Skript.registerExpression(c, type, ExpressionType.PROPERTY, "[the] " + property + " of %" + fromType + "%", "%" + fromType + "%'[s] " + property);
+		final Plugin plugin = (Plugin) PluginFinder.INSTANCE.findPluginCaller();
+		final SkriptAddon skriptAddon = (plugin != null) ? Skript.getAddon(plugin.getName()) : Skript.getAddonInstance();
+
+		Skript.addonRegisterExpression(skriptAddon, c, type, ExpressionType.PROPERTY, "[the] " + property + " of %" + fromType + "%", "%" + fromType + "%'[s] " + property);
 	}
 	
 	@SuppressWarnings("null")

--- a/src/main/java/ch/njol/skript/lang/ExpressionInfo.java
+++ b/src/main/java/ch/njol/skript/lang/ExpressionInfo.java
@@ -18,6 +18,7 @@
  */
 package ch.njol.skript.lang;
 
+import ch.njol.skript.SkriptAddon;
 import org.eclipse.jdt.annotation.Nullable;
 
 public class ExpressionInfo<E extends Expression<T>, T> extends SyntaxElementInfo<E> {
@@ -26,14 +27,22 @@ public class ExpressionInfo<E extends Expression<T>, T> extends SyntaxElementInf
 	@Nullable
 	public ExpressionType expressionType;
 	
-	public ExpressionInfo(final String[] patterns, final Class<T> returnType, final Class<E> c, final String originClassPath) throws IllegalArgumentException {
-		this(patterns, returnType, c, originClassPath, null);
+	public ExpressionInfo(final SkriptAddon addon, final String[] patterns, final Class<T> returnType, final Class<E> c, final String originClassPath) throws IllegalArgumentException {
+		this(addon, patterns, returnType, c, originClassPath, null);
 	}
-	
-	public ExpressionInfo(final String[] patterns, final Class<T> returnType, final Class<E> c, final String originClassPath, @Nullable ExpressionType expressionType) throws IllegalArgumentException {
-		super(patterns, c, originClassPath);
+
+	public ExpressionInfo(final String[] patterns, final Class<T> returnType, final Class<E> c, final String originClassPath) throws IllegalArgumentException {
+		this(null, patterns, returnType, c, originClassPath);
+	}
+
+	public ExpressionInfo(final SkriptAddon addon, final String[] patterns, final Class<T> returnType, final Class<E> c, final String originClassPath, @Nullable ExpressionType expressionType) throws IllegalArgumentException {
+		super(addon, patterns, c, originClassPath);
 		this.returnType = returnType;
 		this.expressionType = expressionType;
+	}
+
+	public ExpressionInfo(final String[] patterns, final Class<T> returnType, final Class<E> c, final String originClassPath, @Nullable ExpressionType expressionType) throws IllegalArgumentException {
+		this(null, patterns, returnType, c, originClassPath, expressionType);
 	}
 	
 	/**

--- a/src/main/java/ch/njol/skript/lang/SkriptEventInfo.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptEventInfo.java
@@ -20,6 +20,7 @@ package ch.njol.skript.lang;
 
 import java.util.Locale;
 
+import ch.njol.skript.SkriptAddon;
 import org.bukkit.event.Event;
 import org.bukkit.event.player.PlayerInteractAtEntityEvent;
 import org.eclipse.jdt.annotation.Nullable;
@@ -45,14 +46,15 @@ public final class SkriptEventInfo<E extends SkriptEvent> extends SyntaxElementI
 	private String[] requiredPlugins;
 	
 	/**
+	 * @param addon The addon that registered the event.
 	 * @param name Capitalised name of the event without leading "On" which is added automatically (Start the name with an asterisk to prevent this).
 	 * @param patterns
 	 * @param c The SkriptEvent's class
 	 * @param originClassPath The class path for the origin of this event.
 	 * @param events The Bukkit-Events this SkriptEvent listens to
 	 */
-	public SkriptEventInfo(String name, final String[] patterns, final Class<E> c, final String originClassPath, final Class<? extends Event>[] events) {
-		super(patterns, c, originClassPath);
+	public SkriptEventInfo(final SkriptAddon addon, String name, final String[] patterns, final Class<E> c, final String originClassPath, final Class<? extends Event>[] events) {
+		super(addon, patterns, c, originClassPath);
 		assert name != null;
 		assert patterns != null && patterns.length > 0;
 		assert c != null;
@@ -82,7 +84,18 @@ public final class SkriptEventInfo<E extends SkriptEvent> extends SyntaxElementI
 		// uses the name without 'on ' or '*'
 		this.id = "" + name.toLowerCase(Locale.ENGLISH).replaceAll("[#'\"<>/&]", "").replaceAll("\\s+", "_");
 	}
-	
+
+	/**
+	 * @param name Capitalised name of the event without leading "On" which is added automatically (Start the name with an asterisk to prevent this).
+	 * @param patterns
+	 * @param c The SkriptEvent's class
+	 * @param originClassPath The class path for the origin of this event.
+	 * @param events The Bukkit-Events this SkriptEvent listens to
+	 */
+	public SkriptEventInfo(String name, final String[] patterns, final Class<E> c, final String originClassPath, final Class<? extends Event>[] events) {
+		this(null, name, patterns, c, originClassPath, events);
+	}
+
 	/**
 	 * Use this as {@link #description(String...)} to prevent warnings about missing documentation.
 	 */

--- a/src/main/java/ch/njol/skript/lang/SyntaxElementInfo.java
+++ b/src/main/java/ch/njol/skript/lang/SyntaxElementInfo.java
@@ -18,6 +18,8 @@
  */
 package ch.njol.skript.lang;
 
+import ch.njol.skript.SkriptAddon;
+
 import java.util.Arrays;
 
 /**
@@ -25,15 +27,24 @@ import java.util.Arrays;
  * @param <E> the syntax element this info is for
  */
 public class SyntaxElementInfo<E extends SyntaxElement> {
-	
+
+	public final SkriptAddon addon;
 	public final Class<E> c;
 	public final String[] patterns;
 	public final String originClassPath;
-	
-	public SyntaxElementInfo(final String[] patterns, final Class<E> c, final String originClassPath) throws IllegalArgumentException {
-		this.patterns = patterns;
+
+	public SyntaxElementInfo(final SkriptAddon addon, final String[] patterns, final Class<E> c, final String originClassPath) throws IllegalArgumentException {
+		this.addon = addon;
 		this.c = c;
 		this.originClassPath = originClassPath;
+
+		if (addon != null) {
+			for (int i = 0; i < patterns.length; i++) {
+				if (patterns[i] != null)
+					patterns[i] = String.format("[%s] %s", addon.getName(), patterns[i]);
+			}
+		}
+		this.patterns = patterns;
 		try {
 			c.getConstructor();
 //			if (!c.getDeclaredConstructor().isAccessible())
@@ -45,7 +56,11 @@ public class SyntaxElementInfo<E extends SyntaxElement> {
 			throw new IllegalStateException("Skript cannot run properly because a security manager is blocking it!");
 		}
 	}
-	
+
+	public SyntaxElementInfo(final String[] patterns, final Class<E> c, final String originClassPath) throws IllegalArgumentException {
+		this(null, patterns, c, originClassPath);
+	}
+
 	/**
 	 * Get the class that represents this element.
 	 * @return The Class of the element

--- a/src/main/java/ch/njol/skript/util/visual/VisualEffects.java
+++ b/src/main/java/ch/njol/skript/util/visual/VisualEffects.java
@@ -100,7 +100,7 @@ public class VisualEffects {
 		for (int i = 0; i < visualEffectTypes.length; i++) {
 			patterns[i] = visualEffectTypes[i].getPattern();
 		}
-		elementInfo = new SyntaxElementInfo<>(patterns, VisualEffect.class, VisualEffect.class.getName());
+		elementInfo = new SyntaxElementInfo<>(Skript.getAddonInstance(), patterns, VisualEffect.class, VisualEffect.class.getName());
 	}
 
 	private static void registerColorable(String id) {


### PR DESCRIPTION
### Description
Add an optional prefix for all patterns with the addon's name that registered it. Patterns recorded by Skript will also be prefixed by it.

---
**Target Minecraft Versions:** any
**Requirements:** /
**Related Issues:** none
