### PR TITLE
Support Worlds into ExprName.java

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprName.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprName.java
@@ -39,6 +39,7 @@ import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.World;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
@@ -58,47 +59,51 @@ import ch.njol.util.coll.CollectionUtils;
 import net.md_5.bungee.api.ChatColor;
 
 @Name("Name / Display Name / Tab List Name")
-@Description({"Represents the Minecraft account, display or tab list name of a player, or the custom name of an item, entity, block, inventory, or gamerule.",
-		"",
-		"<ul>",
-		"\t<li><strong>Players</strong>",
-		"\t\t<ul>",
-		"\t\t\t<li><strong>Name:</strong> The Minecraft account name of the player. Can't be changed, but 'display name' can be changed.</li>",
-		"\t\t\t<li><strong>Display Name:</strong> The name of the player that is displayed in messages. " +
-			"This name can be changed freely and can include colour codes, and is shared among all plugins (e.g. chat plugins will use the display name).</li>",
-		"\t\t</ul>",
-		"\t</li>",
-		"\t<li><strong>Entities</strong>",
-		"\t\t<ul>",
-		"\t\t\t<li><strong>Name:</strong> The custom name of the entity. Can be changed. But for living entities, " +
-			"the players will have to target the entity to see its name tag. For non-living entities, the name will not be visible at all. To prevent this, use 'display name'.</li>",
-		"\t\t\t<li><strong>Display Name:</strong> The custom name of the entity. Can be changed, " +
-			"which will also enable <em>custom name visibility</em> of the entity so name tag of the entity will be visible always.</li>",
-		"\t\t</ul>",
-		"\t</li>",
-		"\t<li><strong>Items</strong>",
-		"\t\t<ul>",
-		"\t\t\t<li><strong>Name and Display Name:</strong> The <em>custom</em> name of the item (not the Minecraft locale name). Can be changed.</li>",
-		"\t\t</ul>",
-		"\t</li>",
-		"\t<li><strong>Inventories</strong>",
-		"\t\t<ul>",
-		"\t\t\t<li><strong>Name and Display Name:</strong> The name/title of the inventory. " +
-			"Changing name of an inventory means opening the same inventory with the same contents but with a different name to its current viewers.</li>",
-		"\t\t</ul>",
-		"\t</li>",
-		"\t<li><strong>Gamerules (1.13+)</strong>",
-		"\t\t<ul>",
-		"\t\t\t<li><strong>Name:</strong> The name of the gamerule. Cannot be changed.</li>",
-		"\t\t</ul>",
-		"\t</li>",
-		"</ul>"})
-@Examples({"on join:",
-		"	player has permission \"name.red\"",
-		"	set the player's display name to \"&lt;red&gt;[admin] &lt;gold&gt;%name of player%\"",
-		"	set the player's tab list name to \"&lt;green&gt;%player's name%\"",
-		"set the name of the player's tool to \"Legendary Sword of Awesomeness\""})
-@Since("before 2.1, 2.2-dev20 (inventory name), 2.4 (non-living entity support, changeable inventory name)")
+@Description({
+	"Represents the Minecraft account, display or tab list name of a player, or the custom name of an item, entity, block, inventory, or gamerule.",
+	"",
+	"<ul>",
+	"\t<li><strong>Players</strong>",
+	"\t\t<ul>",
+	"\t\t\t<li><strong>Name:</strong> The Minecraft account name of the player. Can't be changed, but 'display name' can be changed.</li>",
+	"\t\t\t<li><strong>Display Name:</strong> The name of the player that is displayed in messages. " +
+		"This name can be changed freely and can include colour codes, and is shared among all plugins (e.g. chat plugins will use the display name).</li>",
+	"\t\t</ul>",
+	"\t</li>",
+	"\t<li><strong>Entities</strong>",
+	"\t\t<ul>",
+	"\t\t\t<li><strong>Name:</strong> The custom name of the entity. Can be changed. But for living entities, " +
+		"the players will have to target the entity to see its name tag. For non-living entities, the name will not be visible at all. To prevent this, use 'display name'.</li>",
+	"\t\t\t<li><strong>Display Name:</strong> The custom name of the entity. Can be changed, " +
+		"which will also enable <em>custom name visibility</em> of the entity so name tag of the entity will be visible always.</li>",
+	"\t\t</ul>",
+	"\t</li>",
+	"\t<li><strong>Items</strong>",
+	"\t\t<ul>",
+	"\t\t\t<li><strong>Name and Display Name:</strong> The <em>custom</em> name of the item (not the Minecraft locale name). Can be changed.</li>",
+	"\t\t</ul>",
+	"\t</li>",
+	"\t<li><strong>Inventories</strong>",
+	"\t\t<ul>",
+	"\t\t\t<li><strong>Name and Display Name:</strong> The name/title of the inventory. " +
+		"Changing name of an inventory means opening the same inventory with the same contents but with a different name to its current viewers.</li>",
+	"\t\t</ul>",
+	"\t</li>",
+	"\t<li><strong>Gamerules (1.13+)</strong>",
+	"\t\t<ul>",
+	"\t\t\t<li><strong>Name:</strong> The name of the gamerule. Cannot be changed.</li>",
+	"\t\t</ul>",
+	"\t</li>",
+	"</ul>"
+})
+@Examples({
+	"on join:",
+	"	player has permission \"name.red\"",
+	"	set the player's display name to \"&lt;red&gt;[admin] &lt;gold&gt;%name of player%\"",
+	"	set the player's tab list name to \"&lt;green&gt;%player's name%\"",
+	"set the name of the player's tool to \"Legendary Sword of Awesomeness\""
+})
+@Since("before 2.1, 2.2-dev20 (inventory name), 2.4 (non-living entity support, changeable inventory name), INSERT VERSION (worlds support)")
 public class ExprName extends SimplePropertyExpression<Object, String> {
 
 	@Nullable
@@ -107,8 +112,8 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 
 	static {
 		HAS_GAMERULES = Skript.classExists("org.bukkit.GameRule");
-		register(ExprName.class, String.class, "(1¦name[s]|2¦(display|nick|chat|custom)[ ]name[s])", "offlineplayers/entities/blocks/itemtypes/inventories/slots"
-                + (HAS_GAMERULES ? "/gamerules" : ""));
+		register(ExprName.class, String.class, "(1¦name[s]|2¦(display|nick|chat|custom)[ ]name[s])", "offlineplayers/entities/blocks/itemtypes/inventories/slots/worlds"
+			+ (HAS_GAMERULES ? "/gamerules" : ""));
 		register(ExprName.class, String.class, "(3¦(player|tab)[ ]list name[s])", "players");
 
 		// Get the old method for getting the name of an inventory.
@@ -132,6 +137,10 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		mark = parseResult.mark;
 		setExpr(exprs[0]);
+		if (mark != 1 && World.class.isAssignableFrom(getExpr().getReturnType())) {
+			Skript.error("Can't use 'display name' with worlds. Use 'name' instead.");
+			return false;
+		}
 		return true;
 	}
 
@@ -165,8 +174,8 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 			if (TITLE_METHOD != null) {
 				try {
 					return (String) TITLE_METHOD.invoke(o);
-				} catch (Throwable e) {
-					Skript.exception(e);
+				} catch (Throwable ex) {
+					Skript.exception(ex);
 					return null;
 				}
 			} else {
@@ -180,9 +189,11 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 				ItemMeta m = is.getItemMeta();
 				return m.hasDisplayName() ? m.getDisplayName() : null;
 			}
+		} else if (o instanceof World) {
+			return ((World) o).getName();
 		} else if (HAS_GAMERULES && o instanceof GameRule) {
-            return ((GameRule) o).getName();
-        }
+			return ((GameRule) o).getName();
+		}
 		return null;
 	}
 
@@ -190,13 +201,17 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 	@Nullable
 	public Class<?>[] acceptChange(ChangeMode mode) {
 		if (mode == ChangeMode.SET || mode == ChangeMode.RESET) {
-			if (mark == 1 && Player.class.isAssignableFrom(getExpr().getReturnType())) {
-				Skript.error("Can't change the Minecraft name of a player. Change the 'display name' or 'tab list name' instead.");
-				return null;
+			if (mark == 1) {
+				if (Player.class.isAssignableFrom(getExpr().getReturnType())) {
+					Skript.error("Can't change the Minecraft name of a player. Change the 'display name' or 'tab list name' instead.");
+					return null;
+				} else if (World.class.isAssignableFrom(getExpr().getReturnType())) {
+					return null;
+				}
 			}
 			return CollectionUtils.array(String.class);
 		}
-		return null;	
+		return null;
 	}
 
 	@Override
@@ -205,7 +220,7 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 		for (Object o : getExpr().getArray(e)) {
 			if (o instanceof Player) {
 				switch (mark) {
-					case 2: 
+					case 2:
 						((Player) o).setDisplayName(name != null ? name + ChatColor.RESET : ((Player) o).getName());
 						break;
 					case 3: // Null check not necessary. This method will use the player's name if 'name' is null.

--- a/src/main/java/ch/njol/skript/expressions/ExprName.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprName.java
@@ -60,7 +60,7 @@ import net.md_5.bungee.api.ChatColor;
 
 @Name("Name / Display Name / Tab List Name")
 @Description({
-	"Represents the Minecraft account, display or tab list name of a player, or the custom name of an item, entity, block, inventory, or gamerule.",
+	"Represents the Minecraft account, display or tab list name of a player, or the custom name of an item, entity, block, inventory, gamerule or world.",
 	"",
 	"<ul>",
 	"\t<li><strong>Players</strong>",
@@ -94,16 +94,21 @@ import net.md_5.bungee.api.ChatColor;
 	"\t\t\t<li><strong>Name:</strong> The name of the gamerule. Cannot be changed.</li>",
 	"\t\t</ul>",
 	"\t</li>",
+	"\t<li><strong>Worlds</strong>",
+	"\t\t<ul>",
+	"\t\t\t<li><strong>Name:</strong> The name of the world. Cannot be changed.</li>",
+	"\t\t</ul>",
+	"\t</li>",
 	"</ul>"
 })
 @Examples({
 	"on join:",
-	"	player has permission \"name.red\"",
-	"	set the player's display name to \"&lt;red&gt;[admin] &lt;gold&gt;%name of player%\"",
-	"	set the player's tab list name to \"&lt;green&gt;%player's name%\"",
+	"\tplayer has permission \"name.red\"",
+	"\tset the player's display name to \"&lt;red&gt;[admin] &lt;gold&gt;%name of player%\"",
+	"\tset the player's tab list name to \"&lt;green&gt;%player's name%\"",
 	"set the name of the player's tool to \"Legendary Sword of Awesomeness\""
 })
-@Since("before 2.1, 2.2-dev20 (inventory name), 2.4 (non-living entity support, changeable inventory name), INSERT VERSION (worlds support)")
+@Since("before 2.1, 2.2-dev20 (inventory name), 2.4 (non-living entity support, changeable inventory name), INSERT VERSION (worlds)")
 public class ExprName extends SimplePropertyExpression<Object, String> {
 
 	@Nullable


### PR DESCRIPTION
### Description
***This PR is a replacement PR for https://github.com/SkriptLang/Skript/pull/5259.***

*Forwarded from above stated PR*
This PR adds World support to ExprName.java.

Before PR:
![image](https://user-images.githubusercontent.com/72163224/209167286-516a325e-848a-4969-88ae-5d5264711513.png)

After PR:
![imageA](https://user-images.githubusercontent.com/72163224/209168055-e27c6c0f-f920-4360-b45e-d4a2e1bea39c.png)

Requested changes stated from old PR has been carried over to this PR.
---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
