### PR TITLE
Add error when disabling hooks via config after server start

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -319,6 +319,14 @@ public final class Skript extends JavaPlugin implements Listener {
 	}
 
 	/**
+	 * @return whether hooks have been loaded,
+	 * and if {@link #disableHookRegistration(Class[])} won't error because of this.
+	 */
+	public static boolean isFinishedLoadingHooks() {
+		return finishedLoadingHooks;
+	}
+
+	/**
 	 * Disables the registration for the given hook classes. If Skript has been enabled, this method
 	 * will throw an API exception. It should be used in something like {@link JavaPlugin#onLoad()}.
 	 * @param hooks The hooks to disable the registration of.

--- a/src/main/java/ch/njol/skript/SkriptConfig.java
+++ b/src/main/java/ch/njol/skript/SkriptConfig.java
@@ -24,6 +24,7 @@ import ch.njol.skript.config.EnumParser;
 import ch.njol.skript.config.Option;
 import ch.njol.skript.config.OptionSection;
 import ch.njol.skript.config.SectionNode;
+import ch.njol.skript.hooks.Hook;
 import ch.njol.skript.hooks.VaultHook;
 import ch.njol.skript.hooks.regions.GriefPreventionHook;
 import ch.njol.skript.hooks.regions.PreciousStonesHook;
@@ -278,38 +279,41 @@ public class SkriptConfig {
 	public final static Option<Boolean> disableHookVault = new Option<>("disable hooks.vault", false)
 		.optional(true)
 		.setter(value -> {
-			if (value) {
-				Skript.disableHookRegistration(VaultHook.class);
-			}
+			userDisableHooks(VaultHook.class, value);
 		});
 	public final static Option<Boolean> disableHookGriefPrevention = new Option<>("disable hooks.regions.grief prevention", false)
 		.optional(true)
 		.setter(value -> {
-			if (value) {
-				Skript.disableHookRegistration(GriefPreventionHook.class);
-			}
+			userDisableHooks(GriefPreventionHook.class, value);
 		});
 	public final static Option<Boolean> disableHookPreciousStones = new Option<>("disable hooks.regions.precious stones", false)
 		.optional(true)
 		.setter(value -> {
-			if (value) {
-				Skript.disableHookRegistration(PreciousStonesHook.class);
-			}
+			userDisableHooks(PreciousStonesHook.class, value);
 		});
 	public final static Option<Boolean> disableHookResidence = new Option<>("disable hooks.regions.residence", false)
 		.optional(true)
 		.setter(value -> {
-			if (value) {
-				Skript.disableHookRegistration(ResidenceHook.class);
-			}
+			userDisableHooks(ResidenceHook.class, value);
 		});
 	public final static Option<Boolean> disableHookWorldGuard = new Option<>("disable hooks.regions.worldguard", false)
 		.optional(true)
 		.setter(value -> {
-			if (value) {
-				Skript.disableHookRegistration(WorldGuardHook.class);
-			}
+			userDisableHooks(WorldGuardHook.class, value);
 		});
+	/**
+	 * Disables the specified hook depending on the option value, or gives an error if this isn't allowed at this time.
+	 */
+	private static void userDisableHooks(Class<? extends Hook<?>> hookClass, boolean value) {
+		if (Skript.isFinishedLoadingHooks()) {
+			Skript.error("Hooks cannot be disabled once the server has started. " +
+				"Please restart the server to disable the hooks.");
+			return;
+		}
+		if (value) {
+			Skript.disableHookRegistration(hookClass);
+		}
+	}
 
 	public final static Option<Pattern> playerNameRegexPattern = new Option<>("player name regex pattern", Pattern.compile("[a-zA-Z0-9_]{1,16}"), s -> {
 		try {


### PR DESCRIPTION
### Description
Adds an error message instead of an exception when changing the hook enabled config options and reloading config (after server has started).

Error: https://pastebin.com/frfCmne9

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** none
