### PR TITLE
⚒️ Fix event-player in drop/pickup events

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -635,6 +635,12 @@ public final class BukkitEventValues {
 			}
 		}, 0);
 		// PlayerDropItemEvent
+		EventValues.registerEventValue(PlayerDropItemEvent.class, Player.class, new Getter<Player, PlayerDropItemEvent>() {
+			@Override
+			public @Nullable Player get(PlayerDropItemEvent e) {
+				return e.getPlayer();
+			}
+		}, 0);
 		EventValues.registerEventValue(PlayerDropItemEvent.class, Item.class, new Getter<Item, PlayerDropItemEvent>() {
 			@Override
 			@Nullable
@@ -650,6 +656,12 @@ public final class BukkitEventValues {
 			}
 		}, 0);
 		// PlayerPickupItemEvent
+		EventValues.registerEventValue(PlayerPickupItemEvent.class, Player.class, new Getter<Player, PlayerPickupItemEvent>() {
+			@Override
+			public @Nullable Player get(PlayerPickupItemEvent e) {
+				return e.getPlayer();
+			}
+		}, 0);
 		EventValues.registerEventValue(PlayerPickupItemEvent.class, Item.class, new Getter<Item, PlayerPickupItemEvent>() {
 			@Override
 			@Nullable
@@ -662,12 +674,6 @@ public final class BukkitEventValues {
 			@Nullable
 			public ItemType get(final PlayerPickupItemEvent e) {
 				return new ItemType(e.getItem().getItemStack());
-			}
-		}, 0);
-		EventValues.registerEventValue(PlayerPickupItemEvent.class, Entity.class, new Getter<Entity, PlayerPickupItemEvent>() {
-			@Override
-			public @Nullable Entity get(PlayerPickupItemEvent e) {
-				return e.getPlayer();
 			}
 		}, 0);
 		// EntityPickupItemEvent

--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -637,7 +637,8 @@ public final class BukkitEventValues {
 		// PlayerDropItemEvent
 		EventValues.registerEventValue(PlayerDropItemEvent.class, Player.class, new Getter<Player, PlayerDropItemEvent>() {
 			@Override
-			public @Nullable Player get(PlayerDropItemEvent e) {
+			@Nullable
+			public Player get(PlayerDropItemEvent e) {
 				return e.getPlayer();
 			}
 		}, 0);
@@ -658,7 +659,8 @@ public final class BukkitEventValues {
 		// PlayerPickupItemEvent
 		EventValues.registerEventValue(PlayerPickupItemEvent.class, Player.class, new Getter<Player, PlayerPickupItemEvent>() {
 			@Override
-			public @Nullable Player get(PlayerPickupItemEvent e) {
+			@Nullable
+			public Player get(PlayerPickupItemEvent e) {
 				return e.getPlayer();
 			}
 		}, 0);


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

This PR makes this code work
```v
on pickup:
	send "1" # used to default to dropped item not player

on drop:
	send "2"
```
- Changed pickup event's getPlayer() method return type to Player instead of Entity to fix this
- Added event-player to drop event

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->Any
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->None
**Related Issues:** <!-- Links to related issues --> #1322
