### PR TITLE
Fix falling block spawning with sections

### DIFF
--- a/src/main/java/ch/njol/skript/entity/EntityData.java
+++ b/src/main/java/ch/njol/skript/entity/EntityData.java
@@ -413,35 +413,28 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	}
 	
 	@Nullable
-	public E spawn(final Location loc) {
-		assert loc != null;
-		try {
-			final E e = loc.getWorld().spawn(loc, getType());
-			if (baby.isTrue())
-				EntityUtils.setBaby(e);
-			else if (baby.isFalse())
-				EntityUtils.setAdult(e);
-			set(e);
-			return e;
-		} catch (final IllegalArgumentException e) {
-			if (Skript.testing())
-				Skript.error("Can't spawn " + getType().getName());
-			return null;
-		}
+	public final E spawn(Location loc) {
+		return spawn(loc, null);
 	}
 
+	@SuppressWarnings("unchecked")
 	@Nullable
-	public E spawn(Location loc, Consumer<E> consumer) {
+	public E spawn(Location loc, @Nullable Consumer<E> consumer) {
 		assert loc != null;
 		try {
-			E e = loc.getWorld().spawn(loc, (Class<E>) getType(), consumer);
+			E e;
+			if (consumer != null)
+				e = loc.getWorld().spawn(loc, (Class<E>) getType(), consumer);
+			else
+				e = loc.getWorld().spawn(loc, getType());
+
 			if (baby.isTrue())
 				EntityUtils.setBaby(e);
 			else if (baby.isFalse())
 				EntityUtils.setAdult(e);
 			set(e);
 			return e;
-		} catch (final IllegalArgumentException e) {
+		} catch (IllegalArgumentException e) {
 			if (Skript.testing())
 				Skript.error("Can't spawn " + getType().getName());
 			return null;

--- a/src/main/java/ch/njol/skript/entity/FallingBlockData.java
+++ b/src/main/java/ch/njol/skript/entity/FallingBlockData.java
@@ -25,6 +25,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.FallingBlock;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Consumer;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
@@ -110,21 +111,21 @@ public class FallingBlockData extends EntityData<FallingBlock> {
 		}
 		return true;
 	}
-	
+
 	@SuppressWarnings("deprecation")
 	@Override
 	@Nullable
-	public FallingBlock spawn(final Location loc) {
-		final ItemType t = CollectionUtils.getRandom(types);
+	public FallingBlock spawn(Location loc, @Nullable Consumer<FallingBlock> consumer) {
+		ItemType t = CollectionUtils.getRandom(types);
 		assert t != null;
-		final ItemStack i = t.getRandom();
+		ItemStack i = t.getRandom();
 		if (i == null || i.getType() == Material.AIR || !i.getType().isBlock()) {
 			assert false : i;
 			return null;
 		}
 		return loc.getWorld().spawnFallingBlock(loc, i.getType(), (byte) i.getDurability());
 	}
-	
+
 	@Override
 	public void set(final FallingBlock entity) {
 		assert false;

--- a/src/main/java/ch/njol/skript/entity/PlayerData.java
+++ b/src/main/java/ch/njol/skript/entity/PlayerData.java
@@ -20,6 +20,7 @@ package ch.njol.skript.entity;
 
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
+import org.bukkit.util.Consumer;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.lang.Literal;
@@ -63,13 +64,13 @@ public class PlayerData extends EntityData<Player> {
 	public Class<? extends Player> getType() {
 		return Player.class;
 	}
-	
+
 	@Override
 	@Nullable
-	public Player spawn(final Location loc) {
+	public Player spawn(Location loc, @Nullable Consumer<Player> consumer) {
 		return null;
 	}
-	
+
 	@Override
 	protected int hashCode_i() {
 		return op;

--- a/src/main/java/ch/njol/skript/entity/ThrownPotionData.java
+++ b/src/main/java/ch/njol/skript/entity/ThrownPotionData.java
@@ -24,6 +24,7 @@ import org.bukkit.Location;
 import org.bukkit.entity.ThrownPotion;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.util.Consumer;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
@@ -97,21 +98,25 @@ public class ThrownPotionData extends EntityData<ThrownPotion> {
 		}
 		return true;
 	}
-	
-	@Nullable
+
 	@Override
-	public ThrownPotion spawn(Location loc) {
+	public @Nullable ThrownPotion spawn(Location loc, @Nullable Consumer<ThrownPotion> consumer) {
 		ItemType t = CollectionUtils.getRandom(types);
 		assert t != null;
-		final ItemStack i = t.getRandom();
-		if (i == null) {
+		ItemStack i = t.getRandom();
+		if (i == null)
 			return null;
-		}
-		ThrownPotion potion = loc.getWorld().spawn(loc, ThrownPotion.class);
+
+		ThrownPotion potion;
+		if (consumer != null)
+			potion = loc.getWorld().spawn(loc, ThrownPotion.class, consumer);
+		else
+			potion = loc.getWorld().spawn(loc, ThrownPotion.class);
+
 		potion.setItem(i);
 		return potion;
 	}
-	
+
 	@Override
 	public void set(final ThrownPotion entity) {
 		if (types != null) {

--- a/src/main/java/ch/njol/skript/entity/XpOrbData.java
+++ b/src/main/java/ch/njol/skript/entity/XpOrbData.java
@@ -20,6 +20,7 @@ package ch.njol.skript.entity;
 
 import org.bukkit.Location;
 import org.bukkit.entity.ExperienceOrb;
+import org.bukkit.util.Consumer;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.lang.Literal;
@@ -68,18 +69,18 @@ public class XpOrbData extends EntityData<ExperienceOrb> {
 		if (xp != -1)
 			entity.setExperience(xp);
 	}
-	
+
 	@Override
 	@Nullable
-	public ExperienceOrb spawn(final Location loc) {
-		final ExperienceOrb orb = super.spawn(loc);
+	public ExperienceOrb spawn(Location loc, @Nullable Consumer<ExperienceOrb> consumer) {
+		ExperienceOrb orb = super.spawn(loc, consumer);
 		if (orb == null)
 			return null;
 		if (xp == -1)
 			orb.setExperience(1);
 		return orb;
 	}
-	
+
 	private final static ArgsMessage format = new ArgsMessage("entities.xp-orb.format");
 	
 	@Override


### PR DESCRIPTION
### Description
Fixes falling block spawning with sections by making EntityData implementations override `spawn(Location, Consumer)` instead of `spawn(Location)`. 

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4716
