### PR TITLE
Change Material#isAir since the method is only avalible in versions 1.15 and later

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffDrop.java
+++ b/src/main/java/ch/njol/skript/effects/EffDrop.java
@@ -85,7 +85,7 @@ public class EffDrop extends Effect {
 					if (o instanceof ItemStack)
 						o = new ItemType((ItemStack) o);
 					for (ItemStack is : ((ItemType) o).getItem().getAll()) {
-						if (is.getType() != Material.AIR && is.getAmount() > 0) {
+						if (!is.getType().isAir() && is.getAmount() > 0) {
 							if (useVelocity) {
 								lastSpawned = l.getWorld().dropItemNaturally(itemDropLoc, is);
 							} else {

--- a/src/main/java/ch/njol/skript/effects/EffDrop.java
+++ b/src/main/java/ch/njol/skript/effects/EffDrop.java
@@ -85,7 +85,7 @@ public class EffDrop extends Effect {
 					if (o instanceof ItemStack)
 						o = new ItemType((ItemStack) o);
 					for (ItemStack is : ((ItemType) o).getItem().getAll()) {
-						if (!isAir(is) && is.getAmount() > 0) {
+						if (!isAir(is.getType()) && is.getAmount() > 0) {
 							if (useVelocity) {
 								lastSpawned = l.getWorld().dropItemNaturally(itemDropLoc, is);
 							} else {

--- a/src/main/java/ch/njol/skript/effects/EffDrop.java
+++ b/src/main/java/ch/njol/skript/effects/EffDrop.java
@@ -104,7 +104,7 @@ public class EffDrop extends Effect {
 	// Only 1.15 and versions after have Material#isAir method
 	private static final boolean IS_AIR_EXISTS = Skript.methodExists(Material.class, "isAir");
 	// Version 1.14 have multiple air types but no Material#isAir method
-	private static final boolean otherAirExists = Skript.isRunningMinecraft(1, 14);
+	private static final boolean OTHER_AIR_EXISTS = Skript.isRunningMinecraft(1, 14);
 
 	private static boolean isAir(Material type) {
 		if (isAirExists) {

--- a/src/main/java/ch/njol/skript/effects/EffDrop.java
+++ b/src/main/java/ch/njol/skript/effects/EffDrop.java
@@ -107,13 +107,13 @@ public class EffDrop extends Effect {
 	private static final boolean OTHER_AIR_EXISTS = Skript.isRunningMinecraft(1, 14);
 
 	private static boolean isAir(Material type) {
-		if (isAirExists) {
+		if (IS_AIR_EXISTS) {
 			return type.isAir();
-		} else if (otherAirExists) { 
+		} else if (OTHER_AIR_EXISTS) { 
 			return type == Material.AIR || type == Material.CAVE_AIR || type == Material.VOID_AIR;
-		} else { // All versions prior to 1.14 only have 1 air type
-			return type == Material.AIR;
-		}
+		} 
+		// All versions prior to 1.14 only have 1 air type
+		return type == Material.AIR;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/effects/EffDrop.java
+++ b/src/main/java/ch/njol/skript/effects/EffDrop.java
@@ -85,7 +85,7 @@ public class EffDrop extends Effect {
 					if (o instanceof ItemStack)
 						o = new ItemType((ItemStack) o);
 					for (ItemStack is : ((ItemType) o).getItem().getAll()) {
-						if (!is.getType().isAir() && is.getAmount() > 0) {
+						if (!isAir(is) && is.getAmount() > 0) {
 							if (useVelocity) {
 								lastSpawned = l.getWorld().dropItemNaturally(itemDropLoc, is);
 							} else {
@@ -98,6 +98,20 @@ public class EffDrop extends Effect {
 					}
 				}
 			}
+		}
+	}
+
+	private boolean isAir(ItemStack is){
+		//All versions prior to 1.14 only have 1 air type
+		if(Skript.isRunningMinecraft(1,14)){
+			//All versions prior to 1.15 only have Material#isAir method
+			if(Skript.methodExists(Material.class, "isAir")){
+				return is.getType().isAir();
+			}else{
+				return is.getType() == Material.AIR || is.getType() == Material.CAVE_AIR || is.getType() == Material.VOID_AIR;
+			}
+		}else{
+			return is.getType() == Material.AIR;
 		}
 	}
 

--- a/src/main/java/ch/njol/skript/effects/EffDrop.java
+++ b/src/main/java/ch/njol/skript/effects/EffDrop.java
@@ -101,7 +101,7 @@ public class EffDrop extends Effect {
 		}
 	}
 
-	private boolean isAir(ItemStack is){
+	private boolean isAir(ItemStack is) {
 		//All versions prior to 1.14 only have 1 air type
 		if(Skript.isRunningMinecraft(1,14)){
 			//All versions prior to 1.15 only have Material#isAir method

--- a/src/main/java/ch/njol/skript/effects/EffDrop.java
+++ b/src/main/java/ch/njol/skript/effects/EffDrop.java
@@ -102,7 +102,7 @@ public class EffDrop extends Effect {
 	}
 
 	// Only 1.15 and versions after have Material#isAir method
-	private static final boolean isAirExists = Skript.methodExists(Material.class, "isAir");
+	private static final boolean IS_AIR_EXISTS = Skript.methodExists(Material.class, "isAir");
 	// Version 1.14 have multiple air types but no Material#isAir method
 	private static final boolean otherAirExists = Skript.isRunningMinecraft(1, 14);
 

--- a/src/main/java/ch/njol/skript/effects/EffDrop.java
+++ b/src/main/java/ch/njol/skript/effects/EffDrop.java
@@ -101,13 +101,18 @@ public class EffDrop extends Effect {
 		}
 	}
 
-	private static boolean isAir(ItemStack is) {
-		if(Skript.isRunningMinecraft(1,14) && Skript.methodExists(Material.class, "isAir")) { // Only 1.15 and versions after have Material#isAir method
-			return is.getType().isAir();
-		else if(Skript.isRunningMinecraft(1,14)) { // Version 1.14 have multiple air types but no Material#isAir method
-			return is.getType() == Material.AIR || is.getType() == Material.CAVE_AIR || is.getType() == Material.VOID_AIR;
+	// Only 1.15 and versions after have Material#isAir method
+	private static final boolean isAirExists = Skript.methodExists(Material.class, "isAir");
+	// Version 1.14 have multiple air types but no Material#isAir method
+	private static final boolean otherAirExists = Skript.isRunningMinecraft(1, 14);
+
+	private static boolean isAir(Material type) {
+		if (isAirExists) {
+			return type.isAir();
+		} else if (otherAirExists) { 
+			return type == Material.AIR || type == Material.CAVE_AIR || type == Material.VOID_AIR;
 		} else { // All versions prior to 1.14 only have 1 air type
-			return is.getType() == Material.AIR;
+			return type == Material.AIR;
 		}
 	}
 

--- a/src/main/java/ch/njol/skript/effects/EffDrop.java
+++ b/src/main/java/ch/njol/skript/effects/EffDrop.java
@@ -101,16 +101,12 @@ public class EffDrop extends Effect {
 		}
 	}
 
-	private boolean isAir(ItemStack is) {
-		//All versions prior to 1.14 only have 1 air type
-		if(Skript.isRunningMinecraft(1,14)){
-			//All versions prior to 1.15 only have Material#isAir method
-			if(Skript.methodExists(Material.class, "isAir")){
-				return is.getType().isAir();
-			}else{
-				return is.getType() == Material.AIR || is.getType() == Material.CAVE_AIR || is.getType() == Material.VOID_AIR;
-			}
-		}else{
+	private static boolean isAir(ItemStack is) {
+		if(Skript.isRunningMinecraft(1,14) && Skript.methodExists(Material.class, "isAir")) { // Only 1.15 and versions after have Material#isAir method
+			return is.getType().isAir();
+		else if(Skript.isRunningMinecraft(1,14)) { // Version 1.14 have multiple air types but no Material#isAir method
+			return is.getType() == Material.AIR || is.getType() == Material.CAVE_AIR || is.getType() == Material.VOID_AIR;
+		} else { // All versions prior to 1.14 only have 1 air type
 			return is.getType() == Material.AIR;
 		}
 	}


### PR DESCRIPTION
### Description
My previous fix used the Material#isAir method which isn't avalible in versions prior to 1.15, so here is another fix :)

I have tested it on 1.18, 1.14 and 1.11
---
**Target Minecraft Versions:** any
**Requirements:** No additional requirements
**Related Issues:** No related issues
