### PR TITLE
Add lang file updates on version change

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ latest version of Skript.
 Please see our [contribution guidelines](https://github.com/SkriptLang/Skript/blob/master/.github/contributing.md)
 before reporting issues.
 
+## Help Us Test
+We have an [official Discord community](https://discord.gg/ZPsZAg6ygu) for testing Skript's new features and releases.
+
 ## A Note About Add-ons
 We don't support add-ons here, even though some of Skript developers have also
 developed their own add-ons.

--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -1218,13 +1218,11 @@ public final class Skript extends JavaPlugin implements Listener {
 	 * @return A {@link SkriptAddon} representing Skript.
 	 */
 	public static SkriptAddon getAddonInstance() {
-		SkriptAddon a = addon;
-		if (a == null) {
+		if (addon == null) {
 			addon = new SkriptAddon(Skript.getInstance());
 			addon.setLanguageFileDirectory("lang");
-			return addon;
 		}
-		return a;
+		return addon;
 	}
 	
 	// ================ CONDITIONS & EFFECTS & SECTIONS ================

--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -1218,12 +1218,13 @@ public final class Skript extends JavaPlugin implements Listener {
 	 * @return A {@link SkriptAddon} representing Skript.
 	 */
 	public static SkriptAddon getAddonInstance() {
-		final SkriptAddon a = addon;
-		if (a == null)
-			return addon = new SkriptAddon(Skript.getInstance())
-					.setLanguageFileDirectory("lang");
-		else
-			return a;
+		SkriptAddon a = addon;
+		if (a == null) {
+			addon = new SkriptAddon(Skript.getInstance());
+			addon.setLanguageFileDirectory("lang");
+			return addon;
+		}
+		return a;
 	}
 	
 	// ================ CONDITIONS & EFFECTS & SECTIONS ================

--- a/src/main/java/ch/njol/skript/config/Config.java
+++ b/src/main/java/ch/njol/skript/config/Config.java
@@ -184,11 +184,18 @@ public class Config implements Comparable<Config> {
 	}
 	
 	public boolean setValues(final Config other, final String... excluded) {
-		return setValues(other, false, excluded);
+		return getMainNode().setValues(other.getMainNode(), excluded);
 	}
 
-	public boolean setValues(Config other, boolean countValues, String... excluded) {
-		return getMainNode().setValues(other.getMainNode(), countValues, excluded);
+	/**
+	 * Compares the keys and values of this Config and another.
+	 * @param other The other Config.
+	 * @param excluded Keys to exclude from this comparison.
+	 * @return True if there are differences in the keys and their values
+	 *  of this Config and the other Config.
+	 */
+	public boolean compareValues(Config other, String... excluded) {
+		return getMainNode().compareValues(other.getMainNode(), excluded);
 	}
 	
 	@Nullable

--- a/src/main/java/ch/njol/skript/config/Config.java
+++ b/src/main/java/ch/njol/skript/config/Config.java
@@ -184,7 +184,11 @@ public class Config implements Comparable<Config> {
 	}
 	
 	public boolean setValues(final Config other, final String... excluded) {
-		return getMainNode().setValues(other.getMainNode(), excluded);
+		return setValues(other, false, excluded);
+	}
+
+	public boolean setValues(Config other, boolean countValues, String... excluded) {
+		return getMainNode().setValues(other.getMainNode(), countValues, excluded);
 	}
 	
 	@Nullable

--- a/src/main/java/ch/njol/skript/localization/Language.java
+++ b/src/main/java/ch/njol/skript/localization/Language.java
@@ -308,7 +308,7 @@ public class Language {
 				Config newLangConfig = new Config(newConfigIn, "Skript.jar/" + langFileName, false, false, ":");
 				newConfigIn.close();
 
-				if (newLangConfig.setValues(langConfig, true, "version")) { // New config is different
+				if (!newLangConfig.compareValues(langConfig, "version")) {
 					File langFile = new File(Skript.getInstance().getDataFolder(), langFileName);
 
 					File langFileBackup = FileUtils.backup(langFile);

--- a/src/main/java/ch/njol/skript/localization/Language.java
+++ b/src/main/java/ch/njol/skript/localization/Language.java
@@ -308,14 +308,16 @@ public class Language {
 				Config newLangConfig = new Config(newConfigIn, "Skript.jar/" + langFileName, false, false, ":");
 				newConfigIn.close();
 
+				File langFile = new File(Skript.getInstance().getDataFolder(), langFileName);
 				if (!newLangConfig.compareValues(langConfig, "version")) {
-					File langFile = new File(Skript.getInstance().getDataFolder(), langFileName);
-
 					File langFileBackup = FileUtils.backup(langFile);
 					newLangConfig.getMainNode().set("version", Skript.getVersion().toString());
 					langConfig = newLangConfig;
 					langConfig.save(langFile);
 					Skript.info("The lang file '" + name + ".lang' has been updated to the latest version. A backup of your old lang file has been created as " + langFileBackup.getName());
+				} else { // Only the version changed, don't bother creating a backup
+					langConfig.getMainNode().set("version", Skript.getVersion().toString());
+					langConfig.save(langFile);
 				}
 			}
 

--- a/src/main/java/ch/njol/skript/localization/Language.java
+++ b/src/main/java/ch/njol/skript/localization/Language.java
@@ -22,6 +22,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptAddon;
 import ch.njol.skript.config.Config;
 import ch.njol.skript.util.ExceptionUtils;
+import ch.njol.skript.util.FileUtils;
 import ch.njol.skript.util.Version;
 import org.bukkit.plugin.Plugin;
 import org.eclipse.jdt.annotation.Nullable;
@@ -197,8 +198,8 @@ public class Language {
 				englishIs = null;
 			}
 		}
-		HashMap<String, String> def = load(defaultIs, "default");
-		HashMap<String, String> en = load(englishIs, "english");
+		HashMap<String, String> def = load(defaultIs, "default", false);
+		HashMap<String, String> en = load(englishIs, "english", addon == Skript.getAddonInstance());
 
 		String v = def.get("version");
 		if (v == null)
@@ -220,9 +221,9 @@ public class Language {
 		name = "" + name.toLowerCase(Locale.ENGLISH);
 
 		localizedLanguage = new HashMap<>();
-		boolean exists = load(Skript.getAddonInstance(), name);
+		boolean exists = load(Skript.getAddonInstance(), name, true);
 		for (SkriptAddon addon : Skript.getAddons()) {
-			exists |= load(addon, name);
+			exists |= load(addon, name, false);
 		}
 		if (!exists) {
 			if (name.equals("english")) {
@@ -241,18 +242,18 @@ public class Language {
 		return true;
 	}
 	
-	private static boolean load(SkriptAddon addon, String name) {
+	private static boolean load(SkriptAddon addon, String name, boolean tryUpdate) {
 		if (addon.getLanguageFileDirectory() == null)
 			return false;
 		// Backwards addon compatibility
 		if (name.equals("english") && addon.plugin.getResource(addon.getLanguageFileDirectory() + "/default.lang") == null)
 			return true;
 
-		HashMap<String, String> l = load(addon.plugin.getResource(addon.getLanguageFileDirectory() + "/" + name + ".lang"), name);
+		HashMap<String, String> l = load(addon.plugin.getResource(addon.getLanguageFileDirectory() + "/" + name + ".lang"), name, tryUpdate);
 		File file = new File(addon.plugin.getDataFolder(), addon.getLanguageFileDirectory() + File.separator + name + ".lang");
 		try {
 			if (file.exists())
-				l.putAll(load(new FileInputStream(file), name));
+				l.putAll(load(new FileInputStream(file), name, tryUpdate));
 		} catch (FileNotFoundException e) {
 			assert false;
 		}
@@ -289,19 +290,39 @@ public class Language {
 		return true;
 	}
 	
-	private static HashMap<String, String> load(@Nullable InputStream in, String name) {
+	private static HashMap<String, String> load(@Nullable InputStream in, String name, boolean tryUpdate) {
 		if (in == null)
 			return new HashMap<>();
+
 		try {
-			return new Config(in, name + ".lang", false, false, ":").toMap(".");
+			Config langConfig = new Config(in, name + ".lang", false, false, ":");
+			in.close();
+
+			if (tryUpdate && !Skript.getVersion().toString().equals(langConfig.get("version"))) {
+				String langFileName = "lang/" + name + ".lang";
+
+				InputStream newConfigIn = Skript.getInstance().getResource(langFileName);
+				if (newConfigIn == null) {
+					Skript.error("The lang file '" + name + ".lang' is outdated, but Skript couldn't find the newest version of it in its jar.");
+					return new HashMap<>();
+				}
+				Config newLangConfig = new Config(newConfigIn, "Skript.jar/" + langFileName, false, false, ":");
+				newConfigIn.close();
+
+				File langFile = new File(Skript.getInstance().getDataFolder(), langFileName);
+
+				File langFileBackup = FileUtils.backup(langFile);
+				newLangConfig.getMainNode().set("version", Skript.getVersion().toString());
+				langConfig = newLangConfig;
+				langConfig.save(langFile);
+				Skript.info("The lang file '" + name + ".lang' has been updated to the latest version. A backup of your old lang file has been created as " + langFileBackup.getName());
+			}
+
+			return langConfig.toMap(".");
 		} catch (IOException e) {
 			//noinspection ThrowableNotThrown
 			Skript.exception(e, "Could not load the language file '" + name + ".lang': " + ExceptionUtils.toString(e));
 			return new HashMap<>();
-		} finally {
-			try {
-				in.close();
-			} catch (IOException ignored) { }
 		}
 	}
 

--- a/src/main/java/ch/njol/skript/localization/Language.java
+++ b/src/main/java/ch/njol/skript/localization/Language.java
@@ -309,13 +309,15 @@ public class Language {
 				Config newLangConfig = new Config(newConfigIn, "Skript.jar/" + langFileName, false, false, ":");
 				newConfigIn.close();
 
-				File langFile = new File(Skript.getInstance().getDataFolder(), langFileName);
+				if (newLangConfig.setValues(langConfig, true, "version")) { // New config is different
+					File langFile = new File(Skript.getInstance().getDataFolder(), langFileName);
 
-				File langFileBackup = FileUtils.backup(langFile);
-				newLangConfig.getMainNode().set("version", Skript.getVersion().toString());
-				langConfig = newLangConfig;
-				langConfig.save(langFile);
-				Skript.info("The lang file '" + name + ".lang' has been updated to the latest version. A backup of your old lang file has been created as " + langFileBackup.getName());
+					File langFileBackup = FileUtils.backup(langFile);
+					newLangConfig.getMainNode().set("version", Skript.getVersion().toString());
+					langConfig = newLangConfig;
+					langConfig.save(langFile);
+					Skript.info("The lang file '" + name + ".lang' has been updated to the latest version. A backup of your old lang file has been created as " + langFileBackup.getName());
+				}
 			}
 
 			return langConfig.toMap(".");

--- a/src/main/java/ch/njol/skript/localization/Language.java
+++ b/src/main/java/ch/njol/skript/localization/Language.java
@@ -294,9 +294,8 @@ public class Language {
 		if (in == null)
 			return new HashMap<>();
 
-		try {
+		try (in) {
 			Config langConfig = new Config(in, name + ".lang", false, false, ":");
-			in.close();
 
 			if (tryUpdate && !Skript.getVersion().toString().equals(langConfig.get("version"))) {
 				String langFileName = "lang/" + name + ".lang";

--- a/src/main/java/ch/njol/skript/localization/Language.java
+++ b/src/main/java/ch/njol/skript/localization/Language.java
@@ -294,7 +294,7 @@ public class Language {
 		if (in == null)
 			return new HashMap<>();
 
-		try (in) {
+		try {
 			Config langConfig = new Config(in, name + ".lang", false, false, ":");
 
 			if (tryUpdate && !Skript.getVersion().toString().equals(langConfig.get("version"))) {
@@ -324,6 +324,10 @@ public class Language {
 			//noinspection ThrowableNotThrown
 			Skript.exception(e, "Could not load the language file '" + name + ".lang': " + ExceptionUtils.toString(e));
 			return new HashMap<>();
+		} finally {
+			try {
+				in.close();
+			} catch (IOException ignored) { }
 		}
 	}
 


### PR DESCRIPTION
### Description
This PR enables lang file updates when Skript detects a version change.
There are a few questions where I'm looking for input though:
- Should we allow addons to opt into this feature? Should it only be for Skript? My thought is that addon opt in would only be possible for addons that handle language files the same as Skript (I'm not sure any do tbh)
- Right now, it *always* updates and creates a backup of a lang file if a version change is detected. This is because Skript has no built-in capability of detecting differences in *values* of Config objects, only the actual keys themselves. Should we add a way for Skript to check if the values themselves have changed? It might result in *slightly* longer startup time when the version changes, but it might be better than just assuming it's changed.

---
**Target Minecraft Versions:** Any
**Requirements:** N/A
**Related Issues:** Needs merged before:
- https://github.com/SkriptLang/Skript/pull/4108
