### PR TITLE
Make Skript only accept registrations if it is enabled

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -1204,12 +1204,14 @@ public final class Skript extends JavaPlugin implements Listener {
 	private static boolean acceptRegistrations = true;
 	
 	public static boolean isAcceptRegistrations() {
-		return acceptRegistrations;
+		if (instance == null)
+			throw new IllegalStateException("Skript was never loaded");
+		return acceptRegistrations && instance.isEnabled();
 	}
 	
 	public static void checkAcceptRegistrations() {
-		if (!acceptRegistrations)
-			throw new SkriptAPIException("Registering is disabled after initialisation!");
+		if (!isAcceptRegistrations())
+			throw new SkriptAPIException("Registration can only be done during plugin initialization");
 	}
 	
 	private static void stopAcceptingRegistrations() {


### PR DESCRIPTION
### Description
Makes Skript only accept registrations if the plugin is loaded & enabled.

I've seen multiple addon devs accidentally include Skript within their addon jar, this'll make it easier for them to detect the problem.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
