### PR TITLE
Fix broken comparisons on 1.12 and below

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/ItemData.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemData.java
@@ -347,6 +347,8 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 			if (itemForm && item.blockValues != null && !item.blockValues.isDefault()) {
 				return MatchQuality.SAME_MATERIAL;
 			}
+		} else if (itemFlags != 0 && ItemUtils.getDamage(stack) != ItemUtils.getDamage(item.stack)) {
+			return MatchQuality.DIFFERENT; // On 1.12 and below, items may share a material but have a different data value (ex: white wool vs red wool)
 		}
 		
 		/*

--- a/src/test/skript/tests/regressions/3419-item comparisons.sk
+++ b/src/test/skript/tests/regressions/3419-item comparisons.sk
@@ -138,3 +138,16 @@ test "item comparisons":
 
 	assert {_three} is {_four} with "a sand block of unbreaking 3 with lore ""Sandy Block"" should be a sand block of unbreaking 3"
 	assert {_four} is not {_three} with "a sand block of unbreaking 3 should NOT be a sand block of unbreaking 3 with lore ""Sandy Block"""
+
+	# Same material but different data values (1.12 and below) (see https://github.com/SkriptLang/Skript/issues/4643)
+
+
+	set block at spawn of world "world" to a chest
+	set {_inventory} to inventory of block at spawn of world "world"
+	add 64 white wool and 64 red wool to {_inventory}
+
+	assert amount of white wool in {_inventory} is 64 with "Inventory doesn't have 64 white wool, but it should (amount found: %amount of white wool in {_inventory}%)"
+	assert amount of red wool in {_inventory} is 64 with "Inventory doesn't have 64 red wool, but it should (amount found: %amount of red wool in {_inventory}%)"
+
+	remove all items from {_inventory}
+	set block at spawn of world "world" to air


### PR DESCRIPTION
### Description

This PR fixes the comparison issue described in the related issue.
This was caused by #4162, as the methods used for comparisons in utility methods were changed.  However, the new method comparison process no longer included a crucial check, causing this issue. I have added the check along with a test.

Before PR (taken from the linked issue):
![image](https://user-images.githubusercontent.com/29044720/156937894-8e931925-724b-4c17-ae29-1ca5912acb0b.png)
After PR:
![image](https://user-images.githubusercontent.com/29044720/156937765-01fe233a-4913-485f-b2dd-add770a2ad4c.png)


---
**Target Minecraft Versions:** 1.12 and below
**Requirements:** None
**Related Issues:**
- #4643 