### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -11,10 +11,7 @@ body:
     attributes:
       label: Skript/Server Version
       description: Run '/skript info' and paste the full, unmodified output here.
-      value: |
-        ```
-        Replace this text with your output from the command.
-        ```
+      render: markdown
     validations:
       required: true
   - type: textarea
@@ -41,13 +38,9 @@ body:
     attributes:
       label: Errors or Screenshots
       description: |
-        Please paste any console errors you've encountered here. Make sure to copy the entire error.
         If you have encountered any weird behavior in-game that you would like to share, you may share a screenshot or video.
-        If you are going to use a paste site, please use something like https://gist.github.com/ or https://paste.gg/.
-      value: |
-        ```
-        Replace this text with your paste link or errors/screenshots/videos.
-        ```
+        Please paste any console errors you've encountered here. Make sure to copy the entire error.
+        If your error is long, we ask that you instead use a site such as https://gist.github.com/ or https://paste.gg/ and share the link here.
     validations:
       required: false
   - type: textarea
@@ -61,5 +54,5 @@ body:
       label: Agreement
       description: Please agree to the following before submitting your bug report.
       options:
-        - label: I have read the guidelines above and confirm I am following them with this report.
+        - label: I have read the guidelines above and affirm I am following them with this report.
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
     - name: Skript Documentation
-      url: https://skriptlang.github.io/Skript/index.html
+      url: https://docs.skriptlang.org
       about: Need help getting started? Check out the docs!
     - name: SkUnity Discord
       url: https://discord.gg/0l3WlzBPKX7WNjkf

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+    - name: Skript Documentation
+      url: https://skriptlang.github.io/Skript/index.html
+      about: Need help getting started? Check out the docs!
     - name: SkUnity Discord
       url: https://discord.gg/0l3WlzBPKX7WNjkf
       about: Need help with your scripts? Come ask on Discord!

--- a/.github/ISSUE_TEMPLATE/suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/suggestion.yml
@@ -31,6 +31,6 @@ body:
       label: Agreement
       description: Please agree to the following before submitting your suggestion.
       options:
-        - label: I have read the guidelines above and confirm I am following them with this suggestion.
+        - label: I have read the guidelines above and affirm I am following them with this suggestion.
           required: true
 


### PR DESCRIPTION
### Description
This PR makes a few changes to the issue templates.
- Forces the Skript Info field to render in mardown (sometimes people mess up the backticks and the whole template is messed up)
- Turns Errors/Screenshots section into a normal text area. Rewords recommendation of using a paste website.
- Minor wording changes

If anyone has any other changes they would like to see implemented, feel free to suggest them.

---
**Target Minecraft Versions:** N/A
**Requirements:** None
**Related Issues:** None
