### PR TITLE
Fix ExprSets NPE

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprSets.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSets.java
@@ -69,8 +69,8 @@ public class ExprSets extends SimpleExpression<Object> {
 	private Expression<ItemType> types;
 	private int pattern = -1;
 
-	@SuppressWarnings("unchecked")
 	@Override
+	@SuppressWarnings("unchecked")
 	public boolean init(Expression<?>[] vars, int matchedPattern, Kleenean isDelayed, ParseResult parser) {
 		if (vars.length > 0)
 			types = (Expression<ItemType>) vars[0];
@@ -101,7 +101,7 @@ public class ExprSets extends SimpleExpression<Object> {
 	public Iterator<Object> iterator(Event event) {
 		if (pattern == 4)
 			return new ArrayIterator<>(SkriptColor.values());
-		if (pattern == 0 || pattern == 3)
+		if (pattern == 0 || pattern == 2)
 			return new Iterator<Object>() {
 				
 				private final Iterator<Material> iter = new ArrayIterator<>(Material.values());
@@ -160,7 +160,12 @@ public class ExprSets extends SimpleExpression<Object> {
 			}
 		});
 	}
-	
+
+	@Override
+	public boolean isSingle() {
+		return false;
+	}
+
 	@Override
 	public Class<? extends Object> getReturnType() {
 		if (pattern == 4)
@@ -176,12 +181,7 @@ public class ExprSets extends SimpleExpression<Object> {
 			return "colours";
 		return (pattern < 2 ? "blocks" : "items") + (types != null ? " of type" + (types.isSingle() ? "" : "s") + " " + types.toString(event, debug) : "");
 	}
-	
-	@Override
-	public boolean isSingle() {
-		return false;
-	}
-	
+
 	@Override
 	public boolean isLoopOf(String s) {
 		return pattern == 4 && (s.equalsIgnoreCase("color") || s.equalsIgnoreCase("colour"))|| pattern >= 2 && s.equalsIgnoreCase("block") || pattern < 2 && s.equalsIgnoreCase("item");

--- a/src/main/java/ch/njol/skript/expressions/ExprSets.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSets.java
@@ -181,7 +181,9 @@ public class ExprSets extends SimpleExpression<Object> {
 
 	@Override
 	public boolean isLoopOf(String s) {
-		return (pattern == 4 && s.equalsIgnoreCase("color") || s.equalsIgnoreCase("colour")) || (pattern >= 2 && s.equalsIgnoreCase("block")) || (pattern < 2 && s.equalsIgnoreCase("item"));
+		return (pattern == 4 && s.equalsIgnoreCase("color") || s.equalsIgnoreCase("colour"))
+			|| (pattern == 2 || pattern == 3 && s.equalsIgnoreCase("block"))
+			|| (pattern < 2 && s.equalsIgnoreCase("item"));
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprSets.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSets.java
@@ -67,7 +67,7 @@ public class ExprSets extends SimpleExpression<Object> {
 
 	@Nullable
 	private Expression<ItemType> types;
-	private int pattern = -1;
+	private int pattern;
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -130,9 +130,8 @@ public class ExprSets extends SimpleExpression<Object> {
 
 			@Override
 			public boolean hasNext() {
-				while (!current.hasNext() && it.hasNext()) {
+				while (!current.hasNext() && it.hasNext())
 					current = it.next().getAll().iterator();
-				}
 				return current.hasNext();
 			}
 
@@ -152,8 +151,7 @@ public class ExprSets extends SimpleExpression<Object> {
 			if (ob == null)
 				return false;
 			if (ob instanceof ItemStack)
-				if (!((ItemStack) ob).getType().isBlock())
-					return false;
+				return ((ItemStack) ob).getType().isBlock();
 			return true;
 		});
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprSets.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSets.java
@@ -62,7 +62,7 @@ public class ExprSets extends SimpleExpression<Object> {
 		Skript.registerExpression(ExprSets.class, Object.class, ExpressionType.COMBINED,
 				"[(all [[of] the]|the|every)] item(s|[ ]types)", "[(all [[of] the]|the)] items of type[s] %itemtypes%",
 				"[(all [[of] the]|the|every)] block(s|[ ]types)", "[(all [[of] the]|the)] blocks of type[s] %itemtypes%",
-				"[(all [[of] the]|the|every)] colo[u]rs)");
+				"[(all [[of] the]|the|every)] colo[u]rs");
 	}
 
 	@Nullable


### PR DESCRIPTION
### Description
This PR fixes the NPE being thrown by checking for the wrong pattern in the get method (and also cleans up like the whole class)

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** https://github.com/SkriptLang/Skript/issues/5065
