### PR TITLE
Fix Section parsing NPE v2

### DIFF
--- a/src/main/java/ch/njol/skript/lang/EffectSection.java
+++ b/src/main/java/ch/njol/skript/lang/EffectSection.java
@@ -25,7 +25,6 @@ import ch.njol.skript.lang.parser.ParserInstance;
 import ch.njol.util.Kleenean;
 import org.eclipse.jdt.annotation.Nullable;
 
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -75,12 +74,14 @@ public abstract class EffectSection extends Section {
 	@SuppressWarnings({"unchecked", "rawtypes", "ConstantConditions"})
 	public static EffectSection parse(String expr, @Nullable String defaultError, @Nullable SectionNode sectionNode, @Nullable List<TriggerItem> triggerItems) {
 		SectionContext sectionContext = ParserInstance.get().getData(SectionContext.class);
-		sectionContext.sectionNode = sectionNode;
-		sectionContext.triggerItems = triggerItems;
 
-		return (EffectSection) SkriptParser.parse(expr, (Iterator) Skript.getSections().stream()
-				.filter(info -> EffectSection.class.isAssignableFrom(info.c))
-				.iterator(), defaultError);
+		return sectionContext.modify(sectionNode, triggerItems, () ->
+			(EffectSection) SkriptParser.parse(
+				expr,
+				(Iterator) Skript.getSections().stream()
+					.filter(info -> EffectSection.class.isAssignableFrom(info.c))
+					.iterator(),
+				defaultError));
 	}
 
 }


### PR DESCRIPTION
### Description
Pretty much the same issue as https://github.com/SkriptLang/Skript/pull/4353, this time fixed properly. 
The previous PR assumed the only place the SectionContext data could be modified was during the init section of a Section, but it could also be done while parsing (effect)sections, before init is even called.

In the case of the issue linked by parsing of an expression, which lead to the parsing of an effect (because of SkQuery's lambda literals), which led to EffectSection parsing, which modified the SectionContext data.

This time, the issue has been fixed at the source: the modification of the SectionContext data itself.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4473
