### PR TITLE
Improve exception throwing of PatternCompiler

### DIFF
--- a/src/main/java/ch/njol/skript/patterns/PatternCompiler.java
+++ b/src/main/java/ch/njol/skript/patterns/PatternCompiler.java
@@ -45,8 +45,14 @@ public class PatternCompiler {
 	 */
 	public static SkriptPattern compile(String pattern) {
 		AtomicInteger atomicInteger = new AtomicInteger(0);
-		PatternElement first = compile(pattern, atomicInteger);
-		return new SkriptPattern(first, atomicInteger.get());
+		try {
+			PatternElement first = compile(pattern, atomicInteger);
+			return new SkriptPattern(first, atomicInteger.get());
+		} catch (MalformedPatternException e) {
+			throw e;
+		} catch (RuntimeException e) {
+			throw new MalformedPatternException(pattern, "caught exception while compiling pattern", e);
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Description
This change makes it so any exception caught while compiling a pattern is rethrown with more information about the pattern.

For example, I malformed the pattern of EffMessage.
Before PR:
https://pastebin.com/dzp0Q1Mh
```
ch.njol.skript.SkriptAPIException: No class info found for objectst
```

After PR:
https://pastebin.com/aZZHG6Kc
```
java.lang.RuntimeException: pattern compiling exception, element class: ch.njol.skript.effects.EffMessage
Caused by: ch.njol.skript.patterns.MalformedPatternException: caught exception while compiling pattern [pattern: (message|send [message[s]]) %objectst% [to %commandsenders%] [from %-player%]]
Caused by: ch.njol.skript.SkriptAPIException: No class info found for objectst
```

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4541
