### PR TITLE
Update test download system

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,10 +11,10 @@ jobs:
             - uses: actions/checkout@v2
               with:
                   submodules: recursive
-            - name: Set up JDK 16
+            - name: Set up JDK 17
               uses: actions/setup-java@v1
               with:
-                  java-version: 16
+                  java-version: 17
             - name: Build Skript
               run: ./gradlew nightlyRelease
             - name: Run test scripts

--- a/.github/workflows/repo.yml
+++ b/.github/workflows/repo.yml
@@ -11,10 +11,10 @@ jobs:
             - uses: actions/checkout@v2
               with:
                   submodules: recursive
-            - name: Set up JDK 16
+            - name: Set up JDK 17
               uses: actions/setup-java@v1
               with:
-                  java-version: 16
+                  java-version: 17
             - name: Publish Skript
               run: ./gradlew publish
               env:

--- a/build.gradle
+++ b/build.gradle
@@ -189,7 +189,7 @@ void createTestTask(String name, String environments, boolean devMode) {
 }
 
 // Register different Skript testing tasks
-createTestTask('quickTest', 'src/test/skript/environments/main/paper-1.16.5.json', false)
+createTestTask('quickTest', 'src/test/skript/environments/main/paper-1.18.1.json', false)
 createTestTask('skriptTest', 'src/test/skript/environments/main', false)
 createTestTask('skriptTestFull', 'src/test/skript/environments/', false)
 createTestTask('skriptTestDev', 'src/test/skript/environments/main/' + (project.property('testEnv') == null

--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -18,62 +18,6 @@
  */
 package ch.njol.skript;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.Thread.UncaughtExceptionHandler;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
-import java.util.logging.Filter;
-import java.util.logging.Level;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipException;
-import java.util.zip.ZipFile;
-
-import ch.njol.skript.lang.Section;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.Material;
-import org.bukkit.Server;
-import org.bukkit.command.CommandSender;
-import org.bukkit.command.PluginCommand;
-import org.bukkit.entity.Player;
-import org.bukkit.event.Event;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerCommandPreprocessEvent;
-import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.event.server.PluginDisableEvent;
-import org.bukkit.event.server.ServerCommandEvent;
-import org.bukkit.plugin.Plugin;
-import org.bukkit.plugin.PluginDescriptionFile;
-import org.bukkit.plugin.java.JavaPlugin;
-import org.eclipse.jdt.annotation.Nullable;
-
-import com.google.gson.Gson;
 import ch.njol.skript.aliases.Aliases;
 import ch.njol.skript.bukkitutil.BukkitUnsafe;
 import ch.njol.skript.bukkitutil.BurgerHelper;
@@ -98,6 +42,7 @@ import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionInfo;
 import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.Section;
 import ch.njol.skript.lang.SkriptEvent;
 import ch.njol.skript.lang.SkriptEventInfo;
 import ch.njol.skript.lang.Statement;
@@ -144,6 +89,58 @@ import ch.njol.util.StringUtils;
 import ch.njol.util.coll.CollectionUtils;
 import ch.njol.util.coll.iterator.CheckedIterator;
 import ch.njol.util.coll.iterator.EnumerationIterable;
+import com.google.gson.Gson;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.Server;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.server.PluginDisableEvent;
+import org.bukkit.event.server.ServerCommandEvent;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginDescriptionFile;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.eclipse.jdt.annotation.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.Thread.UncaughtExceptionHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.logging.Filter;
+import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
+import java.util.zip.ZipFile;
 
 // TODO meaningful error if someone uses an %expression with percent signs% outside of text or a variable
 
@@ -602,48 +599,51 @@ public final class Skript extends JavaPlugin implements Listener {
 				
 				// Skript initialization done
 				debug("Early init done");
-				if (TestMode.ENABLED) { // Ignore late init (scripts, etc.) in test mode
-					if (TestMode.DEV_MODE) { // Run tests NOW!
-						info("Test development mode enabled. Test scripts are at " + TestMode.TEST_DIR);
-					} else {
-						info("Running all tests from " + TestMode.TEST_DIR);
-						
-						// Treat parse errors as fatal testing failure
-						@SuppressWarnings("null")
-						CountingLogHandler errorCounter = new CountingLogHandler(Level.SEVERE);
-						try {
-							errorCounter.start();
-							File testDir = TestMode.TEST_DIR.toFile();
-							assert testDir != null;
-							List<Config> configs = ScriptLoader.loadStructures(testDir);
-							ScriptLoader.loadScripts(configs, errorCounter).join();
-						} finally {
-							errorCounter.stop();
+
+				Bukkit.getScheduler().runTaskLater(Skript.this, () -> {
+					if (TestMode.ENABLED) { // Ignore late init (scripts, etc.) in test mode
+						if (TestMode.DEV_MODE) { // Run tests NOW!
+							info("Test development mode enabled. Test scripts are at " + TestMode.TEST_DIR);
+						} else {
+							info("Running all tests from " + TestMode.TEST_DIR);
+
+							// Treat parse errors as fatal testing failure
+							@SuppressWarnings("null")
+							CountingLogHandler errorCounter = new CountingLogHandler(Level.SEVERE);
+							try {
+								errorCounter.start();
+								File testDir = TestMode.TEST_DIR.toFile();
+								assert testDir != null;
+								List<Config> configs = ScriptLoader.loadStructures(testDir);
+								ScriptLoader.loadScripts(configs, errorCounter).join();
+							} finally {
+								errorCounter.stop();
+							}
+
+							Bukkit.getPluginManager().callEvent(new SkriptTestEvent());
+
+							info("Collecting results to " + TestMode.RESULTS_FILE);
+							if (errorCounter.getCount() > 0) {
+								TestTracker.testStarted("parse scripts");
+								TestTracker.testFailed(errorCounter.getCount() + " error(s) found");
+							}
+							if (errored) { // Check for exceptions thrown while script was executing
+								TestTracker.testStarted("run scripts");
+								TestTracker.testFailed("exception was thrown during execution");
+							}
+							String results = new Gson().toJson(TestTracker.collectResults());
+							try {
+								Files.write(TestMode.RESULTS_FILE, results.getBytes(StandardCharsets.UTF_8));
+							} catch (IOException e) {
+								Skript.exception(e, "Failed to write test results.");
+							}
+							info("Testing done, shutting down the server.");
+							Bukkit.getServer().shutdown();
 						}
-						
-						Bukkit.getPluginManager().callEvent(new SkriptTestEvent());
-						
-						info("Collecting results to " + TestMode.RESULTS_FILE);
-						if (errorCounter.getCount() > 0) {
-							TestTracker.testStarted("parse scripts");
-							TestTracker.testFailed(errorCounter.getCount() + " error(s) found");
-						}
-						if (errored) { // Check for exceptions thrown while script was executing
-							TestTracker.testStarted("run scripts");
-							TestTracker.testFailed("exception was thrown during execution");
-						}
-						String results = new Gson().toJson(TestTracker.collectResults());
-						try {
-							Files.write(TestMode.RESULTS_FILE, results.getBytes(StandardCharsets.UTF_8));
-						} catch (IOException e) {
-							Skript.exception(e, "Failed to write test results.");
-						}
-						info("Testing done, shutting down the server.");
-						Bukkit.getServer().shutdown();
+
+						return;
 					}
-					
-					return;
-				}
+				}, 100);
 				
 				final long vld = System.currentTimeMillis() - vls;
 				if (logNormal())

--- a/src/main/java/ch/njol/skript/tests/platform/Environment.java
+++ b/src/main/java/ch/njol/skript/tests/platform/Environment.java
@@ -18,96 +18,161 @@
  */
 package ch.njol.skript.tests.platform;
 
+import ch.njol.skript.tests.TestResults;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.eclipse.jdt.annotation.Nullable;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.lang.ProcessBuilder.Redirect;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Timer;
-import java.util.TimerTask;
-
-import com.google.gson.Gson;
-
-import ch.njol.skript.tests.TestResults;
+import java.util.*;
 
 /**
  * Test environment information.
  */
 public class Environment {
-	
+
+	private static final Gson gson = new Gson();
+
 	/**
 	 * Name of this environment. For example, spigot-1.14.
 	 */
 	private final String name;
-	
+
 	/**
 	 * Resource that needs to be downloaded for the environment.
 	 */
 	public static class Resource {
-		
+
 		/**
 		 * Where to get this resource.
 		 */
-		private String source;
-		
+		private final String source;
+
 		/**
 		 * Path under platform root where it should be placed.
 		 * Directories created as needed.
 		 */
-		private String target;
+		private final String target;
 
 		public Resource(String url, String target) {
 			this.source = url;
 			this.target = target;
 		}
-		
+
 		public String getSource() {
+			System.out.println("wrong source");
 			return source;
 		}
 
-		
 		public String getTarget() {
 			return target;
 		}
-		
+
 	}
-	
+
+	public static class PaperResource extends Resource {
+
+		private final String version;
+		@Nullable
+		private transient String source;
+
+		@SuppressWarnings("ConstantConditions")
+		public PaperResource(String version, String target) {
+			super(null, target);
+			this.version = version;
+		}
+
+		@Override
+		public String getSource() {
+			try {
+				generateSource();
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+			if (source == null)
+				throw new IllegalStateException();
+			return source;
+		}
+
+		private void generateSource() throws IOException {
+			if (source != null)
+				return;
+
+			String stringUrl = "https://papermc.io/api/v2/projects/paper/versions/" + version;
+			URL url = new URL(stringUrl);
+			JsonObject jsonObject;
+			try (InputStream is = url.openStream()) {
+				InputStreamReader reader = new InputStreamReader(is, StandardCharsets.UTF_8);
+				jsonObject = gson.fromJson(reader, JsonObject.class);
+			}
+
+			JsonArray jsonArray = jsonObject.get("builds").getAsJsonArray();
+
+			int latestBuild = -1;
+			for (JsonElement jsonElement : jsonArray) {
+				int build = jsonElement.getAsInt();
+				if (build > latestBuild) {
+					latestBuild = build;
+				}
+			}
+
+			if (latestBuild == -1)
+				throw new IllegalStateException("No builds for this version");
+
+			source = "https://papermc.io/api/v2/projects/paper/versions/" + version + "/builds/" + latestBuild
+				+ "/downloads/paper-" + version + "-" + latestBuild + ".jar";
+		}
+	}
+
 	/**
 	 * Resources that need to be copied.
 	 */
 	private final List<Resource> resources;
-	
+
 	/**
 	 * Resources that need to be downloaded.
 	 */
+	@Nullable
 	private final List<Resource> downloads;
-	
+
+	/**
+	 * Paper resources that need to be downloaded.
+	 */
+	@Nullable
+	private final List<PaperResource> paperDownloads;
+
 	/**
 	 * Where Skript should be placed under platform root.
 	 * Directories created as needed.
 	 */
 	private final String skriptTarget;
-	
+
 	/**
 	 * Added after platform's own JVM flags.
 	 */
 	private final String[] commandLine;
-	
-	public Environment(String name, List<Resource> resources, List<Resource> downloads, String skriptTarget, String... commandLine) {
+
+	public Environment(String name, List<Resource> resources, @Nullable List<Resource> downloads, @Nullable List<PaperResource> paperDownloads, String skriptTarget, String... commandLine) {
 		this.name = name;
 		this.resources = resources;
 		this.downloads = downloads;
+		this.paperDownloads = paperDownloads;
 		this.skriptTarget = skriptTarget;
 		this.commandLine = commandLine;
 	}
-	
+
 	public String getName() {
 		return name;
 	}
@@ -115,21 +180,21 @@ public class Environment {
 	public void initialize(Path dataRoot, Path runnerRoot, boolean remake) throws IOException {
 		Path env = runnerRoot.resolve(name);
 		boolean onlyCopySkript = Files.exists(env) && !remake;
-		
+
 		// Copy Skript to platform
 		Path skript = env.resolve(skriptTarget);
 		Files.createDirectories(skript.getParent());
 		try {
 			Files.copy(new File(getClass().getProtectionDomain().getCodeSource().getLocation()
-				    .toURI()).toPath(), skript, StandardCopyOption.REPLACE_EXISTING);
+				.toURI()).toPath(), skript, StandardCopyOption.REPLACE_EXISTING);
 		} catch (URISyntaxException e) {
 			throw new AssertionError(e);
 		}
-		
+
 		if (onlyCopySkript) {
 			return;
 		}
-		
+
 		// Copy resources
 		for (Resource resource : resources) {
 			Path source = dataRoot.resolve(resource.getSource());
@@ -137,11 +202,18 @@ public class Environment {
 			Files.createDirectories(target.getParent());
 			Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
 		}
-		
+
+		List<Resource> downloads = new ArrayList<>();
+		if (this.downloads != null)
+			downloads.addAll(this.downloads);
+		if (this.paperDownloads != null)
+			downloads.addAll(this.paperDownloads);
 		// Download additional resources
 		for (Resource resource : downloads) {
 			assert resource != null;
-			URL url = new URL(resource.getSource());
+			String source = resource.getSource();
+			System.out.println("Source: " + source + " | " + resource + " | " + resource.getTarget());
+			URL url = new URL(source);
 			Path target = env.resolve(resource.getTarget());
 			Files.createDirectories(target.getParent());
 			try (InputStream is = url.openStream()) {
@@ -149,7 +221,7 @@ public class Environment {
 			}
 		}
 	}
-	
+
 	public TestResults runTests(Path runnerRoot, Path testsRoot, boolean devMode, String... jvmArgs) throws IOException, InterruptedException {
 		Path env = runnerRoot.resolve(name);
 		List<String> args = new ArrayList<>();
@@ -161,25 +233,25 @@ public class Environment {
 		args.add("-Dskript.testing.results=test_results.json");
 		args.addAll(Arrays.asList(jvmArgs));
 		args.addAll(Arrays.asList(commandLine));
-		
+
 		Process process = new ProcessBuilder(args)
-				.directory(env.toFile())
-				.redirectOutput(Redirect.INHERIT)
-				.redirectError(Redirect.INHERIT)
-				.redirectInput(Redirect.INHERIT)
-				.start();
-		
+			.directory(env.toFile())
+			.redirectOutput(Redirect.INHERIT)
+			.redirectError(Redirect.INHERIT)
+			.redirectInput(Redirect.INHERIT)
+			.start();
+
 		// When we exit, try to make them exit too
 		Runtime.getRuntime().addShutdownHook(new Thread(() ->  {
 			if (process.isAlive()) {
 				process.destroy();
 			}
 		}));
-		
+
 		// Catch tests running for abnormally long time
 		if (!devMode) {
 			new Timer("runner watchdog", true).schedule(new TimerTask() {
-				
+
 				@Override
 				public void run() {
 					if (process.isAlive()) {
@@ -189,16 +261,16 @@ public class Environment {
 				}
 			}, 8 * 60_000);
 		}
-		
+
 		int code = process.waitFor();
 		if (code != 0) {
 			throw new IOException("environment returned with code " + code);
 		}
-		
+
 		// Read test results
 		TestResults results = new Gson().fromJson(new String(Files.readAllBytes(env.resolve("test_results.json"))), TestResults.class);
 		assert results != null;
 		return results;
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/tests/platform/Environment.java
+++ b/src/main/java/ch/njol/skript/tests/platform/Environment.java
@@ -72,7 +72,6 @@ public class Environment {
 		}
 
 		public String getSource() {
-			System.out.println("wrong source");
 			return source;
 		}
 
@@ -212,7 +211,6 @@ public class Environment {
 		for (Resource resource : downloads) {
 			assert resource != null;
 			String source = resource.getSource();
-			System.out.println("Source: " + source + " | " + resource + " | " + resource.getTarget());
 			URL url = new URL(source);
 			Path target = env.resolve(resource.getTarget());
 			Files.createDirectories(target.getParent());

--- a/src/test/skript/environments/extra/paper-1.10.2.json
+++ b/src/test/skript/environments/extra/paper-1.10.2.json
@@ -3,8 +3,11 @@
 	"resources": [
 		{"source": "server.properties.generic", "target": "server.properties"}
 	],
-	"downloads": [
-		{"source": "https://papermc.io/api/v2/projects/paper/versions/1.10.2/builds/916/downloads/paper-1.10.2-916.jar", "target": "paperclip.jar"}
+	"paperDownloads": [
+		{
+			"version": "1.10.2",
+			"target": "paperclip.jar"
+		}
 	],
 	"skriptTarget": "plugins/Skript.jar",
 	"commandLine": [

--- a/src/test/skript/environments/extra/paper-1.11.2.json
+++ b/src/test/skript/environments/extra/paper-1.11.2.json
@@ -3,8 +3,11 @@
 	"resources": [
 		{"source": "server.properties.generic", "target": "server.properties"}
 	],
-	"downloads": [
-		{"source": "https://papermc.io/api/v2/projects/paper/versions/1.11.2/builds/1104/downloads/paper-1.11.2-1104.jar", "target": "paperclip.jar"}
+	"paperDownloads": [
+		{
+			"version": "1.11.2",
+			"target": "paperclip.jar"
+		}
 	],
 	"skriptTarget": "plugins/Skript.jar",
 	"commandLine": [

--- a/src/test/skript/environments/extra/paper-1.13.2.json
+++ b/src/test/skript/environments/extra/paper-1.13.2.json
@@ -3,8 +3,11 @@
 	"resources": [
 		{"source": "server.properties.generic", "target": "server.properties"}
 	],
-	"downloads": [
-		{"source": "https://papermc.io/api/v2/projects/paper/versions/1.13.2/builds/655/downloads/paper-1.13.2-655.jar", "target": "paperclip.jar"}
+	"paperDownloads": [
+		{
+			"version": "1.13.2",
+			"target": "paperclip.jar"
+		}
 	],
 	"skriptTarget": "plugins/Skript.jar",
 	"commandLine": [

--- a/src/test/skript/environments/extra/paper-1.16.5.json
+++ b/src/test/skript/environments/extra/paper-1.16.5.json
@@ -3,8 +3,11 @@
 	"resources": [
 		{"source": "server.properties.generic", "target": "server.properties"}
 	],
-	"downloads": [
-		{"source": "https://papermc.io/api/v2/projects/paper/versions/1.16.5/builds/790/downloads/paper-1.16.5-790.jar", "target": "paperclip.jar"}
+	"paperDownloads": [
+		{
+			"version": "1.16.5",
+			"target": "paperclip.jar"
+		}
 	],
 	"skriptTarget": "plugins/Skript.jar",
 	"commandLine": [

--- a/src/test/skript/environments/extra/paper-1.17.1.json
+++ b/src/test/skript/environments/extra/paper-1.17.1.json
@@ -3,8 +3,11 @@
 	"resources": [
 		{"source": "server.properties.generic", "target": "server.properties"}
 	],
-	"downloads": [
-		{"source": "https://papermc.io/api/v2/projects/paper/versions/1.17.1/builds/388/downloads/paper-1.17.1-388.jar", "target": "paperclip.jar"}
+	"paperDownloads": [
+		{
+			"version": "1.17.1",
+			"target": "paperclip.jar"
+		}
 	],
 	"skriptTarget": "plugins/Skript.jar",
 	"commandLine": [

--- a/src/test/skript/environments/main/paper-1.12.2.json
+++ b/src/test/skript/environments/main/paper-1.12.2.json
@@ -3,8 +3,11 @@
 	"resources": [
 		{"source": "server.properties.generic", "target": "server.properties"}
 	],
-	"downloads": [
-		{"source": "https://papermc.io/api/v2/projects/paper/versions/1.12.2/builds/1618/downloads/paper-1.12.2-1618.jar", "target": "paperclip.jar"}
+	"paperDownloads": [
+		{
+			"version": "1.12.2",
+			"target": "paperclip.jar"
+		}
 	],
 	"skriptTarget": "plugins/Skript.jar",
 	"commandLine": [

--- a/src/test/skript/environments/main/paper-1.18.1.json
+++ b/src/test/skript/environments/main/paper-1.18.1.json
@@ -1,17 +1,17 @@
 {
-	"name": "paper-1.14.4",
+	"name": "paper-1.18.1",
 	"resources": [
 		{"source": "server.properties.generic", "target": "server.properties"}
 	],
 	"paperDownloads": [
 		{
-			"version": "1.14.4",
+			"version": "1.18.1",
 			"target": "paperclip.jar"
 		}
 	],
 	"skriptTarget": "plugins/Skript.jar",
 	"commandLine": [
 		"-Dcom.mojang.eula.agree=true",
-		"-jar", "paperclip.jar"
+		"-jar", "paperclip.jar", "--nogui"
 	]
 }

--- a/src/test/skript/environments/main/paper-1.9.4.json
+++ b/src/test/skript/environments/main/paper-1.9.4.json
@@ -3,8 +3,11 @@
 	"resources": [
 		{"source": "server.properties.generic", "target": "server.properties"}
 	],
-	"downloads": [
-		{"source": "https://papermc.io/api/v2/projects/paper/versions/1.9.4/builds/773/downloads/paper-1.9.4-773.jar", "target": "paperclip.jar"}
+	"paperDownloads": [
+		{
+			"version": "1.9.4",
+			"target": "paperclip.jar"
+		}
 	],
 	"skriptTarget": "plugins/Skript.jar",
 	"commandLine": [


### PR DESCRIPTION
### Description
With this update the Paper downloads will automatically use the latest build of their respective version, instead of relying on updates for them. Also updates the testing system to use 1.18.1 as the latest version.

Also updates the Java version used by the workflows to Java 17, and delays the tests by 5 seconds to make sure the server is fully started.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4119, #4441, #3767 (all non-fixing)
