### PR TITLE
Add error when spawn section used on 1.9.4

### DIFF
--- a/src/main/java/ch/njol/skript/sections/EffSecSpawn.java
+++ b/src/main/java/ch/njol/skript/sections/EffSecSpawn.java
@@ -88,6 +88,8 @@ public class EffSecSpawn extends EffectSection {
 		}, 0);
 	}
 
+	private static final boolean BUKKIT_CONSUMER_EXISTS = Skript.classExists("org.bukkit.util.Consumer");
+
 	@Nullable
 	public static Entity lastSpawned = null;
 
@@ -113,8 +115,14 @@ public class EffSecSpawn extends EffectSection {
 		types = (Expression<EntityType>) exprs[matchedPattern];
 		locations = Direction.combine((Expression<? extends Direction>) exprs[1 + matchedPattern], (Expression<? extends Location>) exprs[2 + matchedPattern]);
 
-		if (sectionNode != null)
+		if (sectionNode != null) {
+			if (!BUKKIT_CONSUMER_EXISTS) {
+				Skript.error("The spawn section isn't available on your Minecraft version, use a spawn effect instead");
+				return false;
+			}
+
 			trigger = loadCode(sectionNode, "spawn", SpawnEvent.class);
+		}
 
 		return true;
 	}

--- a/src/test/skript/tests/syntaxes/sections/EffSecSpawn.sk
+++ b/src/test/skript/tests/syntaxes/sections/EffSecSpawn.sk
@@ -1,4 +1,4 @@
-test "event-value-converting":
+test "spawn section" when minecraft version is not "1.9.4":
 	spawn a pig at spawn of "world":
 		assert event-entity is a pig with "entity not a pig"
 		set {_test} to event-entity


### PR DESCRIPTION
### Description
Adds an error when attempting to use a spawn section on 1.9.4, as they aren't supported on that version (the method for spawning an entity with a consumer didn't exist yet, nor did the consumer interface).

Example of exception on 1.9.4 without fix: https://pastebin.com/c0U6LpsP

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
