### PR TITLE
EvtSkript’s 'on server start/stop' Set to Warn Only Once

### DIFF
--- a/src/main/java/ch/njol/skript/events/EvtSkript.java
+++ b/src/main/java/ch/njol/skript/events/EvtSkript.java
@@ -45,12 +45,14 @@ public class EvtSkript extends SelfRegisteringSkriptEvent {
 	}
 	
 	private boolean isStart;
+	private static boolean notified = false;
 	
 	@Override
 	public boolean init(final Literal<?>[] args, final int matchedPattern, final ParseResult parser) {
 		isStart = matchedPattern == 0;
-		if (parser.mark == 0) {
-			Skript.warning("Server start/stop events are actually called when Skript is started or stopped. It is thus recommended to use 'on Skript start/stop' instead.");
+		if (parser.mark == 0 && notified == false) {
+			Skript.warning("Server start/stop events are actually called when Skript is started or stopped. It is thus recommended to use 'on skript start/stop' instead. (This is a one time message)");
+			notified = true;
 		}
 		return true;
 	}
@@ -58,15 +60,15 @@ public class EvtSkript extends SelfRegisteringSkriptEvent {
 	private final static Collection<Trigger> start = new ArrayList<>(), stop = new ArrayList<>();
 	
 	public static void onSkriptStart() {
-		final Event e = new SkriptStartEvent();
+		final Event event = new SkriptStartEvent();
 		for (final Trigger t : start)
-			t.execute(e);
+			t.execute(event);
 	}
 	
 	public static void onSkriptStop() {
-		final Event e = new SkriptStopEvent();
+		final Event event = new SkriptStopEvent();
 		for (final Trigger t : stop)
-			t.execute(e);
+			t.execute(event);
 	}
 	
 	@Override
@@ -92,7 +94,7 @@ public class EvtSkript extends SelfRegisteringSkriptEvent {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "on server " + (isStart ? "start" : "stop");
 	}
 	


### PR DESCRIPTION
### Description
This PR sets EvtSkript’s [warning](https://github.com/SkriptLang/Skript/blob/8952a00c885743de45395f8ecdd9dbd724a96d5c/src/main/java/ch/njol/skript/events/EvtSkript.java#L53) to only warn the user once throughout the server uptime, instead of on every script reload containing the event listener with pattern `on server start/stop`.

In my opinion, there is no reason to force users to switch to `on skript start:`, additionally no longer stresses out the ones with OCDs.

### Preview
Script file reloaded twice without modifications:
![9FFC6AB9-1CE2-4680-A752-7D1CE843B9E3](https://user-images.githubusercontent.com/72163224/212023861-2d0a539b-71fc-4acf-a5c3-bda4307071ca.jpeg)

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
