### PR TITLE
Fix Actions not running on master branch

### DIFF
--- a/.github/workflows/java-17-builds.yml
+++ b/.github/workflows/java-17-builds.yml
@@ -3,7 +3,7 @@ name: Java 17 CI (MC 1.17+)
 on:
     push:
         branches:
-            - main
+            - master
             - 'dev/**'
     pull_request:
 

--- a/.github/workflows/java-8-builds.yml
+++ b/.github/workflows/java-8-builds.yml
@@ -3,7 +3,7 @@ name: Java 8 CI (MC 1.13-1.16)
 on:
     push:
         branches:
-            - main
+            - master
             - 'dev/**'
     pull_request:
 


### PR DESCRIPTION
### Description
Fixes the tests not running on the master branch, when a commit is made. This is caused by https://github.com/SkriptLang/Skript/pull/4946, which mistakenly used the branch name `main` instead of `master`, but we don't have such a branch.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4946 (non-fixing)
