### PR TITLE
Fix damage cause projectile comparison

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/DefaultComparators.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultComparators.java
@@ -509,13 +509,13 @@ public class DefaultComparators {
 			public Relation compare(DamageCause dc, EntityData e) {
 				switch (dc) {
 					case ENTITY_ATTACK:
-						return Relation.get(e.isSupertypeOf(EntityData.fromClass(Entity.class)));
+						return Relation.get(EntityData.fromClass(Entity.class).isSupertypeOf(e));
 					case PROJECTILE:
-						return Relation.get(e.isSupertypeOf(EntityData.fromClass(Projectile.class)));
+						return Relation.get(EntityData.fromClass(Projectile.class).isSupertypeOf(e));
 					case WITHER:
-						return Relation.get(e.isSupertypeOf(EntityData.fromClass(Wither.class)));
+						return Relation.get(EntityData.fromClass(Wither.class).isSupertypeOf(e));
 					case FALLING_BLOCK:
-						return Relation.get(e.isSupertypeOf(EntityData.fromClass(FallingBlock.class)));
+						return Relation.get(EntityData.fromClass(FallingBlock.class).isSupertypeOf(e));
 						//$CASES-OMITTED$
 					default:
 						return Relation.NOT_EQUAL;


### PR DESCRIPTION
### Description
The line `if damage cause is projectile` was parsed as `if event-damage cause is the event-projectile`. This isn't a problem, as Skript has comparator built in to handle this (a DamageCause - EntityData comparator). However, this comparator had an issue, it switched its arguments around.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4709
