### PR TITLE
🚀 Fix some extra and missing `[the]`s

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprAmount.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAmount.java
@@ -37,7 +37,6 @@ import org.eclipse.jdt.annotation.Nullable;
 import java.util.Map;
 
 /**
- * TODO should 'amount of [item]' return the size of the stack?
  * 
  * @author Peter Güttinger
  */
@@ -65,8 +64,8 @@ public class ExprAmount extends SimpleExpression<Long> {
 
 	static {
 		Skript.registerExpression(ExprAmount.class, Long.class, ExpressionType.PROPERTY,
-				"(amount|number|size) of %objects%",
-				"recursive (amount|number|size) of %objects%");
+				"[the] (amount|number|size) of %objects%",
+				"[the] recursive (amount|number|size) of %objects%");
 	}
 
 	@SuppressWarnings("null")
@@ -135,7 +134,7 @@ public class ExprAmount extends SimpleExpression<Long> {
 
 	@Override
 	public String toString(@Nullable Event e, boolean debug) {
-		return (recursive ? "recursize size of " : "amount of ") + exprs.toString(e, debug);
+		return (recursive ? "recursive size of " : "amount of ") + exprs.toString(e, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprArrowPierceLevel.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprArrowPierceLevel.java
@@ -47,7 +47,7 @@ public class ExprArrowPierceLevel extends SimplePropertyExpression<Projectile, L
 	
 	static {
 		if (CAN_USE_PIERCE)
-			register(ExprArrowPierceLevel.class, Long.class, "[the] arrow pierce level", "projectiles");
+			register(ExprArrowPierceLevel.class, Long.class, "arrow pierce level", "projectiles");
 	}
 	
 	@Nullable

--- a/src/main/java/ch/njol/skript/expressions/ExprFallDistance.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFallDistance.java
@@ -39,7 +39,7 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprFallDistance extends SimplePropertyExpression<Entity, Number> {
 	
 	static {
-		register(ExprFallDistance.class, Number.class, "[the] fall[en] (distance|height)", "entities");
+		register(ExprFallDistance.class, Number.class, "fall[en] (distance|height)", "entities");
 	}
 	
 	@Nullable

--- a/src/main/java/ch/njol/skript/expressions/ExprProjectileBounceState.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprProjectileBounceState.java
@@ -39,7 +39,7 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprProjectileBounceState extends SimplePropertyExpression<Projectile, Boolean> {
 	
 	static {
-		register(ExprProjectileBounceState.class, Boolean.class, "[the] projectile bounce (state|ability|mode)", "projectiles");
+		register(ExprProjectileBounceState.class, Boolean.class, "projectile bounce (state|ability|mode)", "projectiles");
 	}
 	
 	@Nullable

--- a/src/main/java/ch/njol/skript/expressions/ExprProjectileCriticalState.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprProjectileCriticalState.java
@@ -45,7 +45,7 @@ public class ExprProjectileCriticalState extends SimplePropertyExpression<Projec
 	private static final boolean abstractArrowExists = Skript.classExists("org.bukkit.entity.AbstractArrow");
 	
 	static {
-		register(ExprProjectileCriticalState.class, Boolean.class, "[the] (projectile|arrow) critical (state|ability|mode)", "projectiles");
+		register(ExprProjectileCriticalState.class, Boolean.class, "(projectile|arrow) critical (state|ability|mode)", "projectiles");
 	}
 	
 	@Nullable


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
A little PR hopefully accepted one to fix some missing and extra `[the]` in some syntaxes.
Thanks to @Moderocky for pointing out `ExprAmount`

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->Any
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->None
**Related Issues:** <!-- Links to related issues -->None
