### PR TITLE
add to to within

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprBlocks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBlocks.java
@@ -63,7 +63,7 @@ public class ExprBlocks extends SimpleExpression<Block> {
 				"[(all [[of] the]|the)] blocks from %location% [on] %direction%",
 				"[(all [[of] the]|the)] blocks from %location% to %location%",
 				"[(all [[of] the]|the)] blocks between %location% and %location%",
-				"[(all [[of] the]|the)] blocks within %location% and %location%",
+				"[(all [[of] the]|the)] blocks within %location% (to|and) %location%",
 				"[(all [[of] the]|the)] blocks (in|within) %chunk%");
 	}
 	


### PR DESCRIPTION
Add `to` to within. Follows the SkQuery syntax which can be removed from SkQuery after this. I always use `to` as SkQuery is way older than the within syntax in Skript.
