### PR TITLE
Fix test servers crashing part 2

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -648,7 +648,11 @@ public final class Skript extends JavaPlugin implements Listener {
 								Skript.exception(e, "Failed to write test results.");
 							}
 							info("Testing done, shutting down the server.");
-							Bukkit.getServer().shutdown();
+							// Delay server shutdown to stop the server from crashing because the current tick takes a long time due to all the tests
+							Bukkit.getScheduler().runTaskLater(Skript.this, () -> {
+								Bukkit.getServer().shutdown();
+							}, 5);
+
 						}
 
 						return;


### PR DESCRIPTION
### Description
The previous fix (#4900) didn't work (see https://github.com/SkriptLang/Skript/pull/4845/commits/75e9ca17db24e9c9339547dd8096a1d514a7d92c for example, the previous PR was included in this test but it crashed nevertheless) because I though Paper would be a bit smarter: the `disable.watchdog` property they use to determine whether watchdog should be disabled or not, doesn't actually apply to the scenario that causes our servers to crash:
![image](https://user-images.githubusercontent.com/29547183/178720093-3c73f68d-17c6-4d72-8865-a1efc37745dd.png), the DISABLE_WATCHDOG field isn't used for this check.

This scenario is explained below:
- the server is stopping (Server#shutdown is called, which Skript does after running its tests)
![image](https://user-images.githubusercontent.com/29547183/178720331-343d3132-6416-4aaa-958b-a299895539ef.png)
- the server hasn't stopped yet, i.e. is still in a tick: [MinecraftServer#x on 1.17.1](https://pastebin.com/pSMHbrB5)
![image](https://user-images.githubusercontent.com/29547183/178720394-07823fa6-81b6-4496-b8aa-7dab071f99da.png)
![image](https://user-images.githubusercontent.com/29547183/178720485-3f67e88b-f717-4ea3-b4f2-0441486e2d28.png)
- the last server tick was over a second ago, which is easily reachable because all of our tests are run in this tick, because the server is shut down right after running the tests.
- a bit of luck for watchdog to run at the right time, because it only runs once a second (WatchdogThread#run)
![image](https://user-images.githubusercontent.com/29547183/178721436-417f28d0-8e8c-4133-98a1-f4d9c424c17a.png)

To fix this, this PR simply delays the shutdown for a couple ticks (a single tick is probably enough but I'm not risking that).

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4900, https://github.com/SkriptLang/Skript/issues/3767#issuecomment-1106605090 (neither fixing)
