### PR TITLE
Fix Locale-related String conversion issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,7 +142,7 @@ tasks.create('testNaming') {
 		// Regression tests
 		for (def file : project.file('src/test/skript/tests/regressions').listFiles()) {
 			def name = file.getName()
-			if (name.toLowerCase() != name) {
+			if (name.toLowerCase(Locale.ENGLISH) != name) {
 				throw new InvalidUserDataException('invalid test name: ' + name)
 			}
 		}

--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -701,7 +701,7 @@ public class ScriptLoader {
 					if (!SkriptParser.validateLine(event))
 						continue;
 					
-					if (event.toLowerCase().startsWith("command ")) {
+					if (event.toLowerCase(Locale.ENGLISH).startsWith("command ")) {
 						
 						getParser().setCurrentEvent("command", CommandEvent.class);
 						
@@ -715,7 +715,7 @@ public class ScriptLoader {
 						getParser().deleteCurrentEvent();
 						
 						continue;
-					} else if (event.toLowerCase().startsWith("function ")) {
+					} else if (event.toLowerCase(Locale.ENGLISH).startsWith("function ")) {
 						
 						getParser().setCurrentEvent("function", FunctionEvent.class);
 						
@@ -964,7 +964,7 @@ public class ScriptLoader {
 				if (!SkriptParser.validateLine(event))
 					continue;
 				
-				if (event.toLowerCase().startsWith("function ")) {
+				if (event.toLowerCase(Locale.ENGLISH).startsWith("function ")) {
 					
 					getParser().setCurrentEvent("function", FunctionEvent.class);
 					
@@ -1163,7 +1163,7 @@ public class ScriptLoader {
 			assert false : node;
 			return null;
 		}
-		if (event.toLowerCase().startsWith("on "))
+		if (event.toLowerCase(Locale.ENGLISH).startsWith("on "))
 			event = "" + event.substring("on ".length());
 		
 		NonNullPair<SkriptEventInfo<?>, SkriptEvent> parsedEvent =

--- a/src/main/java/ch/njol/skript/SkriptCommandTabCompleter.java
+++ b/src/main/java/ch/njol/skript/SkriptCommandTabCompleter.java
@@ -56,7 +56,7 @@ public class SkriptCommandTabCompleter implements TabCompleter {
 				// Live update, this will get all old and new (even not loaded) scripts
 				Files.walk(scripts.toPath())
 					.map(Path::toFile)
-					.filter(f -> (!f.isDirectory() && f.getName().toLowerCase().endsWith(".sk")) ||
+					.filter(f -> (!f.isDirectory() && StringUtils.endsWithIgnoreCase(f.getName(), ".sk")) ||
 						f.isDirectory()) // filter folders and skript files only
 					.filter(f -> { // Filtration for enable, disable and reload
 						if (args[0].equalsIgnoreCase("enable"))

--- a/src/main/java/ch/njol/skript/aliases/Aliases.java
+++ b/src/main/java/ch/njol/skript/aliases/Aliases.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import jdk.vm.ci.meta.Local;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;

--- a/src/main/java/ch/njol/skript/aliases/Aliases.java
+++ b/src/main/java/ch/njol/skript/aliases/Aliases.java
@@ -28,10 +28,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import jdk.vm.ci.meta.Local;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -269,7 +271,7 @@ public abstract class Aliases {
 				t.setAmount(1);
 		}
 		
-		String lc = s.toLowerCase();
+		String lc = s.toLowerCase(Locale.ENGLISH);
 		String of = Language.getSpaced("enchantments.of").toLowerCase();
 		int c = -1;
 		outer: while ((c = lc.indexOf(of, c + 1)) != -1) {
@@ -335,7 +337,7 @@ public abstract class Aliases {
 	@Nullable
 	private static ItemType getAlias(final String s) {
 		ItemType i;
-		String lc = "" + s.toLowerCase();
+		String lc = "" + s.toLowerCase(Locale.ENGLISH);
 		final Matcher m = p_any.matcher(lc);
 		if (m.matches()) {
 			lc = "" + m.group(m.groupCount());

--- a/src/main/java/ch/njol/skript/aliases/AliasesParser.java
+++ b/src/main/java/ch/njol/skript/aliases/AliasesParser.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -682,7 +683,7 @@ public class AliasesParser {
 				Skript.warning(m_empty_alias.toString());
 			} else {
 				// Intern id to save some memory
-				id = id.toLowerCase().intern();
+				id = id.toLowerCase(Locale.ENGLISH).intern();
 				assert id != null;
 				try {
 					// Create singular and plural forms of the alias

--- a/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
@@ -174,7 +174,7 @@ public class SkriptClasses {
 					
 					@Override
 					public String toVariableNameString(final WeatherType o) {
-						return "" + o.name().toLowerCase();
+						return "" + o.name().toLowerCase(Locale.ENGLISH);
 					}
 
 				})
@@ -702,7 +702,7 @@ public class SkriptClasses {
 
 					@Override
 					public String toVariableNameString(final StructureType o) {
-						return "" + o.name().toLowerCase();
+						return "" + o.name().toLowerCase(Locale.ENGLISH);
 					}
 				}).serializer(new EnumSerializer<>(StructureType.class)));
 

--- a/src/main/java/ch/njol/skript/command/CommandHelp.java
+++ b/src/main/java/ch/njol/skript/command/CommandHelp.java
@@ -22,6 +22,7 @@ import static org.bukkit.ChatColor.GRAY;
 import static org.bukkit.ChatColor.RESET;
 
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map.Entry;
 
 import org.bukkit.command.CommandSender;
@@ -120,7 +121,7 @@ public class CommandHelp {
 			showHelp(sender);
 			return false;
 		}
-		final Object help = arguments.get(args[index].toLowerCase());
+		final Object help = arguments.get(args[index].toLowerCase(Locale.ENGLISH));
 		if (help == null && wildcardArg == null) {
 			showHelp(sender, m_invalid_argument.toString(argsColor + args[index]));
 			return false;

--- a/src/main/java/ch/njol/skript/command/Commands.java
+++ b/src/main/java/ch/njol/skript/command/Commands.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -241,7 +242,7 @@ public abstract class Commands {
 	 */
 	static boolean handleCommand(final CommandSender sender, final String command) {
 		final String[] cmd = command.split("\\s+", 2);
-		cmd[0] = cmd[0].toLowerCase();
+		cmd[0] = cmd[0].toLowerCase(Locale.ENGLISH);
 		if (cmd[0].endsWith("?")) {
 			final ScriptCommand c = commands.get(cmd[0].substring(0, cmd[0].length() - 1));
 			if (c != null) {
@@ -346,7 +347,7 @@ public abstract class Commands {
 		final boolean a = m.matches();
 		assert a;
 
-		final String command = "" + m.group(1).toLowerCase();
+		final String command = "" + m.group(1).toLowerCase(Locale.ENGLISH);
 		final ScriptCommand existingCommand = commands.get(command);
 		if (alsoRegister && existingCommand != null && existingCommand.getLabel().equals(command)) {
 			final File f = existingCommand.getScript();
@@ -530,7 +531,7 @@ public abstract class Commands {
 		}
 		commands.put(command.getLabel(), command);
 		for (final String alias : command.getActiveAliases()) {
-			commands.put(alias.toLowerCase(), command);
+			commands.put(alias.toLowerCase(Locale.ENGLISH), command);
 		}
 		command.registerHelp();
 	}

--- a/src/main/java/ch/njol/skript/command/ScriptCommand.java
+++ b/src/main/java/ch/njol/skript/command/ScriptCommand.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -131,7 +132,7 @@ public class ScriptCommand implements TabExecutor {
 						 @Nullable VariableString cooldownStorage, final int executableBy, final List<TriggerItem> items) {
 		Validate.notNull(name, pattern, arguments, description, usage, aliases, items);
 		this.name = name;
-		label = "" + name.toLowerCase();
+		label = "" + name.toLowerCase(Locale.ENGLISH);
 		this.permission = permission;
 		if (permissionMessage == null) {
 			VariableString defaultMsg = VariableString.newInstance(Language.get("commands.no permission message"));
@@ -321,7 +322,7 @@ public class ScriptCommand implements TabExecutor {
 				aliases.remove(label);
 			final Iterator<String> as = activeAliases.iterator();
 			while (as.hasNext()) {
-				final String lowerAlias = as.next().toLowerCase();
+				final String lowerAlias = as.next().toLowerCase(Locale.ENGLISH);
 				if (knownCommands.containsKey(lowerAlias) && (aliases == null || !aliases.contains(lowerAlias))) {
 					as.remove();
 					continue;

--- a/src/main/java/ch/njol/skript/doc/HTMLGenerator.java
+++ b/src/main/java/ch/njol/skript/doc/HTMLGenerator.java
@@ -201,7 +201,7 @@ public class HTMLGenerator {
 					if (filesInside.isDirectory()) 
 						continue;
 						
-					if (!filesInside.getName().toLowerCase().endsWith(".png")) { // Copy images
+					if (!filesInside.getName().toLowerCase(Locale.ENGLISH).endsWith(".png")) { // Copy images
 						writeFile(new File(fileTo + "/" + filesInside.getName()), readFile(filesInside));
 					}
 					

--- a/src/main/java/ch/njol/skript/effects/EffLog.java
+++ b/src/main/java/ch/njol/skript/effects/EffLog.java
@@ -24,6 +24,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.logging.Level;
 
 import org.bukkit.event.Event;
@@ -90,7 +91,7 @@ public class EffLog extends Effect {
 		for (final String message : messages.getArray(e)) {
 			if (files != null) {
 				for (String s : files.getArray(e)) {
-					s = s.toLowerCase();
+					s = s.toLowerCase(Locale.ENGLISH);
 					if (!s.endsWith(".log"))
 						s += ".log";
 					if (s.equals("server.log")) {

--- a/src/main/java/ch/njol/skript/expressions/ExprCommandInfo.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCommandInfo.java
@@ -19,6 +19,7 @@
 package ch.njol.skript.expressions;
 
 import java.util.ArrayList;
+import java.util.Locale;
 import java.util.Objects;
 
 import org.bukkit.command.Command;
@@ -153,6 +154,6 @@ public class ExprCommandInfo extends SimpleExpression<String> {
 
 	@Override
 	public String toString(@Nullable Event e, boolean debug) {
-		return "the " + type.name().toLowerCase().replace("_", " ") + " of command " + commandName.toString(e, debug);
+		return "the " + type.name().toLowerCase(Locale.ENGLISH).replace("_", " ") + " of command " + commandName.toString(e, debug);
 	}
 }

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -62,6 +62,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
@@ -996,7 +997,7 @@ public class SkriptParser {
 
 				String priorityString = split[split.length - 1];
 				try {
-					priority = EventPriority.valueOf(priorityString.toUpperCase());
+					priority = EventPriority.valueOf(priorityString.toUpperCase(Locale.ENGLISH));
 				} catch (IllegalArgumentException e) { // Priority doesn't exist
 					log.printErrors("The priority " + priorityString + " doesn't exist");
 					return null;

--- a/src/main/java/ch/njol/skript/lang/UnparsedLiteral.java
+++ b/src/main/java/ch/njol/skript/lang/UnparsedLiteral.java
@@ -201,12 +201,12 @@ public class UnparsedLiteral implements Literal<Object> {
 //			if (t != null) {
 //				if (!m.group().matches("\\s*,\\s*")) {
 //					if (isAndSet) {
-//						if (and != m.group().toLowerCase().contains("and")) {
+//						if (and != m.group().toLowerCase(Locale.ENGLISH).contains("and")) {
 //							Skript.warning("list has multiple 'and' or 'or', will default to 'and'");
 //							and = true;
 //						}
 //					} else {
-//						and = m.group().toLowerCase().contains("and");
+//						and = m.group().toLowerCase(Locale.ENGLISH).contains("and");
 //						isAndSet = true;
 //					}
 //				}

--- a/src/main/java/ch/njol/skript/lang/function/Parameter.java
+++ b/src/main/java/ch/njol/skript/lang/function/Parameter.java
@@ -30,6 +30,8 @@ import ch.njol.skript.util.LiteralUtils;
 import ch.njol.skript.util.Utils;
 import org.eclipse.jdt.annotation.Nullable;
 
+import java.util.Locale;
+
 public final class Parameter<T> {
 	
 	/**
@@ -58,7 +60,7 @@ public final class Parameter<T> {
 	
 	@SuppressWarnings("null")
 	public Parameter(String name, ClassInfo<T> type, boolean single, @Nullable Expression<? extends T> def) {
-		this.name = name != null ? name.toLowerCase() : null;
+		this.name = name != null ? name.toLowerCase(Locale.ENGLISH) : null;
 		this.type = type;
 		this.def = def;
 		this.single = single;

--- a/src/main/java/ch/njol/skript/localization/Language.java
+++ b/src/main/java/ch/njol/skript/localization/Language.java
@@ -217,7 +217,7 @@ public class Language {
 	}
 	
 	public static boolean load(String name) {
-		name = "" + name.toLowerCase();
+		name = "" + name.toLowerCase(Locale.ENGLISH);
 
 		localizedLanguage = new HashMap<>();
 		boolean exists = load(Skript.getAddonInstance(), name);

--- a/src/main/java/ch/njol/skript/patterns/LiteralPatternElement.java
+++ b/src/main/java/ch/njol/skript/patterns/LiteralPatternElement.java
@@ -20,6 +20,8 @@ package ch.njol.skript.patterns;
 
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Locale;
+
 /**
  * A {@link PatternElement} that contains a literal string to be matched, for example {@code hello world}.
  * This element does not handle spaces as would be expected.
@@ -29,7 +31,7 @@ public class LiteralPatternElement extends PatternElement {
 	private final char[] literal;
 
 	public LiteralPatternElement(String literal) {
-		this.literal = literal.toLowerCase().toCharArray();
+		this.literal = literal.toLowerCase(Locale.ENGLISH).toCharArray();
 	}
 
 	public boolean isEmpty() {

--- a/src/main/java/ch/njol/skript/patterns/SkriptPattern.java
+++ b/src/main/java/ch/njol/skript/patterns/SkriptPattern.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 public class SkriptPattern {
 
@@ -42,7 +43,7 @@ public class SkriptPattern {
 	@Nullable
 	public MatchResult match(String expr, int flags, ParseContext parseContext) {
 		// Matching shortcut
-		String lowerExpr = expr.toLowerCase();
+		String lowerExpr = expr.toLowerCase(Locale.ENGLISH);
 		for (String keyword : keywords)
 			if (!lowerExpr.contains(keyword))
 				return null;

--- a/src/main/java/ch/njol/skript/registrations/Classes.java
+++ b/src/main/java/ch/njol/skript/registrations/Classes.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -334,7 +335,7 @@ public abstract class Classes {
 	@Nullable
 	public static ClassInfo<?> getClassInfoFromUserInput(String name) {
 		checkAllowClassInfoInteraction();
-		name = "" + name.toLowerCase();
+		name = "" + name.toLowerCase(Locale.ENGLISH);
 		for (final ClassInfo<?> ci : getClassInfos()) {
 			final Pattern[] uip = ci.getUserInputPatterns();
 			if (uip == null)

--- a/src/main/java/ch/njol/skript/util/EnchantmentType.java
+++ b/src/main/java/ch/njol/skript/util/EnchantmentType.java
@@ -20,6 +20,7 @@ package ch.njol.skript.util;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -118,7 +119,7 @@ public class EnchantmentType implements YggdrasilSerializable {
 				NAMES.put(e, names[0]);
 				
 				for (String name : names)
-					PATTERNS.put(name.toLowerCase(), e);
+					PATTERNS.put(name.toLowerCase(Locale.ENGLISH), e);
 			}
 		});
 	}
@@ -152,7 +153,7 @@ public class EnchantmentType implements YggdrasilSerializable {
 	
 	@Nullable
 	public static Enchantment parseEnchantment(final String s) {
-		return PATTERNS.get(s.toLowerCase());
+		return PATTERNS.get(s.toLowerCase(Locale.ENGLISH));
 	}
 	
 	@SuppressWarnings("null")

--- a/src/main/java/ch/njol/skript/util/PotionDataUtils.java
+++ b/src/main/java/ch/njol/skript/util/PotionDataUtils.java
@@ -90,7 +90,7 @@ public enum PotionDataUtils {
 	
 	PotionDataUtils(String potionType, boolean extended, boolean upgraded, int duration, int amplifier) {
 		try {
-			this.potionType = PotionType.valueOf(potionType.toUpperCase(Locale.ROOT));
+			this.potionType = PotionType.valueOf(potionType.toUpperCase(Locale.ENGLISH));
 			this.name = potionType;
 		} catch (IllegalArgumentException ignore) {
 			this.potionType = null;

--- a/src/main/java/ch/njol/skript/util/PotionEffectUtils.java
+++ b/src/main/java/ch/njol/skript/util/PotionEffectUtils.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.bukkit.entity.LivingEntity;
@@ -75,7 +76,7 @@ public abstract class PotionEffectUtils {
 					final String[] ls = Language.getList("potions." + t.getName());
 					names[t.getId()] = ls[0];
 					for (final String l : ls) {
-						types.put(l.toLowerCase(), t);
+						types.put(l.toLowerCase(Locale.ENGLISH), t);
 					}
 				}
 			}
@@ -84,7 +85,7 @@ public abstract class PotionEffectUtils {
 	
 	@Nullable
 	public static PotionEffectType parseType(final String s) {
-		return types.get(s.toLowerCase());
+		return types.get(s.toLowerCase(Locale.ENGLISH));
 	}
 	
 	// This is a stupid bandaid to fix comparison issues when converting potion datas

--- a/src/main/java/ch/njol/skript/util/SkriptColor.java
+++ b/src/main/java/ch/njol/skript/util/SkriptColor.java
@@ -23,6 +23,7 @@ import java.io.StreamCorruptedException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -76,7 +77,7 @@ public enum SkriptColor implements Color {
 				String node = LANGUAGE_NODE + "." + color.name();
 				color.setAdjective(new Adjective(node + ".adjective"));
 				for (String name : Language.getList(node + ".names"))
-					names.put(name.toLowerCase(), color);
+					names.put(name.toLowerCase(Locale.ENGLISH), color);
 			}
 		});
 	}

--- a/src/main/java/ch/njol/skript/util/StructureType.java
+++ b/src/main/java/ch/njol/skript/util/StructureType.java
@@ -19,6 +19,7 @@
 package ch.njol.skript.util;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Pattern;
@@ -115,7 +116,7 @@ public enum StructureType {
 				parseMap.put(Pattern.compile(pattern, Pattern.CASE_INSENSITIVE), t);
 			}
 		}
-		s = "" + s.toLowerCase();
+		s = "" + s.toLowerCase(Locale.ENGLISH);
 		for (final Entry<Pattern, StructureType> e : parseMap.entrySet()) {
 			if (e.getKey().matcher(s).matches())
 				return e.getValue();

--- a/src/main/java/ch/njol/skript/util/Timespan.java
+++ b/src/main/java/ch/njol/skript/util/Timespan.java
@@ -19,6 +19,7 @@
 package ch.njol.skript.util;
 
 import java.util.HashMap;
+import java.util.Locale;
 
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -53,8 +54,8 @@ public class Timespan implements YggdrasilSerializable, Comparable<Timespan> { /
 			@Override
 			public void onLanguageChange() {
 				for (int i = 0; i < names.length; i++) {
-					parseValues.put(names[i].getSingular().toLowerCase(), times[i]);
-					parseValues.put(names[i].getPlural().toLowerCase(), times[i]);
+					parseValues.put(names[i].getSingular().toLowerCase(Locale.ENGLISH), times[i]);
+					parseValues.put(names[i].getPlural().toLowerCase(Locale.ENGLISH), times[i]);
 				}
 			}
 		});
@@ -76,7 +77,7 @@ public class Timespan implements YggdrasilSerializable, Comparable<Timespan> { /
 				t += times[offset + i] * Utils.parseLong("" + ss[i]);	
 			}
 		} else { // <number> minutes/seconds/.. etc
-			final String[] subs = s.toLowerCase().split("\\s+");
+			final String[] subs = s.toLowerCase(Locale.ENGLISH).split("\\s+");
 			for (int i = 0; i < subs.length; i++) {
 				String sub = subs[i];
 				
@@ -117,7 +118,7 @@ public class Timespan implements YggdrasilSerializable, Comparable<Timespan> { /
 				if (sub.endsWith(","))
 					sub = sub.substring(0, sub.length() - 1);
 
-				final Long d = parseValues.get(sub.toLowerCase());
+				final Long d = parseValues.get(sub.toLowerCase(Locale.ENGLISH));
 				if (d == null)
 					return null;
 				

--- a/src/main/java/ch/njol/skript/util/Utils.java
+++ b/src/main/java/ch/njol/skript/util/Utils.java
@@ -43,6 +43,7 @@ import org.eclipse.jdt.annotation.Nullable;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
@@ -229,8 +230,8 @@ public abstract class Utils {
 		for (final String[] p : plurals) {
 			if (s.endsWith(p[1]))
 				return new NonNullPair<>(s.substring(0, s.length() - p[1].length()) + p[0], Boolean.TRUE);
-			if (s.endsWith(p[1].toUpperCase()))
-				return new NonNullPair<>(s.substring(0, s.length() - p[1].length()) + p[0].toUpperCase(), Boolean.TRUE);
+			if (s.endsWith(p[1].toUpperCase(Locale.ENGLISH)))
+				return new NonNullPair<>(s.substring(0, s.length() - p[1].length()) + p[0].toUpperCase(Locale.ENGLISH), Boolean.TRUE);
 		}
 		return new NonNullPair<>(s, Boolean.FALSE);
 	}
@@ -486,9 +487,9 @@ public abstract class Utils {
 				chat.clear();
 				for (final ChatColor style : styles) {
 					for (final String s : Language.getList("chat styles." + style.name())) {
-						chat.put(s.toLowerCase(), style.toString());
+						chat.put(s.toLowerCase(Locale.ENGLISH), style.toString());
 						if (english)
-							englishChat.put(s.toLowerCase(), style.toString());
+							englishChat.put(s.toLowerCase(Locale.ENGLISH), style.toString());
 					}
 				}
 			}
@@ -521,7 +522,7 @@ public abstract class Utils {
 				SkriptColor color = SkriptColor.fromName("" + m.group(1));
 				if (color != null)
 					return color.getFormattedChat();
-				final String tag = m.group(1).toLowerCase();
+				final String tag = m.group(1).toLowerCase(Locale.ENGLISH);
 				final String f = chat.get(tag);
 				if (f != null)
 					return f;
@@ -559,7 +560,7 @@ public abstract class Utils {
 				SkriptColor color = SkriptColor.fromName("" + m.group(1));
 				if (color != null)
 					return color.getFormattedChat();
-				final String tag = m.group(1).toLowerCase();
+				final String tag = m.group(1).toLowerCase(Locale.ENGLISH);
 				final String f = englishChat.get(tag);
 				if (f != null)
 					return f;

--- a/src/main/java/ch/njol/skript/util/chat/ChatMessages.java
+++ b/src/main/java/ch/njol/skript/util/chat/ChatMessages.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -227,7 +228,7 @@ public class ChatMessages {
 					} else {
 						name = tag;
 					}
-					name = name.toLowerCase(); // Tags are case-insensitive
+					name = name.toLowerCase(Locale.ENGLISH); // Tags are case-insensitive
 					
 					boolean tryHex = Utils.HEX_SUPPORTED && name.startsWith("#");
 					ChatColor chatColor = null;

--- a/src/main/java/ch/njol/skript/util/chat/MessageComponent.java
+++ b/src/main/java/ch/njol/skript/util/chat/MessageComponent.java
@@ -138,7 +138,7 @@ public class MessageComponent {
 			
 			@SuppressWarnings("null")
 			Action() {
-				spigotName = this.name().toUpperCase();
+				spigotName = this.name().toUpperCase(Locale.ENGLISH);
 			}
 		}
 		

--- a/src/main/java/ch/njol/util/Kleenean.java
+++ b/src/main/java/ch/njol/util/Kleenean.java
@@ -18,6 +18,8 @@
  */
 package ch.njol.util;
 
+import java.util.Locale;
+
 /**
  * A three-valued logic type (true, unknown, false), named after Stephen Cole Kleene.
  * 
@@ -39,7 +41,7 @@ public enum Kleenean {
 	
 	@Override
 	public final String toString() {
-		return "" + name().toLowerCase();
+		return "" + name().toLowerCase(Locale.ENGLISH);
 	}
 	
 	public final Kleenean is(final Kleenean other) {


### PR DESCRIPTION
### Description
In many parts of Skript, when converting to lower/upper case, a Locale is not specified. This means that the default Locale is used (usually dependent on the user's system).

The following, taken from the `String#toLowerCase()` javadoc, is an example of why this is an issue:

*Note: This method is locale sensitive, and may produce unexpected results if used for strings that are intended to be interpreted locale independently. Examples are programming language identifiers, protocol keys, and HTML tags. For instance, "TITLE".toLowerCase() in a Turkish locale returns "t\u0131tle", where '\u0131' is the LATIN SMALL LETTER DOTLESS I character.*

The result within Skript is that unexpected characters sometimes pop up during the parsing process for users on different locales, causing parsing to unexpectedly fail without much explanation to the user.

Also see: https://github.com/SkriptLang/Skript/issues/4821#issuecomment-1159765803

The fix is to simply specify `Locale.ENGLISH` for most occurences of `String#toLowerCase` and `String#toUpperCase` .

---
**Target Minecraft Versions:** N/A
**Requirements:** N/A
**Related Issues:**
- https://github.com/SkriptLang/Skript/issues/4712 (closed due to no response)
- https://github.com/SkriptLang/Skript/issues/4821
