### PR TITLE
Remove Dependabot language label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,15 @@
 version: 2
 updates:
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "daily"
-- package-ecosystem: gradle
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+        interval: "daily"
+    labels:
+      - "dependencies"
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+        interval: daily
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
### Description
Removes the language / ecosystem labels from Dependabot PRs, but keeps the generic `dependencies` label, see https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#labels
Also changes the file indentation to match that of the Dependabot docs, IMO it's better because the `-` from lists is no longer on the same level as its parent

*When merging, delete the `java` label (and `github_actions` label if it exists)*

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
