### PR TITLE
Implementation of Java tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,11 +159,17 @@ tasks.create('testNaming') {
 	}
 }
 
+task testJar(type: Jar) {
+	dependsOn(compileTestJava)
+	archiveName = 'Skript-tests.jar'
+	from 'build/classes/java/test', 'src/test/resources/plugin.yml'
+}
+
 // Create a test task with given name, environments dir/file and is it development mode task
 void createTestTask(String name, String environments, boolean devMode) {
 	tasks.create(name) {
 		// Compile Skript and check test naming
-		dependsOn jar, testNaming
+		dependsOn jar, testClasses, testJar, testNaming
 		doFirst {
 			if (devMode) {
 				standardInput = System.in

--- a/src/main/java/ch/njol/skript/tests/platform/Environment.java
+++ b/src/main/java/ch/njol/skript/tests/platform/Environment.java
@@ -35,6 +35,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.*;
 
@@ -186,6 +187,8 @@ public class Environment {
 		try {
 			Files.copy(new File(getClass().getProtectionDomain().getCodeSource().getLocation()
 				.toURI()).toPath(), skript, StandardCopyOption.REPLACE_EXISTING);
+			Files.copy(Paths.get(getClass().getProtectionDomain().getCodeSource().getLocation()
+				.toURI()).getParent().normalize().resolve("Skript-tests.jar"), env.resolve("plugins/Skript-tests.jar"), StandardCopyOption.REPLACE_EXISTING);
 		} catch (URISyntaxException e) {
 			throw new AssertionError(e);
 		}

--- a/src/main/java/ch/njol/skript/tests/runner/EffJavaTest.java
+++ b/src/main/java/ch/njol/skript/tests/runner/EffJavaTest.java
@@ -1,0 +1,85 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.tests.runner;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.SkriptAPIException;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+public class EffJavaTest extends Effect {
+
+	static {
+		Skript.registerEffect(EffJavaTest.class, "run java test %string% (from|located in) [class] %string%");
+	}
+
+	@Nullable
+	private Expression<String> javaTestName;
+
+	@Nullable
+	private Expression<String> javaTestClass;
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		javaTestName = (Expression<String>) exprs[0];
+		javaTestClass = (Expression<String>) exprs[1];
+		return true;
+	}
+
+	@Override
+	protected void execute(Event e) {
+		assert javaTestName != null && javaTestClass != null;
+		String javaTestName = this.javaTestName.getSingle(e);
+		String javaTestClass = this.javaTestClass.getSingle(e);
+
+		if (javaTestName == null) {
+			throw new SkriptAPIException("Test name not provided");
+		} else if (javaTestClass == null) {
+			TestTracker.testStarted(javaTestName);
+			TestTracker.testFailed("Test failed because test class was null");
+		} else {
+			JavaTest test = null;
+			try {
+				@SuppressWarnings("unchecked")
+				Class<? extends JavaTest> testClass = (Class<? extends JavaTest>) Class.forName(javaTestClass);
+				test = testClass.getDeclaredConstructor().newInstance();
+			} catch (Exception ex) {
+				TestTracker.testStarted(javaTestName);
+				TestTracker.testFailed("Test failed because a " + ex.getClass().getSimpleName() + " occurred: " + ex.getMessage());
+			}
+
+			if (test != null) {
+				test.run(javaTestName);
+			}
+		}
+
+	}
+
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		assert javaTestClass != null && javaTestName != null;
+		return "run java test " + javaTestName.toString(e, debug) + " located in " + javaTestClass.toString(e, debug);
+	}
+
+}

--- a/src/main/java/ch/njol/skript/tests/runner/JavaTest.java
+++ b/src/main/java/ch/njol/skript/tests/runner/JavaTest.java
@@ -1,0 +1,27 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.tests.runner;
+
+import org.eclipse.jdt.annotation.NonNull;
+
+public interface JavaTest {
+
+	void run(@NonNull String testName);
+
+}

--- a/src/test/java/ch/njol/test/skript/SkriptTester.java
+++ b/src/test/java/ch/njol/test/skript/SkriptTester.java
@@ -1,0 +1,25 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.test.skript;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class SkriptTester extends JavaPlugin {
+
+}

--- a/src/test/java/ch/njol/test/skript/effects/TestEffJavaTest.java
+++ b/src/test/java/ch/njol/test/skript/effects/TestEffJavaTest.java
@@ -1,0 +1,32 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.test.skript.effects;
+
+import ch.njol.skript.tests.runner.JavaTest;
+import ch.njol.skript.tests.runner.TestTracker;
+import org.eclipse.jdt.annotation.NonNull;
+
+public class TestEffJavaTest implements JavaTest {
+
+	@Override
+	public void run(@NonNull String testName) {
+		TestTracker.testStarted(testName);
+	}
+
+}

--- a/src/test/resources/plugin.yml
+++ b/src/test/resources/plugin.yml
@@ -1,0 +1,34 @@
+#
+#   This file is part of Skript.
+#
+#  Skript is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Skript is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Copyright Peter Güttinger, SkriptLang team and contributors
+#
+
+
+name: SkriptTester
+
+description: Companion plugin for running Skript tests
+
+authors: ['SkriptLang Team', Contributors]
+
+website: https://skriptlang.github.io/Skript
+
+main: ch.njol.test.skript.SkriptTester
+
+version: 1-tester
+api-version: 1.13
+
+loadbefore: [Skript]

--- a/src/test/resources/runner_data/spigot.yml.generic
+++ b/src/test/resources/runner_data/spigot.yml.generic
@@ -1,0 +1,170 @@
+# This is the main configuration file for Spigot.
+# As you can see, there's tons to configure. Some options may impact gameplay, so use
+# with caution, and make sure you know what each option does before configuring.
+# For a reference for any variable inside this file, check out the Spigot wiki at
+# http://www.spigotmc.org/wiki/spigot-configuration/
+#
+# If you need help with the configuration or have any questions related to Spigot,
+# join us at the Discord or drop by our forums and leave a post.
+#
+# Discord: https://www.spigotmc.org/go/discord
+# Forums: http://www.spigotmc.org/
+
+settings:
+  debug: false
+  bungeecord: false
+  player-shuffle: 0
+  sample-count: 12
+  user-cache-size: 1000
+  timeout-time: 3600
+  restart-on-crash: true
+  restart-script: ./start.sh
+  netty-threads: 4
+  attribute:
+    maxHealth:
+      max: 2048.0
+    movementSpeed:
+      max: 2048.0
+    attackDamage:
+      max: 2048.0
+  log-villager-deaths: true
+  log-named-deaths: true
+  moved-wrongly-threshold: 0.0625
+  save-user-cache-on-stop-only: false
+  moved-too-quickly-multiplier: 10.0
+messages:
+  whitelist: You are not whitelisted on this server!
+  unknown-command: Unknown command. Type "/help" for help.
+  server-full: The server is full!
+  outdated-client: Outdated client! Please use {0}
+  outdated-server: Outdated server! I'm still on {0}
+  restart: Server is restarting
+advancements:
+  disable-saving: false
+  disabled:
+  - minecraft:story/disabled
+players:
+  disable-saving: false
+world-settings:
+  default:
+    below-zero-generation-in-existing-chunks: true
+    verbose: false
+    end-portal-sound-radius: 0
+    hanging-tick-frequency: 100
+    zombie-aggressive-towards-villager: true
+    arrow-despawn-rate: 1200
+    trident-despawn-rate: 1200
+    simulation-distance: default
+    view-distance: default
+    thunder-chance: 100000
+    merge-radius:
+      item: 2.5
+      exp: 3.0
+    item-despawn-rate: 6000
+    dragon-death-sound-radius: 0
+    wither-spawn-sound-radius: 0
+    enable-zombie-pigmen-portal-spawns: true
+    nerf-spawner-mobs: false
+    mob-spawn-range: 8
+    growth:
+      cactus-modifier: 100
+      cane-modifier: 100
+      melon-modifier: 100
+      mushroom-modifier: 100
+      pumpkin-modifier: 100
+      sapling-modifier: 100
+      beetroot-modifier: 100
+      carrot-modifier: 100
+      potato-modifier: 100
+      wheat-modifier: 100
+      netherwart-modifier: 100
+      vine-modifier: 100
+      cocoa-modifier: 100
+      bamboo-modifier: 100
+      sweetberry-modifier: 100
+      kelp-modifier: 100
+      twistingvines-modifier: 100
+      weepingvines-modifier: 100
+      cavevines-modifier: 100
+      glowberry-modifier: 100
+    entity-tracking-range:
+      players: 48
+      animals: 48
+      monsters: 48
+      misc: 32
+      other: 64
+    ticks-per:
+      hopper-transfer: 8
+      hopper-check: 1
+    hopper-amount: 1
+    entity-activation-range:
+      animals: 32
+      monsters: 32
+      raiders: 48
+      misc: 16
+      water: 16
+      villagers: 32
+      flying-monsters: 32
+      wake-up-inactive:
+        animals-max-per-tick: 4
+        animals-every: 1200
+        animals-for: 100
+        monsters-max-per-tick: 8
+        monsters-every: 400
+        monsters-for: 100
+        villagers-max-per-tick: 4
+        villagers-every: 600
+        villagers-for: 100
+        flying-monsters-max-per-tick: 8
+        flying-monsters-every: 200
+        flying-monsters-for: 100
+      villagers-work-immunity-after: 100
+      villagers-work-immunity-for: 20
+      villagers-active-for-panic: true
+      tick-inactive-villagers: true
+      ignore-spectators: false
+    max-tnt-per-tick: 100
+    hunger:
+      jump-walk-exhaustion: 0.05
+      jump-sprint-exhaustion: 0.2
+      combat-exhaustion: 0.1
+      regen-exhaustion: 6.0
+      swim-multiplier: 0.01
+      sprint-multiplier: 0.1
+      other-multiplier: 0.0
+    max-tick-time:
+      tile: 50
+      entity: 50
+    seed-village: 10387312
+    seed-desert: 14357617
+    seed-igloo: 14357618
+    seed-jungle: 14357619
+    seed-swamp: 14357620
+    seed-monument: 10387313
+    seed-shipwreck: 165745295
+    seed-ocean: 14357621
+    seed-outpost: 165745296
+    seed-endcity: 10387313
+    seed-slime: 987234911
+    seed-bastion: 30084232
+    seed-fortress: 30084232
+    seed-mansion: 10387319
+    seed-fossil: 14357921
+    seed-portal: 34222645
+    seed-stronghold: default
+commands:
+  spam-exclusions:
+  - /skill
+  replace-commands:
+  - setblock
+  - summon
+  - testforblock
+  - tellraw
+  log: true
+  tab-complete: 0
+  send-namespaced: true
+  silent-commandblock-console: false
+config-version: 12
+stats:
+  disable-saving: false
+  forced-stats: {}

--- a/src/test/skript/environments/main/paper-1.18.1.json
+++ b/src/test/skript/environments/main/paper-1.18.1.json
@@ -1,7 +1,8 @@
 {
 	"name": "paper-1.18.1",
 	"resources": [
-		{"source": "server.properties.generic", "target": "server.properties"}
+		{"source": "server.properties.generic", "target": "server.properties"},
+		{"source": "spigot.yml.generic", "target": "spigot.yml"}
 	],
 	"paperDownloads": [
 		{

--- a/src/test/skript/tests/syntaxes/effects/EffJavaTest.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffJavaTest.sk
@@ -1,0 +1,2 @@
+on load:
+	run java test "Java test runs" located in "ch.njol.test.skript.effects.TestEffJavaTest"


### PR DESCRIPTION
### Description
Add support for tests written in Java to the testing system. This is useful because it allows you to test the results of a syntax using API methods that aren't yet (or may never be) implemented in Skript. Example test can be found in `TestEffJavaTest` and `EffJavaTest.sk`. Java tests are called like so:
```
on load:
	run java test "Java test runs" located in "ch.njol.test.skript.effects.TestEffJavaTest"
```
---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
