### PR TITLE
Fix ExprSaturation issues

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprSaturation.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSaturation.java
@@ -18,67 +18,44 @@
  */
 package ch.njol.skript.expressions;
 
-import org.bukkit.entity.Player;
-import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
-
-import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
-import ch.njol.skript.expressions.base.PropertyExpression;
-import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.skript.util.Getter;
-import ch.njol.util.Kleenean;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
 import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
 
 @Name("Saturation")
 @Description("The saturation of a player. If used in a player event, it can be omitted and will default to event-player.")
 @Examples("set saturation of player to 20")
-@Since("2.2-Fixes-v10, 2.2-dev35 (fully modifiable)")
-public class ExprSaturation extends PropertyExpression<Player, Number> {
+@Since("2.2-Fixes-v10, 2.2-dev35 (fully modifiable), INSERT VERSION (syntax pattern changed)")
+public class ExprSaturation extends SimplePropertyExpression<Player, Number> {
 
 	static {
-		Skript.registerExpression(ExprSaturation.class, Number.class, ExpressionType.PROPERTY, "[the] saturation [of %players%]", "%players%'[s] saturation");
+		register(ExprSaturation.class, Number.class, "saturation", "players");
 	}
-	
+
 	@Override
-	public Class<? extends Number> getReturnType() {
-		return Number.class;
-	}
-	
-	@SuppressWarnings({"null", "unchecked"})
-	@Override
-	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
-		setExpr((Expression<? extends Player>) exprs[0]);
-		return true;
-	}
-	
-	@Override
-	protected Number[] get(final Event e, final Player[] source) {
-		return get(source, new Getter<Number, Player>() {
-			@Override
-			public Number get(final Player player) {
-				return player.getSaturation();
-			}
-		});
-	}
-	
 	@Nullable
+	public Number convert(Player player) {
+		return player.getSaturation();
+	}
+
 	@Override
+	@Nullable
 	public Class<?>[] acceptChange(Changer.ChangeMode mode) {
 		return (mode != ChangeMode.REMOVE_ALL) ? CollectionUtils.array(Number.class) : null;
 	}
-	
+
 	@SuppressWarnings("null")
 	@Override
 	public void change(Event e, @Nullable Object[] delta, Changer.ChangeMode mode) {
-		float value = ((Number)delta[0]).floatValue();
+		Float value = delta != null ? ((Number)delta[0]).floatValue() : null;
 		switch (mode) {
 			case ADD:
 				for (Player player : getExpr().getArray(e))
@@ -100,10 +77,15 @@ public class ExprSaturation extends PropertyExpression<Player, Number> {
 				break;
 		}
 	}
-	
+
 	@Override
-	public String toString(final @Nullable Event event, final boolean debug) {
-		return "saturation" + (getExpr().isDefault() ? "" : " of " + getExpr().toString(event, debug));
+	public Class<? extends Number> getReturnType() {
+		return Number.class;
 	}
-	
+
+	@Override
+	protected String getPropertyName() {
+		return "saturation";
+	}
+
 }


### PR DESCRIPTION
### Description
Fixes an NPE when using e.g. `reset saturation of player`.
Changes the syntax of the saturation expression to that of a normal property expression, reducing syntax conflict between saturation, the potion effect and saturation, the expression involving a player.


Changelog: see https://github.com/SkriptLang/Skript/pull/4554#pullrequestreview-869349032

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4552, #692
