### PR TITLE
Implement unregistering event listeners when possible

### DIFF
--- a/src/main/java/ch/njol/skript/SkriptEventHandler.java
+++ b/src/main/java/ch/njol/skript/SkriptEventHandler.java
@@ -279,20 +279,39 @@ public final class SkriptEventHandler {
 				&& priority == pair2.getSecond().getEvent().getEventPriority()
 				&& handlerList == getHandlerList(pair2.getFirst())
 			)) { // We can unregister this listener :)
-				for (RegisteredListener registeredListener : handlerList.getRegisteredListeners()) {
-					Listener listener = registeredListener.getListener();
+				Listener listener = getSkriptListener(handlerList, priority);
+				if (listener != null) {
+					handlerList.unregister(listener);
 
-					if (
-						registeredListener.getPlugin() == Skript.getInstance()
-							&& listener instanceof PriorityListener
-							&& ((PriorityListener) listener).priority == priority
-					)
-						handlerList.unregister(listener);
+					// Special handling for this event
+					if (pair.getFirst().equals(PlayerInteractEntityEvent.class)) {
+						// No null checks needed as this can all be asserted as true due to the main condition
+						HandlerList specialHandlerList = getHandlerList(PlayerInteractAtEntityEvent.class);
+						assert specialHandlerList != null;
+						Listener specialListener = getSkriptListener(specialHandlerList, priority);
+						assert specialListener != null;
+						specialHandlerList.unregister(specialListener);
+					}
 				}
 			}
 
 			return true;
 		});
+	}
+
+	@Nullable
+	private static Listener getSkriptListener(HandlerList handlerList, EventPriority priority) {
+		for (RegisteredListener registeredListener : handlerList.getRegisteredListeners()) {
+			Listener listener = registeredListener.getListener();
+			if (
+				registeredListener.getPlugin() == Skript.getInstance()
+				&& listener instanceof PriorityListener
+				&& ((PriorityListener) listener).priority == priority
+			) {
+				return listener;
+			}
+		}
+		return null;
 	}
 
 	/**
@@ -361,8 +380,9 @@ public final class SkriptEventHandler {
 				registeredListener.getPlugin() == Skript.getInstance()
 				&& listener instanceof PriorityListener
 				&& ((PriorityListener) listener).priority == priority
-			)
+			) {
 				return true;
+			}
 		}
 		return false;
 	}

--- a/src/main/java/ch/njol/skript/events/EvtClick.java
+++ b/src/main/java/ch/njol/skript/events/EvtClick.java
@@ -64,7 +64,9 @@ public class EvtClick extends SkriptEvent {
 	private static final ClickEventTracker entityInteractTracker = new ClickEventTracker(Skript.getInstance());
 	
 	static {
-		Class<? extends PlayerEvent>[] eventTypes = CollectionUtils.array(PlayerInteractEvent.class, PlayerInteractEntityEvent.class);
+		Class<? extends PlayerEvent>[] eventTypes = CollectionUtils.array(
+			PlayerInteractEvent.class, PlayerInteractEntityEvent.class, PlayerInteractAtEntityEvent.class
+		);
 		
 		Skript.registerEvent("Click", EvtClick.class, eventTypes,
 				"[(" + RIGHT + "¦right|" + LEFT + "¦left)(| |-)][mouse(| |-)]click[ing] [on %-entitydata/itemtype%] [(with|using|holding) %-itemtype%]",


### PR DESCRIPTION
### Description
This PR expands SkriptEventHandler's unregister method to attempt to unregister Skript's listener from the event's HandlerList if possible (meaning there are no other triggers depending on it).

Very brief and minor testing seems to indicate that it works. Logic was taken from other methods where these sorts of checks are done.

---
**Target Minecraft Versions:** Any
**Requirements:** None
**Related Issues:** It's been discussed, but I don't think there's an issue
