### PR TITLE
Fix tests

### DIFF
--- a/src/test/skript/tests/syntaxes/expressions/ExprIndices.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprIndices.sk
@@ -9,8 +9,8 @@ test "sorted indices":
 	set {_leader-board::marcelo} to 17
 	set {_leader-board::leandro} to 17
 
-	set {_descending-indices::*} to sorted indices of {_leader-board::*} in descending order
-	set {_ascending-indices::*} to sorted {_leader-board::*}'s indices in ascending order
+	set {_descending-indices::*} to indices of {_leader-board::*} in descending order
+	set {_ascending-indices::*} to {_leader-board::*}'s indices in ascending order
 	set {_ascending-values::*} to sorted {_leader-board::*}
 	set {_descending-values::*} to reversed {_ascending-values::*}
 


### PR DESCRIPTION
### Description
Updates tests according to https://github.com/SkriptLang/Skript/pull/4578#issuecomment-1034045530, see that comment for cause of breaking:
- ExprIndices.sk has the `sorted` keyword removed where it was not needed and could cause parsing issues.
- The new order of loading classes via SkriptAddon#loadClasses is via sorting with `String#compareToIgnoreCase`, which is slightly different from what it was before, but close enough (the only difference is that inner classes would previously be loaded first before their parents, though Java might have to load the parent first anyway, in which case there is no difference).

---
**Target Minecraft Versions:** any
**Requirements:**  none
**Related Issues:** #4578
