### PR TITLE
Fix console colors

### DIFF
--- a/src/main/java/ch/njol/skript/log/RedirectingLogHandler.java
+++ b/src/main/java/ch/njol/skript/log/RedirectingLogHandler.java
@@ -28,8 +28,7 @@ import java.util.logging.Level;
  * Redirects the log to a {@link CommandSender}.
  */
 public class RedirectingLogHandler extends LogHandler {
-	
-	@Nullable
+
 	private final CommandSender recipient;
 	
 	private final String prefix;
@@ -37,16 +36,13 @@ public class RedirectingLogHandler extends LogHandler {
 	private int numErrors = 0;
 	
 	public RedirectingLogHandler(CommandSender recipient, @Nullable String prefix) {
-		this.recipient = recipient == Bukkit.getConsoleSender() ? null : recipient;
+		this.recipient = recipient;
 		this.prefix = prefix == null ? "" : prefix;
 	}
 	
 	@Override
 	public LogResult log(LogEntry entry) {
-		if (recipient != null)
-			recipient.sendMessage(prefix + entry.toFormattedString());
-		else
-			SkriptLogger.LOGGER.log(entry.getLevel(), prefix + entry.toFormattedString());
+		SkriptLogger.sendFormatted(recipient, prefix + entry.toFormattedString());
 		if (entry.level == Level.SEVERE)
 			numErrors++;
 		return LogResult.DO_NOT_LOG;

--- a/src/main/java/ch/njol/skript/log/RetainingLogHandler.java
+++ b/src/main/java/ch/njol/skript/log/RetainingLogHandler.java
@@ -112,16 +112,11 @@ public class RetainingLogHandler extends LogHandler {
 		assert !printedErrorOrLog;
 		printedErrorOrLog = true;
 		stop();
-		
-		boolean console = recipient == Bukkit.getConsoleSender(); // log as SEVERE instead of INFO
-		
+
 		boolean hasError = false;
 		for (LogEntry e : log) {
 			if (e.getLevel().intValue() >= Level.SEVERE.intValue()) {
-				if (console)
-					SkriptLogger.LOGGER.severe(e.toFormattedString());
-				else
-					recipient.sendMessage(e.toFormattedString());
+				SkriptLogger.sendFormatted(recipient, e.toFormattedString());
 				e.logged();
 				hasError = true;
 			} else {
@@ -130,10 +125,7 @@ public class RetainingLogHandler extends LogHandler {
 		}
 		
 		if (!hasError && def != null) {
-			if (console)
-				SkriptLogger.LOGGER.severe(def);
-			else
-				recipient.sendMessage(def);
+			SkriptLogger.sendFormatted(recipient, def);
 		}
 		return hasError;
 	}

--- a/src/main/java/ch/njol/skript/log/SkriptLogger.java
+++ b/src/main/java/ch/njol/skript/log/SkriptLogger.java
@@ -23,6 +23,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
@@ -181,7 +183,7 @@ public abstract class SkriptLogger {
 			}
 		}
 		entry.logged();
-		LOGGER.log(entry.getLevel(), "[Skript] " + entry.toFormattedString());
+		sendFormatted(Bukkit.getConsoleSender(), "[Skript] " + entry.toFormattedString());
 	}
 	
 	public static void logAll(Collection<LogEntry> entries) {
@@ -201,5 +203,17 @@ public abstract class SkriptLogger {
 	public static boolean log(Verbosity minVerb) {
 		return minVerb.compareTo(verbosity) <= 0;
 	}
-	
+
+	/**
+	 * Sends the given formatted message to the given {@link CommandSender}.
+	 */
+	public static void sendFormatted(CommandSender commandSender, String message) {
+		if (commandSender instanceof ConsoleCommandSender) {
+			for (String s : message.split("\n"))
+				Bukkit.getConsoleSender().sendMessage(s);
+		} else {
+			commandSender.sendMessage(message);
+		}
+	}
+
 }

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -51,16 +51,16 @@ skript command:
 	invalid script: Can't find the script <grey>'<gold>%s<grey>'<red> in the scripts folder!
 	invalid folder: Can't find the folder <grey>'<gold>%s<grey>'<red> in the scripts folder!
 	reload:
-		warning line info: <gold><bold>Line %s:<gray> (%s)\n
-		error line info: <light red><bold>Line %s:<gray> (%s)\n
+		warning line info: <gold><bold>Line %s:<gray> (%s)<reset>\n
+		error line info: <light red><bold>Line %s:<gray> (%s)<reset>\n
 		reloading: Reloading <gold>%s<reset>...
 		reloaded: <lime>Successfully reloaded <gold>%s<lime>. <gray>(<gold>%2$sms<gray>)
 		error: <light red>Encountered <gold>%2$s <light red>error¦¦s¦ while reloading <gold>%1$s<light red>! <gray>(<gold>%3$sms<gray>)
 		script disabled: <gold>%s<reset> is currently disabled. Use <gray>/<gold>skript <cyan>enable <red>%s<reset> to enable it.
-		warning details: <yellow>    %s\n
-		error details: <light red>    %s\n
-		other details: <white>    %s\n
-		line details: <gold>    Line: <gray>%s\n <reset>
+		warning details: <yellow>    %s<reset>\n
+		error details: <light red>    %s<reset>\n
+		other details: <white>    %s<reset>\n
+		line details: <gold>    Line: <gray>%s<reset>\n <reset>
 
 		config, aliases and scripts: the config, aliases and all scripts
 		scripts: all scripts

--- a/src/main/resources/lang/german.lang
+++ b/src/main/resources/lang/german.lang
@@ -51,16 +51,16 @@ skript command:
 	invalid script: Das Skript <grey>'<gold>%s<grey>'<red> konnte nicht gefunden werden.
 	invalid folder: Der Ordner <grey>'<gold>%s<grey>'<red> konnte nicht gefunden werden.
 	reload:
-		warning line info: <gold><bold>Linie %s: <gray>(%s)\n
-		error line info: <light red><bold>Linie %s: <gray>(%s)\n
+		warning line info: <gold><bold>Linie %s: <gray>(%s)<reset>\n
+		error line info: <light red><bold>Linie %s: <gray>(%s)<reset>\n
 		reloading: Lade <gold>%s <reset>neu...
 		reloaded: <gold>%s <lime>erfolgreich neu geladen. <gray>(<gold>%2$sms<gray>)
 		error: <gold>%2$s <light red>Fehler ¦ist¦sind¦ beim Parsen aufgetreten! <gray>(<gold>%2$sms<gray>)
 		script disabled: <gold>%s<reset> ist derzeit deaktiviert. Verwende <gray>/<gold>skript <cyan>enable <red>%s<reset> um es zu aktivieren.
-		warning details: <yellow>    %s\n
-		error details: <light red>    %s\n
-		other details: <white>    %s\n
-		line details: <gold>    Linie: <gray>%s\n <reset>
+		warning details: <yellow>    %s<reset>\n
+		error details: <light red>    %s<reset>\n
+		other details: <white>    %s<reset>\n
+		line details: <gold>    Linie: <gray>%s<reset>\n <reset>
 		
 		config, aliases and scripts: die Konfiguration, alle Itemnamen und alle Skripte
 		scripts: alle Skripte

--- a/src/main/resources/lang/korean.lang
+++ b/src/main/resources/lang/korean.lang
@@ -51,16 +51,16 @@ skript command:
 	invalid script: 스크립트 폴더에서 <grey>'<gold>%s<grey>'<red> 스크립트를 찾을 수 없습니다!
 	invalid folder: 스크립트 폴더에서 <grey>'<gold>%s<grey>'<red> 폴더를 찾을 수 없습니다!
 	reload:
-		warning line info: <gold><bold>라인 %s: <gray>(%s)\n
-		error line info: <light red><bold>라인 %s: <gray>(%s)\n
+		warning line info: <gold><bold>라인 %s: <gray>(%s)<reset>\n
+		error line info: <light red><bold>라인 %s: <gray>(%s)<reset>\n
 		reloading: <gold>%s<reset>을(를) 다시 로드하는 중입니다...
 		reloaded: <gold>%s<lime>을(를) 다시 로드했습니다. <gray>(<gold>%2$sms<gray>)
 		error: <gold>%1$s<light red>을(를) 다시 로드하는 동안 <gold>%2$s<light red>개의 오류를 발견했습니다! <gray>(<gold>%2$sms<gray>)
 		script disabled: <gold>%s<reset>은 현재 비활성화되어 있습니다. <gray>/<gold>skript<cyan> <red>%s<reset>을 사용하여 활성화하십시오.
-		warning details: <yellow>    %s\n
-		error details: <light red>    %s\n
-		other details: <white>    %s\n
-		line details: <gold>    라인: <gray>%s\n <reset>
+		warning details: <yellow>    %s<reset>\n
+		error details: <light red>    %s<reset>\n
+		other details: <white>    %s<reset>\n
+		line details: <gold>    라인: <gray>%s<reset>\n <reset>
 
 		config, aliases and scripts: 구성(config), 별칭(aliases) 및 모든 스크립트
 		scripts: 모든 스크립트


### PR DESCRIPTION
### Description
Fixes console colors, adds `SkriptLogger#sendFormatted(CommandSender, String)` and replaces some logger uses with it

Spigot:
![image](https://user-images.githubusercontent.com/29547183/163232428-cc0647d9-ef8d-4c9b-97b3-601c1e4c0009.png)
Paper:
![image](https://user-images.githubusercontent.com/29547183/163232489-e8304fe2-b776-4c44-8a74-75d9c11b3303.png)

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4723
