### PR TITLE
Fix message and broadcast with or list, redesign or ExpressionList getting

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffBroadcast.java
+++ b/src/main/java/ch/njol/skript/effects/EffBroadcast.java
@@ -34,6 +34,7 @@ import ch.njol.skript.util.LiteralUtils;
 import ch.njol.skript.util.chat.BungeeConverter;
 import ch.njol.skript.util.chat.ChatMessages;
 import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
 import net.md_5.bungee.api.chat.BaseComponent;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
@@ -86,7 +87,7 @@ public class EffBroadcast extends Effect {
 				receivers.addAll(world.getPlayers());
 		}
 
-		for (Expression<?> message : messages) {
+		for (Expression<?> message : getMessages()) {
 			if (message instanceof VariableString) {
 				BaseComponent[] components = BungeeConverter.convert(((VariableString) message).getMessageComponents(e));
 				receivers.forEach(receiver -> receiver.spigot().sendMessage(components));
@@ -103,7 +104,14 @@ public class EffBroadcast extends Effect {
 			}
 		}
 	}
-	
+
+	private Expression<?>[] getMessages() {
+		if (messageExpr instanceof ExpressionList && !messageExpr.getAnd()) {
+			return new Expression[] {CollectionUtils.getRandom(messages)};
+		}
+		return messages;
+	}
+
 	@Override
 	public String toString(@Nullable Event e, boolean debug) {
 		return "broadcast " + messageExpr.toString(e, debug) + (worlds == null ? "" : " to " + worlds.toString(e, debug));

--- a/src/main/java/ch/njol/skript/effects/EffMessage.java
+++ b/src/main/java/ch/njol/skript/effects/EffMessage.java
@@ -24,6 +24,7 @@ import java.util.UUID;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.util.LiteralUtils;
 import ch.njol.skript.util.chat.MessageComponent;
+import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
@@ -108,7 +109,7 @@ public class EffMessage extends Effect {
 
 		CommandSender[] commandSenders = recipients.getArray(e);
 
-		for (Expression<?> message : messages) {
+		for (Expression<?> message : getMessages()) {
 
 			Object[] messageArray = null;
 			List<MessageComponent> messageComponents = null;
@@ -151,6 +152,13 @@ public class EffMessage extends Effect {
 			receiver.spigot().sendMessage(sender.getUniqueId(), components);
 		else
 			receiver.spigot().sendMessage(components);
+	}
+
+	private Expression<?>[] getMessages() {
+		if (messageExpr instanceof ExpressionList && !messageExpr.getAnd()) {
+			return new Expression[] {CollectionUtils.getRandom(messages)};
+		}
+		return messages;
 	}
 
 	private String toString(Object object) {


### PR DESCRIPTION
### Description
Fixed EffMessage and EffBroadcast to handle 'or' expression lists correctly.
Also changed how a few of ExpressionList's methods work (getSingle, getArray and iterator), how the behaviour changed is explained in example below. The rest of the diff is formatting.

```
command /test:
	trigger:
		broadcast "a", "b" or "c"
		send "A", "B" or "C"
		
		set {_x} to "X"
		set {_y} to {_x} or {_none}
		broadcast "y: %{_y}

```
Before PR:
![image](https://user-images.githubusercontent.com/29547183/151659212-bd82540e-6c57-4a62-b95d-30304f147ce6.png)
After PR:
![image](https://user-images.githubusercontent.com/29547183/151659187-66f9ffaf-5446-4f9f-b5a2-895e5beddd6e.png)

ExpressionList would always try to pick a non-null value instead of picking a random value from the list.
I personally think the new behaviour from this PR makes more sense, but I'd like feedback on it (which is why I added 'up for debate' label)

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4543
