### PR TITLE
Change list parsing order

### DIFF
--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -673,9 +673,10 @@ public class SkriptParser {
 				log.printError();
 				return null;
 			}
-			
+
+			// `b` is the first piece included, `a` is the last
 			outer: for (int b = 0; b < pieces.size();) {
-				for (int a = pieces.size() - b; a >= 1; a--) {
+				for (int a = 1; a <= pieces.size() - b; a++) {
 					if (b == 0 && a == pieces.size()) // i.e. the whole expression - already tried to parse above
 						continue;
 					final int x = pieces.get(b)[0], y = pieces.get(b + a - 1)[1];
@@ -799,9 +800,10 @@ public class SkriptParser {
 				log.printError();
 				return null;
 			}
-			
+
+			// `b` is the first piece included, `a` is the last
 			outer: for (int b = 0; b < pieces.size();) {
-				for (int a = pieces.size() - b; a >= 1; a--) {
+				for (int a = 1; a <= pieces.size() - b; a++) {
 					if (b == 0 && a == pieces.size()) // i.e. the whole expression - already tried to parse above
 						continue;
 					final int x = pieces.get(b)[0], y = pieces.get(b + a - 1)[1];


### PR DESCRIPTION
### Description
Changes the order of list parsing. For example: `1, 2 and 3`. Skript starts by separating the whole expression into `n` pieces (already taking things like parentheses into account), here "1", "2" and "3". Then, it starts parsing the pieces.

Before this change, it takes the first `n-1` pieces, and tries parsing them together as a single expression. If that failed, go for the first `n-2` and so on, until one worked, at which point it'd advance to the remaining pieces and do the same on those. 
With this change, it instead first looks at the first piece, then at the first two, then the first three etc.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #4025
