### PR TITLE
Fix vector length reset when adding/setting pitch & yaw

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprYawPitch.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprYawPitch.java
@@ -127,7 +127,7 @@ public class ExprYawPitch extends SimplePropertyExpression<Object, Number> {
 					yaw += n;
 				else
 					pitch -= n; // Negative because of Minecraft's / Skript's upside down pitch
-				vector = VectorMath.fromYawAndPitch(yaw, pitch);
+				vector = VectorMath.fromYawAndPitch(yaw, pitch).multiply(vector.length());
 				getExpr().change(e, new org.bukkit.util.Vector[]{vector}, ChangeMode.SET);
 				break;
 			case SET:
@@ -135,7 +135,7 @@ public class ExprYawPitch extends SimplePropertyExpression<Object, Number> {
 					yaw = VectorMath.fromSkriptYaw(n);
 				else
 					pitch = VectorMath.fromSkriptPitch(n);
-				vector = VectorMath.fromYawAndPitch(yaw, pitch);
+				vector = VectorMath.fromYawAndPitch(yaw, pitch).multiply(vector.length());
 				getExpr().change(e, new org.bukkit.util.Vector[]{vector}, ChangeMode.SET);
 		}
 	}


### PR DESCRIPTION
## Description

Changes the add and set behaviors of ExprYawPitch to return a vector of the same length as the original, rather than a vector of length 1. I hope I did this correctly, first time contributing to anything.

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions --> Any
**Requirements:** <!-- Required plugins, Minecraft versions, server software... --> None
**Related Issues:** <!-- Links to related issues --> #4610 
