### PR TITLE
Fix bucket empty block event value for irregular water-filled buckets

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -631,7 +631,7 @@ public final class BukkitEventValues {
 			@Override
 			public Block get(final PlayerBucketEmptyEvent e) {
 				final BlockState s = e.getBlockClicked().getRelative(e.getBlockFace()).getState();
-				s.setType(e.getBucket() == Material.WATER_BUCKET ? stationaryWater.getMaterial() : stationaryLava.getMaterial());
+				s.setType(e.getBucket() == Material.LAVA_BUCKET ? stationaryLava.getMaterial() : stationaryWater.getMaterial());
 				s.setRawData((byte) 0);
 				return new BlockStateBlock(s, true);
 			}


### PR DESCRIPTION
### Description
The previous code assumed that if a bucket was emptied, and it wasn't a water bucket, the resulting block would be lava. Since the new update where you can have fish in buckets, this no longer holds. This change will work until Minecraft adds a new placeable bucket with something other than water or lava, or until they add lava-placing buckets that are not Material.LAVA_BUCKET (like lava bucket with fish in it).

Current solution isn't great, I'd prefer something that doesn't depend on the bucket. However, I don't think we can without removing the BlockStateBlock stuff, which allows `event-block` to be compared to water, because `event.getBlock()` doesn't do this as events are called *before* their effect takes place, the effect being water placed in the world in this case.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #5134
