### PR TITLE
Update EffActionBar.java

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffActionBar.java
+++ b/src/main/java/ch/njol/skript/effects/EffActionBar.java
@@ -43,7 +43,7 @@ import net.md_5.bungee.api.chat.BaseComponent;
 public class EffActionBar extends Effect {
 
 	static {
-		Skript.registerEffect(EffActionBar.class, "send [the] action bar [with text] %string% to %players%");
+		Skript.registerEffect(EffActionBar.class, "send [the] action[ ]bar [with text] %string% to %players%");
 	}
 
 	@SuppressWarnings("null")


### PR DESCRIPTION
### Description
Adds optional space between action bar. I always run into this issue when scripting. Sometimes I do it without and I do with a space. This allows for both, making it more user friendly. I called it a fix, because i've been annoyed by this for years even though it's not a fix, just super annoying, and just never pull requested as I only script once in a blue moon.

GitHub automatically fixed the end of the file no line break that was missing.
