### PR TITLE
⚒️ Replace color char in debug statements

### DIFF
--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -57,6 +57,7 @@ import ch.njol.skript.registrations.Converters;
 import ch.njol.skript.sections.SecLoop;
 import ch.njol.skript.util.Date;
 import ch.njol.skript.util.ExceptionUtils;
+import ch.njol.skript.util.SkriptColor;
 import ch.njol.skript.util.Task;
 import ch.njol.skript.variables.TypeHints;
 import ch.njol.skript.variables.Variables;
@@ -741,7 +742,7 @@ public class ScriptLoader {
 						continue;
 					
 					if (Skript.debug() || node.debug())
-						Skript.debug(event + " (" + parsedEvent.getSecond().toString(null, true) + "):");
+						Skript.debug(SkriptColor.replaceColorChar(event + " (" + parsedEvent.getSecond().toString(null, true) + "):"));
 
 					Class<? extends Event>[] eventClasses = parsedEvent.getSecond().getEventClasses();
 					if (eventClasses == null)
@@ -1115,7 +1116,7 @@ public class ScriptLoader {
 					continue;
 
 				if (Skript.debug() || n.debug())
-					Skript.debug(getParser().getIndentation() + stmt.toString(null, true));
+					Skript.debug(SkriptColor.replaceColorChar(getParser().getIndentation() + stmt.toString(null, true)));
 
 				items.add(stmt);
 			} else if (n instanceof SectionNode) {
@@ -1129,7 +1130,7 @@ public class ScriptLoader {
 					continue;
 
 				if (Skript.debug() || n.debug())
-					Skript.debug(getParser().getIndentation() + section.toString(null, true));
+					Skript.debug(SkriptColor.replaceColorChar(getParser().getIndentation() + section.toString(null, true)));
 
 				items.add(section);
 

--- a/src/main/java/ch/njol/skript/command/Commands.java
+++ b/src/main/java/ch/njol/skript/command/Commands.java
@@ -33,6 +33,7 @@ import java.util.concurrent.Future;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import ch.njol.skript.util.SkriptColor;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -277,15 +278,15 @@ public abstract class Commands {
 					log.clear(); // ignore warnings and stuff
 					log.printLog();
 					
-					sender.sendMessage(ChatColor.GRAY + "executing '" + ChatColor.stripColor(command) + "'");
+					sender.sendMessage(ChatColor.GRAY + "executing '" + SkriptColor.replaceColorChar(command) + "'");
 					if (SkriptConfig.logPlayerCommands.value() && !(sender instanceof ConsoleCommandSender))
-						Skript.info(sender.getName() + " issued effect command: " + command);
+						Skript.info(sender.getName() + " issued effect command: " + SkriptColor.replaceColorChar(command));
 					TriggerItem.walk(e, new EffectCommandEvent(sender, command));
 				} else {
 					if (sender == Bukkit.getConsoleSender()) // log as SEVERE instead of INFO like printErrors below
-						SkriptLogger.LOGGER.severe("Error in: " + ChatColor.stripColor(command));
+						SkriptLogger.LOGGER.severe("Error in: " + SkriptColor.replaceColorChar(command));
 					else
-						sender.sendMessage(ChatColor.RED + "Error in: " + ChatColor.GRAY + ChatColor.stripColor(command));
+						sender.sendMessage(ChatColor.RED + "Error in: " + ChatColor.GRAY + SkriptColor.replaceColorChar(command));
 					log.printErrors(sender, "(No specific information is available)");
 				}
 			} finally {
@@ -293,7 +294,7 @@ public abstract class Commands {
 			}
 			return true;
 		} catch (final Exception e) {
-			Skript.exception(e, "Unexpected error while executing effect command '" + command + "' by '" + sender.getName() + "'");
+			Skript.exception(e, "Unexpected error while executing effect command '" + SkriptColor.replaceColorChar(command) + "' by '" + sender.getName() + "'");
 			sender.sendMessage(ChatColor.RED + "An internal error occurred while executing this effect. Please refer to the server log for details.");
 			return true;
 		}

--- a/src/main/java/ch/njol/skript/lang/TriggerItem.java
+++ b/src/main/java/ch/njol/skript/lang/TriggerItem.java
@@ -20,6 +20,7 @@ package ch.njol.skript.lang;
 
 import java.io.File;
 
+import ch.njol.skript.util.SkriptColor;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -124,7 +125,7 @@ public abstract class TriggerItem implements Debuggable {
 	protected final void debug(final Event e, final boolean run) {
 		if (!Skript.debug())
 			return;
-		Skript.debug(getIndentation() + (run ? "" : "-") + toString(e, true));
+		Skript.debug(SkriptColor.replaceColorChar(getIndentation() + (run ? "" : "-") + toString(e, true)));
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/util/SkriptColor.java
+++ b/src/main/java/ch/njol/skript/util/SkriptColor.java
@@ -63,11 +63,10 @@ public enum SkriptColor implements Color {
 	
 	DARK_PURPLE(DyeColor.PURPLE, ChatColor.DARK_PURPLE),
 	LIGHT_PURPLE(DyeColor.MAGENTA, ChatColor.LIGHT_PURPLE);
-	
+
 	private final static Map<String, SkriptColor> names = new HashMap<>();
 	private final static Set<SkriptColor> colors = new HashSet<>();
 	private final static String LANGUAGE_NODE = "colors";
-	private final static Pattern COLOR_CHAR_PATTERN = Pattern.compile("§");
 	
 	static {
 		colors.addAll(Arrays.asList(values()));

--- a/src/main/java/ch/njol/skript/util/SkriptColor.java
+++ b/src/main/java/ch/njol/skript/util/SkriptColor.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.bukkit.ChatColor;
 import org.bukkit.DyeColor;
@@ -66,6 +67,7 @@ public enum SkriptColor implements Color {
 	private final static Map<String, SkriptColor> names = new HashMap<>();
 	private final static Set<SkriptColor> colors = new HashSet<>();
 	private final static String LANGUAGE_NODE = "colors";
+	private final static Pattern COLOR_CHAR_PATTERN = Pattern.compile("§");
 	
 	static {
 		colors.addAll(Arrays.asList(values()));
@@ -219,7 +221,18 @@ public enum SkriptColor implements Color {
 		}
 		return null;
 	}
-	
+
+	/**
+	 * Replace chat color character '§' with '&'
+	 * This is an alternative method to {@link ChatColor#stripColor(String)}
+	 * But does not strip the color code.
+	 * @param s string to replace chat color character of.
+	 * @return String with replaced chat color character
+	 */
+	public static String replaceColorChar(String s) {
+		return COLOR_CHAR_PATTERN.matcher(s).replaceAll("&");
+	}
+
 	@Override
 	public String toString() {
 		return adjective == null ? "" + name() : adjective.toString(-1, 0);

--- a/src/main/java/ch/njol/skript/util/SkriptColor.java
+++ b/src/main/java/ch/njol/skript/util/SkriptColor.java
@@ -230,7 +230,7 @@ public enum SkriptColor implements Color {
 	 * @return String with replaced chat color character
 	 */
 	public static String replaceColorChar(String s) {
-		return COLOR_CHAR_PATTERN.matcher(s).replaceAll("&");
+		return s.replace('\u00A7', '&');
 	}
 
 	@Override


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
- Replaces chat color codes in debugging statements instead of stripping them
- Handle unhandled debugging statements for chat color codes

**Before**
![image](https://user-images.githubusercontent.com/20037329/155758587-e2f01cc1-e1fa-40cb-ace9-19c6740ea738.png)
![image](https://user-images.githubusercontent.com/20037329/155760127-163a67cb-c646-48a7-aed5-499c05a49fe2.png)


**After**
![image](https://user-images.githubusercontent.com/20037329/155758513-8abdba79-174f-4fb3-8c47-4ae0f88f80f5.png)
![image](https://user-images.githubusercontent.com/20037329/155760227-8c33ab46-1bb6-4333-95bd-3915e3d26a89.png)


---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->Any
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->None
**Related Issues:** <!-- Links to related issues --> None
