### PR TITLE
Fix variable names with long numbers

### DIFF
--- a/src/main/java/ch/njol/skript/variables/VariablesMap.java
+++ b/src/main/java/ch/njol/skript/variables/VariablesMap.java
@@ -18,17 +18,15 @@
  */
 package ch.njol.skript.variables;
 
+import ch.njol.skript.lang.Variable;
+import ch.njol.util.StringUtils;
+import org.eclipse.jdt.annotation.Nullable;
+
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
-
-import org.eclipse.jdt.annotation.Nullable;
-
-import ch.njol.skript.lang.Variable;
-import ch.njol.skript.util.Utils;
-import ch.njol.util.StringUtils;
 
 final class VariablesMap {
 
@@ -45,49 +43,85 @@ final class VariablesMap {
 			int j = 0;
 
 			boolean lastNumberNegative = false;
+			boolean afterDecimalPoint = false;
 			while (i < s1.length() && j < s2.length()) {
 				char c1 = s1.charAt(i);
 				char c2 = s2.charAt(j);
 
 				if ('0' <= c1 && c1 <= '9' && '0' <= c2 && c2 <= '9') {
 					// Numbers/digits are treated differently from other characters.
+
+					// The index after the last digit
 					int i2 = StringUtils.findLastDigit(s1, i);
 					int j2 = StringUtils.findLastDigit(s2, j);
 
-					long n1 = Utils.parseLong("" + s1.substring(i, i2));
-					long n2 = Utils.parseLong("" + s2.substring(j, j2));
+					// Amount of leading zeroes
+					int z1 = 0;
+					int z2 = 0;
+
+					// Skip leading zeroes (except for the last if all 0's)
+					if (!afterDecimalPoint) {
+						if (c1 == '0')
+							while (i < i2 - 1 && s1.charAt(i) == '0') {
+								i++;
+								z1++;
+							}
+						if (c2 == '0')
+							while (j < j2 - 1 && s2.charAt(j) == '0') {
+								j++;
+								z2++;
+							}
+					}
+					// Keep in mind that c1 and c2 may not have the right value (e.g. s1.charAt(i)) for the rest of this block
 
 					// If the number is prefixed by a '-', it should be treated as negative, thus inverting the order.
 					// If the previous number was negative, and the only thing separating them was a '.',
 					//  then this number should also be in inverted order.
 					boolean previousNegative = lastNumberNegative;
 
-					lastNumberNegative = i > 0 && s1.charAt(i - 1) == '-';
+					// i - z1 contains the first digit, so i - z1 - 1 may contain a `-` indicating this number is negative
+					lastNumberNegative = i - z1 > 0 && s1.charAt(i - z1 - 1) == '-';
 					int isPositive = (lastNumberNegative | previousNegative) ? -1 : 1;
 
-					if (n1 > n2)
-						return isPositive;
+					// Different length numbers (99 > 9)
+					if (!afterDecimalPoint && i2 - i != j2 - j)
+						return ((i2 - i) - (j2 - j)) * isPositive;
 
-					if (n1 < n2)
-						return -1 * isPositive;
+					// Iterate over the digits
+					while (i < i2 && j < j2) {
+						char d1 = s1.charAt(i);
+						char d2 = s2.charAt(j);
 
-					// Represent same number, but different length, indicating leading zeros
-					if (i2 - i > j2 - j)
-						return -1;
-					if (i2 - i < j2 - j)
-						return 1;
+						// If the digits differ, return a value dependent on the sign
+						if (d1 != d2)
+							return (d1 - d2) * isPositive;
 
-					i = i2;
-					j = j2;
+						i++;
+						j++;
+					}
+
+					// Different length numbers (1.99 > 1.9)
+					if (afterDecimalPoint && i2 - i != j2 - j) {
+						return ((i2 - i) - (j2 - j)) * isPositive;
+					}
+
+					// If the numbers are equal, but either has leading zeroes,
+					//  more leading zeroes is a lesser number (01 < 1)
+					if (z1 != 0 || z2 != 0)
+						return (z1 - z2) * isPositive;
+
+					afterDecimalPoint = true;
 				} else {
 					// Normal characters
-					if (c1 > c2)
-						return 1;
-					if (c1 < c2)
-						return -1;
-					// Reset the last number flag if we're exiting a number.
-					if (c1 != '.')
+					if (c1 != c2)
+						return c1 - c2;
+
+					// Reset the last number flags if we're exiting a number.
+					if (c1 != '.') {
 						lastNumberNegative = false;
+						afterDecimalPoint = false;
+					}
+
 					i++;
 					j++;
 				}
@@ -99,7 +133,7 @@ final class VariablesMap {
 			return 0;
 		}
 	};
-	
+
 	final HashMap<String, Object> hashMap = new HashMap<>();
 	final TreeMap<String, Object> treeMap = new TreeMap<>();
 	


### PR DESCRIPTION
### Description
Changes the variable name comparator to not rely on long parsing, instead comparing digits manually.

Output from the test script in the first linked issue:
![image](https://user-images.githubusercontent.com/29547183/164472851-8de9b534-603e-4f43-9f2a-9b8d77c88deb.png)
Other test code:
```
command /test2:
	trigger:
		loop 100 times:
			set {_i} to 1 + (loop-value) / 100
			set {_l::%{_i}%} to "a"
		loop {_l::*}:
			message loop-index
```
Output: https://pastebin.com/htAPMQXg

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4729, #3929 (latter non-fixing)
