### PR TITLE
Fix isQuotedCorrectly, to account for 1-char string `"`

### DIFF
--- a/src/main/java/ch/njol/skript/lang/VariableString.java
+++ b/src/main/java/ch/njol/skript/lang/VariableString.java
@@ -159,7 +159,7 @@ public class VariableString implements Expression<String> {
 	 * @return Whether the string is quoted correctly
 	 */
 	public static boolean isQuotedCorrectly(String s, boolean withQuotes) {
-		if (withQuotes && (!s.startsWith("\"") || !s.endsWith("\"")))
+		if (withQuotes && (!s.startsWith("\"") || !s.endsWith("\"") || s.length() < 2))
 			return false;
 		boolean quote = false;
 		boolean percentage = false;


### PR DESCRIPTION
### Description
Fixes VariableString#isQuoted correctly, to return false for the input string `"` (with `withQuotes=true`).

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #5149
