### PR TITLE
Fix aliases duplicating item data for default item types

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/AliasesProvider.java
+++ b/src/main/java/ch/njol/skript/aliases/AliasesProvider.java
@@ -306,7 +306,7 @@ public class AliasesProvider {
 			MaterialName materialName = new MaterialName(data.type, name.singular, name.plural, name.gender);
 			aliasesMap.addAlias(new AliasesMap.AliasData(data, materialName, id, related));
 		}
-		 
+
 		// Check if there is item type with this name already, create otherwise
 		ItemType type = aliases.get(name.singular);
 		if (type == null)
@@ -315,11 +315,16 @@ public class AliasesProvider {
 			type = new ItemType();
 			aliases.put(name.singular, type); // Singular form
 			aliases.put(name.plural, type); // Plural form
+			type.addAll(datas);
+		} else { // There is already an item type with this name, we need to *only* add new data
+			newDataLoop: for (ItemData newData : datas) {
+				for (ItemData existingData : type.getTypes()) {
+					if (newData == existingData || newData.matchAlias(existingData).isAtLeast(MatchQuality.EXACT)) // Don't add this data, the item type already contains it!
+						continue newDataLoop;
+				}
+				type.add(newData);
+			}
 		}
-		
-		// Add item datas we got earlier to the type
-		assert datas != null;
-		type.addAll(datas);
 	}
 	
 	public void addVariationGroup(String name, VariationGroup group) {


### PR DESCRIPTION
### Description

Currently, Skript does not perform any sort of duplication check when adding item data. This leads to duplicate item data ending up throughout many of the default item types stored. The goal of this PR is to add a check to avoid adding duplicate item data to default item type.

Before this PR, the default item type for `any spawn egg` included a massive 457,000+ item data. After this PR, it includes only around 60 (1 per spawn egg). You can even test this by comparing the toString output of each (`send "spawn egg" parsed as item type`) - do note that the toString for before this PR will likely lag and/or freeze the server.

---
**Target Minecraft Versions:** Any
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:**
- #4514
  - Technically fixes the issue. Although toString for the mentioned item types will no longer include duplicate values, multiple values will still be present (ex: `redstone lamp or redstone lamp`). The same goes for the hay bale. I wouldn't classify that as a bug though, as that's just how those aliases are defined. The 'any' tag for redstone lamps is optional, which is why it outputs that way. The same goes for haybale, where the `any` tag is optional.
