### PR TITLE
Change Maven dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Or, if you use Maven:
     <groupId>com.github.SkriptLang</groupId>
     <artifactId>Skript</artifactId>
     <version>[versionTag]</version>
+	<scope>provided</scope>
 </dependency>
 ```
 


### PR DESCRIPTION
### Description
Make the `scope` tag `provided` because many new developers include the whole Skript jar in their plugin's jar and won't know why their plugin isn't working
