### PR TITLE
Add 1.19 spawn reasons to default.lang

### DIFF
--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -1775,6 +1775,7 @@ spawn reasons:
 	infection: infection, infected
 	jockey: jockey
 	lightning: lightning
+	metamorphosis: metamorphosis
 	mount: mount
 	natural: natural
 	nether_portal: nether portal
@@ -1789,6 +1790,7 @@ spawn reasons:
 	slime_split: slime split
 	spawner: mob spawner, creature spawner, spawner
 	spawner_egg: spawn egg
+	spell: spell
 	trap: trap
 	village_defense: village defense, golem defense, iron golem defense
 	village_invasion: village invasion, village invading


### PR DESCRIPTION
### Description
Adds 1.19 spawn reasons to default.lang:
- spell
- metamorphosis

---
**Target Minecraft Versions:** 1.19
**Requirements:** none
**Related Issues:** none
