### PR TITLE
Fix the pitch of locations of blocks

### DIFF
--- a/src/main/java/ch/njol/skript/util/BlockUtils.java
+++ b/src/main/java/ch/njol/skript/util/BlockUtils.java
@@ -85,7 +85,7 @@ public class BlockUtils {
 		Location l = b.getLocation().add(0.5, 0.5, 0.5);
 		BlockFace blockFace = Direction.getFacing(b);
 		if (blockFace != BlockFace.SELF) {
-			l.setPitch(Direction.getPitch(Math.sin(blockFace.getModY())));
+			l.setPitch(Direction.getPitch(Math.asin(blockFace.getModY())));
 			l.setYaw(Direction.getYaw(Math.atan2(blockFace.getModZ(), blockFace.getModX())));
 		}
 		return l;


### PR DESCRIPTION
### Description
Fix the computation for the pitch of block locations

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4708, #4280 (latter non-fixing)
