### PR TITLE
Add flavour to Skript info command

### DIFF
--- a/src/main/java/ch/njol/skript/SkriptCommand.java
+++ b/src/main/java/ch/njol/skript/SkriptCommand.java
@@ -328,7 +328,7 @@ public class SkriptCommand implements CommandExecutor {
 				info(sender, "info.documentation");
 				info(sender, "info.tutorials");
 				info(sender, "info.server", Bukkit.getVersion());
-				info(sender, "info.version", Skript.getVersion());
+				info(sender, "info.version", Skript.getVersion() + "(" + Skript.getInstance().getUpdater().getCurrentRelease().flavor + ")");
 				info(sender, "info.addons", Skript.getAddons().isEmpty() ? "None" : "");
 				for (SkriptAddon addon : Skript.getAddons()) {
 					PluginDescriptionFile desc = addon.plugin.getDescription();

--- a/src/main/java/ch/njol/skript/SkriptCommand.java
+++ b/src/main/java/ch/njol/skript/SkriptCommand.java
@@ -328,7 +328,7 @@ public class SkriptCommand implements CommandExecutor {
 				info(sender, "info.documentation");
 				info(sender, "info.tutorials");
 				info(sender, "info.server", Bukkit.getVersion());
-				info(sender, "info.version", Skript.getVersion() + "(" + Skript.getInstance().getUpdater().getCurrentRelease().flavor + ")");
+				info(sender, "info.version", Skript.getVersion() + " (" + Skript.getInstance().getUpdater().getCurrentRelease().flavor + ")");
 				info(sender, "info.addons", Skript.getAddons().isEmpty() ? "None" : "");
 				for (SkriptAddon addon : Skript.getAddons()) {
 					PluginDescriptionFile desc = addon.plugin.getDescription();


### PR DESCRIPTION
### Description
Adds Skript flavour to the Skript info command. This way developers can identify what flavour the user is using.
This came up when we didn't know that the user was using a nightly build and reporting errors.

---
**Related Issues:** https://github.com/SkriptLang/Skript/issues/4974
