### PR TITLE
Changed from check against Material.AIR to Material#isAir in drop effect.

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffDrop.java
+++ b/src/main/java/ch/njol/skript/effects/EffDrop.java
@@ -85,7 +85,7 @@ public class EffDrop extends Effect {
 					if (o instanceof ItemStack)
 						o = new ItemType((ItemStack) o);
 					for (ItemStack is : ((ItemType) o).getItem().getAll()) {
-						if (is.getType() != Material.AIR && is.getAmount() > 0) {
+						if (!is.getType().isAir() && is.getAmount() > 0) {
 							if (useVelocity) {
 								lastSpawned = l.getWorld().dropItemNaturally(itemDropLoc, is);
 							} else {


### PR DESCRIPTION
### Description
I have changed the air check to use Material#isAir instead of checking against Material.Air.

---
**Target Minecraft Versions:**  any
**Requirements:** No additional requirements
**Related Issues:** https://github.com/SkriptLang/Skript/issues/4757
