### PR TITLE
Fix 1.11.2 sweeping edge

### DIFF
--- a/src/main/java/ch/njol/skript/bukkitutil/EnchantmentUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/EnchantmentUtils.java
@@ -69,9 +69,6 @@ public class EnchantmentUtils {
 		if (Skript.isRunningMinecraft(1, 11)) {
 			ENCHANTMENTS.put(Enchantment.BINDING_CURSE, "binding_curse");
 			ENCHANTMENTS.put(Enchantment.VANISHING_CURSE, "vanishing_curse");
-		}
-		
-		if (Skript.isRunningMinecraft(1, 12)) {
 			ENCHANTMENTS.put(Enchantment.SWEEPING_EDGE, "sweeping_edge");
 		}
 	}


### PR DESCRIPTION
### Description
Fixed sweeping edge not being registered on 1.11.2 and Skript erroring because it has no allocation to the enchantment.
Sweeping edge actually came out in 1.11.X but it's only registered in 1.12.

Self tested on Java 8 to be working fine.

**_Note that this is going into dev/2.6 branch_**

---
**Target Minecraft Versions:** 1.11.2
**Related Issues:** https://github.com/SkriptLang/Skript/issues/4933
