### PR TITLE
Fix inconsistency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Or, if you use Maven:
     <groupId>com.github.SkriptLang</groupId>
     <artifactId>Skript</artifactId>
     <version>[versionTag]</version>
-	<scope>provided</scope>
+    <scope>provided</scope>
 </dependency>
 ```
 


### PR DESCRIPTION
The indentation seemed off, it was a tab, the other parts are spaces. Now they are all spaces.