### PR TITLE
Fix legacy method invocation in ExprLanguage

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprLanguage.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLanguage.java
@@ -62,7 +62,7 @@ public class ExprLanguage extends SimplePropertyExpression<Player, String> {
 		if (USE_DEPRECATED_METHOD) {
 			assert getLocaleMethod != null;
 			try {
-				return (String) getLocaleMethod.invoke();
+				return (String) getLocaleMethod.invoke(p.spigot());
 			} catch (Throwable e) {
 				Skript.exception(e);
 				return null;


### PR DESCRIPTION
### Description
Fixes legacy method being invoked with no parameters in ExprLanguage.

---
**Target Minecraft Versions:** 1.9-1.11
**Requirements:** none
**Related Issues:** none