### PR TITLE
Add ExprPlayerProtocolVersion

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprPlayerProtocolVersion.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPlayerProtocolVersion.java
@@ -1,3 +1,21 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
 package ch.njol.skript.expressions;
 
 import ch.njol.skript.Skript;

--- a/src/main/java/ch/njol/skript/expressions/ExprPlayerProtocolVersion.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPlayerProtocolVersion.java
@@ -1,0 +1,31 @@
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import org.bukkit.entity.Player;
+import org.eclipse.jdt.annotation.Nullable;
+
+public class ExprPlayerProtocolVersion extends SimplePropertyExpression<Player, Integer> {
+
+	static {
+		if (Skript.classExists("com.destroystokyo.paper.network.NetworkClient")) {
+			register(ExprPlayerProtocolVersion.class, Integer.class, "[the] [client] protocol version", "players");
+		}
+	}
+
+	@Override
+	public @Nullable Integer convert(Player player) {
+		return player.getProtocolVersion();
+	}
+
+	@Override
+	public Class<? extends Integer> getReturnType() {
+		return Integer.class;
+	}
+
+	@Override
+	protected String getPropertyName() {
+		return "protocol version";
+	}
+
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprPlayerProtocolVersion.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPlayerProtocolVersion.java
@@ -42,7 +42,8 @@ public class ExprPlayerProtocolVersion extends SimplePropertyExpression<Player, 
 	@Override
 	@Nullable
 	public Integer convert(Player player) {
-		return player.getProtocolVersion();
+		int version = player.getProtocolVersion();
+		return version == -1 ? null : version;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprPlayerProtocolVersion.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPlayerProtocolVersion.java
@@ -32,7 +32,8 @@ public class ExprPlayerProtocolVersion extends SimplePropertyExpression<Player, 
 	}
 
 	@Override
-	public @Nullable Integer convert(Player player) {
+	@Nullable
+	public Integer convert(Player player) {
 		return player.getProtocolVersion();
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprPlayerProtocolVersion.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPlayerProtocolVersion.java
@@ -19,15 +19,23 @@
 package ch.njol.skript.expressions;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.doc.*;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
 import org.bukkit.entity.Player;
 import org.eclipse.jdt.annotation.Nullable;
 
+@Name("Player Protocol Version")
+@Description("Player's protocol version. For more information and list of protocol versions <a href='https://wiki.vg/Protocol_version_numbers'>visit wiki.vg</a>.")
+@Examples({"command /protocolversion &ltplayer&gt:",
+	"\ttrigger:",
+	"\t\tsend \"Protocol version of %arg-1%: %protocol version of arg-1%\""})
+@Since("INSERT VERSION")
+@RequiredPlugins("Paper 1.12.2 or newer")
 public class ExprPlayerProtocolVersion extends SimplePropertyExpression<Player, Integer> {
 
 	static {
 		if (Skript.classExists("com.destroystokyo.paper.network.NetworkClient")) {
-			register(ExprPlayerProtocolVersion.class, Integer.class, "[the] [client] protocol version", "players");
+			register(ExprPlayerProtocolVersion.class, Integer.class, "protocol version", "players");
 		}
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprProtocolVersion.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprProtocolVersion.java
@@ -59,7 +59,7 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprProtocolVersion extends SimpleExpression<Long> {
 
 	static {
-		Skript.registerExpression(ExprProtocolVersion.class, Long.class, ExpressionType.SIMPLE, "[the] [(sent|required|fake)] protocol version [number]");
+		Skript.registerExpression(ExprProtocolVersion.class, Long.class, ExpressionType.SIMPLE, "[the] [server] list [(sent|required|fake)] protocol version [number]");
 	}
 
 	private static final boolean PAPER_EVENT_EXISTS = Skript.classExists("com.destroystokyo.paper.event.server.PaperServerListPingEvent");

--- a/src/main/java/ch/njol/skript/expressions/ExprProtocolVersion.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprProtocolVersion.java
@@ -59,7 +59,7 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprProtocolVersion extends SimpleExpression<Long> {
 
 	static {
-		Skript.registerExpression(ExprProtocolVersion.class, Long.class, ExpressionType.SIMPLE, "[the] [server] list [(sent|required|fake)] protocol version [number]");
+		Skript.registerExpression(ExprProtocolVersion.class, Long.class, ExpressionType.SIMPLE, "[the] [server] [(sent|required|fake)] protocol version [number]");
 	}
 
 	private static final boolean PAPER_EVENT_EXISTS = Skript.classExists("com.destroystokyo.paper.event.server.PaperServerListPingEvent");


### PR DESCRIPTION
### Description
Added an expression for getting players' protocol version, exclusive to Paper. Supported all the way back to 1.12.
Also changed ExprProtocolVersion syntax. This can be a breaking change and open to discussion.

---
**Target Minecraft Versions:** any
**Requirements:** Paper
**Related Issues:** #1655
