### PR TITLE
Multiple Inventories Support in ExprInventorySlot

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprInventorySlot.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprInventorySlot.java
@@ -61,17 +61,17 @@ public class ExprInventorySlot extends SimpleExpression<Slot> {
 	@SuppressWarnings("null")
 	private Expression<Number> slots;
 	@SuppressWarnings("null")
-	private Expression<Inventory> invis;
+	private Expression<Inventory> inventories;
 
 	@SuppressWarnings({"null", "unchecked"})
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		if (matchedPattern == 0){
 			slots = (Expression<Number>) exprs[0];
-			invis = (Expression<Inventory>) exprs[1];
+			inventories = (Expression<Inventory>) exprs[1];
 		} else {
 			slots = (Expression<Number>) exprs[1];
-			invis = (Expression<Inventory>) exprs[0];
+			inventories = (Expression<Inventory>) exprs[0];
 		}
 		return true;
 	}
@@ -80,19 +80,19 @@ public class ExprInventorySlot extends SimpleExpression<Slot> {
 	@Nullable
 	protected Slot[] get(Event event) {
 		List<Slot> inventorySlots = new ArrayList<>();
-		for (Inventory invi : invis.getArray(event)) {
-			if (invi == null)
+		for (Inventory inventory : inventories.getArray(event)) {
+			if (inventory == null)
 				continue;
 			for (Number slot : slots.getArray(event)) {
 				int slotIndex = slot.intValue();
-				if (slotIndex >= 0 && slotIndex < invi.getSize()) {
+				if (slotIndex >= 0 && slotIndex < inventory.getSize()) {
 					// Not all indices point to inventory slots. Equipment, for example
-					if (invi instanceof PlayerInventory && slotIndex >= 36) {
-						HumanEntity holder = ((PlayerInventory) invi).getHolder();
+					if (inventory instanceof PlayerInventory && slotIndex >= 36) {
+						HumanEntity holder = ((PlayerInventory) inventory).getHolder();
 						assert holder != null;
 						inventorySlots.add(new EquipmentSlot(holder, slotIndex));
 					} else {
-						inventorySlots.add(new InventorySlot(invi, slotIndex));
+						inventorySlots.add(new InventorySlot(inventory, slotIndex));
 					}
 				}
 			}
@@ -104,7 +104,7 @@ public class ExprInventorySlot extends SimpleExpression<Slot> {
 
 	@Override
 	public boolean isSingle() {
-		return slots.isSingle() || invis.isSingle();
+		return slots.isSingle() || inventories.isSingle();
 	}
 
 	@Override
@@ -114,6 +114,6 @@ public class ExprInventorySlot extends SimpleExpression<Slot> {
 
 	@Override
 	public String toString(@Nullable Event event, boolean debug) {
-		return "slots " + slots.toString(event, debug) + " of " + invis.toString(event, debug);
+		return "slots " + slots.toString(event, debug) + " of " + inventories.toString(event, debug);
 	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprInventorySlot.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprInventorySlot.java
@@ -43,12 +43,14 @@ import ch.njol.util.Kleenean;
 
 @Name("Inventory Slot")
 @Description({"Represents a slot in an inventory. It can be used to change the item in an inventory too."})
-@Examples({"if slot 0 of player is air:",
+@Examples({
+	"if slot 0 of player is air:",
 	"\tset slot 0 of player to 2 stones",
 	"\tremove 1 stone from slot 0 of player",
 	"\tadd 2 stones to slot 0 of inventory of all players",
-	"\tclear slot 1 of player"})
-@Since("2.2-dev24")
+	"\tclear slot 1 of player"
+})
+@Since("2.2-dev24, INSERT VERSION (multiple inventories)")
 public class ExprInventorySlot extends SimpleExpression<Slot> {
 
 	static {

--- a/src/main/java/ch/njol/skript/expressions/ExprInventorySlot.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprInventorySlot.java
@@ -46,30 +46,30 @@ import ch.njol.util.Kleenean;
 @Examples({"if slot 0 of player is air:",
 	"\tset slot 0 of player to 2 stones",
 	"\tremove 1 stone from slot 0 of player",
-	"\tadd 2 stones to slot 0 of player",
+	"\tadd 2 stones to slot 0 of inventory of all players",
 	"\tclear slot 1 of player"})
 @Since("2.2-dev24")
 public class ExprInventorySlot extends SimpleExpression<Slot> {
-	
+
 	static {
 		Skript.registerExpression(ExprInventorySlot.class, Slot.class, ExpressionType.COMBINED,
-				"[the] slot[s] %numbers% of %inventory%", "%inventory%'[s] slot[s] %numbers%");
+			"[the] slot[s] %numbers% of %inventories%", "%inventories%'[s] slot[s] %numbers%");
 	}
 
 	@SuppressWarnings("null")
 	private Expression<Number> slots;
 	@SuppressWarnings("null")
 	private Expression<Inventory> invis;
-	
+
 	@SuppressWarnings({"null", "unchecked"})
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		if (matchedPattern == 0){
-			 slots = (Expression<Number>) exprs[0];
-			 invis = (Expression<Inventory>) exprs[1];
+			slots = (Expression<Number>) exprs[0];
+			invis = (Expression<Inventory>) exprs[1];
 		} else {
-			 slots = (Expression<Number>) exprs[1];
-			 invis = (Expression<Inventory>) exprs[0];			
+			slots = (Expression<Number>) exprs[1];
+			invis = (Expression<Inventory>) exprs[0];
 		}
 		return true;
 	}
@@ -77,42 +77,41 @@ public class ExprInventorySlot extends SimpleExpression<Slot> {
 	@Override
 	@Nullable
 	protected Slot[] get(Event event) {
-		Inventory invi = invis.getSingle(event);
-		if (invi == null)
-			return null;
-		
 		List<Slot> inventorySlots = new ArrayList<>();
-		for (Number slot : slots.getArray(event)) {
-			if (slot.intValue() >= 0 && slot.intValue() < invi.getSize()) {
+		for (Inventory invi : invis.getArray(event)) {
+			if (invi == null)
+				continue;
+			for (Number slot : slots.getArray(event)) {
 				int slotIndex = slot.intValue();
-				// Not all indices point to inventory slots. Equipment, for example
-				if (invi instanceof PlayerInventory && slotIndex >= 36) {
-					HumanEntity holder = ((PlayerInventory) invi).getHolder();
-					assert holder != null;
-					inventorySlots.add(new EquipmentSlot(holder, slotIndex));
-				} else {
-					inventorySlots.add(new InventorySlot(invi, slot.intValue()));
+				if (slotIndex >= 0 && slotIndex < invi.getSize()) {
+					// Not all indices point to inventory slots. Equipment, for example
+					if (invi instanceof PlayerInventory && slotIndex >= 36) {
+						HumanEntity holder = ((PlayerInventory) invi).getHolder();
+						assert holder != null;
+						inventorySlots.add(new EquipmentSlot(holder, slotIndex));
+					} else {
+						inventorySlots.add(new InventorySlot(invi, slotIndex));
+					}
 				}
 			}
 		}
-		
 		if (inventorySlots.isEmpty())
 			return null;
 		return inventorySlots.toArray(new Slot[inventorySlots.size()]);
 	}
-	
+
 	@Override
 	public boolean isSingle() {
-		return slots.isSingle();
+		return slots.isSingle() || invis.isSingle();
 	}
 
 	@Override
 	public Class<? extends Slot> getReturnType() {
 		return Slot.class;
 	}
-	
+
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "slots " + slots.toString(e, debug) + " of " + invis.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "slots " + slots.toString(event, debug) + " of " + invis.toString(event, debug);
 	}
 }


### PR DESCRIPTION
### Description
This PR adds support for multiple inventories in ExprInventorySlot.
There has been a small talk in the Discord server concerning of interacting with multiple slots in multiple inventories, but regardless the main objective of this PR is to interact with a slot in multiple inventories.

### Preview:
![Screenshot_1](https://user-images.githubusercontent.com/72163224/211646530-eaa2cd9c-f7ef-4205-b584-f91dd0a4aed3.png)

PS. Such changes has allowed odd usage as shown below: 
![Screenshot_2](https://user-images.githubusercontent.com/72163224/211643058-5a70554f-aa51-49d5-8669-19a4a5157fc7.png)
---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #5330