### PR TITLE
Fix visual effects range

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffVisualEffect.java
+++ b/src/main/java/ch/njol/skript/effects/EffVisualEffect.java
@@ -47,8 +47,8 @@ public class EffVisualEffect extends Effect {
 
 	static {
 		Skript.registerEffect(EffVisualEffect.class,
-			"(play|show) %visualeffects% (on|%directions%) %entities/locations% [(to %-players%|in (radius|range) of %number%)]",
-			"(play|show) %number% %visualeffects% (on|%directions%) %locations% [(to %-players%|in (radius|range) of %number%)]");
+			"(play|show) %visualeffects% (on|%directions%) %entities/locations% [(to %-players%|in (radius|range) of %-number%)]",
+			"(play|show) %number% %visualeffects% (on|%directions%) %locations% [(to %-players%|in (radius|range) of %-number%)]");
 	}
 
 	@SuppressWarnings("NotNullFieldNotInitialized")


### PR DESCRIPTION
### Description
Fix visual effects not being visible further than 1 block away if optional range was not set. Range wasn't nullable so it defaulted to 1 instead of null, messing the code up.

---
**Target Minecraft Versions:** All
**Requirements:** None
**Related Issues:**
- #4806 
