### PR TITLE
Add isValid for entities

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondIsValid.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsValid.java
@@ -1,0 +1,49 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.conditions;
+
+import org.bukkit.entity.Entity;
+
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+
+@Name("Is Valid")
+@Description("Checks whether an entity has died or been despawned for some other reason.")
+@Examples("if event-entity is valid")
+@Since("INSERT VERSION")
+public class CondIsValid extends PropertyCondition<Entity> {
+
+	static {
+		register(CondIsValid.class, "valid", "entities");
+	}
+
+	@Override
+	public boolean check(Entity entity) {
+		return entity.isValid();
+	}
+
+	@Override
+	protected String getPropertyName() {
+		return "valid";
+	}
+
+}


### PR DESCRIPTION
### Description
Add isValid for entities. When programming in Java, you typically use isValid over isDead because this method checks if the server considers it valid or not which includes it being despawned.

This addition is mainly for the unit testing system to ensure entities are fully gone.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** non closing isValid https://github.com/SkriptLang/Skript/issues/4185
