### PR TITLE
BukkitEventValues - fix missing event-values for pickup events

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -64,6 +64,7 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.EntityEvent;
+import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.entity.EntityTameEvent;
 import org.bukkit.event.entity.FireworkExplodeEvent;
 import org.bukkit.event.entity.HorseJumpEvent;
@@ -663,6 +664,35 @@ public final class BukkitEventValues {
 				return new ItemType(e.getItem().getItemStack());
 			}
 		}, 0);
+		EventValues.registerEventValue(PlayerPickupItemEvent.class, Entity.class, new Getter<Entity, PlayerPickupItemEvent>() {
+			@Override
+			public @Nullable Entity get(PlayerPickupItemEvent e) {
+				return e.getPlayer();
+			}
+		}, 0);
+		// EntityPickupItemEvent
+		if (Skript.classExists("org.bukkit.event.entity.EntityPickupItemEvent")) {
+			EventValues.registerEventValue(EntityPickupItemEvent.class, Entity.class, new Getter<Entity, EntityPickupItemEvent>() {
+				@Override
+				public @Nullable Entity get(EntityPickupItemEvent e) {
+					return e.getEntity();
+				}
+			}, 0);
+			EventValues.registerEventValue(EntityPickupItemEvent.class, Item.class, new Getter<Item, EntityPickupItemEvent>() {
+				@Override
+				@Nullable
+				public Item get(final EntityPickupItemEvent e) {
+					return e.getItem();
+				}
+			}, 0);
+			EventValues.registerEventValue(EntityPickupItemEvent.class, ItemType.class, new Getter<ItemType, EntityPickupItemEvent>() {
+				@Override
+				@Nullable
+				public ItemType get(final EntityPickupItemEvent e) {
+					return new ItemType(e.getItem().getItemStack());
+				}
+			}, 0);
+		}
 		// PlayerItemConsumeEvent
 		if (Skript.supports("org.bukkit.event.player.PlayerItemConsumeEvent")) {
 			EventValues.registerEventValue(PlayerItemConsumeEvent.class, ItemType.class, new Getter<ItemType, PlayerItemConsumeEvent>() {


### PR DESCRIPTION
### Description
This PR aims to add missing event-values for the EntityPickupItemEvent, as well as adds event-entity for PlayerPickupItemEvent as event-entity currently returns the dropped item entity that was picked up (which event-item also does)

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
