### PR TITLE
Fix falling block NPE

### DIFF
--- a/src/main/java/ch/njol/skript/entity/FallingBlockData.java
+++ b/src/main/java/ch/njol/skript/entity/FallingBlockData.java
@@ -52,7 +52,7 @@ public class FallingBlockData extends EntityData<FallingBlock> {
 	
 	private final static Message m_not_a_block_error = new Message("entities.falling block.not a block error");
 	private final static Adjective m_adjective = new Adjective("entities.falling block.adjective");
-	
+
 	@Nullable
 	private ItemType[] types = null;
 	
@@ -88,6 +88,8 @@ public class FallingBlockData extends EntityData<FallingBlock> {
 				Skript.error(m_not_a_block_error.toString());
 				return false;
 			}
+		} else {
+			types = new ItemType[] {new ItemType(Material.STONE)};
 		}
 		return true;
 	}


### PR DESCRIPTION
### Description
Skript will no longer throw a NPE when spawning a falling block without specifying the block type and will default to Stone

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** https://github.com/SkriptLang/Skript/issues/5042
