### PR TITLE
Formalize the clicked synatxes

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprClicked.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprClicked.java
@@ -66,8 +66,8 @@ public class ExprClicked extends SimpleExpression<Object> {
 		BLOCK_AND_ITEMS(1, Block.class, "clicked block/itemtype/entity", "clicked (block|%-*itemtype/entitydata%)"),
 		SLOT(2, Slot.class, "clicked slot", "clicked slot"),
 		INVENTORY(3, Inventory.class, "clicked inventory", "clicked inventory"),
-		TYPE(4, ClickType.class, "click type", "click (type|action)"),
-		ACTION(5, InventoryAction.class, "inventory action", "inventory action"),
+		TYPE(4, ClickType.class, "click type", "click[ed] type"),
+		ACTION(5, InventoryAction.class, "inventory action", "(click[ed]|inventory) action"),
 		ENCHANT_BUTTON(6, Number.class, "clicked enchantment button", "clicked [enchant[ment]] button");
 		
 		private String name, syntax;


### PR DESCRIPTION
### Description
Make the clicked syntaxes more proper. Skellett has had these removed for some time now, so users should be adapted to Skript's synatxes now. It was called inventory action as Skellett had clicked action, but now Skript has the freedom to change it back to be proper. I also removed `click action` as being a ClickedType. It should have never been associated with type, and users will have to update to the new proper standards.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none