### PR TITLE
Fix parsing with İ

### DIFF
--- a/src/main/java/ch/njol/skript/patterns/LiteralPatternElement.java
+++ b/src/main/java/ch/njol/skript/patterns/LiteralPatternElement.java
@@ -39,7 +39,7 @@ public class LiteralPatternElement extends PatternElement {
 	@Override
 	@Nullable
 	public MatchResult match(String expr, MatchResult matchResult) {
-		char[] exprChars = expr.toLowerCase().toCharArray();
+		char[] exprChars = expr.toCharArray();
 
 		int exprIndex = matchResult.exprOffset;
 		for (char c : literal) {
@@ -48,7 +48,7 @@ public class LiteralPatternElement extends PatternElement {
 					continue;
 				else if (exprChars[exprIndex] != ' ')
 					return null;
-			} else if (exprIndex == exprChars.length || c != exprChars[exprIndex])
+			} else if (exprIndex == exprChars.length || Character.toLowerCase(c) != Character.toLowerCase(exprChars[exprIndex]))
 				return null;
 			exprIndex++;
 		}


### PR DESCRIPTION
### Description
Issue was caused by pattern compiling PR. A string with the character `İ` converted to lower case using String#toLowerCase will have that part replaced by two characters instead of one, which the implementing code had expected. This didn't occur before, because the old implementation used Character#toLowerCase to compare characters, which is also the change this PR implements.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4465
