### PR TITLE
Allow multiple players in the food level

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprFoodLevel.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFoodLevel.java
@@ -49,7 +49,7 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprFoodLevel extends PropertyExpression<Player, Number> {
 	
 	static {
-		Skript.registerExpression(ExprFoodLevel.class, Number.class, ExpressionType.PROPERTY, "[the] (food|hunger)[[ ](level|met(er|re)|bar)] [of %player%]", "%player%'[s] (food|hunger)[[ ](level|met(er|re)|bar)]");
+		Skript.registerExpression(ExprFoodLevel.class, Number.class, ExpressionType.PROPERTY, "[the] (food|hunger)[[ ](level|met(er|re)|bar)] [of %players%]", "%players%'[s] (food|hunger)[[ ](level|met(er|re)|bar)]");
 	}
 	
 	@SuppressWarnings({"unchecked", "null"})


### PR DESCRIPTION
Allow manipulation of multiple players in the food level

### Description
For some reason this expression is setup to support multiple players, but the syntax doesn't. After 10 years, it's never been changed.

---
**Target Minecraft Versions:** any
**Requirements:** none
