### PR TITLE
Add filter support to ExprItemsIn

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprAmount.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAmount.java
@@ -75,6 +75,9 @@ public class ExprAmount extends SimpleExpression<Long> {
 
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		// work around syntax conflict with ExprItemsIn and ExprAmountOfItems
+		if (exprs[0] instanceof ExprItemsIn)
+			return false;
 		this.exprs = exprs[0] instanceof ExpressionList ? (ExpressionList<?>) exprs[0] : new ExpressionList<>(new Expression<?>[]{exprs[0]}, Object.class, false);
 		this.recursive = matchedPattern == 1;
 		for (Expression<?> expr : this.exprs.getExpressions()) {

--- a/src/main/java/ch/njol/skript/expressions/ExprAmount.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAmount.java
@@ -75,9 +75,6 @@ public class ExprAmount extends SimpleExpression<Long> {
 
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		// work around syntax conflict with ExprItemsIn and ExprAmountOfItems
-		if (exprs[0] instanceof ExprItemsIn)
-			return false;
 		this.exprs = exprs[0] instanceof ExpressionList ? (ExpressionList<?>) exprs[0] : new ExpressionList<>(new Expression<?>[]{exprs[0]}, Object.class, false);
 		this.recursive = matchedPattern == 1;
 		for (Expression<?> expr : this.exprs.getExpressions()) {

--- a/src/main/java/ch/njol/skript/expressions/ExprItemsIn.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprItemsIn.java
@@ -77,8 +77,12 @@ public class ExprItemsIn extends SimpleExpression<Slot> {
 	 * be a variable when used with that expression (it is always an anonymous SimpleExpression)
 	 */
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		types = (Expression<ItemType>) exprs[0];
-		inventories = (Expression<Inventory>) exprs[1];
+		if (matchedPattern == 0) {
+			inventories = (Expression<Inventory>) exprs[0];
+		} else {
+			types = (Expression<ItemType>) exprs[0];
+			inventories = (Expression<Inventory>) exprs[1];
+		}
 		if (inventories instanceof Variable && !inventories.isSingle() && parseResult.mark != 1)
 			Skript.warning("'items in {variable::*}' does not actually represent the items stored in the variable. Use either '{variable::*}' (e.g. 'loop {variable::*}') if the variable contains items, or 'items in inventories {variable::*}' if the variable contains inventories.");
 		return true;

--- a/src/main/java/ch/njol/skript/expressions/ExprItemsIn.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprItemsIn.java
@@ -59,7 +59,7 @@ public class ExprItemsIn extends SimpleExpression<Slot> {
 
 	static {
 		Skript.registerExpression(ExprItemsIn.class, Slot.class, ExpressionType.PROPERTY,
-			"[all [[of] the]] (items|%-*itemtypes%) ([with]in|of|contained in|out of) [1:inventor(y|ies)] %inventories%",
+			"[all [[of] the]] items ([with]in|of|contained in|out of) [1:inventor(y|ies)] %inventories%",
 			"all [[of] the] %itemtypes% ([with]in|of|contained in|out of) [1:inventor(y|ies)] %inventories%"
 		);
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprItemsIn.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprItemsIn.java
@@ -22,8 +22,11 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
+import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.lang.Literal;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
@@ -40,109 +43,137 @@ import ch.njol.skript.util.slot.InventorySlot;
 import ch.njol.skript.util.slot.Slot;
 import ch.njol.util.Kleenean;
 
-/**
- * @author Peter Güttinger
- */
 @Name("Items In")
-@Description({"All items in an inventory. Useful for looping or storing in a list variable.",
-		"Please note that the positions of the items in the inventory are not saved, only their order is preserved."})
-@Examples({"loop all items in the player's inventory:",
-		"	loop-item is enchanted",
-		"	remove loop-item from the player",
-		"set {inventory::%uuid of player%::*} to items in the player's inventory"})
-@Since("2.0")
+@Description({
+	"All items or specific type(s) of items in an inventory. Useful for looping or storing in a list variable.",
+	"Please note that the positions of the items in the inventory are not saved, only their order is preserved."
+})
+@Examples({
+	"loop all items in the player's inventory:",
+	"\tloop-item is enchanted",
+	"\tremove loop-item from the player",
+	"set {inventory::%uuid of player%::*} to items in the player's inventory"
+})
+@Since("2.0, INSERT VERSION (specific types of items)")
 public class ExprItemsIn extends SimpleExpression<Slot> {
+
 	static {
-		Skript.registerExpression(ExprItemsIn.class, Slot.class, ExpressionType.PROPERTY, "[(all [[of] the]|the)] items ([with]in|of|contained in|out of) (|1¦inventor(y|ies)) %inventories%");
+		Skript.registerExpression(ExprItemsIn.class, Slot.class, ExpressionType.PROPERTY,
+			"[all [[of] the]|the] (items|%-*itemtypes%) ([with]in|of|contained in|out of) (|1¦inventor(y|ies)) %inventories%",
+			"all [[of] the|the] %itemtypes% ([with]in|of|contained in|out of) (|1¦inventor(y|ies)) %inventories%"
+		);
 	}
-	
+
 	@SuppressWarnings("null")
-	private Expression<Inventory> invis;
-	
-	@SuppressWarnings({"unchecked", "null"})
+	private Expression<Inventory> inventories;
+
+	@Nullable
+	private Expression<ItemType> types;
+
 	@Override
+	@SuppressWarnings({"unchecked", "null"})
 	/*
 	 * the parse result will be null if it is used via the ExprInventory expression, however the expression will never
 	 * be a variable when used with that expression (it is always a anonymous SimpleExpression)
 	 */
-	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, @Nullable final ParseResult parseResult) {
-		invis = (Expression<Inventory>) exprs[0];
-		if (invis instanceof Variable && !invis.isSingle() && parseResult.mark != 1)
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		types = (Expression<ItemType>) exprs[0];
+		inventories = (Expression<Inventory>) exprs[1];
+		if (inventories instanceof Variable && !inventories.isSingle() && parseResult.mark != 1)
 			Skript.warning("'items in {variable::*}' does not actually represent the items stored in the variable. Use either '{variable::*}' (e.g. 'loop {variable::*}') if the variable contains items, or 'items in inventories {variable::*}' if the variable contains inventories.");
 		return true;
 	}
-	
-	@SuppressWarnings("null")
+
 	@Override
-	protected Slot[] get(final Event e) {
-		final ArrayList<Slot> r = new ArrayList<>();
-		for (final Inventory invi : invis.getArray(e)) {
+	@SuppressWarnings("null")
+	protected Slot[] get(Event event) {
+		ArrayList<Slot> itemSlots = new ArrayList<>();
+		ItemType[] types = this.types == null ? null : this.types.getArray(event);
+		for (Inventory invi : inventories.getArray(event)) {
 			for (int i = 0; i < invi.getSize(); i++) {
-				if (invi.getItem(i) != null)
-					r.add(new InventorySlot(invi, i));
+				if (isAllowedItem(types, invi.getItem(i)))
+					itemSlots.add(new InventorySlot(invi, i));
 			}
 		}
-		return r.toArray(new Slot[r.size()]);
+		return itemSlots.toArray(new Slot[itemSlots.size()]);
 	}
-	
+
 	@Override
 	@Nullable
-	public Iterator<Slot> iterator(final Event e) {
-		final Iterator<? extends Inventory> is = invis.iterator(e);
-		if (is == null || !is.hasNext())
+	public Iterator<Slot> iterator(Event event) {
+		Iterator<? extends Inventory> inventoryIterator = inventories.iterator(event);
+		ItemType[] types = this.types == null ? null : this.types.getArray(event);
+		if (inventoryIterator == null || !inventoryIterator.hasNext())
 			return null;
 		return new Iterator<Slot>() {
 			@SuppressWarnings("null")
-			Inventory current = is.next();
-			
+			Inventory current = inventoryIterator.next();
+
 			int next = 0;
-			
-			@SuppressWarnings("null")
+
 			@Override
+			@SuppressWarnings("null")
 			public boolean hasNext() {
-				while (next < current.getSize() && current.getItem(next) == null)
+				while (next < current.getSize() && !isAllowedItem(types, current.getItem(next)))
 					next++;
-				while (next >= current.getSize() && is.hasNext()) {
-					current = is.next();
+				while (next >= current.getSize() && inventoryIterator.hasNext()) {
+					current = inventoryIterator.next();
 					next = 0;
-					while (next < current.getSize() && current.getItem(next) == null)
+					while (next < current.getSize() && !isAllowedItem(types, current.getItem(next)))
 						next++;
 				}
 				return next < current.getSize();
 			}
-			
+
 			@Override
 			public Slot next() {
 				if (!hasNext())
 					throw new NoSuchElementException();
 				return new InventorySlot(current, next++);
 			}
-			
+
 			@Override
 			public void remove() {
 				throw new UnsupportedOperationException();
 			}
 		};
 	}
-	
+
 	@Override
-	public boolean isLoopOf(final String s) {
+	public boolean isLoopOf(String s) {
 		return s.equalsIgnoreCase("item");
 	}
-	
+
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "items in " + invis.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		if (types == null)
+			return "items in " + inventories.toString(event, debug);
+		return "all " + types.toString(event, debug) + " in " + inventories.toString(event, debug);
 	}
-	
+
 	@Override
 	public boolean isSingle() {
 		return false;
 	}
-	
+
 	@Override
 	public Class<Slot> getReturnType() {
 		return Slot.class;
 	}
-	
+
+	private boolean isAllowedItem(@Nullable ItemType[] types, @Nullable ItemStack item) {
+		if (types == null)
+			return item != null;
+		if (item == null)
+			return false;
+
+		ItemType potentiallyAllowedItem = new ItemType(item);
+		for (ItemType type : types) {
+			if (potentiallyAllowedItem.isSimilar(type))
+				return true;
+		}
+
+		return false;
+	}
+
 }

--- a/src/test/skript/tests/syntaxes/expressions/ExprItemsIn.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprItemsIn.sk
@@ -1,0 +1,21 @@
+test "filtering ExprItemsIn":
+	set {_world} to random world out of all worlds
+	set block at spawn of {_world} to chest
+	set {_inv} to inventory of (block at spawn of {_world})
+	set slot 1 of {_inv} to dirt
+	set slot 2 of {_inv} to stone
+	set slot 3 of {_inv} to bucket
+	assert all blocks in inventory {_inv} are dirt or stone with "found correct items with ExprItemsIn##get"
+	assert (all blocks in inventory {_inv} where [true is true]) are dirt or stone with "found correct items with ExprItemsIn##iterator"
+	set {_dirt} to dirt
+	assert all {_dirt} in inventory {_inv} is dirt with "found incorrect items with variable itemtypes"
+
+test "unfiltered ExprItemsIn":
+	set {_world} to random world out of all worlds
+	set block at spawn of {_world} to chest
+	set {_inv} to inventory of (block at spawn of {_world})
+	set slot 1 of {_inv} to dirt
+	set slot 2 of {_inv} to stone
+	set slot 3 of {_inv} to bucket
+	assert all items in inventory {_inv} are dirt, stone or bucket with "found correct items with ExprItemsIn##get"
+	assert (all items in inventory {_inv} where [true is true]) are dirt, stone or bucket with "found correct items with ExprItemsIn##iterator"


### PR DESCRIPTION
### Description

Adds supports to get only certain item types when using ExprItemIn (e.g. `all swords in player's inventory`).

---
**Target Minecraft Versions:** All
**Requirements:** None
**Related Issues:** #4612
