### PR TITLE
Re-add error from EffChange

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffChange.java
+++ b/src/main/java/ch/njol/skript/effects/EffChange.java
@@ -225,6 +225,7 @@ public class EffChange extends Effect {
 						Skript.error(what + " can't be set to " + changer + " because the latter is " + SkriptParser.notOfType(r), ErrorQuality.SEMANTIC_ERROR);
 					else
 						Skript.error(changer + " can't be " + (mode == ChangeMode.ADD ? "added to" : "removed from") + " " + what + " because the former is " + SkriptParser.notOfType(r), ErrorQuality.SEMANTIC_ERROR);
+					log.printError();
 					return false;
 				}
 				log.printLog();


### PR DESCRIPTION
### Description
For example when using the code `add 1 to player`
Before PR:
![image](https://user-images.githubusercontent.com/29547183/151702519-5bf951f1-12c3-4f5a-be13-f4450e79f39d.png)
After PR:
![image](https://user-images.githubusercontent.com/29547183/151702526-995c18d3-c0fd-48fd-b73c-6ad304f2e82b.png)

Caused by #4104

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4552, #4104 (both non-fixing)

