### PR TITLE
Fix typo in empty folder warning

### DIFF
--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -69,7 +69,7 @@ skript command:
 		script: <gold>%s<reset>
 		scripts in folder: all scripts in <gold>%s<reset>
 		x scripts in folder: <gold>%2$s <reset>script¦¦s¦ in <gold>%1$s<reset>
-		empty folder: <gold>%s<reset>r does not contain any enabled scripts.
+		empty folder: <gold>%s<reset> does not contain any enabled scripts.
 	enable:
 		all:
 			enabling: Enabling all disabled scripts...


### PR DESCRIPTION
### Description
Fixes typo
Previous:
![image](https://user-images.githubusercontent.com/29547183/161302930-378be8e5-db1d-41ea-9626-9b39e88d58f4.png)

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
