### PR TITLE
Fix ExprChestInventory exceptions from too large chest inventories

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprChestInventory.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprChestInventory.java
@@ -31,6 +31,7 @@ import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -47,8 +48,8 @@ public class ExprChestInventory extends SimpleExpression<Inventory> {
 			"[a [new]] chest inventory with %number% row[s] [(named|with name) %-string%]");
 	}
 
-	private static final String DEFAULT_CHEST_TITLE = "Chest";
-	private static final int DEFAULT_CHEST_ROWS = 3;
+	private static final String DEFAULT_CHEST_TITLE = InventoryType.CHEST.getDefaultTitle();
+	private static final int DEFAULT_CHEST_ROWS = InventoryType.CHEST.getDefaultSize() / 9;
 
 	@Nullable
 	private Expression<Number> rows;
@@ -79,8 +80,8 @@ public class ExprChestInventory extends SimpleExpression<Inventory> {
 		// Sanitize inventory size
 		if (size < 0)
 			size = 0;
-		if (size > 6 * 9) // Too big values cause visual weirdness, or exceptions on newer server versions
-			size = 6 * 9;
+		if (size > 54) // Too big values cause visual weirdness, or exceptions on newer server versions
+			size = 54;
 
 		return CollectionUtils.array(Bukkit.createInventory(null, size, name));
 	}
@@ -97,8 +98,10 @@ public class ExprChestInventory extends SimpleExpression<Inventory> {
 
 	@Override
 	public String toString(@Nullable Event e, boolean debug) {
-		return "chest inventory" + " named " + (name != null ? name.toString(e, debug) : "\"Chest\"") +
-			" with " + (rows != null ? rows.toString(e, debug) : "3" + " rows");
+		return "chest inventory named "
+			+ (name != null ? name.toString(e, debug) : "\"" + DEFAULT_CHEST_TITLE + "\"") +
+			" with "
+			+ (rows != null ? rows.toString(e, debug) : "" + DEFAULT_CHEST_ROWS + " rows");
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprChestInventory.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprChestInventory.java
@@ -37,65 +37,68 @@ import org.eclipse.jdt.annotation.Nullable;
 @Name("Custom Chest Inventory")
 @Description("Returns a chest inventory with the given amount of rows and the name. Use the <a href=effects.html#EffOpenInventory>open inventory</a> effect to open it.")
 @Examples({"open chest inventory with 1 row named \"test\" to player",
-           "set {_inventory} to chest inventory with 1 row"})
+	"set {_inventory} to chest inventory with 1 row"})
 @Since("2.2-dev34")
 public class ExprChestInventory extends SimpleExpression<Inventory> {
 
-    static {
-        Skript.registerExpression(ExprChestInventory.class, Inventory.class, ExpressionType.COMBINED,
-        		"[a [new]] chest inventory (named|with name) %string% [with %-number% row[s]]",
-        		"[a [new]] chest inventory with %number% row[s] [(named|with name) %-string%]");
-    }
+	static {
+		Skript.registerExpression(ExprChestInventory.class, Inventory.class, ExpressionType.COMBINED,
+			"[a [new]] chest inventory (named|with name) %string% [with %-number% row[s]]",
+			"[a [new]] chest inventory with %number% row[s] [(named|with name) %-string%]");
+	}
 
-    @Nullable
-    private Expression<Number> rows;
-    @Nullable
-    private Expression<String> name;
+	private static final String DEFAULT_CHEST_TITLE = "Chest";
+	private static final int DEFAULT_CHEST_ROWS = 3;
 
-    @SuppressWarnings("unchecked")
+	@Nullable
+	private Expression<Number> rows;
+	@Nullable
+	private Expression<String> name;
+
+	@SuppressWarnings("unchecked")
 	@Override
-    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
-        name = (Expression<String>) exprs[matchedPattern];
-        rows = (Expression<Number>) exprs[matchedPattern ^ 1];
-        return true;
-    }
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		name = (Expression<String>) exprs[matchedPattern];
+		rows = (Expression<Number>) exprs[matchedPattern ^ 1];
+		return true;
+	}
 
-    @Override
-    protected Inventory[] get(Event e) {
-        String name = this.name != null ? this.name.getSingle(e) : "Chest";
-        Number rows = this.rows != null ? this.rows.getSingle(e) : 3;
+	@Override
+	protected Inventory[] get(Event e) {
+		String name = this.name != null ? this.name.getSingle(e) : DEFAULT_CHEST_TITLE;
+		Number rows = this.rows != null ? this.rows.getSingle(e) : DEFAULT_CHEST_ROWS;
 
-        // Shouldn't be null at this point, but empty variables are a thing
-        rows = rows == null ? 3 : rows;
-        name = name == null ? "Chest" : name;
+		rows = rows == null ? DEFAULT_CHEST_ROWS : rows;
+		name = name == null ? DEFAULT_CHEST_TITLE : name;
 
-        int size = rows.intValue() * 9;
-        if (size % 9 != 0) {
-            size = 27;
-        }
-        
-        // Sanitize inventory size
-        if (size < 0) // Negative sizes go and crash stuff deep in NMS code
-        	size = 0;
-        if (size > 255) // Too big values cause visual weirdness
-        	size = 255 * 9; // Plus, REALLY big values will HANG the server
-        return CollectionUtils.array(Bukkit.createInventory(null, size, name));
-    }
+		int size = rows.intValue() * 9;
+		if (size % 9 != 0) {
+			size = 27;
+		}
 
-    @Override
-    public boolean isSingle() {
-        return true;
-    }
+		// Sanitize inventory size
+		if (size < 0)
+			size = 0;
+		if (size > 6 * 9) // Too big values cause visual weirdness, or exceptions on newer server versions
+			size = 6 * 9;
 
-    @Override
-    public Class<? extends Inventory> getReturnType() {
-        return Inventory.class;
-    }
+		return CollectionUtils.array(Bukkit.createInventory(null, size, name));
+	}
 
-    @Override
-    public String toString(@Nullable Event e, boolean debug) {
-        return "chest inventory" + " named " + (name != null ? name.toString(e, debug) : "\"Chest\"") +
-                " with " + (rows != null ? rows.toString(e, debug) : "3" + " rows");
-    }
+	@Override
+	public boolean isSingle() {
+		return true;
+	}
+
+	@Override
+	public Class<? extends Inventory> getReturnType() {
+		return Inventory.class;
+	}
+
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		return "chest inventory" + " named " + (name != null ? name.toString(e, debug) : "\"Chest\"") +
+			" with " + (rows != null ? rows.toString(e, debug) : "3" + " rows");
+	}
 
 }


### PR DESCRIPTION
### Description
Title says all. While these inventories are allowed in older server versions (including 1.13), since the client doesn't display them properly, I think it's a good idea to disallow them on those versions too. The check made on newer server versions is: `9 <= size && size <= 54 && size % 9 == 0`, used to be just `size % 9 == 0`. Also fixes indentation of the file (used spaces instead of tabs).

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4736
