### PR TITLE
DefaultComparators - add comparator for BlockData - BlockData

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/DefaultComparators.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultComparators.java
@@ -219,6 +219,19 @@ public class DefaultComparators {
 			}
 		});
 
+		// BlockData - BlockData
+		Comparators.registerComparator(BlockData.class, BlockData.class, new Comparator<BlockData, BlockData>() {
+			@Override
+			public Relation compare(BlockData data1, BlockData data2) {
+				return Relation.get(data1.matches(data2));
+			}
+
+			@Override
+			public boolean supportsOrdering() {
+				return false;
+			}
+		});
+
 		// ItemType - ItemType
 		Comparators.registerComparator(ItemType.class, ItemType.class, new Comparator<ItemType, ItemType>() {
 			@Override


### PR DESCRIPTION
### Description
This PR aims to fix an issue with Skript not being able to compare block datas with each other

---
**Target Minecraft Versions:** 1.13+
**Requirements:** none
**Related Issues:** #5251
