### PR TITLE
Fix scripts example folder generation

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -420,8 +420,9 @@ public final class Skript extends JavaPlugin implements Listener {
 						continue;
 					File saveTo = null;
 					if (populateExamples && e.getName().startsWith(SCRIPTSFOLDER + "/")) {
-						String fileName = e.getName().substring(e.getName().lastIndexOf(File.separatorChar) + 1);
-						if (fileName.startsWith(ScriptLoader.DISABLED_SCRIPT_PREFIX))
+						String fileName = e.getName().substring(e.getName().indexOf("/") + 1);
+						// All example scripts must be disabled for jar security.
+						if (!fileName.startsWith(ScriptLoader.DISABLED_SCRIPT_PREFIX))
 							fileName = ScriptLoader.DISABLED_SCRIPT_PREFIX + fileName;
 						saveTo = new File(scriptsFolder, fileName);
 					} else if (populateLanguageFiles


### PR DESCRIPTION
### Description
Fixes scripts example folder generation. It's generating as `plugins/Skript/scripts/scripts/--example/` rather than `plugins/Skript/scripts/-example/` Also makes sure that all scripts carried over from the jar are disabled or in a disabled folder for jar security. Someone may add a malicious example script and distribute that said jar as anyone can do that without compiling code.
