### PR TITLE
Add Paper's PlayerTradeEvent in SimpleEvents

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -1372,10 +1372,10 @@ public final class BukkitEventValues {
 			EventValues.registerEventValue(PlayerTradeEvent.class, Entity.class, new Getter<Entity, PlayerTradeEvent>() {
 				@Override
 				@Nullable
-				public Entity get(PlayerTradeEvent e) {
-					return e.getVillager();
+				public Entity get(PlayerTradeEvent event) {
+					return event.getVillager();
 				}
-			}, 0);
+			}, EventValues.TIME_NOW);
 		}
 		// PlayerChangedWorldEvent
 		EventValues.registerEventValue(PlayerChangedWorldEvent.class, World.class, new Getter<World, PlayerChangedWorldEvent>() {

--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -60,6 +60,7 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.entity.Vehicle;
+import org.bukkit.entity.AbstractVillager;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockCanBuildEvent;
 import org.bukkit.event.block.BlockDamageEvent;
@@ -1371,10 +1372,10 @@ public final class BukkitEventValues {
 		}, 0);
 		// PlayerTradeEvent
 		if (Skript.classExists("io.papermc.paper.event.player.PlayerTradeEvent")) {
-			EventValues.registerEventValue(PlayerTradeEvent.class, Entity.class, new Getter<Entity, PlayerTradeEvent>() {
+			EventValues.registerEventValue(PlayerTradeEvent.class, AbstractVillager.class, new Getter<AbstractVillager, PlayerTradeEvent>() {
 				@Override
 				@Nullable
-				public Entity get(PlayerTradeEvent event) {
+				public AbstractVillager get(PlayerTradeEvent event) {
 					return event.getVillager();
 				}
 			}, EventValues.TIME_NOW);

--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -38,6 +38,7 @@ import com.destroystokyo.paper.event.block.AnvilDamagedEvent;
 import com.destroystokyo.paper.event.entity.ProjectileCollideEvent;
 import com.destroystokyo.paper.event.player.PlayerArmorChangeEvent;
 import io.papermc.paper.event.entity.EntityMoveEvent;
+import io.papermc.paper.event.player.PlayerTradeEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.FireworkEffect;
@@ -1366,6 +1367,16 @@ public final class BukkitEventValues {
 				return evt.getEntity();
 			}
 		}, 0);
+		// PlayerTradeEvent
+		if (Skript.classExists("io.papermc.paper.event.player.PlayerTradeEvent")) {
+			EventValues.registerEventValue(PlayerTradeEvent.class, Entity.class, new Getter<Entity, PlayerTradeEvent>() {
+				@Override
+				@Nullable
+				public Entity get(PlayerTradeEvent e) {
+					return e.getVillager();
+				}
+			}, 0);
+		}
 		// PlayerChangedWorldEvent
 		EventValues.registerEventValue(PlayerChangedWorldEvent.class, World.class, new Getter<World, PlayerChangedWorldEvent>() {
 			@Nullable

--- a/src/main/java/ch/njol/skript/events/SimpleEvents.java
+++ b/src/main/java/ch/njol/skript/events/SimpleEvents.java
@@ -625,7 +625,7 @@ public class SimpleEvents {
 					"\tchance of 50%:",
 					"\t\tcancel event",
 					"\t\tsend \"The trade was somehow denied!\" to player")
-				.since("2.6.3");
+				.since("INSERT VERSION");
 		}
 		if (Skript.classExists("com.destroystokyo.paper.event.block.AnvilDamagedEvent")) {
 			Skript.registerEvent("Anvil Damage", SimpleEvent.class, AnvilDamagedEvent.class, "anvil damag(e|ing)")

--- a/src/main/java/ch/njol/skript/events/SimpleEvents.java
+++ b/src/main/java/ch/njol/skript/events/SimpleEvents.java
@@ -108,6 +108,7 @@ import com.destroystokyo.paper.event.entity.ProjectileCollideEvent;
 import com.destroystokyo.paper.event.player.PlayerArmorChangeEvent;
 import com.destroystokyo.paper.event.player.PlayerJumpEvent;
 import com.destroystokyo.paper.event.server.PaperServerListPingEvent;
+import io.papermc.paper.event.player.PlayerTradeEvent;
 import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptEventHandler;
 import ch.njol.skript.lang.util.SimpleEvent;
@@ -616,6 +617,16 @@ public class SimpleEvents {
 				"\t\tset repair cost to repair cost * 50%",
 				"\t\tsend \"You're LUCKY! You got 50% discount.\" to player")
 			.since("INSERT VERSION");
+		if (Skript.classExists("io.papermc.paper.event.player.PlayerTradeEvent")) {
+			Skript.registerEvent("Player Trade", SimpleEvent.class, PlayerTradeEvent.class, "player trad(e|ing)")
+				.description("Called when a player has traded with a villager.")
+				.requiredPlugins("Paper 1.16.5+")
+				.examples("on player trade:",
+					"\tchance of 50%:",
+					"\t\tcancel event",
+					"\t\tsend \"The trade was somehow denied!\" to player")
+				.since("2.6.3");
+		}
 		if (Skript.classExists("com.destroystokyo.paper.event.block.AnvilDamagedEvent")) {
 			Skript.registerEvent("Anvil Damage", SimpleEvent.class, AnvilDamagedEvent.class, "anvil damag(e|ing)")
 				.description("Called when an anvil is damaged/broken from being used to repair/rename items.",


### PR DESCRIPTION
### Description
I am planning to add Paper's PlayerTradeEvent so that you don't need any addons or anything else.

---
**Target Minecraft Versions:** Any
**Requirements:** Paper 1.16+
**Related Issues:** None
