### PR TITLE
Fixes docs side nav padding

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -106,7 +106,7 @@ a:visited {
     grid-column-end: 1;
     position: sticky;
     top: 60px;
-	padding-top: 60px;
+    padding-top: 60px;
     height: max-content;
 }
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -106,6 +106,7 @@ a:visited {
     grid-column-end: 1;
     position: sticky;
     top: 60px;
+	padding-top: 60px;
     height: max-content;
 }
 


### PR DESCRIPTION
### Description
Fixing the top padding of the side nav bar when at top scroll.

Before
<img width="307" alt="before" src="https://user-images.githubusercontent.com/16087552/197608776-a0165b68-cacc-410c-ba8b-479b08a8fda7.png">

After
<img width="310" alt="after" src="https://user-images.githubusercontent.com/16087552/197608797-72edff56-6a14-4108-a8a9-965f16742eec.png">

This applied to any page with the side nav bar. Conditions, Effects etc
