### PR TITLE
Allow parse tags to be expanded onto optional pattern elements

### DIFF
--- a/src/main/java/ch/njol/skript/patterns/OptionalPatternElement.java
+++ b/src/main/java/ch/njol/skript/patterns/OptionalPatternElement.java
@@ -46,6 +46,10 @@ public class OptionalPatternElement extends PatternElement {
 		return matchNext(expr, matchResult);
 	}
 
+	public PatternElement getPatternElement() {
+		return patternElement;
+	}
+
 	@Override
 	public String toString() {
 		return "[" + patternElement.toFullString() + "]";

--- a/src/main/java/ch/njol/skript/patterns/ParseTagPatternElement.java
+++ b/src/main/java/ch/njol/skript/patterns/ParseTagPatternElement.java
@@ -51,18 +51,28 @@ public class ParseTagPatternElement extends PatternElement {
 			if (next instanceof LiteralPatternElement) {
 				// (:a)
 				tag = next.toString().trim();
-			} else if (next instanceof GroupPatternElement && ((GroupPatternElement) next).getPatternElement() instanceof ChoicePatternElement) {
-				// :(a|b)
-				ChoicePatternElement choicePatternElement = (ChoicePatternElement) ((GroupPatternElement) next).getPatternElement();
-				List<PatternElement> patternElements = choicePatternElement.getPatternElements();
-				for (int i = 0; i < patternElements.size(); i++) {
-					PatternElement patternElement = patternElements.get(i);
-					// Prevent a pattern such as :(a|b|) from being turned into (a:a|b:b|:), instead (a:a|b:b|)
-					if (patternElement instanceof LiteralPatternElement && !patternElement.toString().isEmpty()) {
-						ParseTagPatternElement newTag = new ParseTagPatternElement(patternElement.toString().trim());
-						newTag.setNext(patternElement);
-						newTag.originalNext = patternElement;
-						patternElements.set(i, newTag);
+			} else {
+				// Get the inner element from either a group or optional pattern element
+				PatternElement inner = null;
+				if (next instanceof GroupPatternElement) {
+					inner = ((GroupPatternElement) next).getPatternElement();
+				} else if (next instanceof OptionalPatternElement) {
+					inner = ((OptionalPatternElement) next).getPatternElement();
+				}
+
+				if (inner instanceof ChoicePatternElement) {
+					// :(a|b)
+					ChoicePatternElement choicePatternElement = (ChoicePatternElement) inner;
+					List<PatternElement> patternElements = choicePatternElement.getPatternElements();
+					for (int i = 0; i < patternElements.size(); i++) {
+						PatternElement patternElement = patternElements.get(i);
+						// Prevent a pattern such as :(a|b|) from being turned into (a:a|b:b|:), instead (a:a|b:b|)
+						if (patternElement instanceof LiteralPatternElement && !patternElement.toString().isEmpty()) {
+							ParseTagPatternElement newTag = new ParseTagPatternElement(patternElement.toString().trim());
+							newTag.setNext(patternElement);
+							newTag.originalNext = patternElement;
+							patternElements.set(i, newTag);
+						}
 					}
 				}
 			}

--- a/src/main/java/ch/njol/skript/patterns/ParseTagPatternElement.java
+++ b/src/main/java/ch/njol/skript/patterns/ParseTagPatternElement.java
@@ -61,7 +61,7 @@ public class ParseTagPatternElement extends PatternElement {
 				}
 
 				if (inner instanceof ChoicePatternElement) {
-					// :(a|b)
+					// :(a|b) or :[a|b]
 					ChoicePatternElement choicePatternElement = (ChoicePatternElement) inner;
 					List<PatternElement> patternElements = choicePatternElement.getPatternElements();
 					for (int i = 0; i < patternElements.size(); i++) {


### PR DESCRIPTION
### Description
Allows for syntax like `:[abc|def]` meaning `[(abc:abc|def:def)]`

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
