### PR TITLE
FallingBlockData - fix an issue with missing consumer

### DIFF
--- a/src/main/java/ch/njol/skript/entity/FallingBlockData.java
+++ b/src/main/java/ch/njol/skript/entity/FallingBlockData.java
@@ -24,7 +24,6 @@ import java.util.Iterator;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.FallingBlock;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Consumer;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -112,18 +111,22 @@ public class FallingBlockData extends EntityData<FallingBlock> {
 		return true;
 	}
 
-	@SuppressWarnings("deprecation")
 	@Override
 	@Nullable
 	public FallingBlock spawn(Location loc, @Nullable Consumer<FallingBlock> consumer) {
 		ItemType t = CollectionUtils.getRandom(types);
 		assert t != null;
-		ItemStack i = t.getRandom();
-		if (i == null || i.getType() == Material.AIR || !i.getType().isBlock()) {
-			assert false : i;
+		Material material = t.getMaterial();
+
+		if (material == Material.AIR || !material.isBlock()) {
+			assert false;
 			return null;
 		}
-		return loc.getWorld().spawnFallingBlock(loc, i.getType(), (byte) i.getDurability());
+		FallingBlock fallingBlock = loc.getWorld().spawnFallingBlock(loc, material.createBlockData());
+		if (consumer != null)
+			consumer.accept(fallingBlock);
+
+		return fallingBlock;
 	}
 
 	@Override


### PR DESCRIPTION
### Description
This PR aims to fix an issue in FallingBlockData where there was a missing consumer.
I noticed this issue in SkBee, since the consumer was never used, I wasn't able to use the consumer in SkBee.
Also cleaned up some deprecated code.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
