### PR TITLE
Hex Color Fix

### DIFF
--- a/src/main/java/ch/njol/skript/util/Utils.java
+++ b/src/main/java/ch/njol/skript/util/Utils.java
@@ -589,7 +589,7 @@ public abstract class Utils {
 	@SuppressWarnings("null")
 	@Nullable
 	public static ChatColor parseHexColor(String hex) {
-		if (!HEX_SUPPORTED || !hex.matches("(?i)#[0-9a-z]{6}")) // Proper hex code validation
+		if (!HEX_SUPPORTED || !hex.matches("(?i)#?[0-9a-z]{6}")) // Proper hex code validation
 			return null;
 		
 		hex = hex.replace("#", "");


### PR DESCRIPTION
### Description
With the latest update, Hex colors couldnt be used within containers like variables, or functions. 
Idk why tho. But this fixes it 🎉 

---
**Target Minecraft Versions:** 1.16+
**Requirements:** Skript
**Related Issues:** https://github.com/SkriptLang/Skript/issues/4527
