### PR TITLE
ExprJoinSplit config case sensitivity

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprJoinSplit.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprJoinSplit.java
@@ -80,14 +80,14 @@ public class ExprJoinSplit extends SimpleExpression<String> {
 	@Override
 	@Nullable
 	protected String[] get(Event event) {
-		String[] s = strings.getArray(event);
-		String d = delimiter != null ? delimiter.getSingle(event) : "";
-		if (s.length == 0 || d == null)
+		String[] strings = this.strings.getArray(event);
+		String delimiter = this.delimiter != null ? this.delimiter.getSingle(event) : "";
+		if (strings.length == 0 || delimiter == null)
 			return new String[0];
 		if (join) {
-			return new String[] {StringUtils.join(s, d)};
+			return new String[] {StringUtils.join(strings, delimiter)};
 		} else {
-			return s[0].split(regex ? d : (caseSensitivity ? "" : "(?i)") + Pattern.quote(d), -1);
+			return strings[0].split(regex ? delimiter : (caseSensitivity ? "" : "(?i)") + Pattern.quote(delimiter), -1);
 		}
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprJoinSplit.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprJoinSplit.java
@@ -80,8 +80,8 @@ public class ExprJoinSplit extends SimpleExpression<String> {
 	@Override
 	@Nullable
 	protected String[] get(Event event) {
-		final String[] s = strings.getArray(event);
-		final String d = delimiter != null ? delimiter.getSingle(event) : "";
+		String[] s = strings.getArray(event);
+		String d = delimiter != null ? delimiter.getSingle(event) : "";
 		if (s.length == 0 || d == null)
 			return new String[0];
 		if (join) {
@@ -102,8 +102,11 @@ public class ExprJoinSplit extends SimpleExpression<String> {
 	}
 
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return join ? "join " + strings.toString(e, debug) + (delimiter != null ? " with " + delimiter.toString(e, debug) : "") : ((regex ? "regex " : "") + "split " + strings.toString(e, debug) + (delimiter != null ? " at " + delimiter.toString(e, debug) : ""));
+	public String toString(@Nullable Event event, boolean debug) {
+		if (join)
+			return "join " + strings.toString(event, debug) + (delimiter != null ? " with " + delimiter.toString(event, debug) : "");
+		return (regex ? "regex " : "") + "split " + strings.toString(event, debug) + (delimiter != null ? " at " + delimiter.toString(event, debug) : "")
+			+ (regex ? "" : "(case sensitive: " + caseSensitivity + ")");
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprJoinSplit.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprJoinSplit.java
@@ -51,8 +51,8 @@ public class ExprJoinSplit extends SimpleExpression<String> {
 	static {
 		Skript.registerExpression(ExprJoinSplit.class, String.class, ExpressionType.COMBINED,
 			"(concat[enate]|join) %strings% [(with|using|by) [[the] delimiter] %-string%]",
-			"split %string% (at|using|by) [[the] delimiter] %string%",
-			"%string% split (at|using|by) [[the] delimiter] %string%",
+			"split %string% (at|using|by) [[the] delimiter] %string% [case:with case sensitivity]",
+			"%string% split (at|using|by) [[the] delimiter] %string% [case:with case sensitivity]",
 			"regex split %string% (at|using|by) [[the] delimiter] %string%",
 			"regex %string% split (at|using|by) [[the] delimiter] %string%");
 	}
@@ -66,12 +66,12 @@ public class ExprJoinSplit extends SimpleExpression<String> {
 	@Nullable
 	private Expression<String> delimiter;
 
-	@SuppressWarnings({"unchecked", "null"})
 	@Override
-	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
+	@SuppressWarnings({"unchecked", "null"})
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		join = matchedPattern == 0;
 		regex = matchedPattern >= 3;
-		caseSensitivity = SkriptConfig.caseSensitive.value();
+		caseSensitivity = SkriptConfig.caseSensitive.value() || parseResult.hasTag("case");
 		strings = (Expression<String>) exprs[0];
 		delimiter = (Expression<String>) exprs[1];
 		return true;
@@ -79,9 +79,9 @@ public class ExprJoinSplit extends SimpleExpression<String> {
 
 	@Override
 	@Nullable
-	protected String[] get(final Event e) {
-		final String[] s = strings.getArray(e);
-		final String d = delimiter != null ? delimiter.getSingle(e) : "";
+	protected String[] get(Event event) {
+		final String[] s = strings.getArray(event);
+		final String d = delimiter != null ? delimiter.getSingle(event) : "";
 		if (s.length == 0 || d == null)
 			return new String[0];
 		if (join) {


### PR DESCRIPTION
### Description
This PR makes the split expression use the config's case sensitivity option

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** https://github.com/SkriptLang/Skript/issues/4886
