### PR TITLE
Disable watchdog in tests

### DIFF
--- a/src/main/java/ch/njol/skript/tests/platform/Environment.java
+++ b/src/main/java/ch/njol/skript/tests/platform/Environment.java
@@ -229,6 +229,7 @@ public class Environment {
 		args.add("-Dskript.testing.dir=" + testsRoot);
 		args.add("-Dskript.testing.devMode=" + devMode);
 		args.add("-Dskript.testing.results=test_results.json");
+		args.add("-Ddisable.watchdog=true");
 		args.addAll(Arrays.asList(jvmArgs));
 		args.addAll(Arrays.asList(commandLine));
 


### PR DESCRIPTION
### Description
Disables Spigot watchdog in our tests, as they've been crashing the test servers lately.

I don't know exactly why watchdog determined that our servers haven't been responding, because the default timeout time, the time that a server should hang until watchdog crashes it, is set to 60 seconds and watchdog crashes the server less than 60 seconds after it *begins* starting.
There is another part to the condition, relating to stopping servers, which probably causes the issue, but I'm not entirely sure.

![image](https://user-images.githubusercontent.com/29547183/178456979-10d0df6a-2c38-45dd-9f21-496015e12484.png)
https://github.com/PaperMC/Paper/blob/master/patches/server/0385-Improved-Watchdog-Support.patch
https://github.com/PaperMC/Paper/blob/master/patches/server/0238-Add-Early-Warning-Feature-to-WatchDog.patch

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** https://github.com/SkriptLang/Skript/issues/3767#issuecomment-1106605090 (non-fixing)
