### PR TITLE
Fix examples and lang files not generating

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -393,7 +393,7 @@ public final class Skript extends JavaPlugin implements Listener {
 		if (!getDataFolder().isDirectory())
 			getDataFolder().mkdirs();
 
-		scriptsFolder = new File(getDataFolder(), SCRIPTSFOLDER + File.separator);
+		scriptsFolder = new File(getDataFolder(), SCRIPTSFOLDER);
 		File config = new File(getDataFolder(), "config.sk");
 		File features = new File(getDataFolder(), "features.sk");
 		File lang = new File(getDataFolder(), "lang");
@@ -419,16 +419,16 @@ public final class Skript extends JavaPlugin implements Listener {
 					if (e.isDirectory())
 						continue;
 					File saveTo = null;
-					if (populateExamples && e.getName().startsWith(SCRIPTSFOLDER + File.separator)) {
+					if (populateExamples && e.getName().startsWith(SCRIPTSFOLDER + "/")) {
 						String fileName = e.getName().substring(e.getName().lastIndexOf(File.separatorChar) + 1);
 						if (fileName.startsWith(ScriptLoader.DISABLED_SCRIPT_PREFIX))
 							fileName = ScriptLoader.DISABLED_SCRIPT_PREFIX + fileName;
 						saveTo = new File(scriptsFolder, fileName);
 					} else if (populateLanguageFiles
-							&& e.getName().startsWith("lang" + File.separator)
+							&& e.getName().startsWith("lang/")
 							&& e.getName().endsWith(".lang")
-							&& !e.getName().endsWith(File.separator + "default.lang")) {
-						String fileName = e.getName().substring(e.getName().lastIndexOf(File.separatorChar) + 1);
+							&& !e.getName().endsWith("/default.lang")) {
+						String fileName = e.getName().substring(e.getName().lastIndexOf("/") + 1);
 						saveTo = new File(lang, fileName);
 					} else if (e.getName().equals("config.sk")) {
 						if (!config.exists())


### PR DESCRIPTION
### Description
ZipEntry#getName does not correlate with Files.seperator.

After:
plugins/Skript/lang/
<img width="148" alt="Untitled2" src="https://user-images.githubusercontent.com/16087552/210127241-64e12d23-b1cb-43a3-8563-f6966e222e60.png">
plugins/Skript/scripts/
<img width="218" alt="Untitled" src="https://user-images.githubusercontent.com/16087552/210127242-b1cfe005-074b-43c0-85a6-f4ef33563667.png">
