### PR TITLE
Remove cap on freeze time in 1.18 freeze syntax

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprFreezeTicks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFreezeTicks.java
@@ -104,8 +104,6 @@ public class ExprFreezeTicks extends SimplePropertyExpression<Entity, Timespan> 
 		//Limit time to between 0 and max
 		if (ticks < 0)
 			ticks = 0;
-		if (entity.getMaxFreezeTicks() < ticks)
-			ticks = entity.getMaxFreezeTicks();
 		// Set new time
 		entity.setFreezeTicks(ticks);
 	}

--- a/src/test/skript/tests/syntaxes/expressions/ExprFreezeTicks.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprFreezeTicks.sk
@@ -6,10 +6,10 @@ test "freeze time" when running minecraft "1.18":
 		add 2 seconds to freeze time of entity
 		assert freeze time of entity is 5 seconds with "freeze time add ##1 failed"
 		add 10 seconds to freeze time of entity
-		assert freeze time of entity is 7 seconds with "freeze time add ##2 failed" # freeze time should be capped at entity's max freeze time (7 seconds for a cow)
+		assert freeze time of entity is 15 seconds with "freeze time add ##2 failed" # freeze time should not be capped at entity's max freeze time (7 seconds for a cow)
 	
-		remove 4 seconds from freeze time of entity
-		assert freeze time of entity is 3 seconds with "freeze time remove ##1 failed"
+		remove 6 seconds from freeze time of entity
+		assert freeze time of entity is 9 seconds with "freeze time remove ##1 failed"
 		remove 10 seconds from freeze time of entity
 		assert freeze time of entity is 0 seconds with "freeze time remove ##2 failed" # freeze time should not be negative
 		delete freeze time of entity


### PR DESCRIPTION
### Description

Removes the artificial cap on freeze ticks imposed in #4781 .
I initially added it as I mistakenly thought the freeze ticks should not exceed the limits vanilla survival sets on it (between 0 and getMaxFreezeTicks). However, this makes it really difficult to freeze and entity for any significant period of time, so allowing it to exceed the getMaxFreezeTicks value makes a lot of sense. Any values above the max do not change the experience of an entity, it just extends the time the entity is in the maximum frozen state.

---
**Target Minecraft Versions:** 1.18+<!-- 'any' means all supported versions -->
**Requirements:** 1.18+ <!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** #4781  <!-- Links to related issues -->
