### PR TITLE
Exclude entity event values from death events

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -400,14 +400,14 @@ public final class BukkitEventValues {
 			public Entity get(final EntityEvent e) {
 				return e.getEntity();
 			}
-		}, 0, "Use 'attacker' and/or 'victim' in damage events", EntityDamageEvent.class);
+		}, 0, "Use 'attacker' and/or 'victim' in damage/death events", EntityDamageEvent.class, EntityDeathEvent.class);
 		EventValues.registerEventValue(EntityEvent.class, CommandSender.class, new Getter<CommandSender, EntityEvent>() {
 			@Override
 			@Nullable
 			public CommandSender get(final EntityEvent e) {
 				return e.getEntity();
 			}
-		}, 0, "Use 'attacker' and/or 'victim' in damage events", EntityDamageEvent.class);
+		}, 0, "Use 'attacker' and/or 'victim' in damage/death events", EntityDamageEvent.class, EntityDeathEvent.class);
 		EventValues.registerEventValue(EntityEvent.class, World.class, new Getter<World, EntityEvent>() {
 			@Override
 			@Nullable


### PR DESCRIPTION
Restricts entity event values from being used in the death event and forces users to use `attacker/victim` to avoid confusion as to why they're not getting a message or why their code isn't erroring.

A user in the SkUnity discord was questioning why they weren't getting any errors and what was wrong with their script. Turns out it wasn't erroring because there was multiple entities involved in the event and either `player` or `event-entity` wasn't working.

Example script that will now error with this pull request:
```vb
on death of player:
	attacker is a player
	message "Needs to specify the sender"
	message "Who is this messaging?" to event-entity
```
Fix of example script:
```vb
on death of player:
	attacker is a player
	message "&dYou just killed %victim%" to attacker
```