### PR TITLE
Fixes sound category on 1.10.2

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffStopSound.java
+++ b/src/main/java/ch/njol/skript/effects/EffStopSound.java
@@ -60,8 +60,8 @@ public class EffStopSound extends Effect {
 						"stop playing sound[s] %strings% [(in|from) %-soundcategory%] [(to|for) %players%]");
 			} else {
 				Skript.registerEffect(EffStopSound.class,
-						"stop sound[s] %strings% [(in|from) %-soundcategory%] [(from playing to|for) %players%]",
-						"stop playing sound[s] %strings% [(in|from) %-soundcategory%] [(to|for) %players%]");
+						"stop sound[s] %strings% [(from playing to|for) %players%]",
+						"stop playing sound[s] %strings% [(to|for) %players%]");
 			}
 		}
 	}


### PR DESCRIPTION
### Description
Fixes sound category for 1.10.2 and lower versions.
The stop sound effect forgot to remove the sound category expression from the second pattern which handles no sound category.

Self tested on Java 8 to be working fine.

**_Note that this is going into dev/2.6 branch_**

---
**Target Minecraft Versions:** 1.10.2 and lower
**Related Issues:** https://github.com/SkriptLang/Skript/issues/4933
