### PR TITLE
⚒️ Fix blocks between with minus Y

### DIFF
--- a/src/main/java/ch/njol/skript/util/BlockLineIterator.java
+++ b/src/main/java/ch/njol/skript/util/BlockLineIterator.java
@@ -18,6 +18,7 @@
  */
 package ch.njol.skript.util;
 
+import ch.njol.skript.bukkitutil.WorldUtils;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.util.BlockIterator;
@@ -85,7 +86,7 @@ public class BlockLineIterator extends StoppableIterator<Block> {
 	private static Vector fitInWorld(final Location l, final Vector dir) {
 		if (0 <= l.getBlockY() && l.getBlockY() < l.getWorld().getMaxHeight())
 			return l.toVector();
-		final double y = Math2.fit(0, l.getY(), l.getWorld().getMaxHeight());
+		final double y = Math2.fit(WorldUtils.getWorldMinHeight(l.getWorld()), l.getY(), l.getWorld().getMaxHeight());
 		if (Math.abs(dir.getY()) < Skript.EPSILON)
 			return new Vector(l.getX(), y, l.getZ());
 		final double dy = y - l.getY();


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Fix retrieving blocks between 2 blocks with at least one of the locations being **-Y** throwing IAE exception

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->1.17.1+
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->None
**Related Issues:** <!-- Links to related issues --> #4645 #4383 (non-fixing)
