### PR TITLE
Make BlockPlaceEvent's event-item value use getItemInHand()

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -238,6 +238,13 @@ public final class BukkitEventValues {
 				return e.getPlayer();
 			}
 		}, 0);
+		EventValues.registerEventValue(BlockPlaceEvent.class, ItemStack.class, new Getter<ItemStack, BlockPlaceEvent>() {
+			@Override
+			@Nullable
+			public ItemStack get(final BlockPlaceEvent e) {
+				return e.getItemInHand();
+			}
+		}, 0);
 		EventValues.registerEventValue(BlockPlaceEvent.class, Block.class, new Getter<Block, BlockPlaceEvent>() {
 			@Override
 			public Block get(final BlockPlaceEvent e) {


### PR DESCRIPTION
### Description

Makes the `event-item` event value return the itemstack from BlockPlaceEvent#getItemInHand().
This allows event-item to maintain information like name, lore, and nbt instead of being the plain item that was placed.

`player's tool` is a current solution to having this behavior, but the user would have to manually check both the main and off hands to see which was placed. Having `event-item` return the correct item seems like a more elegant and useful solution.

The current implementation may be breaking as it returns the full itemstack, and users may rely on `event-item` returning a single item in comparisons. The code can easily be changed to return a single item to prevent this, though I think being able to get the amount of the placed item is a worthwhile addition.

---
**Target Minecraft Versions:** Any
**Requirements:** None
**Related Issues:** None
