### PR TITLE
dev/2.6 Implement missing methods for Block implementations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ allprojects {
 dependencies {
 	shadow group: 'io.papermc', name: 'paperlib', version: '1.0.7'
 	shadow group: 'org.bstats', name: 'bstats-bukkit', version: '3.0.0'
-	implementation group: 'io.papermc.paper', name: 'paper-api', version: '1.19-R0.1-SNAPSHOT'
+	implementation group: 'io.papermc.paper', name: 'paper-api', version: '1.19.2-R0.1-SNAPSHOT'
 	implementation group: 'org.eclipse.jdt', name: 'org.eclipse.jdt.annotation', version: '2.2.600'
 	implementation group: 'com.google.code.findbugs', name: 'findbugs', version: '3.0.1'
 	implementation group: 'com.sk89q.worldguard', name: 'worldguard-legacy', version: '7.0.0-SNAPSHOT'

--- a/src/main/java/ch/njol/skript/util/BlockStateBlock.java
+++ b/src/main/java/ch/njol/skript/util/BlockStateBlock.java
@@ -363,6 +363,16 @@ public class BlockStateBlock implements Block {
 	}
 
 	@Override
+	public void tick() {
+		state.getBlock().tick();
+	}
+
+	@Override
+	public void randomTick() {
+		state.getBlock().randomTick();
+	}
+
+	@Override
 	public boolean applyBoneMeal(BlockFace blockFace) {
 		return state.getBlock().applyBoneMeal(blockFace);
 	}

--- a/src/main/java/ch/njol/skript/util/DelayedChangeBlock.java
+++ b/src/main/java/ch/njol/skript/util/DelayedChangeBlock.java
@@ -363,6 +363,16 @@ public class DelayedChangeBlock implements Block {
 	}
 
 	@Override
+	public void tick() {
+		b.tick();
+	}
+
+	@Override
+	public void randomTick() {
+		b.randomTick();
+	}
+
+	@Override
 	public boolean applyBoneMeal(BlockFace blockFace) {
 		return b.applyBoneMeal(blockFace);
 	}


### PR DESCRIPTION
### Description
Updates dev/2.6 to support 1.19.2
dev/2.6 currently doesn't work in 1.19.2 as it's missing pull request (#5009) that fixed missing implementations.

Implement missing methods for Block implementations on dev/2.6 branch.

---
**Target Minecraft Versions:** 1.9.4-1.19.2
**Skript target version:** 2.6.4
