### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ local.properties
 .settings/
 .loadpath
 .recommenders
+.project
+.classpath
 
 # External tool builders
 .externalToolBuilders/


### PR DESCRIPTION
### Description
Adds `.project` and `.classpath` Eclipse gitignore file types.

Reopening this because it never happened https://github.com/SkriptLang/Skript/pull/3148
It was closed because it was rumored to have been completed soon.
