### PR TITLE
Add event naming rule to code conventions

### DIFF
--- a/code-conventions.md
+++ b/code-conventions.md
@@ -78,6 +78,7 @@ code. Contributors should also see the dedicated
   - And that is the only place where snake_case is acceptable
 * Use prefixes where their use has been already estabilished (such as ExprSomeRandomThing)
   - Otherwise, use postfixes (such as LoopSection)
+* Event objects in syntax elements should be named `e`
   
 ## Comments
 * Prefer to comment *why* you're doing things instead of how you're doing them


### PR DESCRIPTION
### Description
Adds a naming rule for Event objects to the code conventions. Currently, some contributors use `e` and others use `event`. I think we should probably find a standard before this inconsistency continues to grow in the codebase. **While my vote would be for using `e`, I mostly opened this PR as a place to hold the discussion. The actual standard should be whatever most of us agree on.**

---
**Target Minecraft Versions:** any
**Requirements:** any
**Related Issues:** any
