### PR TITLE
Use equals comparator when classes share a superclass

### DIFF
--- a/src/main/java/ch/njol/skript/registrations/Comparators.java
+++ b/src/main/java/ch/njol/skript/registrations/Comparators.java
@@ -110,8 +110,8 @@ public class Comparators {
 			}
 		}
 		
-		// same class but no comparator
-		if (s == f && f != Object.class && s != Object.class) {
+		// same class or superclass but no comparator
+		if ((s == f && f != Object.class) || (s.getSuperclass() == f.getSuperclass() && f.getSuperclass() != Object.class)) {
 			return Comparator.equalsComparator;
 		}
 		


### PR DESCRIPTION
### Description
This PR allows the method responsible for finding a comparator to return the equals comparator if the two classes share an immediate superclass. One issue caused by the lack of these checks is the weird comparison stuff that goes on with potions such as:
https://github.com/SkriptLang/Skript/blob/e43c37e02a8508137bf4e114f0f79880cc9cc283/src/main/java/ch/njol/skript/util/PotionEffectUtils.java#L90-L99

However, I was wondering if it should compare if the classes share a common superclass at *any* point, not just the first level.

---
**Target Minecraft Versions:** Any
**Requirements:** None
**Related Issues:** #4183 (needs this PR)
