### PR TITLE
The Lifetime PR

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondHasUnlimitedLifetime.java
+++ b/src/main/java/ch/njol/skript/conditions/CondHasUnlimitedLifetime.java
@@ -47,4 +47,5 @@ public class CondHasUnlimitedLifetime extends PropertyCondition<Entity> {
 	protected String getPropertyName() {
 		return "unlimited lifetime";
 	}
+
 }

--- a/src/main/java/ch/njol/skript/conditions/CondHasUnlimitedLifetime.java
+++ b/src/main/java/ch/njol/skript/conditions/CondHasUnlimitedLifetime.java
@@ -1,0 +1,50 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.conditions;
+
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
+
+@Name("Item Has Unlimited Lifetime")
+@Description("Checks whether the given entities are an item with an unlimited lifetime.")
+@Examples("if last dropped item has an unlimited lifetime:")
+@Since("INSERT VERSION")
+public class CondHasUnlimitedLifetime extends PropertyCondition<Entity> {
+
+	static {
+		register(CondHasUnlimitedLifetime.class, PropertyType.HAVE, "[an] (unlimited|infinite) life(time|span) ", "entities");
+	}
+
+	@Override
+	public boolean check(Entity entity) {
+		if (!(entity instanceof Item))
+			return false;
+		return ((Item) entity).isUnlimitedLifetime();
+	}
+
+	@Override
+	protected String getPropertyName() {
+		return "unlimited lifetime";
+	}
+}

--- a/src/main/java/ch/njol/skript/conditions/CondHasUnlimitedLifetime.java
+++ b/src/main/java/ch/njol/skript/conditions/CondHasUnlimitedLifetime.java
@@ -33,7 +33,7 @@ import org.bukkit.entity.Item;
 public class CondHasUnlimitedLifetime extends PropertyCondition<Entity> {
 
 	static {
-		register(CondHasUnlimitedLifetime.class, PropertyType.HAVE, "[an] (unlimited|infinite) life(time|span) ", "entities");
+		register(CondHasUnlimitedLifetime.class, PropertyType.HAVE, "[an] (unlimited|infinite) life(time|span)", "entities");
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/effects/EffUnlimitedLifetime.java
+++ b/src/main/java/ch/njol/skript/effects/EffUnlimitedLifetime.java
@@ -22,6 +22,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -37,6 +38,7 @@ import org.eclipse.jdt.annotation.Nullable;
 	"drop tripwire hook at player's location",
 	"make last dropped item have unlimited lifetime"
 })
+@Since("INSERT VERSION")
 public class EffUnlimitedLifetime extends Effect {
 
 	static {
@@ -53,8 +55,7 @@ public class EffUnlimitedLifetime extends Effect {
 
 	@Override
 	protected void execute(Event event) {
-		Entity[] entities = entityExpr.getArray(event);
-		for (Entity entity : entities) {
+		for (Entity entity : entityExpr.getArray(event)) {
 			if (!(entity instanceof Item))
 				continue;
 			((Item) entity).setUnlimitedLifetime(true);

--- a/src/main/java/ch/njol/skript/effects/EffUnlimitedLifetime.java
+++ b/src/main/java/ch/njol/skript/effects/EffUnlimitedLifetime.java
@@ -40,8 +40,7 @@ import org.eclipse.jdt.annotation.Nullable;
 public class EffUnlimitedLifetime extends Effect {
 
 	static {
-		Skript.registerEffect(EffUnlimitedLifetime.class,
-			"make %entities% have [an] (unlimited|infinite) life(time|span)");
+		Skript.registerEffect(EffUnlimitedLifetime.class, "make %entities% have [an] (unlimited|infinite) life(time|span)");
 	}
 
 	private Expression<Entity> entityExpr;

--- a/src/main/java/ch/njol/skript/effects/EffUnlimitedLifetime.java
+++ b/src/main/java/ch/njol/skript/effects/EffUnlimitedLifetime.java
@@ -35,7 +35,8 @@ import org.eclipse.jdt.annotation.Nullable;
 @Description("Makes a dropped item have an unlimited lifetime.")
 @Examples({
 	"drop tripwire hook at player's location",
-	"make last dropped item have unlimited lifetime"})
+	"make last dropped item have unlimited lifetime"
+})
 public class EffUnlimitedLifetime extends Effect {
 
 	static {

--- a/src/main/java/ch/njol/skript/effects/EffUnlimitedLifetime.java
+++ b/src/main/java/ch/njol/skript/effects/EffUnlimitedLifetime.java
@@ -1,0 +1,68 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+@Name("Unlimited Lifetime")
+@Description("Makes a dropped item have an unlimited lifetime.")
+@Examples({
+	"drop tripwire hook at player's location",
+	"make last dropped item have unlimited lifetime"})
+public class EffUnlimitedLifetime extends Effect {
+
+	static {
+		Skript.registerEffect(EffUnlimitedLifetime.class,
+			"make %entities% have [an] (unlimited|infinite) life(time|span)");
+	}
+
+	private Expression<Entity> entityExpr;
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		entityExpr = (Expression<Entity>) exprs[0];
+		return true;
+	}
+
+	@Override
+	protected void execute(Event event) {
+		Entity[] entities = entityExpr.getArray(event);
+		for (Entity entity : entities) {
+			if (!(entity instanceof Item))
+				continue;
+			((Item) entity).setUnlimitedLifetime(true);
+		}
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "make " + entityExpr.toString(event, debug) + " have an unlimited lifetime";
+	}
+}

--- a/src/main/java/ch/njol/skript/effects/EffUnlimitedLifetime.java
+++ b/src/main/java/ch/njol/skript/effects/EffUnlimitedLifetime.java
@@ -65,4 +65,5 @@ public class EffUnlimitedLifetime extends Effect {
 	public String toString(@Nullable Event event, boolean debug) {
 		return "make " + entityExpr.toString(event, debug) + " have an unlimited lifetime";
 	}
+
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprEntityLifetime.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntityLifetime.java
@@ -1,0 +1,92 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.util.Timespan;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+@Name("Entity's Lifetime")
+@Description("The lifetime of an entity.")
+@Examples("set event-entity's lifetime to 50 seconds")
+@Since("INSERT VERSION")
+public class ExprEntityLifetime extends SimplePropertyExpression<Entity, Timespan> {
+
+	static {
+		register(ExprEntityLifetime.class, Timespan.class, "life(time|span)", "entities");
+	}
+
+	@Override
+	public @Nullable Timespan convert(Entity entity) {
+		return Timespan.fromTicks_i(entity.getTicksLived());
+	}
+
+	@Override
+	public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
+		switch (mode) {
+			case SET:
+			case ADD:
+			case RESET:
+			case REMOVE:
+				return CollectionUtils.array(Timespan.class);
+		}
+		return null;
+	}
+
+	@Override
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+		Entity[] entities = this.getExpr().getArray(event);
+		int ticks = delta == null ? 0 : (int) ((Timespan) delta[0]).getTicks_i();
+		switch (mode) {
+			case SET:
+				for (Entity entity : entities)
+					entity.setTicksLived(ticks);
+				break;
+			case ADD:
+				for (Entity entity : entities)
+					entity.setTicksLived(entity.getTicksLived() + ticks);
+				break;
+			case RESET:
+				for (Entity entity : entities)
+					entity.setTicksLived(1);
+				break;
+			case REMOVE:
+				for (Entity entity : entities)
+					entity.setTicksLived(entity.getTicksLived() - ticks);
+		}
+	}
+
+	@Override
+	public Class<? extends Timespan> getReturnType() {
+		return Timespan.class;
+	}
+
+	@Override
+	protected String getPropertyName() {
+		return "lifetime";
+	}
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprEntityLifetime.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntityLifetime.java
@@ -76,7 +76,7 @@ public class ExprEntityLifetime extends SimplePropertyExpression<Entity, Timespa
 				break;
 			case REMOVE:
 				for (Entity entity : entities)
-					entity.setTicksLived(entity.getTicksLived() - ticks);
+					entity.setTicksLived(Math.max(1, entity.getTicksLived() - ticks));
 		}
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprEntityLifetime.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntityLifetime.java
@@ -78,6 +78,9 @@ public class ExprEntityLifetime extends SimplePropertyExpression<Entity, Timespa
 			case REMOVE:
 				for (Entity entity : entities)
 					entity.setTicksLived(Math.max(1, entity.getTicksLived() - ticks));
+				break;
+			default:
+				assert false;
 		}
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprEntityLifetime.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntityLifetime.java
@@ -53,6 +53,7 @@ public class ExprEntityLifetime extends SimplePropertyExpression<Entity, Timespa
 			case SET:
 			case ADD:
 			case RESET:
+			case DELETE:
 			case REMOVE:
 				return CollectionUtils.array(Timespan.class);
 		}
@@ -62,23 +63,19 @@ public class ExprEntityLifetime extends SimplePropertyExpression<Entity, Timespa
 	@Override
 	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		Entity[] entities = this.getExpr().getArray(event);
-		int ticks = delta == null ? 0 : (int) ((Timespan) delta[0]).getTicks_i();
+		int ticks = delta == null ? 1 : (int) ((Timespan) delta[0]).getTicks_i();
 		switch (mode) {
+			case DELETE:
+			case RESET:
 			case SET:
 				for (Entity entity : entities)
 					entity.setTicksLived(ticks);
 				break;
+			case REMOVE:
+				ticks *= -1;
 			case ADD:
 				for (Entity entity : entities)
 					entity.setTicksLived(entity.getTicksLived() + ticks);
-				break;
-			case RESET:
-				for (Entity entity : entities)
-					entity.setTicksLived(1);
-				break;
-			case REMOVE:
-				for (Entity entity : entities)
-					entity.setTicksLived(Math.max(1, entity.getTicksLived() - ticks));
 				break;
 			default:
 				assert false;

--- a/src/main/java/ch/njol/skript/expressions/ExprEntityLifetime.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntityLifetime.java
@@ -90,4 +90,5 @@ public class ExprEntityLifetime extends SimplePropertyExpression<Entity, Timespa
 	protected String getPropertyName() {
 		return "lifetime";
 	}
+
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprEntityLifetime.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntityLifetime.java
@@ -47,7 +47,8 @@ public class ExprEntityLifetime extends SimplePropertyExpression<Entity, Timespa
 	}
 
 	@Override
-	public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
+	@Nullable
+	public Class<?>[] acceptChange(ChangeMode mode) {
 		switch (mode) {
 			case SET:
 			case ADD:

--- a/src/main/java/ch/njol/skript/expressions/ExprEntityLifetime.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntityLifetime.java
@@ -41,7 +41,8 @@ public class ExprEntityLifetime extends SimplePropertyExpression<Entity, Timespa
 	}
 
 	@Override
-	public @Nullable Timespan convert(Entity entity) {
+	@Nullable
+	public Timespan convert(Entity entity) {
 		return Timespan.fromTicks_i(entity.getTicksLived());
 	}
 


### PR DESCRIPTION
### Description
Adds a variety of lifetime syntax (including ones from issue #5110).  
One thing to note is that when testing, the minimum you can set the ticks of an entities lifetime is 1, as 0 throws an illegal argument exception, but i think thats okay.

---
**Target Minecraft Versions:** ANY
**Requirements:** N/A
**Related Issues:** #5110
