### PR TITLE
Fix 'no scripts found' warning displaying with a config line

### DIFF
--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -490,7 +490,7 @@ public class ScriptLoader {
 				}
 				
 				if (scriptInfo.files == 0)
-					SkriptLogger.log(new LogEntry(Level.WARNING, m_no_scripts.toString(), null));
+					Skript.warning(m_no_scripts.toString());
 				if (Skript.logNormal() && scriptInfo.files > 0)
 					Skript.info(m_scripts_loaded.toString(
 						scriptInfo.files,

--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -490,7 +490,7 @@ public class ScriptLoader {
 				}
 				
 				if (scriptInfo.files == 0)
-					Skript.warning(m_no_scripts.toString());
+					SkriptLogger.log(new LogEntry(Level.WARNING, m_no_scripts.toString(), null));
 				if (Skript.logNormal() && scriptInfo.files > 0)
 					Skript.info(m_scripts_loaded.toString(
 						scriptInfo.files,

--- a/src/main/java/ch/njol/skript/variables/Variables.java
+++ b/src/main/java/ch/njol/skript/variables/Variables.java
@@ -36,6 +36,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.regex.Pattern;
 
+import ch.njol.skript.log.SkriptLogger;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.configuration.serialization.ConfigurationSerialization;
@@ -215,6 +216,8 @@ public abstract class Variables {
 				return false;
 			}
 		} finally {
+			SkriptLogger.setNode(null);
+
 			// make sure to put the loaded variables into the variables map
 			final int n = onStoragesLoaded();
 			if (n != 0) {


### PR DESCRIPTION
### Description
Before PR:
![image](https://user-images.githubusercontent.com/29547183/151672508-46508364-d2fc-42fd-bb99-b1a7d354f179.png)
This line in the config is unrelated, and it doesn't need to be displayed with the warning.
After PR:
![image](https://user-images.githubusercontent.com/29547183/151672525-a3df5e5e-f27d-45ab-adcd-c79841e71737.png)

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
