### PR TITLE
Add time states to biomes

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprBiome.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBiome.java
@@ -21,8 +21,6 @@ package ch.njol.skript.expressions;
 import org.bukkit.Location;
 import org.bukkit.block.Biome;
 import org.bukkit.event.Event;
-import org.bukkit.event.player.PlayerTeleportEvent;
-import org.bukkit.event.world.SpawnChangeEvent;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
@@ -31,14 +29,12 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
-import ch.njol.skript.effects.Delay;
 import ch.njol.skript.expressions.base.PropertyExpression;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.Direction;
 import ch.njol.util.Kleenean;
-import ch.njol.util.coll.CollectionUtils;
 
 /**
  * @author Peter Güttinger
@@ -68,12 +64,6 @@ public class ExprBiome extends PropertyExpression<Location, Biome> {
 
 	@Override
 	protected Biome[] get(Event event, Location[] source) {
-		if (getTime() == -1 && !Delay.isDelayed(event) && event instanceof SpawnChangeEvent)
-			return CollectionUtils.array(((SpawnChangeEvent) event).getPreviousLocation().getBlock().getBiome());
-		if (event instanceof PlayerTeleportEvent && !Delay.isDelayed(event)) {
-			Location location = getTime() == -1 ? ((PlayerTeleportEvent) event).getFrom() : ((PlayerTeleportEvent) event).getTo();
-			return CollectionUtils.array(location.getBlock().getBiome());
-		}
 		return get(source, location -> location.getBlock().getBiome());
 	}
 
@@ -110,7 +100,7 @@ public class ExprBiome extends PropertyExpression<Location, Biome> {
 	@SuppressWarnings("unchecked")
 	@Override
 	public boolean setTime(int time) {
-		super.setTime(time, getExpr(), SpawnChangeEvent.class, PlayerTeleportEvent.class);
+		super.setTime(time, getExpr());
 		return true;
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprBiome.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBiome.java
@@ -21,21 +21,24 @@ package ch.njol.skript.expressions;
 import org.bukkit.Location;
 import org.bukkit.block.Biome;
 import org.bukkit.event.Event;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.event.world.SpawnChangeEvent;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
-import ch.njol.skript.classes.Converter;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
+import ch.njol.skript.effects.Delay;
 import ch.njol.skript.expressions.base.PropertyExpression;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.Direction;
 import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
 
 /**
  * @author Peter Güttinger
@@ -51,49 +54,64 @@ import ch.njol.util.Kleenean;
 		"		damage the loop-player by 1"})
 @Since("1.4.4, 2.6.1 (3D biomes)")
 public class ExprBiome extends PropertyExpression<Location, Biome> {
+
 	static {
-		Skript.registerExpression(ExprBiome.class, Biome.class, ExpressionType.PROPERTY, "[the] biome (of|%direction%) %locations%", "%locations%'[s] biome");
+		Skript.registerExpression(ExprBiome.class, Biome.class, ExpressionType.PROPERTY, "[the] biome [(of|%direction%) %locations%]", "%locations%'[s] biome");
 	}
-	
-	@SuppressWarnings({"unchecked", "null"})
+
+	@SuppressWarnings("unchecked")
 	@Override
-	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		setExpr(matchedPattern == 1 ? (Expression<? extends Location>) exprs[0] : Direction.combine((Expression<? extends Direction>) exprs[0], (Expression<? extends Location>) exprs[1]));
 		return true;
 	}
-	
+
 	@Override
-	protected Biome[] get(final Event e, final Location[] source) {
+	protected Biome[] get(Event event, Location[] source) {
+		if (getTime() == -1 && !Delay.isDelayed(event) && event instanceof SpawnChangeEvent)
+			return CollectionUtils.array(((SpawnChangeEvent) event).getPreviousLocation().getBlock().getBiome());
+		if (event instanceof PlayerTeleportEvent && !Delay.isDelayed(event)) {
+			Location location = getTime() == -1 ? ((PlayerTeleportEvent) event).getFrom() : ((PlayerTeleportEvent) event).getTo();
+			return CollectionUtils.array(location.getBlock().getBiome());
+		}
 		return get(source, location -> location.getBlock().getBiome());
 	}
-	
+
 	@Override
 	@Nullable
-	public Class<?>[] acceptChange(final ChangeMode mode) {
+	public Class<?>[] acceptChange(ChangeMode mode) {
 		if (mode == ChangeMode.SET)
 			return new Class[] {Biome.class};
 		return super.acceptChange(mode);
 	}
-	
+
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
-		if (mode == ChangeMode.SET) {
-			assert delta != null;
-			for (final Location l : getExpr().getArray(e))
-				l.getBlock().setBiome((Biome) delta[0]);
-		} else {
-			super.change(e, delta, mode);
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+		if (mode != ChangeMode.SET) {
+			super.change(event, delta, mode);
+			return;
 		}
+		assert delta != null;
+		Biome biome = (Biome) delta[0];
+		for (Location location : getExpr().getArray(event))
+			location.getBlock().setBiome(biome);
 	}
-	
+
 	@Override
 	public Class<? extends Biome> getReturnType() {
 		return Biome.class;
 	}
-	
+
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "the biome at " + getExpr().toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "the biome at " + getExpr().toString(event, debug);
 	}
-	
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean setTime(int time) {
+		super.setTime(time, getExpr(), SpawnChangeEvent.class, PlayerTeleportEvent.class);
+		return true;
+	}
+
 }


### PR DESCRIPTION
### Description
Adds time states and default expressions for biomes from a location (so basically anything).

Also did some micro code improvements, like removing the casting each for loop.

This script below will now work with this pull request
```vb
on teleport:
	broadcast "%biome%"
	if the biome at the future location will be basalt deltas, the end or nether:
		cancel event
```
