### PR TITLE
Re-add ExprIndices pattern 'all' part

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprIndices.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprIndices.java
@@ -59,8 +59,8 @@ public class ExprIndices extends SimpleExpression<String> {
 
 	static {
 		Skript.registerExpression(ExprIndices.class, String.class, ExpressionType.COMBINED,
-				"[the] (indexes|indices) of %~objects%",
-				"[the] %~objects%'[s] (indexes|indices)",
+				"[(the|all [[of] the])] (indexes|indices) of %~objects%",
+				"%~objects%'[s] (indexes|indices)",
 				"[sorted] (indices|indexes) of %~objects% in (ascending|1¦descending) order",
 				"[sorted] %~objects%'[s] (indices|indexes) in (ascending|1¦descending) order"
 		);


### PR DESCRIPTION
### Description
Re-adds the 'all' syntax to ExprIndices, accidentally removed in #3922. Also removes the optional 'the' from the second pattern, as IMO `the {_x::*}'s indices` doesn't make much sense to me (PropertyExpression also doesn't have the 'the' on the `'s` pattern).

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4547, #3922 (latter non-fixing)
