### PR TITLE
Convert all "e" to "event"

### DIFF
--- a/src/main/java/ch/njol/skript/classes/ClassInfo.java
+++ b/src/main/java/ch/njol/skript/classes/ClassInfo.java
@@ -466,7 +466,7 @@ public class ClassInfo<T> implements Debuggable {
 	
 	@Override
 	@NonNull
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		if (debug)
 			return codeName + " (" + c.getCanonicalName() + ")";
 		return getName().getSingular();

--- a/src/main/java/ch/njol/skript/classes/Converter.java
+++ b/src/main/java/ch/njol/skript/classes/Converter.java
@@ -96,7 +96,7 @@ public interface Converter<F, T> {
 		}
 
 		@Override
-		public String toString(@Nullable Event e, boolean debug) {
+		public String toString(@Nullable Event event, boolean debug) {
 			if (debug) {
 				String str = Arrays.stream(chain).map(c -> Classes.getExactClassName(c)).collect(Collectors.joining(" -> "));
 				assert str != null;

--- a/src/main/java/ch/njol/skript/conditions/CondAlphanumeric.java
+++ b/src/main/java/ch/njol/skript/conditions/CondAlphanumeric.java
@@ -62,8 +62,8 @@ public class CondAlphanumeric extends Condition {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return strings.toString(e, debug) + " is" + (isNegated() ? "n't" : "") + " alphanumeric";
+	public String toString(@Nullable Event event, boolean debug) {
+		return strings.toString(event, debug) + " is" + (isNegated() ? "n't" : "") + " alphanumeric";
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondCanHold.java
+++ b/src/main/java/ch/njol/skript/conditions/CondCanHold.java
@@ -92,9 +92,9 @@ public class CondCanHold extends Condition {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return PropertyCondition.toString(this, PropertyType.CAN, e, debug, invis,
-				"hold " + items.toString(e, debug));
+	public String toString(@Nullable Event event, boolean debug) {
+		return PropertyCondition.toString(this, PropertyType.CAN, event, debug, invis,
+				"hold " + items.toString(event, debug));
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondCanSee.java
+++ b/src/main/java/ch/njol/skript/conditions/CondCanSee.java
@@ -77,9 +77,9 @@ public class CondCanSee extends Condition {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return PropertyCondition.toString(this, PropertyType.CAN, e, debug, players,
-				"see" + targetPlayers.toString(e, debug));
+	public String toString(@Nullable Event event, boolean debug) {
+		return PropertyCondition.toString(this, PropertyType.CAN, event, debug, players,
+				"see" + targetPlayers.toString(event, debug));
 	}
 
 }

--- a/src/main/java/ch/njol/skript/conditions/CondCancelled.java
+++ b/src/main/java/ch/njol/skript/conditions/CondCancelled.java
@@ -59,7 +59,7 @@ public class CondCancelled extends Condition {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return isNegated() ? "event is not cancelled" : "event is cancelled";
 	}
 

--- a/src/main/java/ch/njol/skript/conditions/CondChance.java
+++ b/src/main/java/ch/njol/skript/conditions/CondChance.java
@@ -69,8 +69,8 @@ public class CondChance extends Condition {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "chance of " + chance.toString(e, debug) + (percent ? "%" : "");
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "chance of " + chance.toString(event, debug) + (percent ? "%" : "");
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondCompare.java
+++ b/src/main/java/ch/njol/skript/conditions/CondCompare.java
@@ -329,13 +329,13 @@ public class CondCompare extends Condition {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		String s;
 		final Expression<?> third = this.third;
 		if (third == null)
-			s = first.toString(e, debug) + " is " + (isNegated() ? "not " : "") + relation + " " + second.toString(e, debug);
+			s = first.toString(event, debug) + " is " + (isNegated() ? "not " : "") + relation + " " + second.toString(event, debug);
 		else
-			s = first.toString(e, debug) + " is " + (isNegated() ? "not " : "") + "between " + second.toString(e, debug) + " and " + third.toString(e, debug);
+			s = first.toString(event, debug) + " is " + (isNegated() ? "not " : "") + "between " + second.toString(event, debug) + " and " + third.toString(event, debug);
 		if (debug)
 			s += " (comparator: " + comp + ")";
 		return s;

--- a/src/main/java/ch/njol/skript/conditions/CondContains.java
+++ b/src/main/java/ch/njol/skript/conditions/CondContains.java
@@ -158,8 +158,8 @@ public class CondContains extends Condition {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return containers.toString(e, debug) + (isNegated() ? " doesn't contain " : " contains ") + items.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return containers.toString(event, debug) + (isNegated() ? " doesn't contain " : " contains ") + items.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/conditions/CondDamageCause.java
+++ b/src/main/java/ch/njol/skript/conditions/CondDamageCause.java
@@ -83,8 +83,8 @@ public class CondDamageCause extends Condition {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "damage was" + (isNegated() ? " not" : "") + " caused by " + expected.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "damage was" + (isNegated() ? " not" : "") + " caused by " + expected.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondDate.java
+++ b/src/main/java/ch/njol/skript/conditions/CondDate.java
@@ -78,8 +78,8 @@ public class CondDate extends Condition {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return date.toString(e, debug) + " was " + (isNegated() ? "less" : "more") + " than " + delta.toString(e, debug) + " ago";
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return date.toString(event, debug) + " was " + (isNegated() ? "less" : "more") + " than " + delta.toString(event, debug) + " ago";
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondHasMetadata.java
+++ b/src/main/java/ch/njol/skript/conditions/CondHasMetadata.java
@@ -68,9 +68,9 @@ public class CondHasMetadata extends Condition {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return PropertyCondition.toString(this, PropertyType.HAVE, e, debug, holders,
-				"metadata " + (values.isSingle() ? "value " : "values ") + values.toString(e, debug));
+	public String toString(@Nullable Event event, boolean debug) {
+		return PropertyCondition.toString(this, PropertyType.HAVE, event, debug, holders,
+				"metadata " + (values.isSingle() ? "value " : "values ") + values.toString(event, debug));
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondHasPotion.java
+++ b/src/main/java/ch/njol/skript/conditions/CondHasPotion.java
@@ -71,9 +71,9 @@ public class CondHasPotion extends Condition {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return PropertyCondition.toString(this, PropertyType.HAVE, e, debug, livingEntities,
-				"potion " + potionEffects.toString(e, debug));
+	public String toString(@Nullable Event event, boolean debug) {
+		return PropertyCondition.toString(this, PropertyType.HAVE, event, debug, livingEntities,
+				"potion " + potionEffects.toString(event, debug));
 	}
 
 }

--- a/src/main/java/ch/njol/skript/conditions/CondHasScoreboardTag.java
+++ b/src/main/java/ch/njol/skript/conditions/CondHasScoreboardTag.java
@@ -70,9 +70,9 @@ public class CondHasScoreboardTag extends Condition {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return PropertyCondition.toString(this, PropertyType.HAVE, e, debug, entities,
-				"the scoreboard " + (tags.isSingle() ? "tag " : "tags ") + tags.toString(e, debug));
+	public String toString(@Nullable Event event, boolean debug) {
+		return PropertyCondition.toString(this, PropertyType.HAVE, event, debug, entities,
+				"the scoreboard " + (tags.isSingle() ? "tag " : "tags ") + tags.toString(event, debug));
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIncendiary.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIncendiary.java
@@ -82,12 +82,12 @@ public class CondIncendiary extends Condition {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		if (isEvent)
 			return "the event-explosion " + (isNegated() == false ? "is" : "is not") + " incendiary";
 		if (entities.isSingle())
-			return entities.toString(e, debug) + (isNegated() == false ? " is" : " is not") + " incendiary";
-		return entities.toString(e, debug) + (isNegated() == false ? " are" : " are not") + " incendiary";
+			return entities.toString(event, debug) + (isNegated() == false ? " is" : " is not") + " incendiary";
+		return entities.toString(event, debug) + (isNegated() == false ? " are" : " are not") + " incendiary";
 	}
 
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsBlockRedstonePowered.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsBlockRedstonePowered.java
@@ -71,8 +71,8 @@ public class CondIsBlockRedstonePowered extends Condition {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return PropertyCondition.toString(this, PropertyCondition.PropertyType.BE, e, debug, blocks, (isIndirectlyPowered ? "indirectly " : "") + "powered");
+	public String toString(@Nullable Event event, boolean debug) {
+		return PropertyCondition.toString(this, PropertyCondition.PropertyType.BE, event, debug, blocks, (isIndirectlyPowered ? "indirectly " : "") + "powered");
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsEnchanted.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsEnchanted.java
@@ -72,11 +72,11 @@ public class CondIsEnchanted extends Condition {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		final Expression<EnchantmentType> es = enchs;
 		
-		return PropertyCondition.toString(this, PropertyType.BE, e, debug, items,
-				"enchanted" + (es == null ? "" : " with " + es.toString(e, debug)));
+		return PropertyCondition.toString(this, PropertyType.BE, event, debug, items,
+				"enchanted" + (es == null ? "" : " with " + es.toString(event, debug)));
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsInWorld.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsInWorld.java
@@ -72,9 +72,9 @@ public class CondIsInWorld extends Condition {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return PropertyCondition.toString(this, PropertyType.BE, e, debug, entities,
-				"in the " + (worlds.isSingle() ? "world " : "worlds ") + worlds.toString(e, debug));
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return PropertyCondition.toString(this, PropertyType.BE, event, debug, entities,
+				"in the " + (worlds.isSingle() ? "world " : "worlds ") + worlds.toString(event, debug));
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsLoaded.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsLoaded.java
@@ -96,11 +96,11 @@ public class CondIsLoaded extends Condition {
 	
 	@SuppressWarnings("null")
 	@Override
-	public String toString(@Nullable Event e, boolean d) {
+	public String toString(@Nullable Event event, boolean d) {
 		String neg = isNegated() ? " not " : " ";
-		String chunk = pattern == 0 ? "chunk[s] at " + locations.toString(e, d) + (locations.isSingle() ? " is" : " are") + neg + "loaded" : "";
-		String chunkC = pattern == 1 ? "chunk (x:" + x.toString(e, d) + ",z:" + z.toString(e, d) + ",w:" + world.toString(e,d) + ") is" + neg + "loaded" : "";
-		String world = pattern == 2 ? "world[s] " + this.world.toString(e, d) + (this.world.isSingle() ? " is" : " are") + neg + "loaded" : "";
+		String chunk = pattern == 0 ? "chunk[s] at " + locations.toString(event, d) + (locations.isSingle() ? " is" : " are") + neg + "loaded" : "";
+		String chunkC = pattern == 1 ? "chunk (x:" + x.toString(event, d) + ",z:" + z.toString(event, d) + ",w:" + world.toString(event,d) + ") is" + neg + "loaded" : "";
+		String world = pattern == 2 ? "world[s] " + this.world.toString(event, d) + (this.world.isSingle() ? " is" : " are") + neg + "loaded" : "";
 		return chunk + chunkC + world;
 	}
 	

--- a/src/main/java/ch/njol/skript/conditions/CondIsOfType.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsOfType.java
@@ -86,9 +86,9 @@ public class CondIsOfType extends Condition {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return PropertyCondition.toString(this, PropertyType.BE, e, debug, what,
-				"of " + (types.isSingle() ? "type " : "types") + types.toString(e, debug));
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return PropertyCondition.toString(this, PropertyType.BE, event, debug, what,
+				"of " + (types.isSingle() ? "type " : "types") + types.toString(event, debug));
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsPluginEnabled.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsPluginEnabled.java
@@ -80,11 +80,11 @@ public class CondIsPluginEnabled extends Condition {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		String plugin = plugins.isSingle() ? "plugin " : "plugins ";
 		String plural = plugins.isSingle() ? " is" : " are";
 		String pattern = this.pattern == 0 ? " enabled" : this.pattern == 1 ? " not enabled" : " disabled";
-		return plugin + plugins.toString(e, debug) + plural + pattern;
+		return plugin + plugins.toString(event, debug) + plural + pattern;
 	}
 
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsRiding.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsRiding.java
@@ -70,9 +70,9 @@ public class CondIsRiding extends Condition {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return PropertyCondition.toString(this, PropertyType.BE, e, debug, entities,
-				"riding " + types.toString(e, debug));
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return PropertyCondition.toString(this, PropertyType.BE, event, debug, entities,
+				"riding " + types.toString(event, debug));
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsSet.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsSet.java
@@ -81,8 +81,8 @@ public class CondIsSet extends Condition {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return expr.toString(e, debug) + (isNegated() ? " isn't" : " is") + " set";
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return expr.toString(event, debug) + (isNegated() ? " isn't" : " is") + " set";
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsWearing.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsWearing.java
@@ -82,9 +82,9 @@ public class CondIsWearing extends Condition {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return PropertyCondition.toString(this, PropertyType.BE, e, debug, entities,
-				"wearing " + types.toString(e, debug));
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return PropertyCondition.toString(this, PropertyType.BE, event, debug, entities,
+				"wearing " + types.toString(event, debug));
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsWhitelisted.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsWhitelisted.java
@@ -83,8 +83,8 @@ public class CondIsWhitelisted extends Condition {
 	
 	@Override
 	@SuppressWarnings("null")
-	public String toString(@Nullable Event e, boolean debug) {
-		return (player.getSingle(e) != null ? "player" : "server") + (isNegated() ? "not" : "") + "  whitelisted";
+	public String toString(@Nullable Event event, boolean debug) {
+		return (player.getSingle(event) != null ? "player" : "server") + (isNegated() ? "not" : "") + "  whitelisted";
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondItemInHand.java
+++ b/src/main/java/ch/njol/skript/conditions/CondItemInHand.java
@@ -88,9 +88,9 @@ public class CondItemInHand extends Condition {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return entities.toString(e, debug) + " " + (entities.isSingle() ? "is" : "are")
-				+ " holding " + items.toString(e, debug)
+	public String toString(@Nullable Event event, boolean debug) {
+		return entities.toString(event, debug) + " " + (entities.isSingle() ? "is" : "are")
+				+ " holding " + items.toString(event, debug)
 				+ (offTool ? " in off-hand" : "");
 	}
 	

--- a/src/main/java/ch/njol/skript/conditions/CondMatches.java
+++ b/src/main/java/ch/njol/skript/conditions/CondMatches.java
@@ -96,8 +96,8 @@ public class CondMatches extends Condition {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return strings.toString(e, debug) + " " + (isNegated() ? "doesn't match" : "matches") + " " + regex.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return strings.toString(event, debug) + " " + (isNegated() ? "doesn't match" : "matches") + " " + regex.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondPermission.java
+++ b/src/main/java/ch/njol/skript/conditions/CondPermission.java
@@ -85,8 +85,8 @@ public class CondPermission extends Condition {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return PropertyCondition.toString(this, PropertyType.HAVE, e, debug, senders,
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return PropertyCondition.toString(this, PropertyType.HAVE, event, debug, senders,
 				"the permission" + (permissions.isSingle() ? " " : "s ") + permissions.toString());
 	}
 	

--- a/src/main/java/ch/njol/skript/conditions/CondPlayedBefore.java
+++ b/src/main/java/ch/njol/skript/conditions/CondPlayedBefore.java
@@ -66,8 +66,8 @@ public class CondPlayedBefore extends Condition {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return players.toString(e, debug) + (isNegated() ? (players.isSingle() ? " hasn't" : " haven't") : (players.isSingle() ? " has" : " have"))
+	public String toString(@Nullable Event event, boolean debug) {
+		return players.toString(event, debug) + (isNegated() ? (players.isSingle() ? " hasn't" : " haven't") : (players.isSingle() ? " has" : " have"))
 			+ " played on this server before";
 	}
 	

--- a/src/main/java/ch/njol/skript/conditions/CondPvP.java
+++ b/src/main/java/ch/njol/skript/conditions/CondPvP.java
@@ -64,7 +64,7 @@ public class CondPvP extends Condition {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "PvP is " + (enabled ? "enabled" : "disabled") + " in " + worlds.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "PvP is " + (enabled ? "enabled" : "disabled") + " in " + worlds.toString(event, debug);
 	}
 }

--- a/src/main/java/ch/njol/skript/conditions/CondResourcePack.java
+++ b/src/main/java/ch/njol/skript/conditions/CondResourcePack.java
@@ -74,8 +74,8 @@ public class CondResourcePack extends Condition {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "resource pack was " + (isNegated() ? "not " : "") + states.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "resource pack was " + (isNegated() ? "not " : "") + states.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/CondStartsEndsWith.java
+++ b/src/main/java/ch/njol/skript/conditions/CondStartsEndsWith.java
@@ -100,11 +100,11 @@ public class CondStartsEndsWith extends Condition {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		if (isNegated())
-			return strings.toString(e, debug) + " doesn't " + (usingEnds ? "end" : "start") + " with " + affix.toString(e, debug);
+			return strings.toString(event, debug) + " doesn't " + (usingEnds ? "end" : "start") + " with " + affix.toString(event, debug);
 		else
-			return strings.toString(e, debug) + (usingEnds ? " ends" : " starts") + " with " + affix.toString(e, debug);
+			return strings.toString(event, debug) + (usingEnds ? " ends" : " starts") + " with " + affix.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
+++ b/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
@@ -129,8 +129,8 @@ public abstract class PropertyCondition<T> extends Condition implements Checker<
 	}
 	
 	@Override
-	public final boolean check(final Event e) {
-		return expr.check(e, this, isNegated());
+	public final boolean check(final Event event) {
+		return expr.check(event, this, isNegated());
 	}
 	
 	@Override
@@ -152,8 +152,8 @@ public abstract class PropertyCondition<T> extends Condition implements Checker<
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return toString(this, getPropertyType(), e, debug, expr, getPropertyName());
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return toString(this, getPropertyType(), event, debug, expr, getPropertyName());
 	}
 	
 	public static String toString(Condition condition, PropertyType propertyType, @Nullable Event e,

--- a/src/main/java/ch/njol/skript/effects/EffActionBar.java
+++ b/src/main/java/ch/njol/skript/effects/EffActionBar.java
@@ -62,17 +62,17 @@ public class EffActionBar extends Effect {
 
 	@SuppressWarnings("deprecation")
 	@Override
-	protected void execute(final Event e) {
-		String msg = message.getSingle(e);
+	protected void execute(final Event event) {
+		String msg = message.getSingle(event);
 		assert msg != null;
 		BaseComponent[] components = BungeeConverter.convert(ChatMessages.parseToArray(msg));
-		for (Player player : recipients.getArray(e))
+		for (Player player : recipients.getArray(event))
 			player.spigot().sendMessage(ChatMessageType.ACTION_BAR, components);
 	}
 
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "send action bar " + message.toString(e, debug) + " to " + recipients.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "send action bar " + message.toString(event, debug) + " to " + recipients.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffBan.java
+++ b/src/main/java/ch/njol/skript/effects/EffBan.java
@@ -84,12 +84,12 @@ public class EffBan extends Effect {
 	
 	@SuppressWarnings("null")
 	@Override
-	protected void execute(final Event e) {
-		final String reason = this.reason != null ? this.reason.getSingle(e) : null; // don't check for null, just ignore an invalid reason
-		Timespan ts = this.expires != null ? this.expires.getSingle(e) : null;
+	protected void execute(final Event event) {
+		final String reason = this.reason != null ? this.reason.getSingle(event) : null; // don't check for null, just ignore an invalid reason
+		Timespan ts = this.expires != null ? this.expires.getSingle(event) : null;
 		final Date expires = ts != null ? new Date(System.currentTimeMillis() + ts.getMilliSeconds()) : null;
 		final String source = "Skript ban effect";
-		for (final Object o : players.getArray(e)) {
+		for (final Object o : players.getArray(event)) {
 			if (o instanceof Player) {
 				if (ipBan) {
 					InetSocketAddress addr = ((Player) o).getAddress();
@@ -130,9 +130,9 @@ public class EffBan extends Effect {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return (ipBan ? "IP-" : "") + (ban ? "" : "un") + "ban " + players.toString(e, debug) +
-			(reason != null ? " on account of " + reason.toString(e, debug) : "") + (expires != null ? " for " + expires.toString(e, debug) : "");
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return (ipBan ? "IP-" : "") + (ban ? "" : "un") + "ban " + players.toString(event, debug) +
+			(reason != null ? " on account of " + reason.toString(event, debug) : "") + (expires != null ? " for " + expires.toString(event, debug) : "");
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffBreakNaturally.java
+++ b/src/main/java/ch/njol/skript/effects/EffBreakNaturally.java
@@ -62,9 +62,9 @@ public class EffBreakNaturally extends Effect {
 	}
 	
 	@Override
-	protected void execute(final Event e) {
-		ItemType tool = this.tool != null ? this.tool.getSingle(e) : null;
-		for (Block block : this.blocks.getArray(e)) {
+	protected void execute(final Event event) {
+		ItemType tool = this.tool != null ? this.tool.getSingle(event) : null;
+		for (Block block : this.blocks.getArray(event)) {
 			if (tool != null) {
 				ItemStack is = tool.getRandom();
 				if (is != null)
@@ -78,7 +78,7 @@ public class EffBreakNaturally extends Effect {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "break " + blocks.toString(e, debug) + " naturally" + (tool != null ? " using " + tool.toString(e, debug) : "");
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "break " + blocks.toString(event, debug) + " naturally" + (tool != null ? " using " + tool.toString(event, debug) : "");
 	}
 }

--- a/src/main/java/ch/njol/skript/effects/EffBroadcast.java
+++ b/src/main/java/ch/njol/skript/effects/EffBroadcast.java
@@ -77,27 +77,27 @@ public class EffBroadcast extends Effect {
 	
 	@Override
 	@SuppressWarnings("deprecation")
-	public void execute(Event e) {
+	public void execute(Event event) {
 		List<CommandSender> receivers = new ArrayList<>();
 		if (worlds == null) {
 			receivers.addAll(Bukkit.getOnlinePlayers());
 			receivers.add(Bukkit.getConsoleSender());
 		} else {
-			for (World world : worlds.getArray(e))
+			for (World world : worlds.getArray(event))
 				receivers.addAll(world.getPlayers());
 		}
 
 		for (Expression<?> message : getMessages()) {
 			if (message instanceof VariableString) {
-				BaseComponent[] components = BungeeConverter.convert(((VariableString) message).getMessageComponents(e));
+				BaseComponent[] components = BungeeConverter.convert(((VariableString) message).getMessageComponents(event));
 				receivers.forEach(receiver -> receiver.spigot().sendMessage(components));
 			} else if (message instanceof ExprColoured && ((ExprColoured) message).isUnsafeFormat()) { // Manually marked as trusted
-				for (Object realMessage : message.getArray(e)) {
+				for (Object realMessage : message.getArray(event)) {
 					BaseComponent[] components = BungeeConverter.convert(ChatMessages.parse((String) realMessage));
 					receivers.forEach(receiver -> receiver.spigot().sendMessage(components));
 				}
 			} else {
-				for (Object messageObject : message.getArray(e)) {
+				for (Object messageObject : message.getArray(event)) {
 					String realMessage = messageObject instanceof String ? (String) messageObject : Classes.toString(messageObject);
 					receivers.forEach(receiver -> receiver.sendMessage(realMessage));
 				}
@@ -113,8 +113,8 @@ public class EffBroadcast extends Effect {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "broadcast " + messageExpr.toString(e, debug) + (worlds == null ? "" : " to " + worlds.toString(e, debug));
+	public String toString(@Nullable Event event, boolean debug) {
+		return "broadcast " + messageExpr.toString(event, debug) + (worlds == null ? "" : " to " + worlds.toString(event, debug));
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffCancelCooldown.java
+++ b/src/main/java/ch/njol/skript/effects/EffCancelCooldown.java
@@ -68,15 +68,15 @@ public class EffCancelCooldown extends Effect {
 	}
 
 	@Override
-	protected void execute(Event e) {
-		if (!(e instanceof ScriptCommandEvent))
+	protected void execute(Event event) {
+		if (!(event instanceof ScriptCommandEvent))
 			return;
 
-		((ScriptCommandEvent) e).setCooldownCancelled(cancel);
+		((ScriptCommandEvent) event).setCooldownCancelled(cancel);
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return (cancel ? "" : "un") + "cancel the command cooldown";
 	}
 

--- a/src/main/java/ch/njol/skript/effects/EffCancelDrops.java
+++ b/src/main/java/ch/njol/skript/effects/EffCancelDrops.java
@@ -99,7 +99,7 @@ public class EffCancelDrops extends Effect {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		if (cancelItems && !cancelExps)
 			return "cancel the drops of items";
 		else if (cancelExps && !cancelItems)

--- a/src/main/java/ch/njol/skript/effects/EffCancelEvent.java
+++ b/src/main/java/ch/njol/skript/effects/EffCancelEvent.java
@@ -81,22 +81,22 @@ public class EffCancelEvent extends Effect {
 	}
 	
 	@Override
-	public void execute(final Event e) {
-		if (e instanceof Cancellable)
-			((Cancellable) e).setCancelled(cancel);
-		if (e instanceof PlayerInteractEvent) {
-			EvtClick.interactTracker.eventModified((Cancellable) e);
-			((PlayerInteractEvent) e).setUseItemInHand(cancel ? Result.DENY : Result.DEFAULT);
-			((PlayerInteractEvent) e).setUseInteractedBlock(cancel ? Result.DENY : Result.DEFAULT);
-		} else if (e instanceof BlockCanBuildEvent) {
-			((BlockCanBuildEvent) e).setBuildable(!cancel);
-		} else if (e instanceof PlayerDropItemEvent) {
-			PlayerUtils.updateInventory(((PlayerDropItemEvent) e).getPlayer());
+	public void execute(final Event event) {
+		if (event instanceof Cancellable)
+			((Cancellable) event).setCancelled(cancel);
+		if (event instanceof PlayerInteractEvent) {
+			EvtClick.interactTracker.eventModified((Cancellable) event);
+			((PlayerInteractEvent) event).setUseItemInHand(cancel ? Result.DENY : Result.DEFAULT);
+			((PlayerInteractEvent) event).setUseInteractedBlock(cancel ? Result.DENY : Result.DEFAULT);
+		} else if (event instanceof BlockCanBuildEvent) {
+			((BlockCanBuildEvent) event).setBuildable(!cancel);
+		} else if (event instanceof PlayerDropItemEvent) {
+			PlayerUtils.updateInventory(((PlayerDropItemEvent) event).getPlayer());
 		}
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return (cancel ? "" : "un") + "cancel event";
 	}
 	

--- a/src/main/java/ch/njol/skript/effects/EffChange.java
+++ b/src/main/java/ch/njol/skript/effects/EffChange.java
@@ -268,38 +268,38 @@ public class EffChange extends Effect {
 	}
 	
 	@Override
-	protected void execute(Event e) {
-		Object[] delta = changer == null ? null : changer.getArray(e);
+	protected void execute(Event event) {
+		Object[] delta = changer == null ? null : changer.getArray(event);
 		delta = changer == null ? delta : changer.beforeChange(changed, delta);
 
 		if ((delta == null || delta.length == 0) && (mode != ChangeMode.DELETE && mode != ChangeMode.RESET)) {
 			if (mode == ChangeMode.SET && changed.acceptChange(ChangeMode.DELETE) != null)
-				changed.change(e, null, ChangeMode.DELETE);
+				changed.change(event, null, ChangeMode.DELETE);
 			return;
 		}
-		changed.change(e, delta, mode);
+		changed.change(event, delta, mode);
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		final Expression<?> changer = this.changer;
 		switch (mode) {
 			case ADD:
 				assert changer != null;
-				return "add " + changer.toString(e, debug) + " to " + changed.toString(e, debug);
+				return "add " + changer.toString(event, debug) + " to " + changed.toString(event, debug);
 			case SET:
 				assert changer != null;
-				return "set " + changed.toString(e, debug) + " to " + changer.toString(e, debug);
+				return "set " + changed.toString(event, debug) + " to " + changer.toString(event, debug);
 			case REMOVE:
 				assert changer != null;
-				return "remove " + changer.toString(e, debug) + " from " + changed.toString(e, debug);
+				return "remove " + changer.toString(event, debug) + " from " + changed.toString(event, debug);
 			case REMOVE_ALL:
 				assert changer != null;
-				return "remove all " + changer.toString(e, debug) + " from " + changed.toString(e, debug);
+				return "remove all " + changer.toString(event, debug) + " from " + changed.toString(event, debug);
 			case DELETE:
-				return "delete/clear " + changed.toString(e, debug);
+				return "delete/clear " + changed.toString(event, debug);
 			case RESET:
-				return "reset " + changed.toString(e, debug);
+				return "reset " + changed.toString(event, debug);
 		}
 		assert false;
 		return "";

--- a/src/main/java/ch/njol/skript/effects/EffChargeCreeper.java
+++ b/src/main/java/ch/njol/skript/effects/EffChargeCreeper.java
@@ -60,15 +60,15 @@ public class EffChargeCreeper extends Effect {
 	}
 
 	@Override
-	protected void execute(Event e) {
-		for (LivingEntity le : entities.getArray(e)) {
+	protected void execute(Event event) {
+		for (LivingEntity le : entities.getArray(event)) {
 			if (le instanceof Creeper)
 				((Creeper) le).setPowered(charge);
 		}
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "make " + entities.toString(e, debug) + (charge == true ? " charged" : " not charged");
+	public String toString(@Nullable Event event, boolean debug) {
+		return "make " + entities.toString(event, debug) + (charge == true ? " charged" : " not charged");
 	}
 }

--- a/src/main/java/ch/njol/skript/effects/EffColorItems.java
+++ b/src/main/java/ch/njol/skript/effects/EffColorItems.java
@@ -86,10 +86,10 @@ public class EffColorItems extends Effect {
 				
 				@Nullable
 				@Override
-				protected Color[] get(Event e) {
-					Number r = red.getSingle(e),
-						g = green.getSingle(e),
-						b = blue.getSingle(e);
+				protected Color[] get(Event event) {
+					Number r = red.getSingle(event),
+						g = green.getSingle(event),
+						b = blue.getSingle(event);
 					
 					if (r == null || g == null || b == null)
 						return null;
@@ -108,8 +108,8 @@ public class EffColorItems extends Effect {
 				}
 				
 				@Override
-				public String toString(@Nullable Event e, boolean debug) {
-					return "RED: " + red.toString(e, debug) + ", GREEN: " + green.toString(e, debug) + "BLUE: " + blue.toString(e, debug);
+				public String toString(@Nullable Event event, boolean debug) {
+					return "RED: " + red.toString(event, debug) + ", GREEN: " + green.toString(event, debug) + "BLUE: " + blue.toString(event, debug);
 				}
 			};
 			color.init(CollectionUtils.array(exprs[1], exprs[2], exprs[3]), 0, isDelayed, parser);
@@ -118,9 +118,9 @@ public class EffColorItems extends Effect {
 	}
 	
 	@Override
-	protected void execute(Event e) {
-		Color color = this.color.getSingle(e);
-		ItemType[] items = this.items.getArray(e);
+	protected void execute(Event event) {
+		Color color = this.color.getSingle(event);
+		ItemType[] items = this.items.getArray(event);
 		org.bukkit.Color c;
 		
 		if (color == null) {
@@ -152,7 +152,7 @@ public class EffColorItems extends Effect {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "dye " + items.toString(e, debug) + " " + color.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "dye " + items.toString(event, debug) + " " + color.toString(event, debug);
 	}
 }

--- a/src/main/java/ch/njol/skript/effects/EffCommand.java
+++ b/src/main/java/ch/njol/skript/effects/EffCommand.java
@@ -71,13 +71,13 @@ public class EffCommand extends Effect {
 	}
 	
 	@Override
-	public void execute(final Event e) {
-		for (String command : commands.getArray(e)) {
+	public void execute(final Event event) {
+		for (String command : commands.getArray(event)) {
 			assert command != null;
 			if (command.startsWith("/"))
 				command = "" + command.substring(1);
 			if (senders != null) {
-				for (final CommandSender sender : senders.getArray(e)) {
+				for (final CommandSender sender : senders.getArray(event)) {
 					assert sender != null;
 					Skript.dispatchCommand(sender, command);
 				}
@@ -88,8 +88,8 @@ public class EffCommand extends Effect {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "make " + (senders != null ? senders.toString(e, debug) : "the console") + " execute the command " + commands.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "make " + (senders != null ? senders.toString(event, debug) : "the console") + " execute the command " + commands.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffConnect.java
+++ b/src/main/java/ch/njol/skript/effects/EffConnect.java
@@ -57,9 +57,9 @@ public class EffConnect extends Effect {
 	private Expression<String> server;
 
 	@Override
-	protected void execute(Event e) {
-		String server = this.server.getSingle(e);
-		Player[] players = this.players.stream(e)
+	protected void execute(Event event) {
+		String server = this.server.getSingle(event);
+		Player[] players = this.players.stream(event)
 			.filter(Player::isOnline)
 			.toArray(Player[]::new);
 		if (server == null || players.length == 0)
@@ -80,8 +80,8 @@ public class EffConnect extends Effect {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "connect " + players.toString(e, debug) + " to " + server.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "connect " + players.toString(event, debug) + " to " + server.toString(event, debug);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/effects/EffContinue.java
+++ b/src/main/java/ch/njol/skript/effects/EffContinue.java
@@ -70,18 +70,18 @@ public class EffContinue extends Effect {
 	}
 
 	@Override
-	protected void execute(Event e) {
+	protected void execute(Event event) {
 		throw new UnsupportedOperationException();
 	}
 
 	@Nullable
 	@Override
-	protected TriggerItem walk(Event e) {
+	protected TriggerItem walk(Event event) {
 		return section;
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "continue";
 	}
 

--- a/src/main/java/ch/njol/skript/effects/EffDoIf.java
+++ b/src/main/java/ch/njol/skript/effects/EffDoIf.java
@@ -65,12 +65,12 @@ public class EffDoIf extends Effect  {
 	}
 
 	@Override
-	protected void execute(Event e) {}
+	protected void execute(Event event) {}
 	
 	@Nullable
 	@Override
-	public TriggerItem walk(Event e) {
-		if (condition.check(e)) {
+	public TriggerItem walk(Event event) {
+		if (condition.check(event)) {
 			effect.setParent(getParent());
 			effect.setNext(getNext());
 			return effect;
@@ -79,8 +79,8 @@ public class EffDoIf extends Effect  {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return effect.toString(e, debug) + " if " + condition.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return effect.toString(event, debug) + " if " + condition.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffDrop.java
+++ b/src/main/java/ch/njol/skript/effects/EffDrop.java
@@ -73,9 +73,9 @@ public class EffDrop extends Effect {
 	}
 
 	@Override
-	public void execute(Event e) {
-		Object[] os = drops.getArray(e);
-		for (Location l : locations.getArray(e)) {
+	public void execute(Event event) {
+		Object[] os = drops.getArray(event);
+		for (Location l : locations.getArray(event)) {
 			Location itemDropLoc = l.clone().subtract(0.5, 0.5, 0.5); // dropItemNaturally adds 0.15 to 0.85 randomly to all coordinates
 			for (Object o : os) {
 				if (o instanceof Experience) {
@@ -103,8 +103,8 @@ public class EffDrop extends Effect {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "drop " + drops.toString(e, debug) + " " + locations.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "drop " + drops.toString(event, debug) + " " + locations.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffEnchant.java
+++ b/src/main/java/ch/njol/skript/effects/EffEnchant.java
@@ -71,12 +71,12 @@ public class EffEnchant extends Effect {
 	}
 	
 	@Override
-	protected void execute(final Event e) {
-		final ItemType i = item.getSingle(e);
+	protected void execute(final Event event) {
+		final ItemType i = item.getSingle(event);
 		if (i == null)
 			return;
 		if (enchs != null) {
-			final EnchantmentType[] types = enchs.getArray(e);
+			final EnchantmentType[] types = enchs.getArray(event);
 			if (types.length == 0)
 				return;
 			
@@ -85,7 +85,7 @@ public class EffEnchant extends Effect {
 				assert ench != null;
 				i.addEnchantments(new EnchantmentType(ench, type.getLevel()));
 			}
-			item.change(e, new ItemType[] {i}, ChangeMode.SET);
+			item.change(event, new ItemType[] {i}, ChangeMode.SET);
 		} else {
 			final EnchantmentType[] types = i.getEnchantmentTypes();
 			if (types == null)
@@ -95,13 +95,13 @@ public class EffEnchant extends Effect {
 				assert ench != null;
 				i.removeEnchantments(ench);
 			}
-			item.change(e, new ItemType[] {i}, ChangeMode.SET);
+			item.change(event, new ItemType[] {i}, ChangeMode.SET);
 		}
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return enchs == null ? "disenchant " + item.toString(e, debug) : "enchant " + item.toString(e, debug) + " with " + enchs;
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return enchs == null ? "disenchant " + item.toString(event, debug) : "enchant " + item.toString(event, debug) + " with " + enchs;
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffExceptionDebug.java
+++ b/src/main/java/ch/njol/skript/effects/EffExceptionDebug.java
@@ -42,12 +42,12 @@ public class EffExceptionDebug extends Effect {
 	
 
 	@Override
-	protected void execute(Event e) {
+	protected void execute(Event event) {
 		Skript.exception("Created by a script (debugging)...");
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "cause exception";
 	}
 	

--- a/src/main/java/ch/njol/skript/effects/EffExit.java
+++ b/src/main/java/ch/njol/skript/effects/EffExit.java
@@ -112,8 +112,8 @@ public class EffExit extends Effect { // TODO [code style] warn user about code 
 	
 	@Override
 	@Nullable
-	protected TriggerItem walk(final Event e) {
-		debug(e, false);
+	protected TriggerItem walk(final Event event) {
+		debug(event, false);
 		TriggerItem n = this;
 		for (int i = breakLevels; i > 0;) {
 			n = n.getParent();
@@ -122,7 +122,7 @@ public class EffExit extends Effect { // TODO [code style] warn user about code 
 				return null;
 			}
 			if (n instanceof SecLoop) {
-				((SecLoop) n).exit(e);
+				((SecLoop) n).exit(event);
 			} else if (n instanceof SecWhile) {
 				((SecWhile) n).reset();
 			}
@@ -134,12 +134,12 @@ public class EffExit extends Effect { // TODO [code style] warn user about code 
 	}
 	
 	@Override
-	protected void execute(final Event e) {
+	protected void execute(final Event event) {
 		assert false;
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "stop " + breakLevels + " " + names[type];
 	}
 	

--- a/src/main/java/ch/njol/skript/effects/EffExplodeCreeper.java
+++ b/src/main/java/ch/njol/skript/effects/EffExplodeCreeper.java
@@ -84,8 +84,8 @@ public class EffExplodeCreeper extends Effect {
 	}
 
 	@Override
-	protected void execute(final Event e) {
-		for (final LivingEntity le : entities.getArray(e)) {
+	protected void execute(final Event event) {
+		for (final LivingEntity le : entities.getArray(event)) {
 			if (le instanceof Creeper) {
 				if (instant) {
 					((Creeper) le).explode();
@@ -103,8 +103,8 @@ public class EffExplodeCreeper extends Effect {
 	}
 
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return (instant == true ? "instantly explode " : "start the explosion process of ") + entities.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return (instant == true ? "instantly explode " : "start the explosion process of ") + entities.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffExplosion.java
+++ b/src/main/java/ch/njol/skript/effects/EffExplosion.java
@@ -74,11 +74,11 @@ public class EffExplosion extends Effect {
 	}
 
 	@Override
-	public void execute(final Event e) {
-		final Number power = force != null ? force.getSingle(e) : 0;
+	public void execute(final Event event) {
+		final Number power = force != null ? force.getSingle(event) : 0;
 		if (power == null)
 			return;
-		for (final Location l : locations.getArray(e)) {
+		for (final Location l : locations.getArray(event)) {
 			if (!blockDamage)
 				l.getWorld().createExplosion(l.getX(), l.getY(), l.getZ(), power.floatValue(), false, false);
 			else
@@ -87,11 +87,11 @@ public class EffExplosion extends Effect {
 	}
 
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		if (force != null)
-			return "create explosion of force " + force.toString(e, debug) + " " + locations.toString(e, debug);
+			return "create explosion of force " + force.toString(event, debug) + " " + locations.toString(event, debug);
 		else
-			return "create explosion effect " + locations.toString(e, debug);
+			return "create explosion effect " + locations.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffFeed.java
+++ b/src/main/java/ch/njol/skript/effects/EffFeed.java
@@ -54,23 +54,23 @@ public class EffFeed extends Effect {
     }
 
     @Override
-    protected void execute(Event e) {
+    protected void execute(Event event) {
         int level = 20;
 
         if (beefs != null) {
-            Number n = beefs.getSingle(e);
+            Number n = beefs.getSingle(event);
             if (n == null)
                 return;
             level = n.intValue();
         }
-        for (Player player : players.getArray(e)) {
+        for (Player player : players.getArray(event)) {
             player.setFoodLevel(player.getFoodLevel() + level);
         }
     }
 
     @Override
-    public String toString(@Nullable Event e, boolean debug) {
-        return "feed " + players.toString(e, debug) + (beefs != null ? " by " + beefs.toString(e, debug) : "");
+    public String toString(@Nullable Event event, boolean debug) {
+        return "feed " + players.toString(event, debug) + (beefs != null ? " by " + beefs.toString(event, debug) : "");
     }
 
 

--- a/src/main/java/ch/njol/skript/effects/EffForceAttack.java
+++ b/src/main/java/ch/njol/skript/effects/EffForceAttack.java
@@ -68,18 +68,18 @@ public class EffForceAttack extends Effect {
 	}
 	
 	@Override
-	protected void execute(Event e) {
-		Entity target = this.target.getSingle(e);
+	protected void execute(Event event) {
+		Entity target = this.target.getSingle(event);
 		if (target != null) {
-			for (LivingEntity entity : entities.getArray(e)) {
+			for (LivingEntity entity : entities.getArray(event)) {
 				entity.attack(target);
 			}
 		}
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "make " + entities.toString(e, debug) + " attack " + target.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "make " + entities.toString(event, debug) + " attack " + target.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffHealth.java
+++ b/src/main/java/ch/njol/skript/effects/EffHealth.java
@@ -83,15 +83,15 @@ public class EffHealth extends Effect {
 	}
 
 	@Override
-	public void execute(Event e) {
+	public void execute(Event event) {
 		double damage = 0;
 		if (this.damage != null) {
-			Number number = this.damage.getSingle(e);
+			Number number = this.damage.getSingle(event);
 			if (number == null)
 				return;
 			damage = number.doubleValue();
 		}
-		Object[] array = damageables.getArray(e);
+		Object[] array = damageables.getArray(event);
 		Object[] newArray = new Object[array.length];
 
 		boolean requiresChange = false;
@@ -124,12 +124,12 @@ public class EffHealth extends Effect {
 		}
 
 		if (requiresChange)
-			damageables.change(e, newArray, ChangeMode.SET);
+			damageables.change(event, newArray, ChangeMode.SET);
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return (heal ? "heal" : "damage") + " " + damageables.toString(e, debug) + (damage != null ? " by " + damage.toString(e, debug) : "");
+	public String toString(@Nullable Event event, boolean debug) {
+		return (heal ? "heal" : "damage") + " " + damageables.toString(event, debug) + (damage != null ? " by " + damage.toString(event, debug) : "");
 	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffHidePlayerFromServerList.java
+++ b/src/main/java/ch/njol/skript/effects/EffHidePlayerFromServerList.java
@@ -74,17 +74,17 @@ public class EffHidePlayerFromServerList extends Effect {
 	}
 
 	@Override
-	protected void execute(Event e) {
-		if (!(e instanceof ServerListPingEvent))
+	protected void execute(Event event) {
+		if (!(event instanceof ServerListPingEvent))
 			return;
 
-		Iterator<Player> it = ((ServerListPingEvent) e).iterator();		
-		Iterators.removeAll(it, Arrays.asList(players.getArray(e)));
+		Iterator<Player> it = ((ServerListPingEvent) event).iterator();
+		Iterators.removeAll(it, Arrays.asList(players.getArray(event)));
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "hide " + players.toString(e, debug) + " from the server list";
+	public String toString(@Nullable Event event, boolean debug) {
+		return "hide " + players.toString(event, debug) + " from the server list";
 	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffIgnite.java
+++ b/src/main/java/ch/njol/skript/effects/EffIgnite.java
@@ -70,18 +70,18 @@ public class EffIgnite extends Effect {
 	}
 	
 	@Override
-	protected void execute(final Event e) {
+	protected void execute(final Event event) {
 		final int d;
 		if (duration != null) {
-			final Timespan t = duration.getSingle(e);
+			final Timespan t = duration.getSingle(event);
 			if (t == null)
 				return;
 			d = (int) (t.getTicks_i() >= Integer.MAX_VALUE ? Integer.MAX_VALUE : t.getTicks_i());
 		} else {
 			d = ignite ? DEFAULT_DURATION : 0;
 		}
-		for (final Entity en : entities.getArray(e)) {
-			if (e instanceof EntityDamageEvent && ((EntityDamageEvent) e).getEntity() == en && !Delay.isDelayed(e)) {
+		for (final Entity en : entities.getArray(event)) {
+			if (event instanceof EntityDamageEvent && ((EntityDamageEvent) event).getEntity() == en && !Delay.isDelayed(event)) {
 				Bukkit.getScheduler().scheduleSyncDelayedTask(Skript.getInstance(), new Runnable() {
 					@Override
 					public void run() {
@@ -89,19 +89,19 @@ public class EffIgnite extends Effect {
 					}
 				});
 			} else {
-				if (e instanceof EntityCombustEvent && ((EntityCombustEvent) e).getEntity() == en && !Delay.isDelayed(e))
-					((EntityCombustEvent) e).setCancelled(true);// can't change the duration, thus simply cancel the event (and create a new one)
+				if (event instanceof EntityCombustEvent && ((EntityCombustEvent) event).getEntity() == en && !Delay.isDelayed(event))
+					((EntityCombustEvent) event).setCancelled(true);// can't change the duration, thus simply cancel the event (and create a new one)
 				en.setFireTicks(d);
 			}
 		}
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		if (ignite)
-			return "set " + entities.toString(e, debug) + " on fire for " + (duration != null ? duration.toString(e, debug) : Timespan.fromTicks(DEFAULT_DURATION).toString());
+			return "set " + entities.toString(event, debug) + " on fire for " + (duration != null ? duration.toString(event, debug) : Timespan.fromTicks(DEFAULT_DURATION).toString());
 		else
-			return "extinguish " + entities.toString(e, debug);
+			return "extinguish " + entities.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffIncendiary.java
+++ b/src/main/java/ch/njol/skript/effects/EffIncendiary.java
@@ -72,14 +72,14 @@ public class EffIncendiary extends Effect {
 	}
 
 	@Override
-	protected void execute(Event e) {
+	protected void execute(Event event) {
 		if (isEvent) {
-			if (!(e instanceof ExplosionPrimeEvent))
+			if (!(event instanceof ExplosionPrimeEvent))
 				return;
 
-			((ExplosionPrimeEvent) e).setFire(causeFire);
+			((ExplosionPrimeEvent) event).setFire(causeFire);
 		} else {
-			for (Entity entity : entities.getArray(e)) {
+			for (Entity entity : entities.getArray(event)) {
 				if (entity instanceof Explosive)
 					((Explosive) entity).setIsIncendiary(causeFire);
 			}
@@ -87,10 +87,10 @@ public class EffIncendiary extends Effect {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		if (isEvent)
 			return "make the event-explosion " + (causeFire == true ? "" : "not") + " fiery";
-		return "make " + entities.toString(e, debug) + (causeFire == true ? "" : " not") + " incendiary";
+		return "make " + entities.toString(event, debug) + (causeFire == true ? "" : " not") + " incendiary";
 	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffInvulnerability.java
+++ b/src/main/java/ch/njol/skript/effects/EffInvulnerability.java
@@ -57,15 +57,15 @@ public class EffInvulnerability extends Effect {
 	}
 	
 	@Override
-	protected void execute(Event e) {
-		for (Entity entity : entities.getArray(e)) {
+	protected void execute(Event event) {
+		for (Entity entity : entities.getArray(event)) {
 			entity.setInvulnerable(invulnerable);
 		}
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "make " + entities.toString(e, debug) + (invulnerable ? " invulnerable" : " not invulnerable");
+	public String toString(@Nullable Event event, boolean debug) {
+		return "make " + entities.toString(event, debug) + (invulnerable ? " invulnerable" : " not invulnerable");
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffKeepInventory.java
+++ b/src/main/java/ch/njol/skript/effects/EffKeepInventory.java
@@ -77,7 +77,7 @@ public class EffKeepInventory extends Effect {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		if (keepItems && !keepExp)
 			return "keep the inventory";
 		else

--- a/src/main/java/ch/njol/skript/effects/EffKick.java
+++ b/src/main/java/ch/njol/skript/effects/EffKick.java
@@ -63,20 +63,20 @@ public class EffKick extends Effect {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "kick " + players.toString(e, debug) + (reason != null ? " on account of " + reason.toString(e, debug) : "");
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "kick " + players.toString(event, debug) + (reason != null ? " on account of " + reason.toString(event, debug) : "");
 	}
 	
 	@Override
-	protected void execute(final Event e) {
-		final String r = reason != null ? reason.getSingle(e) : "";
+	protected void execute(final Event event) {
+		final String r = reason != null ? reason.getSingle(event) : "";
 		if (r == null)
 			return;
-		for (final Player p : players.getArray(e)) {
-			if (e instanceof PlayerLoginEvent && p.equals(((PlayerLoginEvent) e).getPlayer()) && !Delay.isDelayed(e)) {
-				((PlayerLoginEvent) e).disallow(Result.KICK_OTHER, r);
-			} else if (e instanceof PlayerKickEvent && p.equals(((PlayerKickEvent) e).getPlayer()) && !Delay.isDelayed(e)) {
-				((PlayerKickEvent) e).setLeaveMessage(r);
+		for (final Player p : players.getArray(event)) {
+			if (event instanceof PlayerLoginEvent && p.equals(((PlayerLoginEvent) event).getPlayer()) && !Delay.isDelayed(event)) {
+				((PlayerLoginEvent) event).disallow(Result.KICK_OTHER, r);
+			} else if (event instanceof PlayerKickEvent && p.equals(((PlayerKickEvent) event).getPlayer()) && !Delay.isDelayed(event)) {
+				((PlayerKickEvent) event).setLeaveMessage(r);
 			} else {
 				p.kickPlayer(r);
 			}

--- a/src/main/java/ch/njol/skript/effects/EffKill.java
+++ b/src/main/java/ch/njol/skript/effects/EffKill.java
@@ -66,8 +66,8 @@ public class EffKill extends Effect {
 	}
 
 	@Override
-	protected void execute(final Event e) {
-		for (Entity entity : entities.getArray(e)) {
+	protected void execute(final Event event) {
+		for (Entity entity : entities.getArray(event)) {
 
 			if (entity instanceof EnderDragonPart) {
 				entity = ((EnderDragonPart) entity).getParent();
@@ -93,8 +93,8 @@ public class EffKill extends Effect {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "kill" + entities.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "kill" + entities.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffLeash.java
+++ b/src/main/java/ch/njol/skript/effects/EffLeash.java
@@ -66,25 +66,25 @@ public class EffLeash extends Effect {
 	}
 
 	@Override
-	protected void execute(Event e) {
+	protected void execute(Event event) {
 		if (leash) {
-			Entity holder = this.holder.getSingle(e);
+			Entity holder = this.holder.getSingle(event);
 			if (holder == null)
 				return;
-			for (LivingEntity target : targets.getArray(e))
+			for (LivingEntity target : targets.getArray(event))
 				target.setLeashHolder(holder);
 		} else {
-			for (LivingEntity target : targets.getArray(e))
+			for (LivingEntity target : targets.getArray(event))
 				target.setLeashHolder(null);
 		}
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		if (leash)
-			return "leash " + targets.toString(e, debug) + " to " + holder.toString(e, debug);
+			return "leash " + targets.toString(event, debug) + " to " + holder.toString(event, debug);
 		else
-			return "unleash " + targets.toString(e, debug);
+			return "unleash " + targets.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffLightning.java
+++ b/src/main/java/ch/njol/skript/effects/EffLightning.java
@@ -65,8 +65,8 @@ public class EffLightning extends Effect {
 	}
 	
 	@Override
-	protected void execute(final Event e) {
-		for (final Location l : locations.getArray(e)) {
+	protected void execute(final Event event) {
+		for (final Location l : locations.getArray(event)) {
 			if (effectOnly)
 				lastSpawned = l.getWorld().strikeLightningEffect(l);
 			else
@@ -75,8 +75,8 @@ public class EffLightning extends Effect {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "strike lightning " + (effectOnly ? "effect " : "") + locations.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "strike lightning " + (effectOnly ? "effect " : "") + locations.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffLoadServerIcon.java
+++ b/src/main/java/ch/njol/skript/effects/EffLoadServerIcon.java
@@ -80,8 +80,8 @@ public class EffLoadServerIcon extends AsyncEffect {
 	}
 
     @Override
-    protected void execute(Event e) {
-		String pathString = path.getSingle(e);
+    protected void execute(Event event) {
+		String pathString = path.getSingle(event);
 		if (pathString == null)
 			return;
 		
@@ -97,8 +97,8 @@ public class EffLoadServerIcon extends AsyncEffect {
     }
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "load server icon from file " + path.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "load server icon from file " + path.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffLog.java
+++ b/src/main/java/ch/njol/skript/effects/EffLog.java
@@ -88,10 +88,10 @@ public class EffLog extends Effect {
 	
 	@SuppressWarnings("resource")
 	@Override
-	protected void execute(final Event e) {
-		for (final String message : messages.getArray(e)) {
+	protected void execute(final Event event) {
+		for (final String message : messages.getArray(event)) {
 			if (files != null) {
-				for (String s : files.getArray(e)) {
+				for (String s : files.getArray(event)) {
 					s = s.toLowerCase(Locale.ENGLISH);
 					if (!s.endsWith(".log"))
 						s += ".log";
@@ -128,7 +128,7 @@ public class EffLog extends Effect {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "log " + messages.toString(e, debug) + (files != null ? " to " + files.toString(e, debug) : "");
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "log " + messages.toString(event, debug) + (files != null ? " to " + files.toString(event, debug) : "");
 	}
 }

--- a/src/main/java/ch/njol/skript/effects/EffMakeFly.java
+++ b/src/main/java/ch/njol/skript/effects/EffMakeFly.java
@@ -60,16 +60,16 @@ public class EffMakeFly extends Effect {
 	}
 
 	@Override
-	protected void execute(Event e) {
-		for (Player player : players.getArray(e)) {
+	protected void execute(Event event) {
+		for (Player player : players.getArray(event)) {
 			player.setAllowFlight(flying);
 			player.setFlying(flying);
 		}
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "make " + players.toString(e, debug) + (flying ? " start " : " stop ") + "flying";
+	public String toString(@Nullable Event event, boolean debug) {
+		return "make " + players.toString(event, debug) + (flying ? " start " : " stop ") + "flying";
 	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffMakeSay.java
+++ b/src/main/java/ch/njol/skript/effects/EffMakeSay.java
@@ -58,16 +58,16 @@ public class EffMakeSay extends Effect {
 	}
 
 	@Override
-	protected void execute(Event e) {
-		for (Player player : players.getArray(e)) {
-			for (String message : messages.getArray(e)) {
+	protected void execute(Event event) {
+		for (Player player : players.getArray(event)) {
+			for (String message : messages.getArray(event)) {
 				player.chat(message);
 			}
 		}
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "make " + players.toString(e, debug) + " say " + messages.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "make " + players.toString(event, debug) + " say " + messages.toString(event, debug);
 	}
 }

--- a/src/main/java/ch/njol/skript/effects/EffMessage.java
+++ b/src/main/java/ch/njol/skript/effects/EffMessage.java
@@ -104,10 +104,10 @@ public class EffMessage extends Effect {
 	}
 
 	@Override
-	protected void execute(Event e) {
-		Player sender = this.sender != null ? this.sender.getSingle(e) : null;
+	protected void execute(Event event) {
+		Player sender = this.sender != null ? this.sender.getSingle(event) : null;
 
-		CommandSender[] commandSenders = recipients.getArray(e);
+		CommandSender[] commandSenders = recipients.getArray(event);
 
 		for (Expression<?> message : getMessages()) {
 
@@ -117,10 +117,10 @@ public class EffMessage extends Effect {
 			for (CommandSender receiver : commandSenders) {
 				if (receiver instanceof Player && message instanceof VariableString) {
 					if (messageComponents == null)
-						messageComponents = ((VariableString) message).getMessageComponents(e);
+						messageComponents = ((VariableString) message).getMessageComponents(event);
 				} else {
 					if (messageArray == null)
-						messageArray = message.getArray(e);
+						messageArray = message.getArray(event);
 				}
 
 				if (receiver instanceof Player) { // Can use JSON formatting
@@ -166,9 +166,9 @@ public class EffMessage extends Effect {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "send " + messageExpr.toString(e, debug) + " to " + recipients.toString(e, debug) +
-			(sender != null ? " from " + sender.toString(e, debug) : "");
+	public String toString(@Nullable Event event, boolean debug) {
+		return "send " + messageExpr.toString(event, debug) + " to " + recipients.toString(event, debug) +
+			(sender != null ? " from " + sender.toString(event, debug) : "");
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffOp.java
+++ b/src/main/java/ch/njol/skript/effects/EffOp.java
@@ -59,15 +59,15 @@ public class EffOp extends Effect {
 	}
 	
 	@Override
-	protected void execute(final Event e) {
-		for (final OfflinePlayer p : players.getArray(e)) {
+	protected void execute(final Event event) {
+		for (final OfflinePlayer p : players.getArray(event)) {
 			p.setOp(op);
 		}
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return (op ? "" : "de") + "op " + players.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return (op ? "" : "de") + "op " + players.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffOpenBook.java
+++ b/src/main/java/ch/njol/skript/effects/EffOpenBook.java
@@ -65,12 +65,12 @@ public class EffOpenBook extends Effect {
 	}
 	
 	@Override
-	protected void execute(final Event e) {
-		ItemType itemType = book.getSingle(e);
+	protected void execute(final Event event) {
+		ItemType itemType = book.getSingle(event);
 		if (itemType != null) {
 			ItemStack itemStack = itemType.getRandom();
 			if (itemStack != null && bookItemType.isOfType(itemStack)) {
-				for (Player player : players.getArray(e)) {
+				for (Player player : players.getArray(event)) {
 					player.openBook(itemStack);
 				}
 			}
@@ -78,8 +78,8 @@ public class EffOpenBook extends Effect {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "open book " + book.toString(e, debug) + " to " + players.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "open book " + book.toString(event, debug) + " to " + players.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffOpenInventory.java
+++ b/src/main/java/ch/njol/skript/effects/EffOpenInventory.java
@@ -98,12 +98,12 @@ public class EffOpenInventory extends Effect {
 	}
 	
 	@Override
-	protected void execute(final Event e) {
+	protected void execute(final Event event) {
 		if (invi != null) {
 			Inventory i;
 			
 			assert invi != null;
-			Object o = invi.getSingle(e);
+			Object o = invi.getSingle(event);
 			if (o instanceof Inventory) {
 				i = (Inventory) o;
 			} else if (o instanceof InventoryType) {
@@ -114,7 +114,7 @@ public class EffOpenInventory extends Effect {
 			
 			if (i == null)
 				return;
-			for (final Player p : players.getArray(e)) {
+			for (final Player p : players.getArray(event)) {
 				try {
 					p.openInventory(i);
 				} catch (IllegalArgumentException ex){
@@ -122,7 +122,7 @@ public class EffOpenInventory extends Effect {
 				}
 			}
 		} else {
-			for (final Player p : players.getArray(e)) {
+			for (final Player p : players.getArray(event)) {
 				if (open) {
 					switch (invType) {
 						case WORKBENCH:
@@ -151,8 +151,8 @@ public class EffOpenInventory extends Effect {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return (open ? "open " + (invi != null ? invi.toString(e, debug) : "crafting table") + " to " : "close inventory view of ") + players.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return (open ? "open " + (invi != null ? invi.toString(event, debug) : "crafting table") + " to " : "close inventory view of ") + players.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffPlaySound.java
+++ b/src/main/java/ch/njol/skript/effects/EffPlaySound.java
@@ -115,43 +115,43 @@ public class EffPlaySound extends Effect {
 
 	@Override
 	@SuppressWarnings("null")
-	protected void execute(Event e) {
+	protected void execute(Event event) {
 		Object category = null;
 		if (SOUND_CATEGORIES_EXIST) {
 			category = SoundCategory.MASTER;
 			if (this.category != null) {
-				category = this.category.getSingle(e);
+				category = this.category.getSingle(event);
 				if (category == null)
 					return;
 			}
 		}
 		float volume = 1, pitch = 1;
 		if (this.volume != null) {
-			Number volumeNumber = this.volume.getSingle(e);
+			Number volumeNumber = this.volume.getSingle(event);
 			if (volumeNumber == null)
 				return;
 			volume = volumeNumber.floatValue();
 		}
 		if (this.pitch != null) {
-			Number pitchNumber = this.pitch.getSingle(e);
+			Number pitchNumber = this.pitch.getSingle(event);
 			if (pitchNumber == null)
 				return;
 			pitch = pitchNumber.floatValue();
 		}
 		if (players != null) {
 			if (locations == null) {
-				for (Player p : players.getArray(e))
-					playSound(p, p.getLocation(), sounds.getArray(e), (SoundCategory) category,  volume, pitch);
+				for (Player p : players.getArray(event))
+					playSound(p, p.getLocation(), sounds.getArray(event), (SoundCategory) category,  volume, pitch);
 			} else {
-				for (Player p : players.getArray(e)) {
-					for (Location location : locations.getArray(e))
-						playSound(p, location, sounds.getArray(e), (SoundCategory) category, volume, pitch);
+				for (Player p : players.getArray(event)) {
+					for (Location location : locations.getArray(event))
+						playSound(p, location, sounds.getArray(event), (SoundCategory) category, volume, pitch);
 				}
 			}
 		} else {
 			if (locations != null) {
-				for (Location location : locations.getArray(e))
-					playSound(location, sounds.getArray(e), (SoundCategory) category, volume, pitch);
+				for (Location location : locations.getArray(event))
+					playSound(location, sounds.getArray(event), (SoundCategory) category, volume, pitch);
 			}
 		}
 	}
@@ -214,19 +214,19 @@ public class EffPlaySound extends Effect {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		if (locations != null)
-			return "play sound " + sounds.toString(e, debug) +
-					(category != null ? " in " + category.toString(e, debug) : "") +
-					(volume != null ? " at volume " + volume.toString(e, debug) : "") +
-					(pitch != null ? " at pitch " + pitch.toString(e, debug) : "") +
-					(locations != null ? " at " + locations.toString(e, debug) : "") +
-					(players != null ? " for " + players.toString(e, debug) : "");
+			return "play sound " + sounds.toString(event, debug) +
+					(category != null ? " in " + category.toString(event, debug) : "") +
+					(volume != null ? " at volume " + volume.toString(event, debug) : "") +
+					(pitch != null ? " at pitch " + pitch.toString(event, debug) : "") +
+					(locations != null ? " at " + locations.toString(event, debug) : "") +
+					(players != null ? " for " + players.toString(event, debug) : "");
 		else
-			return "play sound " + sounds.toString(e, debug) +
-					(volume != null ? " at volume " + volume.toString(e, debug) : "") +
-					(pitch != null ? " at pitch " + pitch.toString(e, debug) : "") +
-					(players != null ? " to " + players.toString(e, debug) : "");
+			return "play sound " + sounds.toString(event, debug) +
+					(volume != null ? " at volume " + volume.toString(event, debug) : "") +
+					(pitch != null ? " at pitch " + pitch.toString(event, debug) : "") +
+					(players != null ? " to " + players.toString(event, debug) : "");
 	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffPlayerInfoVisibility.java
+++ b/src/main/java/ch/njol/skript/effects/EffPlayerInfoVisibility.java
@@ -76,15 +76,15 @@ public class EffPlayerInfoVisibility extends Effect {
 	}
 
 	@Override
-	protected void execute(Event e) {
-		if (!(e instanceof PaperServerListPingEvent))
+	protected void execute(Event event) {
+		if (!(event instanceof PaperServerListPingEvent))
 			return;
 
-		((PaperServerListPingEvent) e).setHidePlayers(shouldHide);
+		((PaperServerListPingEvent) event).setHidePlayers(shouldHide);
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return (shouldHide ? "hide" : "show") + " player info in the server list";
 	}
 

--- a/src/main/java/ch/njol/skript/effects/EffPlayerVisibility.java
+++ b/src/main/java/ch/njol/skript/effects/EffPlayerVisibility.java
@@ -79,10 +79,10 @@ public class EffPlayerVisibility extends Effect {
 
     @Override
     @SuppressWarnings("null")
-    protected void execute(Event e) {
-        Player[] targets = targetPlayers == null ? Bukkit.getOnlinePlayers().toArray(new Player[0]) : targetPlayers.getArray(e);
+    protected void execute(Event event) {
+        Player[] targets = targetPlayers == null ? Bukkit.getOnlinePlayers().toArray(new Player[0]) : targetPlayers.getArray(event);
         for (Player targetPlayer : targets) {
-            for (Player player : players.getArray(e)) {
+            for (Player player : players.getArray(event)) {
                 if (reveal) {
                     if (USE_DEPRECATED_METHOD)
                         targetPlayer.showPlayer(player);
@@ -99,8 +99,8 @@ public class EffPlayerVisibility extends Effect {
     }
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return (reveal ? "show " : "hide ") + players.toString(e, debug) + (reveal ? " to " : " from ") + (targetPlayers != null ? targetPlayers.toString(e, debug) : "");
+	public String toString(@Nullable Event event, boolean debug) {
+		return (reveal ? "show " : "hide ") + players.toString(event, debug) + (reveal ? " to " : " from ") + (targetPlayers != null ? targetPlayers.toString(event, debug) : "");
 	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffPoison.java
+++ b/src/main/java/ch/njol/skript/effects/EffPoison.java
@@ -71,16 +71,16 @@ public class EffPoison extends Effect {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "poison " + entites.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "poison " + entites.toString(event, debug);
 	}
 	
 	@Override
-	protected void execute(final Event e) {
-		for (final LivingEntity le : entites.getArray(e)) {
+	protected void execute(final Event event) {
+		for (final LivingEntity le : entites.getArray(event)) {
 			if (!cure) {
 				Timespan dur;
-				int d = (int) (duration != null && (dur = duration.getSingle(e)) != null ? 
+				int d = (int) (duration != null && (dur = duration.getSingle(event)) != null ?
 						(dur.getTicks_i() >= Integer.MAX_VALUE ? Integer.MAX_VALUE : dur.getTicks_i()) : DEFAULT_DURATION);
 				if (le.hasPotionEffect(PotionEffectType.POISON)) {
 					for (final PotionEffect pe : le.getActivePotionEffects()) {

--- a/src/main/java/ch/njol/skript/effects/EffPotion.java
+++ b/src/main/java/ch/njol/skript/effects/EffPotion.java
@@ -115,18 +115,18 @@ public class EffPotion extends Effect {
 	}
 
 	@Override
-	protected void execute(final Event e) {
+	protected void execute(final Event event) {
 		if (potionEffect) {
-			for (LivingEntity livingEntity : entities.getArray(e)) {
-				PotionEffect[] potionEffects = this.potionEffects.getArray(e);
+			for (LivingEntity livingEntity : entities.getArray(event)) {
+				PotionEffect[] potionEffects = this.potionEffects.getArray(event);
 				PotionEffectUtils.addEffects(livingEntity, potionEffects);
 			}
 		} else {
-			final PotionEffectType[] ts = potions.getArray(e);
+			final PotionEffectType[] ts = potions.getArray(event);
 			if (ts.length == 0)
 				return;
 			if (!apply) {
-				for (LivingEntity en : entities.getArray(e)) {
+				for (LivingEntity en : entities.getArray(event)) {
 					for (final PotionEffectType t : ts)
 						en.removePotionEffect(t);
 				}
@@ -134,19 +134,19 @@ public class EffPotion extends Effect {
 			}
 			int a = 0;
 			if (tier != null) {
-				final Number amp = tier.getSingle(e);
+				final Number amp = tier.getSingle(event);
 				if (amp == null)
 					return;
 				a = amp.intValue() - 1;
 			}
 			int d = DEFAULT_DURATION;
 			if (duration != null) {
-				final Timespan dur = duration.getSingle(e);
+				final Timespan dur = duration.getSingle(event);
 				if (dur == null)
 					return;
 				d = (int) (dur.getTicks_i() >= Integer.MAX_VALUE ? Integer.MAX_VALUE : dur.getTicks_i());
 			}
-			for (final LivingEntity en : entities.getArray(e)) {
+			for (final LivingEntity en : entities.getArray(event)) {
 				for (final PotionEffectType t : ts) {
 					int duration = d;
 					if (!replaceExisting) {
@@ -166,13 +166,13 @@ public class EffPotion extends Effect {
 	}
 
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		if (potionEffect)
-			return "apply " + potionEffects.toString(e, debug) + " to " + entities.toString(e, debug);
+			return "apply " + potionEffects.toString(event, debug) + " to " + entities.toString(event, debug);
 		else if (apply)
-			return "apply " + potions.toString(e, debug) + (tier != null ? " of tier " + tier.toString(e, debug) : "") + " to " + entities.toString(e, debug) + (duration != null ? " for " + duration.toString(e, debug) : "");
+			return "apply " + potions.toString(event, debug) + (tier != null ? " of tier " + tier.toString(event, debug) : "") + " to " + entities.toString(event, debug) + (duration != null ? " for " + duration.toString(event, debug) : "");
 		else
-			return "remove " + potions.toString(e, debug) + " from " + entities.toString(e, debug);
+			return "remove " + potions.toString(event, debug) + " from " + entities.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffPush.java
+++ b/src/main/java/ch/njol/skript/effects/EffPush.java
@@ -64,14 +64,14 @@ public class EffPush extends Effect {
 	}
 	
 	@Override
-	protected void execute(final Event e) {
-		final Direction d = direction.getSingle(e);
+	protected void execute(final Event event) {
+		final Direction d = direction.getSingle(event);
 		if (d == null)
 			return;
-		final Number v = speed != null ? speed.getSingle(e) : null;
+		final Number v = speed != null ? speed.getSingle(event) : null;
 		if (speed != null && v == null)
 			return;
-		final Entity[] ents = entities.getArray(e);
+		final Entity[] ents = entities.getArray(event);
 		for (final Entity en : ents) {
 			assert en != null;
 			final Vector mod = d.getDirection(en);
@@ -82,8 +82,8 @@ public class EffPush extends Effect {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "push " + entities.toString(e, debug) + " " + direction.toString(e, debug) + (speed != null ? " at speed " + speed.toString(e, debug) : "");
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "push " + entities.toString(event, debug) + " " + direction.toString(event, debug) + (speed != null ? " at speed " + speed.toString(event, debug) : "");
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffPvP.java
+++ b/src/main/java/ch/njol/skript/effects/EffPvP.java
@@ -59,15 +59,15 @@ public class EffPvP extends Effect {
 	}
 	
 	@Override
-	protected void execute(final Event e) {
-		for (final World w : worlds.getArray(e)) {
+	protected void execute(final Event event) {
+		for (final World w : worlds.getArray(event)) {
 			w.setPVP(enable);
 		}
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return (enable ? "enable" : "disable") + " PvP in " + worlds.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return (enable ? "enable" : "disable") + " PvP in " + worlds.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffResetTitle.java
+++ b/src/main/java/ch/njol/skript/effects/EffResetTitle.java
@@ -55,14 +55,14 @@ public class EffResetTitle extends Effect {
 	}
 	
 	@Override
-	protected void execute(Event e) {
-		for (Player recipient : recipients.getArray(e))
+	protected void execute(Event event) {
+		for (Player recipient : recipients.getArray(event))
 			recipient.resetTitle();
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "reset the title of " + recipients.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "reset the title of " + recipients.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffRespawn.java
+++ b/src/main/java/ch/njol/skript/effects/EffRespawn.java
@@ -67,8 +67,8 @@ public class EffRespawn extends Effect {
 	}
 
 	@Override
-	protected void execute(final Event e) {
-		for (final Player p : players.getArray(e)) {
+	protected void execute(final Event event) {
+		for (final Player p : players.getArray(event)) {
 			if (forceDelay) { // Use Bukkit runnable
 				new BukkitRunnable() {
 
@@ -85,8 +85,8 @@ public class EffRespawn extends Effect {
 	}
 
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "force " + players.toString(e, debug) + " to respawn";
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "force " + players.toString(event, debug) + " to respawn";
 	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffReturn.java
+++ b/src/main/java/ch/njol/skript/effects/EffReturn.java
@@ -106,18 +106,18 @@ public class EffReturn extends Effect {
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	@Override
 	@Nullable
-	protected TriggerItem walk(final Event e) {
-		debug(e, false);
-		if (e instanceof FunctionEvent) {
-			((ScriptFunction) function).setReturnValue(value.getArray(e));
+	protected TriggerItem walk(final Event event) {
+		debug(event, false);
+		if (event instanceof FunctionEvent) {
+			((ScriptFunction) function).setReturnValue(value.getArray(event));
 		} else {
-			assert false : e;
+			assert false : event;
 		}
 
 		TriggerSection parent = getParent();
 		while (parent != null) {
 			if (parent instanceof SecLoop) {
-				((SecLoop) parent).exit(e);
+				((SecLoop) parent).exit(event);
 			} else if (parent instanceof SecWhile) {
 				((SecWhile) parent).reset();
 			}
@@ -128,13 +128,13 @@ public class EffReturn extends Effect {
 	}
 	
 	@Override
-	protected void execute(Event e) {
+	protected void execute(Event event) {
 		assert false;
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "return " + value.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "return " + value.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffScriptFile.java
+++ b/src/main/java/ch/njol/skript/effects/EffScriptFile.java
@@ -70,8 +70,8 @@ public class EffScriptFile extends Effect {
 	}
 	
 	@Override
-	protected void execute(Event e) {
-		String name = fileName.getSingle(e);
+	protected void execute(Event event) {
+		String name = fileName.getSingle(event);
 		if (name == null)
 			return;
 		File scriptFile = SkriptCommand.getScriptFromName(name);
@@ -137,9 +137,9 @@ public class EffScriptFile extends Effect {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return (mark == ENABLE ? "enable" : mark == RELOAD ? "disable" : mark == DISABLE ? "unload" : "")
-			+ " script file " + fileName.toString(e, debug);
+			+ " script file " + fileName.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffSendBlockChange.java
+++ b/src/main/java/ch/njol/skript/effects/EffSendBlockChange.java
@@ -86,19 +86,19 @@ public class EffSendBlockChange extends Effect {
 	}
 
 	@Override
-	protected void execute(Event e) {
-		Object object = this.as.getSingle(e);
+	protected void execute(Event event) {
+		Object object = this.as.getSingle(event);
 		if (object instanceof ItemType) {
 			ItemType itemType = (ItemType) object;
-			for (Player player : players.getArray(e)) {
-				for (Block block : blocks.getArray(e)) {
+			for (Player player : players.getArray(event)) {
+				for (Block block : blocks.getArray(event)) {
 					itemType.sendBlockChange(player, block.getLocation());
 				}
 			}
 		} else if (BLOCK_DATA_SUPPORT && object instanceof BlockData) {
 			BlockData blockData = (BlockData) object;
-			for (Player player : players.getArray(e)) {
-				for (Block block : blocks.getArray(e)) {
+			for (Player player : players.getArray(event)) {
+				for (Block block : blocks.getArray(event)) {
 					player.sendBlockChange(block.getLocation(), blockData);
 				}
 			}
@@ -106,12 +106,12 @@ public class EffSendBlockChange extends Effect {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return String.format(
 				"make %s see %s as %s",
-				players.toString(e, debug),
-				blocks.toString(e, debug),
-				as.toString(e, debug)
+				players.toString(event, debug),
+				blocks.toString(event, debug),
+				as.toString(event, debug)
 		);
 	}
 

--- a/src/main/java/ch/njol/skript/effects/EffSendResourcePack.java
+++ b/src/main/java/ch/njol/skript/effects/EffSendResourcePack.java
@@ -82,16 +82,16 @@ public class EffSendResourcePack extends Effect {
 	// Player#setResourcePack(String) is deprecated on Paper
 	@SuppressWarnings({"deprecation"})
 	@Override
-	protected void execute(Event e) {
+	protected void execute(Event event) {
 		assert url != null;
 		String hash = null;
 		if (this.hash != null)
-			hash = this.hash.getSingle(e);
-		String address = url.getSingle(e);
+			hash = this.hash.getSingle(event);
+		String address = url.getSingle(event);
 		if (address == null) {
 			return; // Can't send, URL not valid
 		}
-		for (Player p : recipients.getArray(e)) {
+		for (Player p : recipients.getArray(event)) {
 			try {
 				if (hash == null) {
 					p.setResourcePack(address);
@@ -106,10 +106,10 @@ public class EffSendResourcePack extends Effect {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "send the resource pack from " + url.toString(e, debug) +
-				(hash != null ? " with hash " + hash.toString(e, debug) : "") +
-				" to " + recipients.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "send the resource pack from " + url.toString(event, debug) +
+				(hash != null ? " with hash " + hash.toString(event, debug) : "") +
+				" to " + recipients.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffSendTitle.java
+++ b/src/main/java/ch/njol/skript/effects/EffSendTitle.java
@@ -91,48 +91,48 @@ public class EffSendTitle extends Effect {
 	
 	@SuppressWarnings("null")
 	@Override
-	protected void execute(final Event e) {
-		String title = this.title != null ? this.title.getSingle(e) : null;
-		String subtitle = this.subtitle != null ? this.subtitle.getSingle(e) : null;
+	protected void execute(final Event event) {
+		String title = this.title != null ? this.title.getSingle(event) : null;
+		String subtitle = this.subtitle != null ? this.subtitle.getSingle(event) : null;
 		
 		if (TIME_SUPPORTED) {
 			int fadeIn, stay, fadeOut;
 			fadeIn = stay = fadeOut = -1;
 
 			if (this.fadeIn != null) {
-				Timespan t = this.fadeIn.getSingle(e);
+				Timespan t = this.fadeIn.getSingle(event);
 				fadeIn = t != null ? (int) t.getTicks_i() : -1;
 			}
 
 			if (this.stay != null) {
-				Timespan t = this.stay.getSingle(e);
+				Timespan t = this.stay.getSingle(event);
 				stay = t != null ? (int) t.getTicks_i() : -1;
 			}
 
 			if (this.fadeOut != null) {
-				Timespan t = this.fadeOut.getSingle(e);
+				Timespan t = this.fadeOut.getSingle(event);
 				fadeOut = t != null ? (int) t.getTicks_i() : -1;
 			}
 			
-			for (Player p : recipients.getArray(e))
+			for (Player p : recipients.getArray(event))
 				p.sendTitle(title, subtitle, fadeIn, stay, fadeOut);
 		} else {
-			for (Player p : recipients.getArray(e))
+			for (Player p : recipients.getArray(event))
 				p.sendTitle(title, subtitle);
 		}
 	}
 	
 	// TODO: util method to simplify this
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		String title = this.title != null ? this.title.toString(e, debug) : "",
-		sub = subtitle != null ? subtitle.toString(e, debug) : "",
-		in = fadeIn != null ? fadeIn.toString(e, debug) : "",
-		stay = this.stay != null ? this.stay.toString(e, debug) : "",
-		out = fadeOut != null ? this.fadeOut.toString(e, debug) : "";
+	public String toString(final @Nullable Event event, final boolean debug) {
+		String title = this.title != null ? this.title.toString(event, debug) : "",
+		sub = subtitle != null ? subtitle.toString(event, debug) : "",
+		in = fadeIn != null ? fadeIn.toString(event, debug) : "",
+		stay = this.stay != null ? this.stay.toString(event, debug) : "",
+		out = fadeOut != null ? this.fadeOut.toString(event, debug) : "";
 		return ("send title " + title +
 				sub == "" ? "" : " with subtitle " + sub) + " to " +
-				recipients.toString(e, debug) + (TIME_SUPPORTED ?
+				recipients.toString(event, debug) + (TIME_SUPPORTED ?
 				" for " + stay + " with fade in " + in + " and fade out" + out : "");
 	}
 	

--- a/src/main/java/ch/njol/skript/effects/EffShear.java
+++ b/src/main/java/ch/njol/skript/effects/EffShear.java
@@ -61,8 +61,8 @@ public class EffShear extends Effect {
 	}
 	
 	@Override
-	protected void execute(final Event e) {
-		for (final LivingEntity en : sheep.getArray(e)) {
+	protected void execute(final Event event) {
+		for (final LivingEntity en : sheep.getArray(event)) {
 			if (en instanceof Sheep) {
 				((Sheep) en).setSheared(shear);
 			}
@@ -70,8 +70,8 @@ public class EffShear extends Effect {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return (shear ? "" : "un") + "shear " + sheep.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return (shear ? "" : "un") + "shear " + sheep.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffShoot.java
+++ b/src/main/java/ch/njol/skript/effects/EffShoot.java
@@ -82,16 +82,16 @@ public class EffShoot extends Effect {
 	
 	@SuppressWarnings("null")
 	@Override
-	protected void execute(final Event e) {
+	protected void execute(final Event event) {
 		lastSpawned = null;
-		final Number v = velocity != null ? velocity.getSingle(e) : DEFAULT_SPEED;
+		final Number v = velocity != null ? velocity.getSingle(event) : DEFAULT_SPEED;
 		if (v == null)
 			return;
-		final Direction dir = direction != null ? direction.getSingle(e) : Direction.IDENTITY;
+		final Direction dir = direction != null ? direction.getSingle(event) : Direction.IDENTITY;
 		if (dir == null)
 			return;
-		for (final Object shooter : shooters.getArray(e)) {
-			for (final EntityData<?> d : types.getArray(e)) {
+		for (final Object shooter : shooters.getArray(event)) {
+			for (final EntityData<?> d : types.getArray(event)) {
 				if (shooter instanceof LivingEntity) {
 					final Vector vel = dir.getDirection(((LivingEntity) shooter).getLocation()).multiply(v.doubleValue());
 					final Class<? extends Entity> type = d.getType();
@@ -131,8 +131,8 @@ public class EffShoot extends Effect {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "shoot " + types.toString(e, debug) + " from " + shooters.toString(e, debug) + (velocity != null ? " at speed " + velocity.toString(e, debug) : "") + (direction != null ? " " + direction.toString(e, debug) : "");
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "shoot " + types.toString(event, debug) + " from " + shooters.toString(event, debug) + (velocity != null ? " at speed " + velocity.toString(event, debug) : "") + (direction != null ? " " + direction.toString(event, debug) : "");
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffSilence.java
+++ b/src/main/java/ch/njol/skript/effects/EffSilence.java
@@ -59,14 +59,14 @@ public class EffSilence extends Effect {
 	}
 	
 	@Override
-	protected void execute(Event e) {
-		for (Entity entity : entities.getArray(e)) {
+	protected void execute(Event event) {
+		for (Entity entity : entities.getArray(event)) {
 			entity.setSilent(silence);
 		}
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return (silence ? "silence " : "unsilence ") + entities.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return (silence ? "silence " : "unsilence ") + entities.toString(event, debug);
 	}
 }

--- a/src/main/java/ch/njol/skript/effects/EffStopServer.java
+++ b/src/main/java/ch/njol/skript/effects/EffStopServer.java
@@ -54,7 +54,7 @@ public class EffStopServer extends Effect {
 	}
 	
 	@Override
-	protected void execute(Event e) {
+	protected void execute(Event event) {
 		if (restart)
 			Bukkit.spigot().restart();
 		else
@@ -63,7 +63,7 @@ public class EffStopServer extends Effect {
 	
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return (restart ? "restart" : "stop") + " the server";
 	}
 	

--- a/src/main/java/ch/njol/skript/effects/EffStopSound.java
+++ b/src/main/java/ch/njol/skript/effects/EffStopSound.java
@@ -87,35 +87,35 @@ public class EffStopSound extends Effect {
 	}
 
 	@Override
-	protected void execute(Event e) {
+	protected void execute(Event event) {
 		Object category = null;
 		if (SOUND_CATEGORIES_EXIST) {
 			category = SoundCategory.MASTER;
 			if (this.category != null) {
-				category = this.category.getSingle(e);
+				category = this.category.getSingle(event);
 				if (category == null)
 					return;
 			}
 		}
-		for (String sound : sounds.getArray(e)) {
+		for (String sound : sounds.getArray(event)) {
 			Sound soundEnum = null;
 			try {
 				soundEnum = Sound.valueOf(sound.toUpperCase(Locale.ENGLISH));
 			} catch (IllegalArgumentException ignored) {}
 			if (soundEnum == null) {
 				if (SOUND_CATEGORIES_EXIST) {
-					for (Player p : players.getArray(e))
+					for (Player p : players.getArray(event))
 						p.stopSound(sound, (SoundCategory) category);
 				} else {
-					for (Player p : players.getArray(e))
+					for (Player p : players.getArray(event))
 						p.stopSound(sound);
 				}
 			} else {
 				if (SOUND_CATEGORIES_EXIST) {
-					for (Player p : players.getArray(e))
+					for (Player p : players.getArray(event))
 						p.stopSound(soundEnum, (SoundCategory) category);
 				} else {
-					for (Player p : players.getArray(e))
+					for (Player p : players.getArray(event))
 						p.stopSound(soundEnum);
 				}
 			}
@@ -123,10 +123,10 @@ public class EffStopSound extends Effect {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "stop sound " + sounds.toString(e, debug) +
-				(category != null ? " in " + category.toString(e, debug) : "") +
-				" from playing to " + players.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "stop sound " + sounds.toString(event, debug) +
+				(category != null ? " in " + category.toString(event, debug) : "") +
+				" from playing to " + players.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffSwingHand.java
+++ b/src/main/java/ch/njol/skript/effects/EffSwingHand.java
@@ -65,21 +65,21 @@ public class EffSwingHand extends Effect {
 	}
 	
 	@Override
-	protected void execute(Event e) {
+	protected void execute(Event event) {
 		if (isMainHand) {
-			for (LivingEntity entity : entities.getArray(e)) {
+			for (LivingEntity entity : entities.getArray(event)) {
 				entity.swingMainHand();
 			}
 		} else {
-			for (LivingEntity entity : entities.getArray(e)) {
+			for (LivingEntity entity : entities.getArray(event)) {
 				entity.swingOffHand();
 			}
 		}
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "make " + entities.toString(e, debug) + " swing their " + (isMainHand ? "hand" : "off hand");
+	public String toString(@Nullable Event event, boolean debug) {
+		return "make " + entities.toString(event, debug) + " swing their " + (isMainHand ? "hand" : "off hand");
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffTeleport.java
+++ b/src/main/java/ch/njol/skript/effects/EffTeleport.java
@@ -79,29 +79,29 @@ public class EffTeleport extends Effect {
 	
 	@Nullable
 	@Override
-	protected TriggerItem walk(Event e) {
-		debug(e, true);
+	protected TriggerItem walk(Event event) {
+		debug(event, true);
 
 		TriggerItem next = getNext();
 
-		boolean delayed = Delay.isDelayed(e);
+		boolean delayed = Delay.isDelayed(event);
 		
-		Location loc = location.getSingle(e);
+		Location loc = location.getSingle(event);
 		if (loc == null)
 			return next;
 
-		Entity[] entityArray = entities.getArray(e); // We have to fetch this before possible async execution to avoid async local variable access.
+		Entity[] entityArray = entities.getArray(event); // We have to fetch this before possible async execution to avoid async local variable access.
 		if (entityArray.length == 0)
 			return next;
 
 		if (!delayed) {
-			if (e instanceof PlayerRespawnEvent && entityArray.length == 1 && entityArray[0].equals(((PlayerRespawnEvent) e).getPlayer())) {
-				((PlayerRespawnEvent) e).setRespawnLocation(loc);
+			if (event instanceof PlayerRespawnEvent && entityArray.length == 1 && entityArray[0].equals(((PlayerRespawnEvent) event).getPlayer())) {
+				((PlayerRespawnEvent) event).setRespawnLocation(loc);
 				return next;
 			}
 
-			if (e instanceof PlayerMoveEvent && entityArray.length == 1 && entityArray[0].equals(((PlayerMoveEvent) e).getPlayer())) {
-				((PlayerMoveEvent) e).setTo(loc);
+			if (event instanceof PlayerMoveEvent && entityArray.length == 1 && entityArray[0].equals(((PlayerMoveEvent) event).getPlayer())) {
+				((PlayerMoveEvent) event).setTo(loc);
 				return next;
 			}
 		}
@@ -113,8 +113,8 @@ public class EffTeleport extends Effect {
 			return next;
 		}
 
-		Delay.addDelayedEvent(e);
-		Object localVars = Variables.removeLocals(e);
+		Delay.addDelayedEvent(event);
+		Object localVars = Variables.removeLocals(event);
 		
 		// This will either fetch the chunk instantly if on Spigot or already loaded or fetch it async if on Paper.
 		PaperLib.getChunkAtAsync(loc).thenAccept(chunk -> {
@@ -125,7 +125,7 @@ public class EffTeleport extends Effect {
 
 			// Re-set local variables
 			if (localVars != null)
-				Variables.setLocalVariables(e, localVars);
+				Variables.setLocalVariables(event, localVars);
 			
 			// Continue the rest of the trigger if there is one
 			Object timing = null;
@@ -137,22 +137,22 @@ public class EffTeleport extends Effect {
 					}
 				}
 
-				TriggerItem.walk(next, e);
+				TriggerItem.walk(next, event);
 			}
-			Variables.removeLocals(e); // Clean up local vars, we may be exiting now
+			Variables.removeLocals(event); // Clean up local vars, we may be exiting now
 			SkriptTimings.stop(timing);
 		});
 		return null;
 	}
 
 	@Override
-	protected void execute(Event e) {
+	protected void execute(Event event) {
 		// Nothing needs to happen here, we're executing in walk
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "teleport " + entities.toString(e, debug) + " to " + location.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "teleport " + entities.toString(event, debug) + " to " + location.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffToggle.java
+++ b/src/main/java/ch/njol/skript/effects/EffToggle.java
@@ -70,8 +70,8 @@ public class EffToggle extends Effect {
 	}
 
 	@Override
-	protected void execute(final Event e) {
-		for (Block b : blocks.getArray(e)) {
+	protected void execute(final Event event) {
+		for (Block b : blocks.getArray(event)) {
 			BlockData data = b.getBlockData();
 			if (toggle == -1) {
 				if (data instanceof Openable)
@@ -95,8 +95,8 @@ public class EffToggle extends Effect {
 	}
 
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "toggle " + blocks.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "toggle " + blocks.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffToggleFlight.java
+++ b/src/main/java/ch/njol/skript/effects/EffToggleFlight.java
@@ -58,13 +58,13 @@ public class EffToggleFlight extends Effect {
 	}
 
 	@Override
-	protected void execute(final Event e) {
-		for (Player player : players.getArray(e))
+	protected void execute(final Event event) {
+		for (Player player : players.getArray(event))
 			player.setAllowFlight(allow);
 	}
 
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "allow flight to " + players.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "allow flight to " + players.toString(event, debug);
 	}
 }

--- a/src/main/java/ch/njol/skript/effects/EffTree.java
+++ b/src/main/java/ch/njol/skript/effects/EffTree.java
@@ -64,19 +64,19 @@ public class EffTree extends Effect {
 	}
 	
 	@Override
-	public void execute(final Event e) {
-		final StructureType type = this.type.getSingle(e);
+	public void execute(final Event event) {
+		final StructureType type = this.type.getSingle(event);
 		if (type == null)
 			return;
-		for (final Location l : blocks.getArray(e)) {
+		for (final Location l : blocks.getArray(event)) {
 			assert l != null : blocks;
 			type.grow(l.getBlock());
 		}
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "grow tree of type " + type.toString(e, debug) + " " + blocks.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "grow tree of type " + type.toString(event, debug) + " " + blocks.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffVectorRotateAroundAnother.java
+++ b/src/main/java/ch/njol/skript/effects/EffVectorRotateAroundAnother.java
@@ -63,18 +63,18 @@ public class EffVectorRotateAroundAnother extends Effect {
 
 	@SuppressWarnings("null")
 	@Override
-	protected void execute(Event e) {
-		Vector v2 = second.getSingle(e);
-		Number d = degree.getSingle(e);
+	protected void execute(Event event) {
+		Vector v2 = second.getSingle(event);
+		Number d = degree.getSingle(event);
 		if (v2 == null || d == null)
 			return;
-		for (Vector v1 : first.getArray(e))
+		for (Vector v1 : first.getArray(event))
 			VectorMath.rot(v1, v2, d.doubleValue());
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "rotate " + first.toString(e, debug) + " around " + second.toString(e, debug) + " by " + degree + "degrees";
+	public String toString(@Nullable Event event, boolean debug) {
+		return "rotate " + first.toString(event, debug) + " around " + second.toString(event, debug) + " by " + degree + "degrees";
 	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffVectorRotateXYZ.java
+++ b/src/main/java/ch/njol/skript/effects/EffVectorRotateXYZ.java
@@ -68,28 +68,28 @@ public class EffVectorRotateXYZ extends Effect {
 
 	@Override
 	@SuppressWarnings("null")
-	protected void execute(Event e) {
-		Number d = degree.getSingle(e);
+	protected void execute(Event event) {
+		Number d = degree.getSingle(event);
 		if (d == null)
 			return;
 		switch (axis) {
 			case 1:
-				for (Vector v : vectors.getArray(e))
+				for (Vector v : vectors.getArray(event))
 					VectorMath.rotX(v, d.doubleValue());
 				break;
 			case 2:
-				for (Vector v : vectors.getArray(e))
+				for (Vector v : vectors.getArray(event))
 					VectorMath.rotY(v, d.doubleValue());
 				break;
 			case 3:
-				for (Vector v : vectors.getArray(e))
+				for (Vector v : vectors.getArray(event))
 					VectorMath.rotZ(v, d.doubleValue());
 		}
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "rotate " + vectors.toString(e, debug) + " around " + axes[axis] + "-axis" + " by " + degree + "degrees";
+	public String toString(@Nullable Event event, boolean debug) {
+		return "rotate " + vectors.toString(event, debug) + " around " + axes[axis] + "-axis" + " by " + degree + "degrees";
 	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffVehicle.java
+++ b/src/main/java/ch/njol/skript/effects/EffVehicle.java
@@ -66,25 +66,25 @@ public class EffVehicle extends Effect {
 	}
 	
 	@Override
-	protected void execute(final Event e) {
+	protected void execute(final Event event) {
 		final Expression<?> vehicles = this.vehicles;
 		final Expression<Entity> passengers = this.passengers;
 		if (vehicles == null) {
 			assert passengers != null;
-			for (final Entity p : passengers.getArray(e))
+			for (final Entity p : passengers.getArray(event))
 				p.leaveVehicle();
 			return;
 		}
 		if (passengers == null) {
 			assert vehicles != null;
-			for (final Object v : vehicles.getArray(e))
+			for (final Object v : vehicles.getArray(event))
 				((Entity) v).eject();
 			return;
 		}
-		final Object[] vs = vehicles.getArray(e);
+		final Object[] vs = vehicles.getArray(event);
 		if (vs.length == 0)
 			return;
-		final Entity[] ps = passengers.getArray(e);
+		final Entity[] ps = passengers.getArray(event);
 		if (ps.length == 0)
 			return;
 		for (final Object v : vs) {
@@ -108,18 +108,18 @@ public class EffVehicle extends Effect {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		final Expression<?> vehicles = this.vehicles;
 		final Expression<Entity> passengers = this.passengers;
 		if (vehicles == null) {
 			assert passengers != null;
-			return "make " + passengers.toString(e, debug) + " dismount";
+			return "make " + passengers.toString(event, debug) + " dismount";
 		}
 		if (passengers == null) {
 			assert vehicles != null;
-			return "eject passenger" + (vehicles.isSingle() ? "" : "s") + " of " + vehicles.toString(e, debug);
+			return "eject passenger" + (vehicles.isSingle() ? "" : "s") + " of " + vehicles.toString(event, debug);
 		}
-		return "make " + passengers.toString(e, debug) + " ride " + vehicles.toString(e, debug);
+		return "make " + passengers.toString(event, debug) + " ride " + vehicles.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffVisualEffect.java
+++ b/src/main/java/ch/njol/skript/effects/EffVisualEffect.java
@@ -107,13 +107,13 @@ public class EffVisualEffect extends Effect {
 	}
 	
 	@Override
-	protected void execute(Event e) {
-		VisualEffect[] effects = this.effects.getArray(e);
-		Direction[] directions = direction.getArray(e);
-		Object[] os = where.getArray(e);
-		Player[] ps = players != null ? players.getArray(e) : null;
-		Number rad = radius != null ? radius.getSingle(e) : 32; // 32=default particle radius
-		Number cnt = count != null ? count.getSingle(e) : 0;
+	protected void execute(Event event) {
+		VisualEffect[] effects = this.effects.getArray(event);
+		Direction[] directions = direction.getArray(event);
+		Object[] os = where.getArray(event);
+		Player[] ps = players != null ? players.getArray(event) : null;
+		Number rad = radius != null ? radius.getSingle(event) : 32; // 32=default particle radius
+		Number cnt = count != null ? count.getSingle(event) : 0;
 
 		// noinspection ConstantConditions
 		if (effects == null || directions == null || os == null || rad == null || cnt == null)
@@ -139,9 +139,9 @@ public class EffVisualEffect extends Effect {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "play " + effects.toString(e, debug) + " " + direction.toString(e, debug) + " "
-			+ where.toString(e, debug) + (players != null ? " to " + players.toString(e, debug) : "");
+	public String toString(@Nullable Event event, boolean debug) {
+		return "play " + effects.toString(event, debug) + " " + direction.toString(event, debug) + " "
+			+ where.toString(event, debug) + (players != null ? " to " + players.toString(event, debug) : "");
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/events/EvtAtTime.java
+++ b/src/main/java/ch/njol/skript/events/EvtAtTime.java
@@ -187,7 +187,7 @@ public class EvtAtTime extends SelfRegisteringSkriptEvent implements Comparable<
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "at " + Time.toString(tick) + " in worlds " + Classes.toString(worlds, true);
 	}
 	

--- a/src/main/java/ch/njol/skript/events/EvtBlock.java
+++ b/src/main/java/ch/njol/skript/events/EvtBlock.java
@@ -144,7 +144,7 @@ public class EvtBlock extends SkriptEvent {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "break/place/burn/fade/form of " + Classes.toString(types);
 	}
 	

--- a/src/main/java/ch/njol/skript/events/EvtBookEdit.java
+++ b/src/main/java/ch/njol/skript/events/EvtBookEdit.java
@@ -49,7 +49,7 @@ public class EvtBookEdit extends SkriptEvent{
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "book edit";
 	}
 }

--- a/src/main/java/ch/njol/skript/events/EvtBookSign.java
+++ b/src/main/java/ch/njol/skript/events/EvtBookSign.java
@@ -49,7 +49,7 @@ public class EvtBookSign extends SkriptEvent{
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "book sign";
 	}
 }

--- a/src/main/java/ch/njol/skript/events/EvtChat.java
+++ b/src/main/java/ch/njol/skript/events/EvtChat.java
@@ -101,7 +101,7 @@ public class EvtChat extends SelfRegisteringSkriptEvent {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "chat";
 	}
 	

--- a/src/main/java/ch/njol/skript/events/EvtClick.java
+++ b/src/main/java/ch/njol/skript/events/EvtClick.java
@@ -210,8 +210,8 @@ public class EvtClick extends SkriptEvent {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return (click == LEFT ? "left" : click == RIGHT ? "right" : "") + "click" + (types != null ? " on " + types.toString(e, debug) : "") + (tools != null ? " holding " + tools.toString(e, debug) : "");
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return (click == LEFT ? "left" : click == RIGHT ? "right" : "") + "click" + (types != null ? " on " + types.toString(event, debug) : "") + (tools != null ? " holding " + tools.toString(event, debug) : "");
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/events/EvtCommand.java
+++ b/src/main/java/ch/njol/skript/events/EvtCommand.java
@@ -76,7 +76,7 @@ public class EvtCommand extends SkriptEvent { // TODO condition to check whether
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "command" + (command != null ? " /" + command : "");
 	}
 	

--- a/src/main/java/ch/njol/skript/events/EvtDamage.java
+++ b/src/main/java/ch/njol/skript/events/EvtDamage.java
@@ -96,9 +96,9 @@ public class EvtDamage extends SkriptEvent {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "damage" + (ofTypes != null ? " of " + ofTypes.toString(e, debug) : "") +
-			(byTypes != null ? " by " + byTypes.toString(e, debug) : "");
+	public String toString(@Nullable Event event, boolean debug) {
+		return "damage" + (ofTypes != null ? " of " + ofTypes.toString(event, debug) : "") +
+			(byTypes != null ? " by " + byTypes.toString(event, debug) : "");
 	}
 	
 //	private final static WeakHashMap<LivingEntity, Integer> lastDamages = new WeakHashMap<LivingEntity, Integer>();

--- a/src/main/java/ch/njol/skript/events/EvtEntity.java
+++ b/src/main/java/ch/njol/skript/events/EvtEntity.java
@@ -101,7 +101,7 @@ public final class EvtEntity extends SkriptEvent {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return (spawn ? "spawn" : "death") + (types != null ? " of " + Classes.toString(types, false) : "");
 	}
 	

--- a/src/main/java/ch/njol/skript/events/EvtEntityBlockChange.java
+++ b/src/main/java/ch/njol/skript/events/EvtEntityBlockChange.java
@@ -96,8 +96,8 @@ public class EvtEntityBlockChange extends SkriptEvent {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return event.name().toLowerCase(Locale.ENGLISH).replace('_', ' ');
+	public String toString(@Nullable Event event, boolean debug) {
+		return this.event.name().toLowerCase(Locale.ENGLISH).replace('_', ' ');
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/events/EvtEntityTarget.java
+++ b/src/main/java/ch/njol/skript/events/EvtEntityTarget.java
@@ -53,7 +53,7 @@ public class EvtEntityTarget extends SkriptEvent {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "entity " + (target ? "" : "un") + "target";
 	}
 	

--- a/src/main/java/ch/njol/skript/events/EvtExperienceSpawn.java
+++ b/src/main/java/ch/njol/skript/events/EvtExperienceSpawn.java
@@ -143,7 +143,7 @@ public class EvtExperienceSpawn extends SelfRegisteringSkriptEvent {
 	};
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "experience spawn";
 	}
 	

--- a/src/main/java/ch/njol/skript/events/EvtFirework.java
+++ b/src/main/java/ch/njol/skript/events/EvtFirework.java
@@ -76,8 +76,8 @@ public class EvtFirework extends SkriptEvent {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "Firework explode " + (colors != null ? " with colors " + colors.toString(e, debug) : "");
+	public String toString(@Nullable Event event, boolean debug) {
+		return "Firework explode " + (colors != null ? " with colors " + colors.toString(event, debug) : "");
 	}
 
 }

--- a/src/main/java/ch/njol/skript/events/EvtFirstJoin.java
+++ b/src/main/java/ch/njol/skript/events/EvtFirstJoin.java
@@ -50,7 +50,7 @@ public class EvtFirstJoin extends SkriptEvent {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "first join";
 	}
 	

--- a/src/main/java/ch/njol/skript/events/EvtGameMode.java
+++ b/src/main/java/ch/njol/skript/events/EvtGameMode.java
@@ -66,7 +66,7 @@ public final class EvtGameMode extends SkriptEvent {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "gamemode change" + (mode != null ? " to " + mode.toString().toLowerCase(Locale.ENGLISH) : "");
 	}
 	

--- a/src/main/java/ch/njol/skript/events/EvtGrow.java
+++ b/src/main/java/ch/njol/skript/events/EvtGrow.java
@@ -92,11 +92,11 @@ public class EvtGrow extends SkriptEvent {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		if (evtType == STRUCTURE)
-			return "grow" + (types != null ? " of " + types.toString(e, debug) : "");
+			return "grow" + (types != null ? " of " + types.toString(event, debug) : "");
 		else if (evtType == BLOCK)
-			return "grow" + (blocks != null ? " of " + blocks.toString(e, debug) : "");
+			return "grow" + (blocks != null ? " of " + blocks.toString(event, debug) : "");
 		return "grow";
 	}
 	

--- a/src/main/java/ch/njol/skript/events/EvtItem.java
+++ b/src/main/java/ch/njol/skript/events/EvtItem.java
@@ -201,7 +201,7 @@ public class EvtItem extends SkriptEvent {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "dispense/spawn/drop/craft/pickup/consume/break/despawn/merge" + (types == null ? "" : " of " + types);
 	}
 	

--- a/src/main/java/ch/njol/skript/events/EvtLevel.java
+++ b/src/main/java/ch/njol/skript/events/EvtLevel.java
@@ -58,7 +58,7 @@ public class EvtLevel extends SkriptEvent {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "level " + (leveling.isTrue() ? "up" : leveling.isFalse() ? "down" : "change");
 	}
 }

--- a/src/main/java/ch/njol/skript/events/EvtMove.java
+++ b/src/main/java/ch/njol/skript/events/EvtMove.java
@@ -101,7 +101,7 @@ public class EvtMove extends SkriptEvent {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return type + " move";
 	}
 

--- a/src/main/java/ch/njol/skript/events/EvtMoveOn.java
+++ b/src/main/java/ch/njol/skript/events/EvtMoveOn.java
@@ -188,7 +188,7 @@ public class EvtMoveOn extends SelfRegisteringSkriptEvent { // TODO on jump
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "walk on " + Classes.toString(types, false);
 	}
 

--- a/src/main/java/ch/njol/skript/events/EvtPeriodical.java
+++ b/src/main/java/ch/njol/skript/events/EvtPeriodical.java
@@ -142,7 +142,7 @@ public class EvtPeriodical extends SelfRegisteringSkriptEvent {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "every " + period;
 	}
 	

--- a/src/main/java/ch/njol/skript/events/EvtPlantGrowth.java
+++ b/src/main/java/ch/njol/skript/events/EvtPlantGrowth.java
@@ -62,7 +62,7 @@ public class EvtPlantGrowth extends SkriptEvent {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "plant growth";
 	}
 }

--- a/src/main/java/ch/njol/skript/events/EvtPressurePlate.java
+++ b/src/main/java/ch/njol/skript/events/EvtPressurePlate.java
@@ -66,7 +66,7 @@ public class EvtPressurePlate extends SkriptEvent {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return tripwire ? "trip" : "stepping on a pressure plate";
 	}
 	

--- a/src/main/java/ch/njol/skript/events/EvtResourcePackResponse.java
+++ b/src/main/java/ch/njol/skript/events/EvtResourcePackResponse.java
@@ -71,8 +71,8 @@ public class EvtResourcePackResponse extends SkriptEvent {
 	}
 
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return states != null ? "resource pack " + states.toString(e, debug) : "resource pack request response";
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return states != null ? "resource pack " + states.toString(event, debug) : "resource pack request response";
 	}
 
 }

--- a/src/main/java/ch/njol/skript/events/EvtScript.java
+++ b/src/main/java/ch/njol/skript/events/EvtScript.java
@@ -93,7 +93,7 @@ public class EvtScript extends SelfRegisteringSkriptEvent {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return (asyncAllowed ? "async " : "") + "script " + (load ? "" : "un") + "load";
 	}
 	

--- a/src/main/java/ch/njol/skript/events/EvtSkript.java
+++ b/src/main/java/ch/njol/skript/events/EvtSkript.java
@@ -92,7 +92,7 @@ public class EvtSkript extends SelfRegisteringSkriptEvent {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "on server " + (isStart ? "start" : "stop");
 	}
 	

--- a/src/main/java/ch/njol/skript/events/EvtWeatherChange.java
+++ b/src/main/java/ch/njol/skript/events/EvtWeatherChange.java
@@ -70,7 +70,7 @@ public class EvtWeatherChange extends SkriptEvent {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "weather change" + (types == null ? "" : " to " + types);
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprAbsorbedBlocks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAbsorbedBlocks.java
@@ -62,11 +62,11 @@ public class ExprAbsorbedBlocks extends SimpleExpression<BlockStateBlock> {
 	
 	@Override
 	@Nullable
-	protected BlockStateBlock[] get(Event e) {
-		if (!(e instanceof SpongeAbsorbEvent))
+	protected BlockStateBlock[] get(Event event) {
+		if (!(event instanceof SpongeAbsorbEvent))
 			return null;
 
-		List<BlockState> bs = ((SpongeAbsorbEvent) e).getBlocks();
+		List<BlockState> bs = ((SpongeAbsorbEvent) event).getBlocks();
 		return bs.stream()
 			.map(BlockStateBlock::new)
 			.toArray(BlockStateBlock[]::new);
@@ -74,11 +74,11 @@ public class ExprAbsorbedBlocks extends SimpleExpression<BlockStateBlock> {
 	
 	@Override
 	@Nullable
-	public Iterator<BlockStateBlock> iterator(Event e) {
-		if (!(e instanceof SpongeAbsorbEvent))
+	public Iterator<BlockStateBlock> iterator(Event event) {
+		if (!(event instanceof SpongeAbsorbEvent))
 			return null;
 
-		List<BlockState> bs = ((SpongeAbsorbEvent) e).getBlocks();
+		List<BlockState> bs = ((SpongeAbsorbEvent) event).getBlocks();
 		return bs.stream()
 			.map(BlockStateBlock::new)
 			.iterator();
@@ -95,7 +95,7 @@ public class ExprAbsorbedBlocks extends SimpleExpression<BlockStateBlock> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "absorbed blocks";
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprAffectedEntities.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAffectedEntities.java
@@ -60,18 +60,18 @@ public class ExprAffectedEntities extends SimpleExpression<LivingEntity> {
 
 	@Nullable
 	@Override
-	protected LivingEntity[] get(Event e) {
-		if (e instanceof AreaEffectCloudApplyEvent)
-			return ((AreaEffectCloudApplyEvent) e).getAffectedEntities().toArray(new LivingEntity[0]);
+	protected LivingEntity[] get(Event event) {
+		if (event instanceof AreaEffectCloudApplyEvent)
+			return ((AreaEffectCloudApplyEvent) event).getAffectedEntities().toArray(new LivingEntity[0]);
 		return null;
 	}
 
 	@Nullable
 	@Override
-	public Iterator<? extends LivingEntity> iterator(Event e) {
-		if (e instanceof AreaEffectCloudApplyEvent)
-			return ((AreaEffectCloudApplyEvent) e).getAffectedEntities().iterator();
-		return super.iterator(e);
+	public Iterator<? extends LivingEntity> iterator(Event event) {
+		if (event instanceof AreaEffectCloudApplyEvent)
+			return ((AreaEffectCloudApplyEvent) event).getAffectedEntities().iterator();
+		return super.iterator(event);
 	}
 
 	@Override
@@ -90,7 +90,7 @@ public class ExprAffectedEntities extends SimpleExpression<LivingEntity> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "the affected entities";
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprAllCommands.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAllCommands.java
@@ -55,7 +55,7 @@ public class ExprAllCommands extends SimpleExpression<String> {
 	@Nullable
 	@Override
 	@SuppressWarnings("null")
-	protected String[] get(Event e) {
+	protected String[] get(Event event) {
 		if (scriptCommandsOnly) {
 			return Commands.getScriptCommands().toArray(new String[0]);
 		} else {
@@ -80,7 +80,7 @@ public class ExprAllCommands extends SimpleExpression<String> {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "all " + (scriptCommandsOnly ? "script " : " ") + "commands";
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprAlphabetList.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAlphabetList.java
@@ -56,8 +56,8 @@ public class ExprAlphabetList extends SimpleExpression<String>{
 	
 	@Override
 	@Nullable
-	protected String[] get(Event e) {
-		String[] sorted = texts.getAll(e).clone(); // Not yet sorted
+	protected String[] get(Event event) {
+		String[] sorted = texts.getAll(event).clone(); // Not yet sorted
 		Arrays.sort(sorted); // Now sorted
 		return sorted;
 	}
@@ -73,8 +73,8 @@ public class ExprAlphabetList extends SimpleExpression<String>{
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "alphabetically sorted strings: " + texts.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "alphabetically sorted strings: " + texts.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprAmount.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAmount.java
@@ -95,18 +95,18 @@ public class ExprAmount extends SimpleExpression<Long> {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	protected Long[] get(Event e) {
+	protected Long[] get(Event event) {
 		if (recursive) {
 			int currentSize = 0;
 			for (Expression<?> expr : exprs.getExpressions()) {
-				Object var = ((Variable<?>) expr).getRaw(e);
+				Object var = ((Variable<?>) expr).getRaw(event);
 				if (var != null) { // Should already be a map
 					currentSize += getRecursiveSize((Map<String, ?>) var);
 				}
 			}
 			return new Long[]{(long) currentSize};
 		}
-		return new Long[]{(long) exprs.getArray(e).length};
+		return new Long[]{(long) exprs.getArray(event).length};
 	}
 
 	@SuppressWarnings("unchecked")
@@ -133,8 +133,8 @@ public class ExprAmount extends SimpleExpression<Long> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return (recursive ? "recursive size of " : "amount of ") + exprs.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return (recursive ? "recursive size of " : "amount of ") + exprs.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprAmountOfItems.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAmountOfItems.java
@@ -58,10 +58,10 @@ public class ExprAmountOfItems extends SimpleExpression<Long> {
 	}
 	
 	@Override
-	protected Long[] get(Event e) {
-		ItemType[] itemTypes = items.getArray(e);
+	protected Long[] get(Event event) {
+		ItemType[] itemTypes = items.getArray(event);
 		long amount = 0;
-		for (Inventory inventory : inventories.getArray(e)) {
+		for (Inventory inventory : inventories.getArray(event)) {
 			itemsLoop: for (ItemStack itemStack : inventory.getContents()) {
 				if (itemStack != null) {
 					for (ItemType itemType : itemTypes) {
@@ -87,8 +87,8 @@ public class ExprAmountOfItems extends SimpleExpression<Long> {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "the number of " + items.toString(e, debug) + " in " + inventories.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "the number of " + items.toString(event, debug) + " in " + inventories.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprAppliedEnchantments.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAppliedEnchantments.java
@@ -64,11 +64,11 @@ public class ExprAppliedEnchantments extends SimpleExpression<EnchantmentType> {
 	@SuppressWarnings("null")
 	@Override
 	@Nullable
-	protected EnchantmentType[] get(Event e) {
-		if (!(e instanceof EnchantItemEvent))
+	protected EnchantmentType[] get(Event event) {
+		if (!(event instanceof EnchantItemEvent))
 			return null;
 
-		return ((EnchantItemEvent) e).getEnchantsToAdd().entrySet().stream()
+		return ((EnchantItemEvent) event).getEnchantsToAdd().entrySet().stream()
 				.map(entry -> new EnchantmentType(entry.getKey(), entry.getValue()))
 				.toArray(EnchantmentType[]::new);
 	}
@@ -127,7 +127,7 @@ public class ExprAppliedEnchantments extends SimpleExpression<EnchantmentType> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "applied enchantments";
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprArgument.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprArgument.java
@@ -213,16 +213,16 @@ public class ExprArgument extends SimpleExpression<Object> {
 	
 	@Override
 	@Nullable
-	protected Object[] get(final Event e) {
+	protected Object[] get(final Event event) {
 		if (argument != null) {
-			return argument.getCurrent(e);
+			return argument.getCurrent(event);
 		}
 
 		String fullCommand;
-		if (e instanceof PlayerCommandPreprocessEvent) {
-			fullCommand = ((PlayerCommandPreprocessEvent) e).getMessage().substring(1).trim();
-		} else if (e instanceof ServerCommandEvent) { // It's a ServerCommandEvent then
-			fullCommand = ((ServerCommandEvent) e).getCommand().trim();
+		if (event instanceof PlayerCommandPreprocessEvent) {
+			fullCommand = ((PlayerCommandPreprocessEvent) event).getMessage().substring(1).trim();
+		} else if (event instanceof ServerCommandEvent) { // It's a ServerCommandEvent then
+			fullCommand = ((ServerCommandEvent) event).getCommand().trim();
 		} else {
 			return new Object[0];
 		}
@@ -267,12 +267,12 @@ public class ExprArgument extends SimpleExpression<Object> {
 	}
 
 	@Override
-	public boolean isLoopOf(String s) {
-		return s.equalsIgnoreCase("argument");
+	public boolean isLoopOf(String string) {
+		return string.equalsIgnoreCase("argument");
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		switch (what) {
 			case LAST:
 				return "the last argument";

--- a/src/main/java/ch/njol/skript/expressions/ExprArrowKnockbackStrength.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprArrowKnockbackStrength.java
@@ -71,12 +71,12 @@ public class ExprArrowKnockbackStrength extends SimplePropertyExpression<Project
 	}
 	
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		int strength = delta != null ? ((Number) delta[0]).intValue() : 0;
 		switch (mode) {
 			case REMOVE:
 				if (abstractArrowExists) {
-					for (Projectile entity : getExpr().getArray(e)) {
+					for (Projectile entity : getExpr().getArray(event)) {
 						if (entity instanceof AbstractArrow) {
 							AbstractArrow abstractArrow = (AbstractArrow) entity;
 							int dmg = abstractArrow.getKnockbackStrength() - strength;
@@ -85,7 +85,7 @@ public class ExprArrowKnockbackStrength extends SimplePropertyExpression<Project
 						}
 					}
 				} else {
-					for (Projectile entity : getExpr().getArray(e)) {
+					for (Projectile entity : getExpr().getArray(event)) {
 						if (entity instanceof Arrow) {
 							Arrow arrow = (Arrow) entity;
 							int dmg = arrow.getKnockbackStrength() - strength;
@@ -97,7 +97,7 @@ public class ExprArrowKnockbackStrength extends SimplePropertyExpression<Project
 				break;
 			case ADD:
 				if (abstractArrowExists)
-					for (Projectile entity : getExpr().getArray(e)) {
+					for (Projectile entity : getExpr().getArray(event)) {
 						if (entity instanceof AbstractArrow) {
 							AbstractArrow abstractArrow = (AbstractArrow) entity;
 							int dmg = abstractArrow.getKnockbackStrength() + strength;
@@ -106,7 +106,7 @@ public class ExprArrowKnockbackStrength extends SimplePropertyExpression<Project
 						}
 					}
 				else
-					for (Projectile entity : getExpr().getArray(e)) {
+					for (Projectile entity : getExpr().getArray(event)) {
 						if (entity instanceof Arrow) {
 							Arrow arrow = (Arrow) entity;
 							int dmg = arrow.getKnockbackStrength() + strength;
@@ -117,7 +117,7 @@ public class ExprArrowKnockbackStrength extends SimplePropertyExpression<Project
 				break;
 			case RESET:
 			case SET:
-				for (Projectile entity : getExpr().getArray(e)) {
+				for (Projectile entity : getExpr().getArray(event)) {
 					if (abstractArrowExists) {
 						if (entity instanceof AbstractArrow) ((AbstractArrow) entity).setKnockbackStrength(strength);
 					} else if (entity instanceof Arrow) {

--- a/src/main/java/ch/njol/skript/expressions/ExprArrowPierceLevel.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprArrowPierceLevel.java
@@ -71,14 +71,14 @@ public class ExprArrowPierceLevel extends SimplePropertyExpression<Projectile, L
 	}
 	
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		int strength = delta != null ? Math.max(((Number) delta[0]).intValue(), 0) : 0;
 		int mod = 1;
 		switch (mode) {
 			case REMOVE:
 				mod = -1;
 			case ADD:
-				for (Projectile entity : getExpr().getArray(e)) {
+				for (Projectile entity : getExpr().getArray(event)) {
 					if (entity instanceof Arrow) {
 						Arrow arrow = (Arrow) entity;
 						int dmg = Math.round(arrow.getPierceLevel() + strength * mod);
@@ -89,7 +89,7 @@ public class ExprArrowPierceLevel extends SimplePropertyExpression<Projectile, L
 				break;
 			case RESET:
 			case SET:
-				for (Projectile entity : getExpr().getArray(e)) {
+				for (Projectile entity : getExpr().getArray(event)) {
 					((Arrow) entity).setPierceLevel(strength);
 				}
 				break;

--- a/src/main/java/ch/njol/skript/expressions/ExprArrowsStuck.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprArrowsStuck.java
@@ -59,9 +59,9 @@ public class ExprArrowsStuck extends SimplePropertyExpression<LivingEntity, Long
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
 		int d = delta == null ? 0 : ((Number) delta[0]).intValue();
-		for (LivingEntity le : getExpr().getArray(e)) {
+		for (LivingEntity le : getExpr().getArray(event)) {
 			switch (mode) {
 				case ADD:
 					int r1 = le.getArrowsStuck() + d;

--- a/src/main/java/ch/njol/skript/expressions/ExprAttacked.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAttacked.java
@@ -88,16 +88,16 @@ public class ExprAttacked extends SimpleExpression<Entity> {
 
 	@Override
 	@Nullable
-	protected Entity[] get(Event e) {
+	protected Entity[] get(Event event) {
 		Entity[] one = (Entity[]) Array.newInstance(type.getType(), 1);
 		Entity entity;
-		if (e instanceof EntityEvent)
-			if (SUPPORT_PROJECTILE_HIT && e instanceof ProjectileHitEvent)
-				entity = ((ProjectileHitEvent) e).getHitEntity();
+		if (event instanceof EntityEvent)
+			if (SUPPORT_PROJECTILE_HIT && event instanceof ProjectileHitEvent)
+				entity = ((ProjectileHitEvent) event).getHitEntity();
 			else
-				entity = ((EntityEvent) e).getEntity();
-		else if (e instanceof VehicleEvent)
-			entity = ((VehicleEvent) e).getVehicle();
+				entity = ((EntityEvent) event).getEntity();
+		else if (event instanceof VehicleEvent)
+			entity = ((VehicleEvent) event).getVehicle();
 		else
 			return null;
 		if (type.isInstance(entity)) {
@@ -118,10 +118,10 @@ public class ExprAttacked extends SimpleExpression<Entity> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		if (e == null)
+	public String toString(@Nullable Event event, boolean debug) {
+		if (event == null)
 			return "the attacked " + type;
-		return Classes.getDebugMessage(getSingle(e));
+		return Classes.getDebugMessage(getSingle(event));
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprAttacker.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAttacker.java
@@ -69,8 +69,8 @@ public class ExprAttacker extends SimpleExpression<Entity> {
 	}
 	
 	@Override
-	protected Entity[] get(Event e) {
-		return new Entity[] {getAttacker(e)};
+	protected Entity[] get(Event event) {
+		return new Entity[] {getAttacker(event)};
 	}
 	
 	@Nullable
@@ -105,10 +105,10 @@ public class ExprAttacker extends SimpleExpression<Entity> {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		if (e == null)
+	public String toString(@Nullable Event event, boolean debug) {
+		if (event == null)
 			return "the attacker";
-		return Classes.getDebugMessage(getSingle(e));
+		return Classes.getDebugMessage(getSingle(event));
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprBed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBed.java
@@ -82,9 +82,9 @@ public class ExprBed extends SimplePropertyExpression<OfflinePlayer, Location> {
 	}
 	
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		Location loc = delta == null ? null : (Location) delta[0];
-		for (OfflinePlayer p : getExpr().getArray(e)) {
+		for (OfflinePlayer p : getExpr().getArray(event)) {
 			Player op = p.getPlayer();
 			if (op != null) // is online
 				op.setBedSpawnLocation(loc, !isSafe);

--- a/src/main/java/ch/njol/skript/expressions/ExprBlock.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBlock.java
@@ -80,8 +80,8 @@ public class ExprBlock extends WrapperExpression<Block> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return getExpr() instanceof EventValueExpression ? "the block" : "the block " + getExpr().toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return getExpr() instanceof EventValueExpression ? "the block" : "the block " + getExpr().toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprBlockData.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBlockData.java
@@ -62,12 +62,12 @@ public class ExprBlockData extends SimplePropertyExpression<Block, BlockData> {
 	}
 	
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		if (delta == null)
 			return;
 		
 		BlockData blockData = ((BlockData) delta[0]);
-		for (Block block : getExpr().getArray(e)) {
+		for (Block block : getExpr().getArray(event)) {
 			block.setBlockData(blockData);
 		}
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprBlockSphere.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBlockSphere.java
@@ -69,9 +69,9 @@ public class ExprBlockSphere extends SimpleExpression<Block> {
 	}
 	
 	@Override
-	public Iterator<Block> iterator(final Event e) {
-		final Location l = center.getSingle(e);
-		final Number r = radius.getSingle(e);
+	public Iterator<Block> iterator(final Event event) {
+		final Location l = center.getSingle(event);
+		final Number r = radius.getSingle(event);
 		if (l == null || r == null)
 			return new EmptyIterator<>();
 		return new BlockSphereIterator(l, r.doubleValue());
@@ -79,12 +79,12 @@ public class ExprBlockSphere extends SimpleExpression<Block> {
 	
 	@Override
 	@Nullable
-	protected Block[] get(final Event e) {
-		final Number r = radius.getSingle(e);
+	protected Block[] get(final Event event) {
+		final Number r = radius.getSingle(event);
 		if (r == null)
 			return new Block[0];
 		final ArrayList<Block> list = new ArrayList<>((int) (1.1 * 4 / 3. * Math.PI * Math.pow(r.doubleValue(), 3)));
-		for (final Block b : new IteratorIterable<>(iterator(e)))
+		for (final Block b : new IteratorIterable<>(iterator(event)))
 			list.add(b);
 		return list.toArray(new Block[list.size()]);
 	}
@@ -95,13 +95,13 @@ public class ExprBlockSphere extends SimpleExpression<Block> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "the blocks in radius " + radius + " around " + center.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "the blocks in radius " + radius + " around " + center.toString(event, debug);
 	}
 	
 	@Override
-	public boolean isLoopOf(final String s) {
-		return s.equalsIgnoreCase("block");
+	public boolean isLoopOf(final String string) {
+		return string.equalsIgnoreCase("block");
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprBlocks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBlocks.java
@@ -109,11 +109,11 @@ public class ExprBlocks extends SimpleExpression<Block> {
 	@SuppressWarnings("null")
 	@Override
 	@Nullable
-	protected Block[] get(final Event e) {
+	protected Block[] get(final Event event) {
 		final Expression<Direction> direction = this.direction;
 		if (direction != null && !from.isSingle()) {
-			final Location[] ls = (Location[]) from.getArray(e);
-			final Direction d = direction.getSingle(e);
+			final Location[] ls = (Location[]) from.getArray(event);
+			final Direction d = direction.getSingle(event);
 			if (ls.length == 0 || d == null)
 				return new Block[0];
 			final Block[] bs = new Block[ls.length];
@@ -123,7 +123,7 @@ public class ExprBlocks extends SimpleExpression<Block> {
 			return bs;
 		}
 		final ArrayList<Block> r = new ArrayList<>();
-		final Iterator<Block> iter = iterator(e);
+		final Iterator<Block> iter = iterator(event);
 		if (iter == null)
 			return new Block[0];
 		for (final Block b : new IteratorIterable<>(iter))
@@ -133,31 +133,31 @@ public class ExprBlocks extends SimpleExpression<Block> {
 	
 	@Override
 	@Nullable
-	public Iterator<Block> iterator(final Event e) {
+	public Iterator<Block> iterator(final Event event) {
 		try {
 			final Expression<Direction> direction = this.direction;
 			if (chunk != null) {
-				Chunk chunk = this.chunk.getSingle(e);
+				Chunk chunk = this.chunk.getSingle(event);
 				if (chunk != null)
 					return new AABB(chunk).iterator();
 			} else if (direction != null) {
 				if (!from.isSingle()) {
-					return new ArrayIterator<>(get(e));
+					return new ArrayIterator<>(get(event));
 				}
-				final Object o = from.getSingle(e);
+				final Object o = from.getSingle(event);
 				if (o == null)
 					return null;
 				final Location l = o instanceof Location ? (Location) o : ((Block) o).getLocation().add(0.5, 0.5, 0.5);
-				final Direction d = direction.getSingle(e);
+				final Direction d = direction.getSingle(event);
 				if (d == null)
 					return null;
 				return new BlockLineIterator(l, o != l ? d.getDirection((Block) o) : d.getDirection(l), SkriptConfig.maxTargetBlockDistance.value());
 			} else {
-				final Location loc = (Location) from.getSingle(e);
+				final Location loc = (Location) from.getSingle(event);
 				if (loc == null)
 					return null;
 				assert end != null;
-				final Location loc2 = end.getSingle(e);
+				final Location loc2 = end.getSingle(event);
 				if (loc2 == null || loc2.getWorld() != loc.getWorld())
 					return null;
 				if (pattern == 4)
@@ -183,19 +183,19 @@ public class ExprBlocks extends SimpleExpression<Block> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		final Expression<Location> end = this.end;
 		if (chunk != null) {
-			return "blocks within chunk " + chunk.toString(e, debug);
+			return "blocks within chunk " + chunk.toString(event, debug);
 		} else if (pattern == 4) {
 			assert end != null;
-			return "blocks within " + from.toString(e, debug) + " and " + end.toString(e, debug);
+			return "blocks within " + from.toString(event, debug) + " and " + end.toString(event, debug);
 		} else if (end != null) {
-			return "blocks from " + from.toString(e, debug) + " to " + end.toString(e, debug);
+			return "blocks from " + from.toString(event, debug) + " to " + end.toString(event, debug);
 		} else {
 			final Expression<Direction> direction = this.direction;
 			assert direction != null;
-			return "block" + (isSingle() ? "" : "s") + " " + direction.toString(e, debug) + " " + from.toString(e, debug);
+			return "block" + (isSingle() ? "" : "s") + " " + direction.toString(event, debug) + " " + from.toString(event, debug);
 		}
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprBookAuthor.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBookAuthor.java
@@ -64,10 +64,10 @@ public class ExprBookAuthor extends SimplePropertyExpression<ItemType, String> {
 	
 	@SuppressWarnings("null")
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		String author = delta == null ? null : (String) delta[0];
 		
-		for (ItemType item : getExpr().getArray(e)) {
+		for (ItemType item : getExpr().getArray(event)) {
 			ItemMeta meta = item.getItemMeta();
 			
 			if (meta instanceof BookMeta) {

--- a/src/main/java/ch/njol/skript/expressions/ExprBookTitle.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBookTitle.java
@@ -63,10 +63,10 @@ public class ExprBookTitle extends SimplePropertyExpression<ItemType, String> {
 	
 	@SuppressWarnings("null")
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		String title = delta == null ? null : (String) delta[0];
 		
-		for (ItemType item : getExpr().getArray(e)) {
+		for (ItemType item : getExpr().getArray(event)) {
 			ItemMeta meta = item.getItemMeta();
 			
 			if (meta instanceof BookMeta) {

--- a/src/main/java/ch/njol/skript/expressions/ExprBurnCookTime.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBurnCookTime.java
@@ -81,12 +81,12 @@ public class ExprBurnCookTime extends PropertyExpression<Block, Timespan> {
 	}
 
 	@Override
-	protected Timespan[] get(Event e, Block[] source) {
+	protected Timespan[] get(Event event, Block[] source) {
 		if (isEvent) {
-			if (!(e instanceof FurnaceBurnEvent))
+			if (!(event instanceof FurnaceBurnEvent))
 				return null;
 
-			return CollectionUtils.array(Timespan.fromTicks_i(((FurnaceBurnEvent) e).getBurnTime()));
+			return CollectionUtils.array(Timespan.fromTicks_i(((FurnaceBurnEvent) event).getBurnTime()));
 		} else {
 			Timespan[] result = Arrays.stream(source)
 					.filter(block -> anyFurnace.isOfType(block))
@@ -101,8 +101,8 @@ public class ExprBurnCookTime extends PropertyExpression<Block, Timespan> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return isEvent ? "the burning time" : "" + String.format("the %sing time of %s", cookTime ? "cook" : "burn", getExpr().toString(e, debug));
+	public String toString(@Nullable Event event, boolean debug) {
+		return isEvent ? "the burning time" : "" + String.format("the %sing time of %s", cookTime ? "cook" : "burn", getExpr().toString(event, debug));
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprChatFormat.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprChatFormat.java
@@ -74,23 +74,23 @@ public class ExprChatFormat extends SimpleExpression<String>{
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "chat format";
 	}
 	
 	@Override
 	@Nullable
-	protected String[] get(Event e) {
-		if (!(e instanceof AsyncPlayerChatEvent))
+	protected String[] get(Event event) {
+		if (!(event instanceof AsyncPlayerChatEvent))
 			return null;
 
-		return new String[]{convertToFriendly(((AsyncPlayerChatEvent) e).getFormat())};
+		return new String[]{convertToFriendly(((AsyncPlayerChatEvent) event).getFormat())};
 	}
 	
 	//delta[0] has to be a String unless Skript has horribly gone wrong
 	@Override
-	public void change(Event e, @Nullable Object[] delta, Changer.ChangeMode mode) {
-		if (delta == null || !(e instanceof AsyncPlayerChatEvent)){
+	public void change(Event event, @Nullable Object[] delta, Changer.ChangeMode mode) {
+		if (delta == null || !(event instanceof AsyncPlayerChatEvent)){
 			return;
 		}
 		String format = null;
@@ -106,7 +106,7 @@ public class ExprChatFormat extends SimpleExpression<String>{
 		if (format == null){
 			return;
 		}
-		((AsyncPlayerChatEvent) e).setFormat(format);
+		((AsyncPlayerChatEvent) event).setFormat(format);
 	}
 	
 	@SuppressWarnings({"null"}) //First parameter is marked as @NonNull and String#replaceAll won't return null

--- a/src/main/java/ch/njol/skript/expressions/ExprChestInventory.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprChestInventory.java
@@ -65,9 +65,9 @@ public class ExprChestInventory extends SimpleExpression<Inventory> {
 	}
 
 	@Override
-	protected Inventory[] get(Event e) {
-		String name = this.name != null ? this.name.getSingle(e) : DEFAULT_CHEST_TITLE;
-		Number rows = this.rows != null ? this.rows.getSingle(e) : DEFAULT_CHEST_ROWS;
+	protected Inventory[] get(Event event) {
+		String name = this.name != null ? this.name.getSingle(event) : DEFAULT_CHEST_TITLE;
+		Number rows = this.rows != null ? this.rows.getSingle(event) : DEFAULT_CHEST_ROWS;
 
 		rows = rows == null ? DEFAULT_CHEST_ROWS : rows;
 		name = name == null ? DEFAULT_CHEST_TITLE : name;
@@ -97,11 +97,11 @@ public class ExprChestInventory extends SimpleExpression<Inventory> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "chest inventory named "
-			+ (name != null ? name.toString(e, debug) : "\"" + DEFAULT_CHEST_TITLE + "\"") +
+			+ (name != null ? name.toString(event, debug) : "\"" + DEFAULT_CHEST_TITLE + "\"") +
 			" with "
-			+ (rows != null ? rows.toString(e, debug) : "" + DEFAULT_CHEST_ROWS + " rows");
+			+ (rows != null ? rows.toString(event, debug) : "" + DEFAULT_CHEST_ROWS + " rows");
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprChunk.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprChunk.java
@@ -68,7 +68,7 @@ public class ExprChunk extends PropertyExpression<Location, Chunk> {
 	}
 	
 	@Override
-	protected Chunk[] get(final Event e, final Location[] source) {
+	protected Chunk[] get(final Event event, final Location[] source) {
 		return get(source, new Converter<Location, Chunk>() {
 			@Override
 			public Chunk convert(final Location l) {
@@ -83,8 +83,8 @@ public class ExprChunk extends PropertyExpression<Location, Chunk> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "the chunk at " + locations.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "the chunk at " + locations.toString(event, debug);
 	}
 	
 	@Override
@@ -96,10 +96,10 @@ public class ExprChunk extends PropertyExpression<Location, Chunk> {
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
 		assert mode == ChangeMode.RESET;
 		
-		final Chunk[] cs = getArray(e);
+		final Chunk[] cs = getArray(event);
 		for (final Chunk c : cs)
 			c.getWorld().regenerateChunk(c.getX(), c.getZ());
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprClicked.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprClicked.java
@@ -174,16 +174,16 @@ public class ExprClicked extends SimpleExpression<Object> {
 	
 	@Override
 	@Nullable
-	protected Object[] get(Event e) {
-		if (!(e instanceof InventoryClickEvent) && clickable != ClickableType.BLOCK_AND_ITEMS && clickable != ClickableType.ENCHANT_BUTTON)
+	protected Object[] get(Event event) {
+		if (!(event instanceof InventoryClickEvent) && clickable != ClickableType.BLOCK_AND_ITEMS && clickable != ClickableType.ENCHANT_BUTTON)
 			return null;
 
 		switch (clickable) {
 			case BLOCK_AND_ITEMS:
-				if (e instanceof PlayerInteractEvent) {
+				if (event instanceof PlayerInteractEvent) {
 					if (entityType != null) // This is supposed to be null as this event should be for blocks
 						return null;
-					Block block = ((PlayerInteractEvent) e).getClickedBlock();
+					Block block = ((PlayerInteractEvent) event).getClickedBlock();
 					
 					if (itemType == null)
 						return new Block[] {block};
@@ -191,10 +191,10 @@ public class ExprClicked extends SimpleExpression<Object> {
 					if (itemType.isOfType(block))
 						return new Block[] {block};
 					return null;
-				} else if (e instanceof PlayerInteractEntityEvent) {
+				} else if (event instanceof PlayerInteractEntityEvent) {
 					if (entityType == null) //We're testing for the entity in this event
 						return null;
-					Entity entity = ((PlayerInteractEntityEvent) e).getRightClicked();
+					Entity entity = ((PlayerInteractEntityEvent) event).getRightClicked();
 					
 					assert entityType != null;
 					if (entityType.isInstance(entity)) {
@@ -207,28 +207,28 @@ public class ExprClicked extends SimpleExpression<Object> {
 				}
 				break;
 			case TYPE:
-				return new ClickType[] {((InventoryClickEvent) e).getClick()};
+				return new ClickType[] {((InventoryClickEvent) event).getClick()};
 			case ACTION:
-				return new InventoryAction[] {((InventoryClickEvent) e).getAction()};
+				return new InventoryAction[] {((InventoryClickEvent) event).getAction()};
 			case INVENTORY:
-				return new Inventory[] {((InventoryClickEvent) e).getClickedInventory()};
+				return new Inventory[] {((InventoryClickEvent) event).getClickedInventory()};
 			case SLOT:
 				// Slots are specific to inventories, so refering to wrong one is impossible
 				// (as opposed to using the numbers directly)
-				Inventory invi = ((InventoryClickEvent) e).getClickedInventory();
+				Inventory invi = ((InventoryClickEvent) event).getClickedInventory();
 				if (invi != null) // Inventory is technically not guaranteed to exist...
-					return CollectionUtils.array(new InventorySlot(invi, ((InventoryClickEvent) e).getSlot()));
+					return CollectionUtils.array(new InventorySlot(invi, ((InventoryClickEvent) event).getSlot()));
 				break;
 			case ENCHANT_BUTTON:
-				if (e instanceof EnchantItemEvent)
-					return new Number[]{((EnchantItemEvent) e).whichButton() + 1};
+				if (event instanceof EnchantItemEvent)
+					return new Number[]{((EnchantItemEvent) event).whichButton() + 1};
 				break;
 		}
 		return null;
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "the " + (clickable != ClickableType.BLOCK_AND_ITEMS ? clickable.getName() : "clicked " + (entityType != null ? entityType : itemType != null ? itemType : "block"));
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprCmdCooldownInfo.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCmdCooldownInfo.java
@@ -129,10 +129,10 @@ public class ExprCmdCooldownInfo extends SimpleExpression<Object> {
 	}
 
 	@Override
-	public void change(Event e, @Nullable Object[] delta, Changer.ChangeMode mode) {
-		if (!(e instanceof ScriptCommandEvent))
+	public void change(Event event, @Nullable Object[] delta, Changer.ChangeMode mode) {
+		if (!(event instanceof ScriptCommandEvent))
 			return;
-		ScriptCommandEvent commandEvent = (ScriptCommandEvent) e;
+		ScriptCommandEvent commandEvent = (ScriptCommandEvent) event;
 		ScriptCommand command = commandEvent.getScriptCommand();
 		Timespan cooldown = command.getCooldown();
 		CommandSender sender = commandEvent.getSender();
@@ -201,7 +201,7 @@ public class ExprCmdCooldownInfo extends SimpleExpression<Object> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "the " + getExpressionName() + " of the cooldown";
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprColorOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprColorOf.java
@@ -69,7 +69,7 @@ public class ExprColorOf extends PropertyExpression<Object, Color> {
 	
 	@SuppressWarnings("null")
 	@Override
-	protected Color[] get(Event e, Object[] source) {
+	protected Color[] get(Event event, Object[] source) {
 		if (source instanceof FireworkEffect[]) {
 			List<Color> colors = new ArrayList<>();
 			
@@ -101,8 +101,8 @@ public class ExprColorOf extends PropertyExpression<Object, Color> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "colour of " + getExpr().toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "colour of " + getExpr().toString(event, debug);
 	}
 
 	@Override
@@ -127,12 +127,12 @@ public class ExprColorOf extends PropertyExpression<Object, Color> {
 
 	@SuppressWarnings("deprecated")
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		if (delta == null)
 			return;
 		DyeColor color = ((Color) delta[0]).asDyeColor();
 
-		for (Object o : getExpr().getArray(e)) {
+		for (Object o : getExpr().getArray(event)) {
 			if (o instanceof Item || o instanceof ItemType) {
 				ItemStack stack = o instanceof Item ? ((Item) o).getItemStack() : ((ItemType) o).getRandom();
 

--- a/src/main/java/ch/njol/skript/expressions/ExprColoured.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprColoured.java
@@ -77,7 +77,7 @@ public class ExprColoured extends PropertyExpression<String, String> {
 	}
 	
 	@Override
-	protected String[] get(final Event e, final String[] source) {
+	protected String[] get(final Event event, final String[] source) {
 		return get(source, new Converter<String, String>() {
 			@Override
 			public String convert(final String s) {
@@ -92,8 +92,8 @@ public class ExprColoured extends PropertyExpression<String, String> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return (color ? "" : "un") + "coloured " + getExpr().toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return (color ? "" : "un") + "coloured " + getExpr().toString(event, debug);
 	}
 	
 	/**

--- a/src/main/java/ch/njol/skript/expressions/ExprCommand.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCommand.java
@@ -103,7 +103,7 @@ public class ExprCommand extends SimpleExpression<String> {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return fullCommand ? "the full command" : "the command";
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprCommandInfo.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCommandInfo.java
@@ -92,9 +92,9 @@ public class ExprCommandInfo extends SimpleExpression<String> {
 	@Nullable
 	@Override
 	@SuppressWarnings("null")
-	protected String[] get(Event e) {
+	protected String[] get(Event event) {
 		CommandMap map = Commands.getCommandMap();
-		Command[] commands = this.commandName.stream(e).map(map::getCommand).filter(Objects::nonNull).toArray(Command[]::new);
+		Command[] commands = this.commandName.stream(event).map(map::getCommand).filter(Objects::nonNull).toArray(Command[]::new);
 		ArrayList<String> result = new ArrayList<>();
 		switch (type) {
 			case NAME:
@@ -153,7 +153,7 @@ public class ExprCommandInfo extends SimpleExpression<String> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "the " + type.name().toLowerCase(Locale.ENGLISH).replace("_", " ") + " of command " + commandName.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "the " + type.name().toLowerCase(Locale.ENGLISH).replace("_", " ") + " of command " + commandName.toString(event, debug);
 	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprCommandSender.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCommandSender.java
@@ -52,7 +52,7 @@ public class ExprCommandSender extends EventValueExpression<CommandSender> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "the command sender";
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprCompassTarget.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCompassTarget.java
@@ -71,8 +71,8 @@ public class ExprCompassTarget extends SimplePropertyExpression<Player, Location
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
-		for (final Player p : getExpr().getArray(e))
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
+		for (final Player p : getExpr().getArray(event))
 			p.setCompassTarget(delta == null ? p.getWorld().getSpawnLocation() : (Location) delta[0]);
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprCoordinate.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCoordinate.java
@@ -82,9 +82,9 @@ public class ExprCoordinate extends SimplePropertyExpression<Location, Number> {
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
 		assert delta != null;
-		final Location l = getExpr().getSingle(e);
+		final Location l = getExpr().getSingle(event);
 		if (l == null)
 			return;
 		double n = ((Number) delta[0]).doubleValue();
@@ -100,7 +100,7 @@ public class ExprCoordinate extends SimplePropertyExpression<Location, Number> {
 				} else {
 					l.setZ(l.getZ() + n);
 				}
-				getExpr().change(e, new Location[] {l}, ChangeMode.SET);
+				getExpr().change(event, new Location[] {l}, ChangeMode.SET);
 				break;
 			case SET:
 				if (axis == 0) {
@@ -110,7 +110,7 @@ public class ExprCoordinate extends SimplePropertyExpression<Location, Number> {
 				} else {
 					l.setZ(n);
 				}
-				getExpr().change(e, new Location[] {l}, ChangeMode.SET);
+				getExpr().change(event, new Location[] {l}, ChangeMode.SET);
 				break;
 			case DELETE:
 			case REMOVE_ALL:

--- a/src/main/java/ch/njol/skript/expressions/ExprCreeperMaxFuseTicks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCreeperMaxFuseTicks.java
@@ -57,9 +57,9 @@ public class ExprCreeperMaxFuseTicks extends SimplePropertyExpression<LivingEnti
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
 		int d = delta == null ? 0 : ((Number) delta[0]).intValue();
-		for (LivingEntity le : getExpr().getArray(e)) {
+		for (LivingEntity le : getExpr().getArray(event)) {
 			if (le instanceof Creeper) {
 				Creeper c = (Creeper) le;
 				switch (mode) {

--- a/src/main/java/ch/njol/skript/expressions/ExprCustomModelData.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCustomModelData.java
@@ -73,10 +73,10 @@ public class ExprCustomModelData extends SimplePropertyExpression<ItemType, Long
 	}
 	
 	@Override
-	public void change(Event e, @Nullable Object[] delta, Changer.ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, Changer.ChangeMode mode) {
 		long data = delta == null ? 0 : ((Number) delta[0]).intValue();
 		if (data > 99999999 || data < 0) data = 0;
-		for (ItemType item : getExpr().getArray(e)) {
+		for (ItemType item : getExpr().getArray(event)) {
 			long oldData = 0;
 			ItemMeta meta = item.getItemMeta();
 			if (meta.hasCustomModelData())
@@ -99,8 +99,8 @@ public class ExprCustomModelData extends SimplePropertyExpression<ItemType, Long
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean d) {
-		return "custom model data of " + getExpr().toString(e, d);
+	public String toString(@Nullable Event event, boolean d) {
+		return "custom model data of " + getExpr().toString(event, d);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprDamage.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDamage.java
@@ -68,13 +68,13 @@ public class ExprDamage extends SimpleExpression<Number> {
 	
 	@Override
 	@Nullable
-	protected Number[] get(final Event e) {
-		if (!(e instanceof EntityDamageEvent || e instanceof VehicleDamageEvent))
+	protected Number[] get(final Event event) {
+		if (!(event instanceof EntityDamageEvent || event instanceof VehicleDamageEvent))
 			return new Number[0];
 		
-		if (e instanceof VehicleDamageEvent)
-			return CollectionUtils.array(((VehicleDamageEvent) e).getDamage());
-		return CollectionUtils.array(HealthUtils.getDamage((EntityDamageEvent) e));
+		if (event instanceof VehicleDamageEvent)
+			return CollectionUtils.array(((VehicleDamageEvent) event).getDamage());
+		return CollectionUtils.array(HealthUtils.getDamage((EntityDamageEvent) event));
 	}
 	
 	@Override
@@ -90,26 +90,26 @@ public class ExprDamage extends SimpleExpression<Number> {
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
-		if (!(e instanceof EntityDamageEvent || e instanceof VehicleDamageEvent))
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
+		if (!(event instanceof EntityDamageEvent || event instanceof VehicleDamageEvent))
 			return;
 		double d = delta == null ? 0 : ((Number) delta[0]).doubleValue();
 		switch (mode) {
 			case SET:
 			case DELETE:
-				if (e instanceof VehicleDamageEvent)
-					((VehicleDamageEvent) e).setDamage(d);
+				if (event instanceof VehicleDamageEvent)
+					((VehicleDamageEvent) event).setDamage(d);
 				else
-					HealthUtils.setDamage((EntityDamageEvent) e, d);
+					HealthUtils.setDamage((EntityDamageEvent) event, d);
 				break;
 			case REMOVE:
 				d = -d;
 				//$FALL-THROUGH$
 			case ADD:
-				if (e instanceof VehicleDamageEvent)
-					((VehicleDamageEvent) e).setDamage(((VehicleDamageEvent) e).getDamage() + d);
+				if (event instanceof VehicleDamageEvent)
+					((VehicleDamageEvent) event).setDamage(((VehicleDamageEvent) event).getDamage() + d);
 				else
-					HealthUtils.setDamage((EntityDamageEvent) e, HealthUtils.getDamage((EntityDamageEvent) e) + d);
+					HealthUtils.setDamage((EntityDamageEvent) event, HealthUtils.getDamage((EntityDamageEvent) event) + d);
 				break;
 			case REMOVE_ALL:
 			case RESET:
@@ -128,7 +128,7 @@ public class ExprDamage extends SimpleExpression<Number> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "the damage";
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprDamageCause.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDamageCause.java
@@ -50,7 +50,7 @@ public class ExprDamageCause extends EventValueExpression<DamageCause> {
 	}
 
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "the damage cause";
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprDamagedItem.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDamagedItem.java
@@ -60,8 +60,8 @@ public class ExprDamagedItem extends PropertyExpression<ItemType, ItemType> {
 	}
 	
 	@Override
-	protected ItemType[] get(Event e, ItemType[] source) {
-		Number damage = this.damage.getSingle(e);
+	protected ItemType[] get(Event event, ItemType[] source) {
+		Number damage = this.damage.getSingle(event);
 		if (damage == null)
 			return source;
 		return get(source.clone(), item -> {
@@ -76,8 +76,8 @@ public class ExprDamagedItem extends PropertyExpression<ItemType, ItemType> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, boolean debug) {
-		return getExpr().toString(e, debug) + " with damage value " + damage.toString(e, debug);
+	public String toString(final @Nullable Event event, boolean debug) {
+		return getExpr().toString(event, debug) + " with damage value " + damage.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprDateAgoLater.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDateAgoLater.java
@@ -65,9 +65,9 @@ public class ExprDateAgoLater extends SimpleExpression<Date> {
     @Override
     @Nullable
     @SuppressWarnings("null")
-    protected Date[] get(Event e) {
-        Timespan timespan = this.timespan.getSingle(e);
-		Date date = this.date != null ? this.date.getSingle(e) : new Date();
+    protected Date[] get(Event event) {
+        Timespan timespan = this.timespan.getSingle(event);
+		Date date = this.date != null ? this.date.getSingle(event) : new Date();
 		if (timespan == null || date == null)
 			return null;
 
@@ -85,8 +85,8 @@ public class ExprDateAgoLater extends SimpleExpression<Date> {
     }
 
     @Override
-    public String toString(@Nullable Event e, boolean debug) {
-        return timespan.toString(e, debug) + " " + (ago ? (date != null ? "before " + date.toString(e, debug) : "ago")
-			: (date != null ? "after " + date.toString(e, debug) : "later"));
+    public String toString(@Nullable Event event, boolean debug) {
+        return timespan.toString(event, debug) + " " + (ago ? (date != null ? "before " + date.toString(event, debug) : "ago")
+			: (date != null ? "after " + date.toString(event, debug) : "later"));
     }
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprDefaultValue.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDefaultValue.java
@@ -81,9 +81,9 @@ public class ExprDefaultValue<T> extends SimpleExpression<T> {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	protected T[] get(Event e) {
-		Object[] first = this.first.getArray(e);
-		Object values[] = first.length != 0 ? first : second.getArray(e);
+	protected T[] get(Event event) {
+		Object[] first = this.first.getArray(event);
+		Object values[] = first.length != 0 ? first : second.getArray(event);
 		try {
 			return Converters.convertArray(values, types, superType);
 		} catch (ClassCastException e1) {
@@ -112,8 +112,8 @@ public class ExprDefaultValue<T> extends SimpleExpression<T> {
 	}
 
 	@Override
-	public String toString(Event e, boolean debug) {
-		return first.toString(e, debug) + " or else " + second.toString(e, debug);
+	public String toString(Event event, boolean debug) {
+		return first.toString(event, debug) + " or else " + second.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprDifference.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDifference.java
@@ -116,8 +116,8 @@ public class ExprDifference extends SimpleExpression<Object> {
 	@SuppressWarnings("unchecked")
 	@Override
 	@Nullable
-	protected Object[] get(final Event e) {
-		final Object f = first.getSingle(e), s = second.getSingle(e);
+	protected Object[] get(final Event event) {
+		final Object f = first.getSingle(event), s = second.getSingle(event);
 		if (f == null || s == null)
 			return null;
 		final Object[] one = (Object[]) Array.newInstance(relativeType, 1);
@@ -143,8 +143,8 @@ public class ExprDifference extends SimpleExpression<Object> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "difference between " + first.toString(e, debug) + " and " + second.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "difference between " + first.toString(event, debug) + " and " + second.toString(event, debug);
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprDifficulty.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDifficulty.java
@@ -56,12 +56,12 @@ public class ExprDifficulty extends SimplePropertyExpression<World, Difficulty> 
 	}
 	
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		if (delta == null)
 			return;
 		
 		Difficulty difficulty = (Difficulty) delta[0];
-		for (World world : getExpr().getArray(e)) {
+		for (World world : getExpr().getArray(event)) {
 			world.setDifficulty(difficulty);
 			if (difficulty != Difficulty.PEACEFUL)
 				world.setSpawnFlags(true, world.getAllowAnimals()); // Force enable spawn monsters as changing difficulty won't change this by itself

--- a/src/main/java/ch/njol/skript/expressions/ExprDirection.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDirection.java
@@ -130,8 +130,8 @@ public class ExprDirection extends SimpleExpression<Direction> {
 	
 	@Override
 	@Nullable
-	protected Direction[] get(final Event e) {
-		final Number n = amount != null ? amount.getSingle(e) : 1;
+	protected Direction[] get(final Event event) {
+		final Number n = amount != null ? amount.getSingle(event) : 1;
 		if (n == null)
 			return new Direction[0];
 		final double ln = n.doubleValue();
@@ -139,7 +139,7 @@ public class ExprDirection extends SimpleExpression<Direction> {
 			final Vector v = direction.clone().multiply(ln);
 			ExprDirection d = next;
 			while (d != null) {
-				final Number n2 = d.amount != null ? d.amount.getSingle(e) : 1;
+				final Number n2 = d.amount != null ? d.amount.getSingle(event) : 1;
 				if (n2 == null)
 					return new Direction[0];
 				assert d.direction != null; // checked in init()
@@ -149,7 +149,7 @@ public class ExprDirection extends SimpleExpression<Direction> {
 			assert v != null;
 			return new Direction[] {new Direction(v)};
 		} else if (relativeTo != null) {
-			final Object o = relativeTo.getSingle(e);
+			final Object o = relativeTo.getSingle(event);
 			if (o == null)
 				return new Direction[0];
 			if (o instanceof Block) {
@@ -202,10 +202,10 @@ public class ExprDirection extends SimpleExpression<Direction> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		final Expression<?> relativeTo = this.relativeTo;
-		return (amount != null ? amount.toString(e, debug) + " meter(s) " : "") + (direction != null ? Direction.toString(direction) :
-				relativeTo != null ? " in " + (horizontal ? "horizontal " : "") + (facing ? "facing" : "direction") + " of " + relativeTo.toString(e, debug) :
+		return (amount != null ? amount.toString(event, debug) + " meter(s) " : "") + (direction != null ? Direction.toString(direction) :
+				relativeTo != null ? " in " + (horizontal ? "horizontal " : "") + (facing ? "facing" : "direction") + " of " + relativeTo.toString(event, debug) :
 						(horizontal ? "horizontally " : "") + Direction.toString(0, yaw, 1));
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprDistance.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDistance.java
@@ -60,16 +60,16 @@ public class ExprDistance extends SimpleExpression<Number> {
 	
 	@Override
 	@Nullable
-	protected Number[] get(final Event e) {
-		final Location l1 = loc1.getSingle(e), l2 = loc2.getSingle(e);
+	protected Number[] get(final Event event) {
+		final Location l1 = loc1.getSingle(event), l2 = loc2.getSingle(event);
 		if (l1 == null || l2 == null || l1.getWorld() != l2.getWorld())
 			return new Number[0];
 		return new Number[] {l1.distance(l2)};
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "distance between " + loc1.toString(e, debug) + " and " + loc2.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "distance between " + loc1.toString(event, debug) + " and " + loc2.toString(event, debug);
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprDrops.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDrops.java
@@ -71,11 +71,11 @@ public class ExprDrops extends SimpleExpression<ItemType> {
 
 	@Override
 	@Nullable
-	protected ItemType[] get(Event e) {
-		if (!(e instanceof EntityDeathEvent))
+	protected ItemType[] get(Event event) {
+		if (!(event instanceof EntityDeathEvent))
 			return null;
 
-		return ((EntityDeathEvent) e).getDrops()
+		return ((EntityDeathEvent) event).getDrops()
 			.stream()
 			.map(ItemType::new)
 			.toArray(ItemType[]::new);
@@ -102,20 +102,20 @@ public class ExprDrops extends SimpleExpression<ItemType> {
 	}
 
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
-		if (!(e instanceof EntityDeathEvent))
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+		if (!(event instanceof EntityDeathEvent))
 			return;
 
-		List<ItemStack> drops = ((EntityDeathEvent) e).getDrops();
+		List<ItemStack> drops = ((EntityDeathEvent) event).getDrops();
 		assert delta != null;
 		for (Object o : delta) {
 			if (o instanceof Experience) {
 				if (mode == ChangeMode.REMOVE_ALL || mode == ChangeMode.REMOVE && ((Experience) o).getInternalXP() == -1) {
-					((EntityDeathEvent) e).setDroppedExp(0);
+					((EntityDeathEvent) event).setDroppedExp(0);
 				} else if (mode == ChangeMode.SET) {
-					((EntityDeathEvent) e).setDroppedExp(((Experience) o).getXP());
+					((EntityDeathEvent) event).setDroppedExp(((Experience) o).getXP());
 				} else {
-					((EntityDeathEvent) e).setDroppedExp(Math.max(0, ((EntityDeathEvent) e).getDroppedExp() + (mode == ChangeMode.ADD ? 1 : -1) * ((Experience) o).getXP()));
+					((EntityDeathEvent) event).setDroppedExp(Math.max(0, ((EntityDeathEvent) event).getDroppedExp() + (mode == ChangeMode.ADD ? 1 : -1) * ((Experience) o).getXP()));
 				}
 			} else {
 				switch (mode) {
@@ -169,7 +169,7 @@ public class ExprDrops extends SimpleExpression<ItemType> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "the drops";
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprDropsOfBlock.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDropsOfBlock.java
@@ -79,9 +79,9 @@ public class ExprDropsOfBlock extends SimpleExpression<ItemType> {
 	@Nullable
 	@Override
 	@SuppressWarnings("null")
-	protected ItemType[] get(Event e) {
+	protected ItemType[] get(Event event) {
 		@Nullable
-		Block[] blocks = this.block.getArray(e);
+		Block[] blocks = this.block.getArray(event);
 		if (block != null) {
 			if (this.item == null) {
 				ArrayList<ItemType> list = new ArrayList<>();
@@ -93,8 +93,8 @@ public class ExprDropsOfBlock extends SimpleExpression<ItemType> {
 				}
 				return list.toArray(new ItemType[0]);
 			} else if (this.entity != null) {
-				ItemType item = this.item.getSingle(e);
-				Entity entity = this.entity.getSingle(e);
+				ItemType item = this.item.getSingle(event);
+				Entity entity = this.entity.getSingle(event);
 				ArrayList<ItemType> list = new ArrayList<>();
 				for (Block block : blocks) {
 					ItemStack[] drops = block.getDrops(item.getRandom(), entity).toArray(new ItemStack[0]);
@@ -104,7 +104,7 @@ public class ExprDropsOfBlock extends SimpleExpression<ItemType> {
 				}
 				return list.toArray(new ItemType[0]);
 			} else {
-				ItemType item = this.item.getSingle(e);
+				ItemType item = this.item.getSingle(event);
 				ArrayList<ItemType> list = new ArrayList<>();
 				for (Block block : blocks) {
 					ItemStack[] drops = block.getDrops(item.getRandom()).toArray(new ItemStack[0]);
@@ -129,8 +129,8 @@ public class ExprDropsOfBlock extends SimpleExpression<ItemType> {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "drops of " + block.toString(e, debug) + (item != null ? (" using " + item.toString(e, debug) + (entity != null ? " as " + entity.toString(e, debug) : null)) : "");
+	public String toString(@Nullable Event event, boolean debug) {
+		return "drops of " + block.toString(event, debug) + (item != null ? (" using " + item.toString(event, debug) + (entity != null ? " as " + entity.toString(event, debug) : null)) : "");
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprDurability.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDurability.java
@@ -83,9 +83,9 @@ public class ExprDurability extends SimplePropertyExpression<Object, Long> {
 	
 	@SuppressWarnings("null")
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
 		int a = delta == null ? 0 : ((Number) delta[0]).intValue();
-		final Object[] os = getExpr().getArray(e);
+		final Object[] os = getExpr().getArray(event);
 		for (final Object o : os) {
 			ItemStack itemStack = null;
 			Block block = null;

--- a/src/main/java/ch/njol/skript/expressions/ExprElement.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprElement.java
@@ -142,7 +142,7 @@ public class ExprElement extends SimpleExpression<Object> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		String prefix;
 		switch (type) {
 			case FIRST:
@@ -161,17 +161,17 @@ public class ExprElement extends SimpleExpression<Object> {
 				if (number instanceof Literal) {
 					Number number = ((Literal<Number>) this.number).getSingle();
 					if (number == null)
-						prefix += this.number.toString(e, debug) + "th";
+						prefix += this.number.toString(event, debug) + "th";
 					else
 						prefix += StringUtils.fancyOrderNumber(number.intValue());
 				} else {
-					prefix += number.toString(e, debug) + "th";
+					prefix += number.toString(event, debug) + "th";
 				}
 				break;
 			default:
 				throw new IllegalStateException();
 		}
-		return prefix + " element of " + expr.toString(e, debug);
+		return prefix + " element of " + expr.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprEnchantItem.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEnchantItem.java
@@ -65,11 +65,11 @@ public class ExprEnchantItem extends SimpleExpression<ItemType> {
 
 	@Override
 	@Nullable
-	protected ItemType[] get(Event e) {
-		if (e instanceof PrepareItemEnchantEvent)
-			return new ItemType[]{new ItemType(((PrepareItemEnchantEvent) e).getItem())};
-		else if (e instanceof EnchantItemEvent)
-			return new ItemType[]{new ItemType(((EnchantItemEvent) e).getItem())};
+	protected ItemType[] get(Event event) {
+		if (event instanceof PrepareItemEnchantEvent)
+			return new ItemType[]{new ItemType(((PrepareItemEnchantEvent) event).getItem())};
+		else if (event instanceof EnchantItemEvent)
+			return new ItemType[]{new ItemType(((EnchantItemEvent) event).getItem())};
 		else
 			return null;
 	}
@@ -121,7 +121,7 @@ public class ExprEnchantItem extends SimpleExpression<ItemType> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "enchanted item";
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprEnchantingExpCost.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEnchantingExpCost.java
@@ -63,8 +63,8 @@ public class ExprEnchantingExpCost extends SimpleExpression<Long> {
 
 	@Override
 	@Nullable
-	protected Long[] get(Event e) {
-		return new Long[]{(long) ((EnchantItemEvent) e).getExpLevelCost()};
+	protected Long[] get(Event event) {
+		return new Long[]{(long) ((EnchantItemEvent) event).getExpLevelCost()};
 	}
 
 	@Override
@@ -112,7 +112,7 @@ public class ExprEnchantingExpCost extends SimpleExpression<Long> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "the displayed cost of enchanting";
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprEnchantmentBonus.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEnchantmentBonus.java
@@ -58,8 +58,8 @@ public class ExprEnchantmentBonus extends SimpleExpression<Long> {
 
 	@Override
 	@Nullable
-	protected Long[] get(Event e) {
-		return new Long[]{(long) ((PrepareItemEnchantEvent) e).getEnchantmentBonus()};
+	protected Long[] get(Event event) {
+		return new Long[]{(long) ((PrepareItemEnchantEvent) event).getEnchantmentBonus()};
 	}
 
 	@Override
@@ -74,7 +74,7 @@ public class ExprEnchantmentBonus extends SimpleExpression<Long> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "enchantment bonus";
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprEnchantmentLevel.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEnchantmentLevel.java
@@ -69,9 +69,9 @@ public class ExprEnchantmentLevel extends SimpleExpression<Long> {
 	}
 
 	@Override
-	protected Long[] get(Event e) {
-		Enchantment[] enchantments = enchants.getArray(e);
-		return Stream.of(items.getArray(e))
+	protected Long[] get(Event event) {
+		Enchantment[] enchantments = enchants.getArray(event);
+		return Stream.of(items.getArray(event))
 			.map(ItemType::getEnchantmentTypes)
 			.flatMap(Stream::of)
 			.filter(enchantment -> CollectionUtils.contains(enchantments, enchantment.getType()))
@@ -94,9 +94,9 @@ public class ExprEnchantmentLevel extends SimpleExpression<Long> {
 	}
 
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
-		ItemType[] itemTypes = items.getArray(e);
-		Enchantment[] enchantments = enchants.getArray(e);
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+		ItemType[] itemTypes = items.getArray(event);
+		Enchantment[] enchantments = enchants.getArray(event);
 		int changeValue = ((Number) delta[0]).intValue();
 
 		for (ItemType itemType : itemTypes) {
@@ -140,8 +140,8 @@ public class ExprEnchantmentLevel extends SimpleExpression<Long> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "the level of " + enchants.toString(e, debug) + " of " + items.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "the level of " + enchants.toString(event, debug) + " of " + items.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprEnchantmentOffer.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEnchantmentOffer.java
@@ -90,29 +90,29 @@ public class ExprEnchantmentOffer extends SimpleExpression<EnchantmentOffer> {
 	@SuppressWarnings({"null", "unused"})
 	@Override
 	@Nullable
-	protected EnchantmentOffer[] get(Event e) {
-		if (!(e instanceof PrepareItemEnchantEvent))
+	protected EnchantmentOffer[] get(Event event) {
+		if (!(event instanceof PrepareItemEnchantEvent))
 			return null;
 
 		if (all)
-			return ((PrepareItemEnchantEvent) e).getOffers();
+			return ((PrepareItemEnchantEvent) event).getOffers();
 		if (exprOfferNumber == null)
 			return new EnchantmentOffer[0];
 		if (exprOfferNumber.isSingle()) {
-			Number offerNumber = exprOfferNumber.getSingle(e);
+			Number offerNumber = exprOfferNumber.getSingle(event);
 			if (offerNumber == null)
 				return new EnchantmentOffer[0];
 			int offer = offerNumber.intValue();
-			if (offer < 1 || offer > ((PrepareItemEnchantEvent) e).getOffers().length)
+			if (offer < 1 || offer > ((PrepareItemEnchantEvent) event).getOffers().length)
 				return new EnchantmentOffer[0];
-			return new EnchantmentOffer[]{((PrepareItemEnchantEvent) e).getOffers()[offer - 1]};
+			return new EnchantmentOffer[]{((PrepareItemEnchantEvent) event).getOffers()[offer - 1]};
 		}
 		List<EnchantmentOffer> offers = new ArrayList<>();
 		int i;
-		for (Number n : exprOfferNumber.getArray(e)) {
+		for (Number n : exprOfferNumber.getArray(event)) {
 			i = n.intValue();
-			if (i >= 1 || i <= ((PrepareItemEnchantEvent) e).getOffers().length)
-				offers.add(((PrepareItemEnchantEvent) e).getOffers()[i - 1]);
+			if (i >= 1 || i <= ((PrepareItemEnchantEvent) event).getOffers().length)
+				offers.add(((PrepareItemEnchantEvent) event).getOffers()[i - 1]);
 		}
 		return offers.toArray(new EnchantmentOffer[0]);
 	}
@@ -188,8 +188,8 @@ public class ExprEnchantmentOffer extends SimpleExpression<EnchantmentOffer> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return all ? "the enchantment offers" : "enchantment offer(s) " + exprOfferNumber.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return all ? "the enchantment offers" : "enchantment offer(s) " + exprOfferNumber.toString(event, debug);
 	}
 
 	/**

--- a/src/main/java/ch/njol/skript/expressions/ExprEnchantments.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEnchantments.java
@@ -68,10 +68,10 @@ public class ExprEnchantments extends SimpleExpression<EnchantmentType> {
 
 	@Override
 	@Nullable
-	protected EnchantmentType[] get(Event e) {
+	protected EnchantmentType[] get(Event event) {
 		List<EnchantmentType> enchantments = new ArrayList<>();
 		
-		for (ItemType item : items.getArray(e)) {
+		for (ItemType item : items.getArray(event)) {
 			EnchantmentType[] enchants = item.getEnchantmentTypes();
 			
 			if (enchants == null)
@@ -93,8 +93,8 @@ public class ExprEnchantments extends SimpleExpression<EnchantmentType> {
 
 	
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
-		ItemType[] source = items.getArray(e);
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+		ItemType[] source = items.getArray(event);
 		
 		EnchantmentType[] enchants = new EnchantmentType[delta != null ? delta.length : 0];
 		
@@ -149,8 +149,8 @@ public class ExprEnchantments extends SimpleExpression<EnchantmentType> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "the enchantments of " + items.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "the enchantments of " + items.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprEntities.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntities.java
@@ -111,11 +111,11 @@ public class ExprEntities extends SimpleExpression<Entity> {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public boolean isLoopOf(String s) {
+	public boolean isLoopOf(String string) {
 		if (!(types instanceof Literal<?>))
 			return false;
 		try (LogHandler ignored = new BlockingLogHandler().start()) {
-			EntityData<?> d = EntityData.parseWithoutIndefiniteArticle(s);
+			EntityData<?> d = EntityData.parseWithoutIndefiniteArticle(string);
 			if (d != null) {
 				for (EntityData<?> t : ((Literal<EntityData<?>>) types).getAll()) {
 					assert t != null;
@@ -131,9 +131,9 @@ public class ExprEntities extends SimpleExpression<Entity> {
 	@Override
 	@Nullable
 	@SuppressWarnings("null")
-	protected Entity[] get(Event e) {
+	protected Entity[] get(Event event) {
 		if (isUsingRadius) {
-			Iterator<? extends Entity> iter = iterator(e);
+			Iterator<? extends Entity> iter = iterator(event);
 			if (iter == null || !iter.hasNext())
 				return null;
 
@@ -143,9 +143,9 @@ public class ExprEntities extends SimpleExpression<Entity> {
 			return l.toArray((Entity[]) Array.newInstance(returnType, l.size()));
 		} else {
 			if (chunks != null) {
-				return EntityData.getAll(types.getArray(e), returnType, chunks.getArray(e));
+				return EntityData.getAll(types.getArray(event), returnType, chunks.getArray(event));
 			} else {
-				return EntityData.getAll(types.getAll(e), returnType, worlds != null ? worlds.getArray(e) : null);
+				return EntityData.getAll(types.getAll(event), returnType, worlds != null ? worlds.getArray(event) : null);
 			}
 		}
 	}
@@ -153,14 +153,14 @@ public class ExprEntities extends SimpleExpression<Entity> {
 	@Override
 	@Nullable
 	@SuppressWarnings("null")
-	public Iterator<? extends Entity> iterator(Event e) {
+	public Iterator<? extends Entity> iterator(Event event) {
 		if (isUsingRadius) {
 			assert center != null;
-			Location l = center.getSingle(e);
+			Location l = center.getSingle(event);
 			if (l == null)
 				return null;
 			assert radius != null;
-			Number n = radius.getSingle(e);
+			Number n = radius.getSingle(event);
 			if (n == null)
 				return null;
 			double d = n.doubleValue();
@@ -170,7 +170,7 @@ public class ExprEntities extends SimpleExpression<Entity> {
 
 			Collection<Entity> es = l.getWorld().getNearbyEntities(l, d, d, d);
 			double radiusSquared = d * d * Skript.EPSILON_MULT;
-			EntityData<?>[] ts = types.getAll(e);
+			EntityData<?>[] ts = types.getAll(event);
 			return new CheckedIterator<>(es.iterator(), e1 -> {
 					if (e1 == null || e1.getLocation().distanceSquared(l) > radiusSquared)
 						return false;
@@ -182,9 +182,9 @@ public class ExprEntities extends SimpleExpression<Entity> {
 				});
 		} else {
 			if (chunks == null || returnType == Player.class)
-				return super.iterator(e);
+				return super.iterator(event);
 
-			return Arrays.stream(EntityData.getAll(types.getArray(e), returnType, chunks.getArray(e))).iterator();
+			return Arrays.stream(EntityData.getAll(types.getArray(event), returnType, chunks.getArray(event))).iterator();
 		}
 	}
 
@@ -200,9 +200,9 @@ public class ExprEntities extends SimpleExpression<Entity> {
 
 	@Override
 	@SuppressWarnings("null")
-	public String toString(@Nullable Event e, boolean debug) {
-		return "all entities of type " + types.toString(e, debug) + (worlds != null ? " in " + worlds.toString(e, debug) :
-				radius != null && center != null ? " in radius " + radius.toString(e, debug) + " around " + center.toString(e, debug) : "");
+	public String toString(@Nullable Event event, boolean debug) {
+		return "all entities of type " + types.toString(event, debug) + (worlds != null ? " in " + worlds.toString(event, debug) :
+				radius != null && center != null ? " in radius " + radius.toString(event, debug) + " around " + center.toString(event, debug) : "");
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprEntity.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntity.java
@@ -108,8 +108,8 @@ public class ExprEntity extends SimpleExpression<Entity> {
 	
 	@Override
 	@Nullable
-	protected Entity[] get(final Event e) {
-		final Entity[] es = entity.getArray(e);
+	protected Entity[] get(final Event event) {
+		final Entity[] es = entity.getArray(event);
 		if (es.length == 0 || type.isInstance(es[0]))
 			return es;
 		return null;
@@ -128,7 +128,7 @@ public class ExprEntity extends SimpleExpression<Entity> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "the " + type;
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprEntityAttribute.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntityAttribute.java
@@ -72,8 +72,8 @@ public class ExprEntityAttribute extends PropertyExpression<Entity, Number> {
 
 	@Override
 	@SuppressWarnings("null")
-	protected Number[] get(Event e, Entity[] entities) {
-		Attribute a = attributes.getSingle(e);
+	protected Number[] get(Event event, Entity[] entities) {
+		Attribute a = attributes.getSingle(event);
 		return Stream.of(entities)
 		    .map(ent -> getAttribute(ent, a))
 		    .map(att -> withModifiers ? att.getValue() : att.getBaseValue())
@@ -90,10 +90,10 @@ public class ExprEntityAttribute extends PropertyExpression<Entity, Number> {
 
 	@Override
 	@SuppressWarnings("null")
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
-		Attribute a = attributes.getSingle(e);
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+		Attribute a = attributes.getSingle(event);
 		double d = delta == null ? 0 : ((Number) delta[0]).doubleValue();
-		for (Entity entity : getExpr().getArray(e)) {
+		for (Entity entity : getExpr().getArray(event)) {
 			AttributeInstance ai = getAttribute(entity, a);
 			if(ai != null) {
 				switch(mode) {
@@ -126,8 +126,8 @@ public class ExprEntityAttribute extends PropertyExpression<Entity, Number> {
 
 	@Override
 	@SuppressWarnings("null")
-	public String toString(@Nullable Event e, boolean debug) {
-		return "entity " + getExpr().toString(e, debug) + "'s " + (attributes == null ? "" : attributes.toString(e, debug)) + "attribute";
+	public String toString(@Nullable Event event, boolean debug) {
+		return "entity " + getExpr().toString(event, debug) + "'s " + (attributes == null ? "" : attributes.toString(event, debug)) + "attribute";
 	}
 	
 	@Nullable

--- a/src/main/java/ch/njol/skript/expressions/ExprEntityTamer.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntityTamer.java
@@ -65,11 +65,11 @@ public class ExprEntityTamer extends SimplePropertyExpression<LivingEntity, Offl
 	}
 	
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		OfflinePlayer player = delta == null ? null : ((OfflinePlayer) delta[0]);
 		switch (mode) {
 			case SET:
-				for (LivingEntity entity : getExpr().getAll(e)) {
+				for (LivingEntity entity : getExpr().getAll(event)) {
 					if (!(entity instanceof Tameable))
 						continue;
 					((Tameable) entity).setOwner(player);
@@ -77,7 +77,7 @@ public class ExprEntityTamer extends SimplePropertyExpression<LivingEntity, Offl
 				break;
 			case DELETE:
 			case RESET:
-				for (LivingEntity entity : getExpr().getAll(e)) {
+				for (LivingEntity entity : getExpr().getAll(event)) {
 					if (!(entity instanceof Tameable))
 						continue;
 					((Tameable) entity).setOwner(null);
@@ -96,8 +96,8 @@ public class ExprEntityTamer extends SimplePropertyExpression<LivingEntity, Offl
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean d) {
-		return "owner of " + getExpr().toString(e, d);
+	public String toString(@Nullable Event event, boolean d) {
+		return "owner of " + getExpr().toString(event, d);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprEventCancelled.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEventCancelled.java
@@ -59,10 +59,10 @@ public class ExprEventCancelled extends SimpleExpression<Boolean> {
 	
 	@Override
 	@Nullable
-	protected Boolean[] get(final Event e) {
-		if (!(e instanceof Cancellable))
+	protected Boolean[] get(final Event event) {
+		if (!(event instanceof Cancellable))
 			return new Boolean[0];
-		return new Boolean[] {((Cancellable) e).isCancelled()};
+		return new Boolean[] {((Cancellable) event).isCancelled()};
 	}
 	
 	@Override
@@ -71,7 +71,7 @@ public class ExprEventCancelled extends SimpleExpression<Boolean> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "is event cancelled";
 	}
 	
@@ -89,16 +89,16 @@ public class ExprEventCancelled extends SimpleExpression<Boolean> {
 	
 	@SuppressWarnings("incomplete-switch")
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
-		if (!(e instanceof Cancellable))
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
+		if (!(event instanceof Cancellable))
 			return;
 		switch (mode) {
 			case DELETE:
-				((Cancellable) e).setCancelled(false);
+				((Cancellable) event).setCancelled(false);
 				break;
 			case SET:
 				assert delta != null;
-				((Cancellable) e).setCancelled((Boolean) delta[0]);
+				((Cancellable) event).setCancelled((Boolean) delta[0]);
 		}
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprEventExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEventExpression.java
@@ -53,8 +53,8 @@ public class ExprEventExpression extends WrapperExpression<Object> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return getExpr().toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return getExpr().toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprExperience.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprExperience.java
@@ -67,11 +67,11 @@ public class ExprExperience extends SimpleExpression<Experience> {
 	
 	@Override
 	@Nullable
-	protected Experience[] get(final Event e) {
-		if (e instanceof ExperienceSpawnEvent)
-			return new Experience[] {new Experience(((ExperienceSpawnEvent) e).getSpawnedXP())};
-		else if (e instanceof BlockBreakEvent)
-			return new Experience[] {new Experience(((BlockBreakEvent) e).getExpToDrop())};
+	protected Experience[] get(final Event event) {
+		if (event instanceof ExperienceSpawnEvent)
+			return new Experience[] {new Experience(((ExperienceSpawnEvent) event).getSpawnedXP())};
+		else if (event instanceof BlockBreakEvent)
+			return new Experience[] {new Experience(((BlockBreakEvent) event).getExpToDrop())};
 		else
 			return new Experience[0];
 	}
@@ -94,12 +94,12 @@ public class ExprExperience extends SimpleExpression<Experience> {
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
 		double d;
-		if (e instanceof ExperienceSpawnEvent)
-			d = ((ExperienceSpawnEvent) e).getSpawnedXP();
-		else if (e instanceof BlockBreakEvent)
-			d = ((BlockBreakEvent) e).getExpToDrop();
+		if (event instanceof ExperienceSpawnEvent)
+			d = ((ExperienceSpawnEvent) event).getSpawnedXP();
+		else if (event instanceof BlockBreakEvent)
+			d = ((BlockBreakEvent) event).getExpToDrop();
 		else
 			return;
 		
@@ -127,10 +127,10 @@ public class ExprExperience extends SimpleExpression<Experience> {
 			d = 0;
 		
 		d = Math.max(0, Math.round(d));
-		if (e instanceof ExperienceSpawnEvent)
-			((ExperienceSpawnEvent) e).setSpawnedXP((int) d);
+		if (event instanceof ExperienceSpawnEvent)
+			((ExperienceSpawnEvent) event).setSpawnedXP((int) d);
 		else
-			((BlockBreakEvent) e).setExpToDrop((int) d);
+			((BlockBreakEvent) event).setExpToDrop((int) d);
 	}
 	
 	@Override
@@ -144,7 +144,7 @@ public class ExprExperience extends SimpleExpression<Experience> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "the experience";
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprExplodedBlocks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprExplodedBlocks.java
@@ -61,11 +61,11 @@ public class ExprExplodedBlocks extends SimpleExpression<Block> {
 	
 	@Nullable
 	@Override
-	protected Block[] get(Event e) {
-		if (!(e instanceof EntityExplodeEvent))
+	protected Block[] get(Event event) {
+		if (!(event instanceof EntityExplodeEvent))
 			return null;
 
-		List<Block> blockList = ((EntityExplodeEvent) e).blockList();
+		List<Block> blockList = ((EntityExplodeEvent) event).blockList();
 		return blockList.toArray(new Block[blockList.size()]);
 	}
 	
@@ -80,7 +80,7 @@ public class ExprExplodedBlocks extends SimpleExpression<Block> {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean d) {
+	public String toString(@Nullable Event event, boolean d) {
 		return "exploded blocks";
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprExplosionBlockYield.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprExplosionBlockYield.java
@@ -65,11 +65,11 @@ public class ExprExplosionBlockYield extends SimpleExpression<Number> {
 
 	@Override
 	@Nullable
-	protected Number[] get(Event e) {
-		if (!(e instanceof EntityExplodeEvent))
+	protected Number[] get(Event event) {
+		if (!(event instanceof EntityExplodeEvent))
 			return null;
 
-		return new Number[]{((EntityExplodeEvent) e).getYield()};
+		return new Number[]{((EntityExplodeEvent) event).getYield()};
 	}
 
 	@Override
@@ -128,7 +128,7 @@ public class ExprExplosionBlockYield extends SimpleExpression<Number> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "the explosion's block yield";
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprExplosionYield.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprExplosionYield.java
@@ -65,11 +65,11 @@ public class ExprExplosionYield extends SimpleExpression<Number> {
 
 	@Override
 	@Nullable
-	protected Number[] get(Event e) {
-		if (!(e instanceof ExplosionPrimeEvent))
+	protected Number[] get(Event event) {
+		if (!(event instanceof ExplosionPrimeEvent))
 			return null;
 
-		return new Number[]{((ExplosionPrimeEvent) e).getRadius()};
+		return new Number[]{((ExplosionPrimeEvent) event).getRadius()};
 	}
 
 	@Override
@@ -127,7 +127,7 @@ public class ExprExplosionYield extends SimpleExpression<Number> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "the yield of the explosion";
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprFacing.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFacing.java
@@ -99,11 +99,11 @@ public class ExprFacing extends SimplePropertyExpression<Object, Direction> {
 	
 	@SuppressWarnings("deprecation")
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
 		assert mode == ChangeMode.SET;
 		assert delta != null;
 		
-		final Block b = (Block) getExpr().getSingle(e);
+		final Block b = (Block) getExpr().getSingle(event);
 		if (b == null)
 			return;
 		BlockData data = b.getBlockData();

--- a/src/main/java/ch/njol/skript/expressions/ExprFallDistance.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFallDistance.java
@@ -55,9 +55,9 @@ public class ExprFallDistance extends SimplePropertyExpression<Entity, Number> {
 	}
 	
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		if (delta != null) {
-			Entity[] entities = getExpr().getArray(e);
+			Entity[] entities = getExpr().getArray(event);
 			if (entities.length < 1)
 				return;
 			Float number = ((Number) delta[0]).floatValue();

--- a/src/main/java/ch/njol/skript/expressions/ExprFertilizedBlocks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFertilizedBlocks.java
@@ -63,22 +63,22 @@ public class ExprFertilizedBlocks extends SimpleExpression<BlockStateBlock> {
 	
 	@Nullable
 	@Override
-	protected BlockStateBlock[] get(Event e) {
-		if (!(e instanceof BlockFertilizeEvent))
+	protected BlockStateBlock[] get(Event event) {
+		if (!(event instanceof BlockFertilizeEvent))
 			return null;
 
-		return ((BlockFertilizeEvent) e).getBlocks().stream()
+		return ((BlockFertilizeEvent) event).getBlocks().stream()
 				.map(BlockStateBlock::new)
 				.toArray(BlockStateBlock[]::new);
 	}
 	
 	@Nullable
 	@Override
-	public Iterator<? extends BlockStateBlock> iterator(Event e) {
-		if (!(e instanceof BlockFertilizeEvent))
+	public Iterator<? extends BlockStateBlock> iterator(Event event) {
+		if (!(event instanceof BlockFertilizeEvent))
 			return null;
 
-		return ((BlockFertilizeEvent) e).getBlocks().stream()
+		return ((BlockFertilizeEvent) event).getBlocks().stream()
 				.map(BlockStateBlock::new)
 				.iterator();
 	}
@@ -94,7 +94,7 @@ public class ExprFertilizedBlocks extends SimpleExpression<BlockStateBlock> {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "the fertilized blocks";
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprFilter.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFilter.java
@@ -143,17 +143,17 @@ public class ExprFilter extends SimpleExpression<Object> {
 	}
 
 	@Override
-	public boolean isLoopOf(String s) {
+	public boolean isLoopOf(String string) {
 		for (ExprInput<?> child : children) { // if they used player input, let's assume loop-player is valid
 			if (child.getClassInfo() == null || child.getClassInfo().getUserInputPatterns() == null)
 				continue;
 
 			for (Pattern pattern : child.getClassInfo().getUserInputPatterns()) {
-				if (pattern.matcher(s).matches())
+				if (pattern.matcher(string).matches())
 					return true;
 			}
 		}
-		return objects.isLoopOf(s); // nothing matched, so we'll rely on the object expression's logic
+		return objects.isLoopOf(string); // nothing matched, so we'll rely on the object expression's logic
 	}
 
 	@Name("Filter Input")

--- a/src/main/java/ch/njol/skript/expressions/ExprFinalDamage.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFinalDamage.java
@@ -59,10 +59,10 @@ public class ExprFinalDamage extends SimpleExpression<Number> {
 	
 	@Override
 	@Nullable
-	protected Number[] get(final Event e) {
-		if (!(e instanceof EntityDamageEvent))
+	protected Number[] get(final Event event) {
+		if (!(event instanceof EntityDamageEvent))
 			return new Number[0];
-		return new Number[] {HealthUtils.getFinalDamage((EntityDamageEvent) e)};
+		return new Number[] {HealthUtils.getFinalDamage((EntityDamageEvent) event)};
 	}
 	
 	@Override
@@ -83,7 +83,7 @@ public class ExprFinalDamage extends SimpleExpression<Number> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "the final damage";
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprFireworkEffect.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFireworkEffect.java
@@ -80,16 +80,16 @@ public class ExprFireworkEffect extends SimpleExpression<FireworkEffect> {
 	
 	@Override
 	@Nullable
-	protected FireworkEffect[] get(Event e) {
-		FireworkEffect.Type type = this.type.getSingle(e);
+	protected FireworkEffect[] get(Event event) {
+		FireworkEffect.Type type = this.type.getSingle(event);
 		if (type == null)
 			return null;
 		FireworkEffect.Builder builder = FireworkEffect.builder().with(type);
 		
-		for (Color colour : color.getArray(e))
+		for (Color colour : color.getArray(event))
 			builder.withColor(colour.asBukkitColor());
 		if (hasFade)
-			for (Color colour : fade.getArray(e))
+			for (Color colour : fade.getArray(event))
 				builder.withFade(colour.asBukkitColor());
 		
 		builder.flicker(flicker);
@@ -98,8 +98,8 @@ public class ExprFireworkEffect extends SimpleExpression<FireworkEffect> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "Firework effect " + type.toString(e, debug) + " with color " + color.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "Firework effect " + type.toString(event, debug) + " with color " + color.toString(event, debug);
 	}	
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprFoodLevel.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFoodLevel.java
@@ -60,12 +60,12 @@ public class ExprFoodLevel extends PropertyExpression<Player, Number> {
 	}
 	
 	@Override
-	protected Number[] get(final Event e, final Player[] source) {
+	protected Number[] get(final Event event, final Player[] source) {
 		return get(source, new Getter<Number, Player>() {
 			@Override
 			public Number get(final Player p) {
-				if (getTime() >= 0 && e instanceof FoodLevelChangeEvent && p.equals(((FoodLevelChangeEvent) e).getEntity()) && !Delay.isDelayed(e)) {
-					return 0.5f * ((FoodLevelChangeEvent) e).getFoodLevel();
+				if (getTime() >= 0 && event instanceof FoodLevelChangeEvent && p.equals(((FoodLevelChangeEvent) event).getEntity()) && !Delay.isDelayed(event)) {
+					return 0.5f * ((FoodLevelChangeEvent) event).getFoodLevel();
 				}
 				return 0.5f * p.getFoodLevel();
 			}
@@ -78,8 +78,8 @@ public class ExprFoodLevel extends PropertyExpression<Player, Number> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "the food level of " + getExpr().toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "the food level of " + getExpr().toString(event, debug);
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprFormatDate.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFormatDate.java
@@ -97,12 +97,12 @@ public class ExprFormatDate extends PropertyExpression<Date, String> {
 	}
 
 	@Override
-	protected String[] get(Event e, Date[] source) {
+	protected String[] get(Event event, Date[] source) {
 		SimpleDateFormat format;
 		String formatString;
 
 		if (customFormat != null && this.format == null) { // customFormat is not Literal or VariableString
-			formatString = customFormat.getSingle(e);
+			formatString = customFormat.getSingle(event);
 			if (formatString == null)
 				return null;
 
@@ -129,8 +129,8 @@ public class ExprFormatDate extends PropertyExpression<Date, String> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return getExpr().toString(e, debug) + " formatted as " + (customFormat != null ? customFormat.toString(e, debug)
+	public String toString(@Nullable Event event, boolean debug) {
+		return getExpr().toString(event, debug) + " formatted as " + (customFormat != null ? customFormat.toString(event, debug)
 			: (format != null ? format.toPattern() : DEFAULT_FORMAT.toPattern()));
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprFreezeTicks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFreezeTicks.java
@@ -58,30 +58,30 @@ public class ExprFreezeTicks extends SimplePropertyExpression<Entity, Timespan> 
 	}
 
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		int time = delta == null ? 0 : (int) ((Timespan) delta[0]).getTicks_i();
 		int newTime;
 		switch (mode) {
 			case ADD:
-				for (Entity entity : getExpr().getArray(e)) {
+				for (Entity entity : getExpr().getArray(event)) {
 					newTime = entity.getFreezeTicks() + time;
 					setFreezeTicks(entity, newTime);
 				}
 				break;
 			case REMOVE:
-				for (Entity entity : getExpr().getArray(e)) {
+				for (Entity entity : getExpr().getArray(event)) {
 					newTime = entity.getFreezeTicks() - time;
 					setFreezeTicks(entity, newTime);
 				}
 				break;
 			case SET:
-				for (Entity entity : getExpr().getArray(e)) {
+				for (Entity entity : getExpr().getArray(event)) {
 					setFreezeTicks(entity, time);
 				}
 				break;
 			case DELETE:
 			case RESET:
-				for (Entity entity : getExpr().getArray(e)) {
+				for (Entity entity : getExpr().getArray(event)) {
 					setFreezeTicks(entity, 0);
 				}
 				break;

--- a/src/main/java/ch/njol/skript/expressions/ExprFurnaceSlot.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFurnaceSlot.java
@@ -156,16 +156,16 @@ public class ExprFurnaceSlot extends PropertyExpression<Block, Slot> {
 	}
 	
 	@Override
-	protected Slot[] get(final Event e, final Block[] source) {
+	protected Slot[] get(final Event event, final Block[] source) {
 		return get(source, new Getter<Slot, Block>() {
 			@Override
 			@Nullable
 			public Slot get(final Block b) {
 				if (!ExprBurnCookTime.anyFurnace.isOfType(b))
 					return null;
-				if (isEvent && getTime() > -1 && !Delay.isDelayed(e)) {
+				if (isEvent && getTime() > -1 && !Delay.isDelayed(event)) {
 					FurnaceInventory invi = ((Furnace) b.getState()).getInventory();
-					return new FurnaceEventSlot(e, invi);
+					return new FurnaceEventSlot(event, invi);
 				} else {
 					FurnaceInventory invi = ((Furnace) b.getState()).getInventory();
 					return new InventorySlot(invi, slot);
@@ -180,10 +180,10 @@ public class ExprFurnaceSlot extends PropertyExpression<Block, Slot> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		if (e == null)
-			return "the " + (getTime() == -1 ? "past " : getTime() == 1 ? "future " : "") + slotNames[slot] + " slot of " + getExpr().toString(e, debug);
-		return Classes.getDebugMessage(getSingle(e));
+	public String toString(final @Nullable Event event, final boolean debug) {
+		if (event == null)
+			return "the " + (getTime() == -1 ? "past " : getTime() == 1 ? "future " : "") + slotNames[slot] + " slot of " + getExpr().toString(event, debug);
+		return Classes.getDebugMessage(getSingle(event));
 	}
 	
 	@SuppressWarnings("unchecked")

--- a/src/main/java/ch/njol/skript/expressions/ExprGameMode.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprGameMode.java
@@ -63,13 +63,13 @@ public class ExprGameMode extends PropertyExpression<Player, GameMode> {
 	}
 	
 	@Override
-	protected GameMode[] get(final Event e, final Player[] source) {
+	protected GameMode[] get(final Event event, final Player[] source) {
 		return get(source, new Converter<Player, GameMode>() {
 			@Override
 			@Nullable
 			public GameMode convert(final Player p) {
-				if (getTime() >= 0 && e instanceof PlayerGameModeChangeEvent && ((PlayerGameModeChangeEvent) e).getPlayer() == p && !Delay.isDelayed(e))
-					return ((PlayerGameModeChangeEvent) e).getNewGameMode();
+				if (getTime() >= 0 && event instanceof PlayerGameModeChangeEvent && ((PlayerGameModeChangeEvent) event).getPlayer() == p && !Delay.isDelayed(event))
+					return ((PlayerGameModeChangeEvent) event).getNewGameMode();
 				return p.getGameMode();
 			}
 		});
@@ -81,8 +81,8 @@ public class ExprGameMode extends PropertyExpression<Player, GameMode> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "the gamemode of " + getExpr().toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "the gamemode of " + getExpr().toString(event, debug);
 	}
 	
 	@Override
@@ -94,12 +94,12 @@ public class ExprGameMode extends PropertyExpression<Player, GameMode> {
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
 		final GameMode m = delta == null ? Bukkit.getDefaultGameMode() : (GameMode) delta[0];
-		for (final Player p : getExpr().getArray(e)) {
-			if (getTime() >= 0 && e instanceof PlayerGameModeChangeEvent && ((PlayerGameModeChangeEvent) e).getPlayer() == p && !Delay.isDelayed(e)) {
-				if (((PlayerGameModeChangeEvent) e).getNewGameMode() != m)
-					((PlayerGameModeChangeEvent) e).setCancelled(true);
+		for (final Player p : getExpr().getArray(event)) {
+			if (getTime() >= 0 && event instanceof PlayerGameModeChangeEvent && ((PlayerGameModeChangeEvent) event).getPlayer() == p && !Delay.isDelayed(event)) {
+				if (((PlayerGameModeChangeEvent) event).getNewGameMode() != m)
+					((PlayerGameModeChangeEvent) event).setCancelled(true);
 			}
 			p.setGameMode(m);
 		}

--- a/src/main/java/ch/njol/skript/expressions/ExprGameRule.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprGameRule.java
@@ -73,24 +73,24 @@ public class ExprGameRule extends SimpleExpression<GameruleValue> {
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
 		assert delta != null;
 		if (mode == ChangeMode.SET) {
-			GameRule bukkitGamerule = gamerule.getSingle(e);
+			GameRule bukkitGamerule = gamerule.getSingle(event);
 			if (bukkitGamerule == null) 
                 return;
-			for (World gameruleWorld : world.getArray(e))
+			for (World gameruleWorld : world.getArray(event))
                 gameruleWorld.setGameRule(bukkitGamerule, delta[0]);
 		}
 	}
 		
 	@Nullable
 	@Override
-	protected GameruleValue[] get(Event e) {
-		GameRule<?> bukkitGamerule = gamerule.getSingle(e);
+	protected GameruleValue[] get(Event event) {
+		GameRule<?> bukkitGamerule = gamerule.getSingle(event);
 		if (bukkitGamerule == null) 
             return null;
-		World[] gameruleWorlds = world.getArray(e);
+		World[] gameruleWorlds = world.getArray(event);
 		GameruleValue[] gameruleValues = new GameruleValue[gameruleWorlds.length];
 		int index = 0;
 		for (World gameruleWorld : gameruleWorlds) {
@@ -112,7 +112,7 @@ public class ExprGameRule extends SimpleExpression<GameruleValue> {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "the gamerule value of " + gamerule.toString(e, debug) + " for world " + world.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "the gamerule value of " + gamerule.toString(event, debug) + " for world " + world.toString(event, debug);
 	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprGlidingState.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprGlidingState.java
@@ -64,8 +64,8 @@ public class ExprGlidingState extends SimplePropertyExpression<LivingEntity, Boo
 	}
 
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
-		for (final LivingEntity entity : getExpr().getArray(e))
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
+		for (final LivingEntity entity : getExpr().getArray(event))
 			entity.setGliding(delta == null ? false : (Boolean) delta[0]);
 	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprGlowing.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprGlowing.java
@@ -63,8 +63,8 @@ public class ExprGlowing extends SimplePropertyExpression<Entity, Boolean> {
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
-		for (final Entity entity : getExpr().getArray(e))
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
+		for (final Entity entity : getExpr().getArray(event))
 			entity.setGlowing(delta == null ? false : (Boolean) delta[0]);
 	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprGravity.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprGravity.java
@@ -64,8 +64,8 @@ public class ExprGravity extends SimplePropertyExpression<Entity, Boolean> {
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
-		for (final Entity entity : getExpr().getArray(e))
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
+		for (final Entity entity : getExpr().getArray(event))
 			entity.setGravity(delta == null ? true : (Boolean) delta[0]);
 	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprHanging.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHanging.java
@@ -68,16 +68,16 @@ public class ExprHanging extends SimpleExpression<Entity> {
 	
 	@Override
 	@Nullable
-	public Entity[] get(Event e) {
-		if (!(e instanceof HangingEvent))
+	public Entity[] get(Event event) {
+		if (!(event instanceof HangingEvent))
 			return null;
 
 		Entity entity = null;
 
 		if (!isRemover)
-			entity = ((HangingEvent) e).getEntity();
-		else if (e instanceof HangingBreakByEntityEvent)
-			entity = ((HangingBreakByEntityEvent) e).getRemover();
+			entity = ((HangingEvent) event).getEntity();
+		else if (event instanceof HangingBreakByEntityEvent)
+			entity = ((HangingBreakByEntityEvent) event).getRemover();
 
 		return new Entity[] { entity };
 	}
@@ -94,7 +94,7 @@ public class ExprHanging extends SimpleExpression<Entity> {
 	
 	@Override
 	@SuppressWarnings("null")
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "hanging " + (isRemover ? "remover" : "entity");
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprHash.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHash.java
@@ -90,7 +90,7 @@ public class ExprHash extends PropertyExpression<String, String> {
 	
 	@SuppressWarnings("null")
 	@Override
-	protected String[] get(final Event e, final String[] source) {
+	protected String[] get(final Event event, final String[] source) {
 		// These can't be null
 		assert md5 != null;
 		assert sha256 != null;
@@ -123,7 +123,7 @@ public class ExprHash extends PropertyExpression<String, String> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "hash of " + getExpr();
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprHealAmount.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHealAmount.java
@@ -65,11 +65,11 @@ public class ExprHealAmount extends SimpleExpression<Number> {
 	
 	@Nullable
 	@Override
-	protected Number[] get(Event e) {
-		if (!(e instanceof EntityRegainHealthEvent))
+	protected Number[] get(Event event) {
+		if (!(event instanceof EntityRegainHealthEvent))
 			return null;
 
-		return new Number[]{((EntityRegainHealthEvent) e).getAmount()};
+		return new Number[]{((EntityRegainHealthEvent) event).getAmount()};
 	}
 	
 	@Nullable
@@ -85,21 +85,21 @@ public class ExprHealAmount extends SimpleExpression<Number> {
 	}
 	
 	@Override
-	public void change(Event e, @Nullable Object[] delta, Changer.ChangeMode mode) {
-		if (!(e instanceof EntityRegainHealthEvent))
+	public void change(Event event, @Nullable Object[] delta, Changer.ChangeMode mode) {
+		if (!(event instanceof EntityRegainHealthEvent))
 			return;
 
 		double value = delta == null ? 0 : ((Number) delta[0]).doubleValue();
 		switch (mode) {
 			case SET:
 			case DELETE:
-				((EntityRegainHealthEvent) e).setAmount(value);
+				((EntityRegainHealthEvent) event).setAmount(value);
 				break;
 			case ADD:
-				((EntityRegainHealthEvent) e).setAmount(((EntityRegainHealthEvent) e).getAmount() + value);
+				((EntityRegainHealthEvent) event).setAmount(((EntityRegainHealthEvent) event).getAmount() + value);
 				break;
 			case REMOVE:
-				((EntityRegainHealthEvent) e).setAmount(((EntityRegainHealthEvent) e).getAmount() - value);
+				((EntityRegainHealthEvent) event).setAmount(((EntityRegainHealthEvent) event).getAmount() - value);
 				break;
 			default:
 				break;
@@ -117,7 +117,7 @@ public class ExprHealAmount extends SimpleExpression<Number> {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "heal amount";
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprHealReason.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHealReason.java
@@ -59,11 +59,11 @@ public class ExprHealReason extends SimpleExpression<RegainReason> {
 	
 	@Nullable
 	@Override
-	protected RegainReason[] get(Event e) {
-		if (!(e instanceof EntityRegainHealthEvent))
+	protected RegainReason[] get(Event event) {
+		if (!(event instanceof EntityRegainHealthEvent))
 			return null;
 
-		return new RegainReason[]{((EntityRegainHealthEvent) e).getRegainReason()};
+		return new RegainReason[]{((EntityRegainHealthEvent) event).getRegainReason()};
 	}
 	
 	@Override
@@ -77,7 +77,7 @@ public class ExprHealReason extends SimpleExpression<RegainReason> {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "heal reason";
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprHealth.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHealth.java
@@ -58,7 +58,7 @@ public class ExprHealth extends PropertyExpression<LivingEntity, Number> {
 	}
 	
 	@Override
-	protected Number[] get(final Event e, final LivingEntity[] source) {
+	protected Number[] get(final Event event, final LivingEntity[] source) {
 //		if (e instanceof EntityDamageEvent && getTime() > 0 && entities.getSource() instanceof ExprAttacked && !Delay.isDelayed(e)) {
 //			return ConverterUtils.convert(entities.getArray(e), Number.class, new Getter<Number, LivingEntity>() {
 //				@Override
@@ -76,8 +76,8 @@ public class ExprHealth extends PropertyExpression<LivingEntity, Number> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "the health of " + getExpr().toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "the health of " + getExpr().toString(event, debug);
 	}
 	
 //	@Override
@@ -105,12 +105,12 @@ public class ExprHealth extends PropertyExpression<LivingEntity, Number> {
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
 		double d = delta == null ? 0 : ((Number) delta[0]).doubleValue();
 		switch (mode) {
 			case DELETE:
 			case SET:
-				for (final LivingEntity entity : getExpr().getArray(e)) {
+				for (final LivingEntity entity : getExpr().getArray(event)) {
 					assert entity != null : getExpr();
 					HealthUtils.setHealth(entity, d);
 				}
@@ -119,13 +119,13 @@ public class ExprHealth extends PropertyExpression<LivingEntity, Number> {
 				d = -d;
 				//$FALL-THROUGH$
 			case ADD:
-				for (final LivingEntity entity : getExpr().getArray(e)) {
+				for (final LivingEntity entity : getExpr().getArray(event)) {
 					assert entity != null : getExpr();
 					HealthUtils.heal(entity, d);
 				}
 				break;
 			case RESET:
-				for (final LivingEntity entity : getExpr().getArray(e)) {
+				for (final LivingEntity entity : getExpr().getArray(event)) {
 					assert entity != null : getExpr();
 					HealthUtils.setHealth(entity, HealthUtils.getMaxHealth(entity));
 				}

--- a/src/main/java/ch/njol/skript/expressions/ExprHiddenPlayers.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHiddenPlayers.java
@@ -63,9 +63,9 @@ public class ExprHiddenPlayers extends SimpleExpression<Player> {
 
 	@Override
 	@Nullable
-	public Player[] get(Event e) {
+	public Player[] get(Event event) {
 		List<Player> list = new ArrayList<>();
-		for (Player player : players.getArray(e)) {
+		for (Player player : players.getArray(event)) {
 			list.addAll(player.spigot().getHiddenPlayers());
 		}
 		return list.toArray(new Player[list.size()]);
@@ -82,8 +82,8 @@ public class ExprHiddenPlayers extends SimpleExpression<Player> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "hidden players for " + players.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "hidden players for " + players.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprHostname.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHostname.java
@@ -58,11 +58,11 @@ public class ExprHostname extends SimpleExpression<String> {
 	
 	@Override
 	@Nullable
-	protected String[] get(Event e) {
-		if (!(e instanceof PlayerLoginEvent))
+	protected String[] get(Event event) {
+		if (!(event instanceof PlayerLoginEvent))
 			return null;
 
-		return new String[] {((PlayerLoginEvent) e).getHostname()};
+		return new String[] {((PlayerLoginEvent) event).getHostname()};
 	}
 	
 	@Override
@@ -76,7 +76,7 @@ public class ExprHostname extends SimpleExpression<String> {
 	}	
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "hostname";
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprHotbarButton.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHotbarButton.java
@@ -55,9 +55,9 @@ public class ExprHotbarButton extends SimpleExpression<Long> {
 	
 	@Nullable
 	@Override
-	protected Long[] get(Event e) {
-		if (e instanceof InventoryClickEvent)
-			return new Long[] {(long) ((InventoryClickEvent) e).getHotbarButton()};
+	protected Long[] get(Event event) {
+		if (event instanceof InventoryClickEvent)
+			return new Long[] {(long) ((InventoryClickEvent) event).getHotbarButton()};
 		return null;
 	}
 	
@@ -72,7 +72,7 @@ public class ExprHotbarButton extends SimpleExpression<Long> {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "the hotbar button";
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprHotbarSlot.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHotbarSlot.java
@@ -70,7 +70,7 @@ public class ExprHotbarSlot extends SimplePropertyExpression<Player, Slot> {
 	}
 	
 	@Override
-	public void change(Event e, @Nullable Object[] delta, Changer.ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, Changer.ChangeMode mode) {
 		assert delta != null;
 		Slot slot = (Slot) delta[0];
 		if (!(slot instanceof InventorySlot))
@@ -80,7 +80,7 @@ public class ExprHotbarSlot extends SimplePropertyExpression<Player, Slot> {
 		if (index > 8) // Only slots in hotbar can be current hotbar slot
 			return;
 		
-		for (Player p : getExpr().getArray(e)) {
+		for (Player p : getExpr().getArray(event)) {
 			p.getInventory().setHeldItemSlot(index);
 		}
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprHoverList.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHoverList.java
@@ -82,11 +82,11 @@ public class ExprHoverList extends SimpleExpression<String> {
 
 	@Override
 	@Nullable
-	public String[] get(Event e) {
-		if (!(e instanceof PaperServerListPingEvent))
+	public String[] get(Event event) {
+		if (!(event instanceof PaperServerListPingEvent))
 			return null;
 
-		return ((PaperServerListPingEvent) e).getPlayerSample().stream()
+		return ((PaperServerListPingEvent) event).getPlayerSample().stream()
 				.map(PlayerProfile::getName)
 				.toArray(String[]::new);
 	}
@@ -111,8 +111,8 @@ public class ExprHoverList extends SimpleExpression<String> {
 
 	@SuppressWarnings("null")
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
-		if (!(e instanceof PaperServerListPingEvent))
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+		if (!(event instanceof PaperServerListPingEvent))
 			return;
 
 		List<PlayerProfile> values = new ArrayList<>();
@@ -127,7 +127,7 @@ public class ExprHoverList extends SimpleExpression<String> {
 			}
 		}
 
-		List<PlayerProfile> sample = ((PaperServerListPingEvent) e).getPlayerSample();
+		List<PlayerProfile> sample = ((PaperServerListPingEvent) event).getPlayerSample();
 		switch (mode){
 			case SET:
 				sample.clear();
@@ -156,7 +156,7 @@ public class ExprHoverList extends SimpleExpression<String> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "the hover list";
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprIP.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprIP.java
@@ -87,24 +87,24 @@ public class ExprIP extends SimpleExpression<String> {
 
 	@Override
 	@Nullable
-	protected String[] get(Event e) {
+	protected String[] get(Event event) {
 		if (!isProperty) {
 			InetAddress address;
-			if (e instanceof PlayerLoginEvent)
+			if (event instanceof PlayerLoginEvent)
 				// Return IP address of the connected player in connect event
-				address = ((PlayerLoginEvent) e).getAddress();
-			else if (e instanceof ServerListPingEvent)
+				address = ((PlayerLoginEvent) event).getAddress();
+			else if (event instanceof ServerListPingEvent)
 				// Return IP address of the pinger in server list ping event
-				address = ((ServerListPingEvent) e).getAddress();
+				address = ((ServerListPingEvent) event).getAddress();
 			else
 				return null;
 			return CollectionUtils.array(address.getHostAddress());
 		}
 
-		return Stream.of(players.getArray(e))
+		return Stream.of(players.getArray(event))
 				.map(player -> {
 					assert player != null;
-					return getIP(player, e);
+					return getIP(player, event);
 				})
 				.toArray(String[]::new);
 	}
@@ -137,10 +137,10 @@ public class ExprIP extends SimpleExpression<String> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		if (e == null || !isProperty)
+	public String toString(@Nullable Event event, boolean debug) {
+		if (event == null || !isProperty)
 			return "the IP address";
-		return "the IP address of " + players.toString(e, debug);
+		return "the IP address of " + players.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprIdOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprIdOf.java
@@ -98,9 +98,9 @@ public class ExprIdOf extends PropertyExpression<ItemType, Long> {
 	
 	@SuppressWarnings("null")
 	@Override
-	protected Long[] get(final Event e, final ItemType[] source) {
+	protected Long[] get(final Event event, final ItemType[] source) {
 		if (single) {
-			final ItemType t = getExpr().getSingle(e);
+			final ItemType t = getExpr().getSingle(event);
 			if (t == null)
 				return new Long[0];
 			return new Long[] {(long) t.getTypes().get(0).getType().getId()};
@@ -115,8 +115,8 @@ public class ExprIdOf extends PropertyExpression<ItemType, Long> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "the id" + (single ? "" : "s") + " of " + getExpr().toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "the id" + (single ? "" : "s") + " of " + getExpr().toString(event, debug);
 	}
 	
 	boolean changeItemStack;
@@ -144,10 +144,10 @@ public class ExprIdOf extends PropertyExpression<ItemType, Long> {
 	
 	@SuppressWarnings("deprecation")
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
 		assert delta != null;
 		final int i = ((Number) delta[0]).intValue();
-		final ItemType it = getExpr().getSingle(e);
+		final ItemType it = getExpr().getSingle(event);
 		if (it == null)
 			return;
 		final ItemStack is = it.getRandom();
@@ -181,24 +181,24 @@ public class ExprIdOf extends PropertyExpression<ItemType, Long> {
 		if (m != null) {
 			is.setType(m);
 			if (changeItemStack)
-				getExpr().change(e, new ItemStack[] {is}, ChangeMode.SET);
+				getExpr().change(event, new ItemStack[] {is}, ChangeMode.SET);
 			else
-				getExpr().change(e, new ItemType[] {new ItemType(is)}, ChangeMode.SET);
+				getExpr().change(event, new ItemType[] {new ItemType(is)}, ChangeMode.SET);
 		}
 	}
 	
 	@Override
 	@Nullable
-	public Iterator<Long> iterator(final Event e) {
+	public Iterator<Long> iterator(final Event event) {
 		if (single) {
-			final ItemType t = getExpr().getSingle(e);
+			final ItemType t = getExpr().getSingle(event);
 			if (t == null)
 				return null;
 			if (t.numTypes() == 0)
 				return null;
 			return new SingleItemIterator<>((long) t.getTypes().get(0).getType().getId());
 		}
-		final Iterator<? extends ItemType> iter = getExpr().iterator(e);
+		final Iterator<? extends ItemType> iter = getExpr().iterator(event);
 		if (iter == null || !iter.hasNext())
 			return null;
 		return new Iterator<Long>() {
@@ -232,8 +232,8 @@ public class ExprIdOf extends PropertyExpression<ItemType, Long> {
 	}
 	
 	@Override
-	public boolean isLoopOf(final String s) {
-		return s.equalsIgnoreCase("id");
+	public boolean isLoopOf(final String string) {
+		return string.equalsIgnoreCase("id");
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprIndexOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprIndexOf.java
@@ -63,8 +63,8 @@ public class ExprIndexOf extends SimpleExpression<Long> {
 	
 	@Override
 	@Nullable
-	protected Long[] get(final Event e) {
-		final String h = haystack.getSingle(e), n = needle.getSingle(e);
+	protected Long[] get(final Event event) {
+		final String h = haystack.getSingle(event), n = needle.getSingle(event);
 		if (h == null || n == null)
 			return new Long[0];
 		final int i = first ? h.indexOf(n) : h.lastIndexOf(n);
@@ -82,8 +82,8 @@ public class ExprIndexOf extends SimpleExpression<Long> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "the " + (first ? "first" : "last") + " index of " + needle.toString(e, debug) + " in " + haystack.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "the " + (first ? "first" : "last") + " index of " + needle.toString(event, debug) + " in " + haystack.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprIndices.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprIndices.java
@@ -92,8 +92,8 @@ public class ExprIndices extends SimpleExpression<String> {
 	@Nullable
 	@Override
 	@SuppressWarnings({"unchecked", "ConstantConditions"})
-	protected String[] get(Event e) {
-		Map<String, Object> variable = (Map<String, Object>) list.getRaw(e);
+	protected String[] get(Event event) {
+		Map<String, Object> variable = (Map<String, Object>) list.getRaw(event);
 
 		if (variable == null) {
 			return null;
@@ -121,8 +121,8 @@ public class ExprIndices extends SimpleExpression<String> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		String text = "indices of " + list.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		String text = "indices of " + list.toString(event, debug);
 
 		if (sort)
 			text = "sorted " + text + " in " + (descending ? "descending" : "ascending") + " order";

--- a/src/main/java/ch/njol/skript/expressions/ExprInventory.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprInventory.java
@@ -72,9 +72,9 @@ public class ExprInventory extends SimpleExpression<Object> {
 
 
 	@Override
-	protected Object[] get(Event e) {
+	protected Object[] get(Event event) {
 		List<Inventory> inventories = new ArrayList<>();
-		for (InventoryHolder holder : holders.getArray(e)) {
+		for (InventoryHolder holder : holders.getArray(event)) {
 			inventories.add(holder.getInventory());
 		}
 		Inventory[] invArray = inventories.toArray(new Inventory[0]);
@@ -87,7 +87,7 @@ public class ExprInventory extends SimpleExpression<Object> {
 			expr.init(new Expression[] {
 					new SimpleExpression() {
 						@Override
-						protected Object[] get(Event e) {
+						protected Object[] get(Event event) {
 							return invArray;
 						}
 
@@ -102,7 +102,7 @@ public class ExprInventory extends SimpleExpression<Object> {
 						}
 
 						@Override
-						public String toString(@Nullable Event e, boolean debug) {
+						public String toString(@Nullable Event event, boolean debug) {
 							return "loop of inventory expression";
 						}
 
@@ -112,7 +112,7 @@ public class ExprInventory extends SimpleExpression<Object> {
 						}
 					}
 			}, 0, Kleenean.FALSE, null);
-			return expr.get(e);
+			return expr.get(event);
 		}
 		return invArray;
 	}
@@ -128,8 +128,8 @@ public class ExprInventory extends SimpleExpression<Object> {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "inventor" + (holders.isSingle() ? "y" : "ies") + " of " + holders.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "inventor" + (holders.isSingle() ? "y" : "ies") + " of " + holders.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprInventoryAction.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprInventoryAction.java
@@ -45,7 +45,7 @@ public class ExprInventoryAction extends EventValueExpression<InventoryAction> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "the inventory action";
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprInventoryInfo.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprInventoryInfo.java
@@ -68,8 +68,8 @@ public class ExprInventoryInfo extends SimpleExpression<Object> {
 	}
 
 	@Override
-	protected Object[] get(Event e) {
-		Inventory[] inventories = this.inventories.getArray(e);
+	protected Object[] get(Event event) {
+		Inventory[] inventories = this.inventories.getArray(event);
 		List<Object> objects = new ArrayList<>();
 		switch (type) {
 			case HOLDER:
@@ -116,8 +116,8 @@ public class ExprInventoryInfo extends SimpleExpression<Object> {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return (type == HOLDER ? "holder of " : type == ROWS ? "rows of " : type == SLOTS ? "slots of " : "viewers of ") + inventories.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return (type == HOLDER ? "holder of " : type == ROWS ? "rows of " : type == SLOTS ? "slots of " : "viewers of ") + inventories.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprInventorySlot.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprInventorySlot.java
@@ -112,7 +112,7 @@ public class ExprInventorySlot extends SimpleExpression<Slot> {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "slots " + slots.toString(e, debug) + " of " + invis.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "slots " + slots.toString(event, debug) + " of " + invis.toString(event, debug);
 	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprItem.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprItem.java
@@ -74,12 +74,12 @@ public class ExprItem extends EventValueExpression<ItemStack> {
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
 		assert mode != ChangeMode.RESET;
 		
 		final ItemType t = delta == null ? null : (ItemType) delta[0];
-		final Item i = item != null ? item.getSingle(e) : null;
-		final Slot s = slot != null ? slot.getSingle(e) : null;
+		final Item i = item != null ? item.getSingle(event) : null;
+		final Slot s = slot != null ? slot.getSingle(event) : null;
 		if (i == null && s == null)
 			return;
 		ItemStack is = i != null ? i.getItemStack() : s != null ? s.getItem() : null;

--- a/src/main/java/ch/njol/skript/expressions/ExprItemWithCustomModelData.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprItemWithCustomModelData.java
@@ -62,8 +62,8 @@ public class ExprItemWithCustomModelData extends PropertyExpression<ItemType, It
 	}
 	
 	@Override
-	protected ItemType[] get(Event e, ItemType[] source) {
-		Number data = this.data.getSingle(e);
+	protected ItemType[] get(Event event, ItemType[] source) {
+		Number data = this.data.getSingle(event);
 		if (data == null)
 			return source;
 		return get(source.clone(), item -> {
@@ -80,8 +80,8 @@ public class ExprItemWithCustomModelData extends PropertyExpression<ItemType, It
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean d) {
-		return getExpr().toString(e, d) + " with custom model data " + data.toString(e, d);
+	public String toString(@Nullable Event event, boolean d) {
+		return getExpr().toString(event, d) + " with custom model data " + data.toString(event, d);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprItemWithLore.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprItemWithLore.java
@@ -63,8 +63,8 @@ public class ExprItemWithLore extends PropertyExpression<ItemType, ItemType> {
 	}
 
 	@Override
-	protected ItemType[] get(Event e, ItemType[] source) {
-		List<String> lore = this.lore.stream(e)
+	protected ItemType[] get(Event event, ItemType[] source) {
+		List<String> lore = this.lore.stream(event)
 			.flatMap(l -> Arrays.stream(l.split("\n")))
 			.collect(Collectors.toList());
 
@@ -84,7 +84,7 @@ public class ExprItemWithLore extends PropertyExpression<ItemType, ItemType> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return getExpr().toString(e, debug) + " with lore " + lore.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return getExpr().toString(event, debug) + " with lore " + lore.toString(event, debug);
 	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprItemsIn.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprItemsIn.java
@@ -74,9 +74,9 @@ public class ExprItemsIn extends SimpleExpression<Slot> {
 	
 	@SuppressWarnings("null")
 	@Override
-	protected Slot[] get(final Event e) {
+	protected Slot[] get(final Event event) {
 		final ArrayList<Slot> r = new ArrayList<>();
-		for (final Inventory invi : invis.getArray(e)) {
+		for (final Inventory invi : invis.getArray(event)) {
 			for (int i = 0; i < invi.getSize(); i++) {
 				if (invi.getItem(i) != null)
 					r.add(new InventorySlot(invi, i));
@@ -87,8 +87,8 @@ public class ExprItemsIn extends SimpleExpression<Slot> {
 	
 	@Override
 	@Nullable
-	public Iterator<Slot> iterator(final Event e) {
-		final Iterator<? extends Inventory> is = invis.iterator(e);
+	public Iterator<Slot> iterator(final Event event) {
+		final Iterator<? extends Inventory> is = invis.iterator(event);
 		if (is == null || !is.hasNext())
 			return null;
 		return new Iterator<Slot>() {
@@ -126,13 +126,13 @@ public class ExprItemsIn extends SimpleExpression<Slot> {
 	}
 	
 	@Override
-	public boolean isLoopOf(final String s) {
-		return s.equalsIgnoreCase("item");
+	public boolean isLoopOf(final String string) {
+		return string.equalsIgnoreCase("item");
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "items in " + invis.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "items in " + invis.toString(event, debug);
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprLastDamage.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLastDamage.java
@@ -74,17 +74,17 @@ public class ExprLastDamage extends SimplePropertyExpression<LivingEntity, Numbe
 	}
 	
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		if (delta != null) {
 			switch (mode) {
 				case SET:
-					for (LivingEntity entity : getExpr().getArray(e))
+					for (LivingEntity entity : getExpr().getArray(event))
 						entity.setLastDamage((Long) delta[0]);
 					break;
 				case REMOVE:
 					delta[0] = (Long) delta[0] * -1;
 				case ADD:
-					for (LivingEntity entity : getExpr().getArray(e))
+					for (LivingEntity entity : getExpr().getArray(event))
 						entity.setLastDamage((Long) delta[0] + entity.getLastDamage());
 					break;
 				default:

--- a/src/main/java/ch/njol/skript/expressions/ExprLastDamageCause.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLastDamageCause.java
@@ -58,7 +58,7 @@ public class ExprLastDamageCause extends PropertyExpression<LivingEntity, Damage
 	}
 	
 	@Override
-	protected DamageCause[] get(Event e, LivingEntity[] source) {
+	protected DamageCause[] get(Event event, LivingEntity[] source) {
 		return get(source, new Getter<DamageCause, LivingEntity>() {
 			@Override
 			public DamageCause get(LivingEntity entity) {
@@ -70,8 +70,8 @@ public class ExprLastDamageCause extends PropertyExpression<LivingEntity, Damage
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "the damage cause " + getExpr().toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "the damage cause " + getExpr().toString(event, debug);
 	}
 	
 	@Override
@@ -83,19 +83,19 @@ public class ExprLastDamageCause extends PropertyExpression<LivingEntity, Damage
 	}
 	
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		DamageCause d = delta == null ? DamageCause.CUSTOM : (DamageCause) delta[0];
 		assert d != null;
 		switch (mode) {
 			case DELETE:
 			case RESET: // Reset damage cause? Umm, maybe it is custom.
-				for (LivingEntity entity : getExpr().getArray(e)) {
+				for (LivingEntity entity : getExpr().getArray(event)) {
 					assert entity != null : getExpr();
 					HealthUtils.setDamageCause(entity, DamageCause.CUSTOM);
 				}
 				break;
 			case SET:
-				for (LivingEntity entity : getExpr().getArray(e)) {
+				for (LivingEntity entity : getExpr().getArray(event)) {
 					assert entity != null : getExpr();
 					HealthUtils.setDamageCause(entity, d);
 				}

--- a/src/main/java/ch/njol/skript/expressions/ExprLastLoadedServerIcon.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLastLoadedServerIcon.java
@@ -60,7 +60,7 @@ public class ExprLastLoadedServerIcon extends SimpleExpression<CachedServerIcon>
 
 	@Override
 	@Nullable
-	public CachedServerIcon[] get(Event e) {
+	public CachedServerIcon[] get(Event event) {
 		return CollectionUtils.array(EffLoadServerIcon.lastLoaded);
 	}
 
@@ -75,7 +75,7 @@ public class ExprLastLoadedServerIcon extends SimpleExpression<CachedServerIcon>
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "the last loaded server icon";
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprLevel.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLevel.java
@@ -50,10 +50,10 @@ public class ExprLevel extends SimplePropertyExpression<Player, Long> {
 	}
 	
 	@Override
-	protected Long[] get(final Event e, final Player[] source) {
+	protected Long[] get(final Event event, final Player[] source) {
 		return super.get(source, p -> {
-			if (e instanceof PlayerLevelChangeEvent && ((PlayerLevelChangeEvent) e).getPlayer() == p && !Delay.isDelayed(e)) {
-				return (long) (getTime() < 0 ? ((PlayerLevelChangeEvent) e).getOldLevel() : ((PlayerLevelChangeEvent) e).getNewLevel());
+			if (event instanceof PlayerLevelChangeEvent && ((PlayerLevelChangeEvent) event).getPlayer() == p && !Delay.isDelayed(event)) {
+				return (long) (getTime() < 0 ? ((PlayerLevelChangeEvent) event).getOldLevel() : ((PlayerLevelChangeEvent) event).getNewLevel());
 			}
 			return (long) p.getLevel();
 		});
@@ -90,15 +90,15 @@ public class ExprLevel extends SimplePropertyExpression<Player, Long> {
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
 		assert mode != ChangeMode.REMOVE_ALL;
 		
 		final int l = delta == null ? 0 : ((Number) delta[0]).intValue();
 		
-		for (final Player p : getExpr().getArray(e)) {
+		for (final Player p : getExpr().getArray(event)) {
 			int level;
-			if (getTime() > 0 && e instanceof PlayerDeathEvent && ((PlayerDeathEvent) e).getEntity() == p && !Delay.isDelayed(e)) {
-				level = ((PlayerDeathEvent) e).getNewLevel();
+			if (getTime() > 0 && event instanceof PlayerDeathEvent && ((PlayerDeathEvent) event).getEntity() == p && !Delay.isDelayed(event)) {
+				level = ((PlayerDeathEvent) event).getNewLevel();
 			} else {
 				level = p.getLevel();
 			}
@@ -122,8 +122,8 @@ public class ExprLevel extends SimplePropertyExpression<Player, Long> {
 			}
 			if (level < 0)
 				continue;
-			if (getTime() > 0 && e instanceof PlayerDeathEvent && ((PlayerDeathEvent) e).getEntity() == p && !Delay.isDelayed(e)) {
-				((PlayerDeathEvent) e).setNewLevel(level);
+			if (getTime() > 0 && event instanceof PlayerDeathEvent && ((PlayerDeathEvent) event).getEntity() == p && !Delay.isDelayed(event)) {
+				((PlayerDeathEvent) event).setNewLevel(level);
 			} else {
 				p.setLevel(level);
 			}

--- a/src/main/java/ch/njol/skript/expressions/ExprLevelProgress.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLevelProgress.java
@@ -74,11 +74,11 @@ public class ExprLevelProgress extends SimplePropertyExpression<Player, Number> 
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
 		assert mode != ChangeMode.REMOVE_ALL;
 		
 		final float d = delta == null ? 0 : ((Number) delta[0]).floatValue();
-		for (final Player p : getExpr().getArray(e)) {
+		for (final Player p : getExpr().getArray(event)) {
 			final float c;
 			switch (mode) {
 				case SET:

--- a/src/main/java/ch/njol/skript/expressions/ExprLightLevel.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLightLevel.java
@@ -71,7 +71,7 @@ public class ExprLightLevel extends PropertyExpression<Location, Byte> {
 	}
 	
 	@Override
-	protected Byte[] get(final Event e, final Location[] source) {
+	protected Byte[] get(final Event event, final Location[] source) {
 		return get(source, new Converter<Location, Byte>() {
 			@Override
 			public Byte convert(final Location l) {
@@ -82,8 +82,8 @@ public class ExprLightLevel extends PropertyExpression<Location, Byte> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return (whatLight == BLOCK ? "block " : whatLight == SKY ? "sky " : "") + "light level " + getExpr().toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return (whatLight == BLOCK ? "block " : whatLight == SKY ? "sky " : "") + "light level " + getExpr().toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprLocation.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLocation.java
@@ -62,8 +62,8 @@ public class ExprLocation extends WrapperExpression<Location> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return getExpr() instanceof EventValueExpression ? "the location" : "the location " + getExpr().toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return getExpr() instanceof EventValueExpression ? "the location" : "the location " + getExpr().toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprLocationAt.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLocationAt.java
@@ -67,9 +67,9 @@ public class ExprLocationAt extends SimpleExpression<Location> {
 	
 	@Override
 	@Nullable
-	protected Location[] get(final Event e) {
-		final World w = world.getSingle(e);
-		final Number x = this.x.getSingle(e), y = this.y.getSingle(e), z = this.z.getSingle(e);
+	protected Location[] get(final Event event) {
+		final World w = world.getSingle(event);
+		final Number x = this.x.getSingle(event), y = this.y.getSingle(event), z = this.z.getSingle(event);
 		if (w == null || x == null || y == null || z == null)
 			return new Location[0];
 		return new Location[] {new Location(w, x.doubleValue(), y.doubleValue(), z.doubleValue())};
@@ -86,8 +86,8 @@ public class ExprLocationAt extends SimpleExpression<Location> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "the location at (" + x.toString(e, debug) + ", " + y.toString(e, debug) + ", " + z.toString(e, debug) + ") in " + world.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "the location at (" + x.toString(event, debug) + ", " + y.toString(event, debug) + ", " + z.toString(event, debug) + ") in " + world.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprLocationFromVector.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLocationFromVector.java
@@ -79,11 +79,11 @@ public class ExprLocationFromVector extends SimpleExpression<Location> {
 
 	@SuppressWarnings("null")
 	@Override
-	protected Location[] get(Event e) {
-		Vector v = vector.getSingle(e);
-		World w = world.getSingle(e);
-		Number y = yaw != null ? yaw.getSingle(e) : null;
-		Number p = pitch != null ? pitch.getSingle(e) : null;
+	protected Location[] get(Event event) {
+		Vector v = vector.getSingle(event);
+		World w = world.getSingle(event);
+		Number y = yaw != null ? yaw.getSingle(event) : null;
+		Number p = pitch != null ? pitch.getSingle(event) : null;
 		if (v == null || w == null)
 			return null;
 		if (y == null || p == null)
@@ -103,10 +103,10 @@ public class ExprLocationFromVector extends SimpleExpression<Location> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		if (yawpitch)
-			return "location from " + vector.toString(e, debug) + " with yaw " + yaw.toString() + " and pitch " + pitch.toString(e, debug);
-		return "location from " + vector.toString(e, debug);
+			return "location from " + vector.toString(event, debug) + " with yaw " + yaw.toString() + " and pitch " + pitch.toString(event, debug);
+		return "location from " + vector.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprLocationOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLocationOf.java
@@ -56,8 +56,8 @@ public class ExprLocationOf extends WrapperExpression<Location> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "the location of " + getExpr().toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "the location of " + getExpr().toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprLocationVectorOffset.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLocationVectorOffset.java
@@ -67,12 +67,12 @@ public class ExprLocationVectorOffset extends SimpleExpression<Location> {
 
 	@SuppressWarnings("null")
 	@Override
-	protected Location[] get(Event e) {
-		Location l = location.getSingle(e);
+	protected Location[] get(Event event) {
+		Location l = location.getSingle(event);
 		if (l == null)
 			return null;
 		Location clone = l.clone();
-		for (Vector v : vectors.getArray(e))
+		for (Vector v : vectors.getArray(event))
 			clone.add(v);
 		return CollectionUtils.array(clone);
 	}
@@ -88,7 +88,7 @@ public class ExprLocationVectorOffset extends SimpleExpression<Location> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return location.toString() + " offset by " + vectors.toString();
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprLoopValue.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLoopValue.java
@@ -154,9 +154,9 @@ public class ExprLoopValue extends SimpleExpression<Object> {
 	
 	@Override
 	@Nullable
-	protected Object[] get(Event e) {
+	protected Object[] get(Event event) {
 		if (isVariableLoop) {
-			@SuppressWarnings("unchecked") Entry<String, Object> current = (Entry<String, Object>) loop.getCurrent(e);
+			@SuppressWarnings("unchecked") Entry<String, Object> current = (Entry<String, Object>) loop.getCurrent(event);
 			if (current == null)
 				return null;
 			if (isIndex)
@@ -166,21 +166,21 @@ public class ExprLoopValue extends SimpleExpression<Object> {
 			return one;
 		}
 		Object[] one = (Object[]) Array.newInstance(getReturnType(), 1);
-		one[0] = loop.getCurrent(e);
+		one[0] = loop.getCurrent(event);
 		return one;
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		if (e == null)
+	public String toString(@Nullable Event event, boolean debug) {
+		if (event == null)
 			return name;
 		if (isVariableLoop) {
-			@SuppressWarnings("unchecked") Entry<String, Object> current = (Entry<String, Object>) loop.getCurrent(e);
+			@SuppressWarnings("unchecked") Entry<String, Object> current = (Entry<String, Object>) loop.getCurrent(event);
 			if (current == null)
 				return Classes.getDebugMessage(null);
 			return isIndex ? "\"" + current.getKey() + "\"" : Classes.getDebugMessage(current.getValue());
 		}
-		return Classes.getDebugMessage(loop.getCurrent(e));
+		return Classes.getDebugMessage(loop.getCurrent(event));
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprLore.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLore.java
@@ -86,9 +86,9 @@ public class ExprLore extends SimpleExpression<String> {
 
 	@Override
 	@Nullable
-	protected String[] get(final Event e) {
-		final Object i = item.getSingle(e);
-		final Number n = lineNumber != null ? lineNumber.getSingle(e) : null;
+	protected String[] get(final Event event) {
+		final Object i = item.getSingle(event);
+		final Number n = lineNumber != null ? lineNumber.getSingle(event) : null;
 		if (n == null && lineNumber != null)
 			return null;
 		if (i == null || i instanceof ItemStack && ((ItemStack) i).getType() == Material.AIR)
@@ -128,8 +128,8 @@ public class ExprLore extends SimpleExpression<String> {
 	}
 
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
-		Object i = item.getSingle(e);
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
+		Object i = item.getSingle(event);
 
 		String[] stringDelta = delta == null ? null : Arrays.copyOf(delta, delta.length, String[].class);
 
@@ -141,7 +141,7 @@ public class ExprLore extends SimpleExpression<String> {
 		if (meta == null)
 			meta = Bukkit.getItemFactory().getItemMeta(Material.STONE);
 
-		Number lineNumber = this.lineNumber != null ? this.lineNumber.getSingle(e) : null;
+		Number lineNumber = this.lineNumber != null ? this.lineNumber.getSingle(event) : null;
 		List<String> lore = meta.hasLore() ? new ArrayList<>(meta.getLore()) : new ArrayList<>();
 
 		if (lineNumber == null) {
@@ -228,11 +228,11 @@ public class ExprLore extends SimpleExpression<String> {
 
 		if (ChangerUtils.acceptsChange(item, ChangeMode.SET, i.getClass())) {
 			Object[] itemDelta = i instanceof ItemStack ? new ItemStack[]{(ItemStack) i} : new ItemType[]{(ItemType) i};
-			item.change(e, itemDelta, ChangeMode.SET);
+			item.change(event, itemDelta, ChangeMode.SET);
 		} else {
 			Object[] itemDelta = i instanceof ItemStack ? new ItemType[]{new ItemType((ItemStack) i)} :
 					new ItemStack[]{((ItemType) i).getRandom()};
-			item.change(e, itemDelta, ChangeMode.SET);
+			item.change(event, itemDelta, ChangeMode.SET);
 		}
 	}
 
@@ -262,7 +262,7 @@ public class ExprLore extends SimpleExpression<String> {
 	}
 
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return (lineNumber != null ? "the line " + lineNumber.toString(e, debug) + " of " : "") + "the lore of " + item.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return (lineNumber != null ? "the line " + lineNumber.toString(event, debug) + " of " : "") + "the lore of " + item.toString(event, debug);
 	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprMOTD.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprMOTD.java
@@ -68,14 +68,14 @@ public class ExprMOTD extends SimpleExpression<String> {
 
 	@Override
 	@Nullable
-	public String[] get(Event e) {
-		if (!isDefault && !(e instanceof ServerListPingEvent))
+	public String[] get(Event event) {
+		if (!isDefault && !(event instanceof ServerListPingEvent))
 			return null;
 
 		if (isDefault)
 			return CollectionUtils.array(Bukkit.getMotd());
 		else
-			return CollectionUtils.array(((ServerListPingEvent) e).getMotd());
+			return CollectionUtils.array(((ServerListPingEvent) event).getMotd());
 	}
 
 	@Override
@@ -126,7 +126,7 @@ public class ExprMOTD extends SimpleExpression<String> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "the " + (isDefault ? "default MOTD" : "MOTD");
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprMaxHealth.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprMaxHealth.java
@@ -73,9 +73,9 @@ public class ExprMaxHealth extends SimplePropertyExpression<LivingEntity, Number
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
 		double d = delta == null ? 0 : ((Number) delta[0]).doubleValue();
-		for (final LivingEntity en : getExpr().getArray(e)) {
+		for (final LivingEntity en : getExpr().getArray(event)) {
 			assert en != null : getExpr();
 			switch (mode) {
 				case SET:

--- a/src/main/java/ch/njol/skript/expressions/ExprMaxMinecartSpeed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprMaxMinecartSpeed.java
@@ -64,10 +64,10 @@ public class ExprMaxMinecartSpeed extends SimplePropertyExpression<Entity, Numbe
 	}
 	
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		if (delta == null) {
 			if (mode == ChangeMode.RESET)
-				for (Entity entity : getExpr().getArray(e)) {
+				for (Entity entity : getExpr().getArray(event)) {
 					if (entity instanceof Minecart)
 						((Minecart) entity).setMaxSpeed(0.4);
 				}
@@ -76,7 +76,7 @@ public class ExprMaxMinecartSpeed extends SimplePropertyExpression<Entity, Numbe
 		int mod = 1;
 		switch (mode) {
 			case SET:
-				for (Entity entity : getExpr().getArray(e)) {
+				for (Entity entity : getExpr().getArray(event)) {
 					if (entity instanceof Minecart)
 						((Minecart) entity).setMaxSpeed(((Number) delta[0]).doubleValue());
 				}
@@ -84,7 +84,7 @@ public class ExprMaxMinecartSpeed extends SimplePropertyExpression<Entity, Numbe
 			case REMOVE:
 				mod = -1;
 			case ADD:
-				for (Entity entity : getExpr().getArray(e)) {
+				for (Entity entity : getExpr().getArray(event)) {
 					if (entity instanceof Minecart) {
 						Minecart minecart = (Minecart) entity;
 						minecart.setMaxSpeed(minecart.getMaxSpeed() + ((Number) delta[0]).doubleValue() * mod);

--- a/src/main/java/ch/njol/skript/expressions/ExprMe.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprMe.java
@@ -52,11 +52,11 @@ public class ExprMe extends SimpleExpression<Player> {
 
 	@Override
 	@Nullable
-	protected Player[] get(Event e) {
-		if (!(e instanceof EffectCommandEvent))
+	protected Player[] get(Event event) {
+		if (!(event instanceof EffectCommandEvent))
 			return null;
 
-		CommandSender commandSender = ((EffectCommandEvent) e).getSender();
+		CommandSender commandSender = ((EffectCommandEvent) event).getSender();
 		if (commandSender instanceof Player)
 			return new Player[] {(Player) commandSender};
 		return null;
@@ -73,7 +73,7 @@ public class ExprMe extends SimpleExpression<Player> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "me";
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprMendingRepairAmount.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprMendingRepairAmount.java
@@ -59,11 +59,11 @@ public class ExprMendingRepairAmount extends SimpleExpression<Long> {
 	}
 
 	@Override
-	protected Long[] get(final Event e) {
-		if (!(e instanceof PlayerItemMendEvent))
+	protected Long[] get(final Event event) {
+		if (!(event instanceof PlayerItemMendEvent))
 			return null;
 
-		return new Long[]{(long) ((PlayerItemMendEvent) e).getRepairAmount()};
+		return new Long[]{(long) ((PlayerItemMendEvent) event).getRepairAmount()};
 	}
 
 	@Nullable
@@ -118,7 +118,7 @@ public class ExprMendingRepairAmount extends SimpleExpression<Long> {
 	}
 
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "the mending repair amount";
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprMessage.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprMessage.java
@@ -179,10 +179,10 @@ public class ExprMessage extends SimpleExpression<String> {
 	}
 	
 	@Override
-	protected String[] get(final Event e) {
+	protected String[] get(final Event event) {
 		for (final Class<? extends Event> c : type.events) {
-			if (c.isInstance(e))
-				return new String[] {type.get(e)};
+			if (c.isInstance(event))
+				return new String[] {type.get(event)};
 		}
 		return new String[0];
 	}
@@ -196,12 +196,12 @@ public class ExprMessage extends SimpleExpression<String> {
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
 		assert mode == ChangeMode.SET;
 		assert delta != null;
 		for (final Class<? extends Event> c : type.events) {
-			if (c.isInstance(e))
-				type.set(e, "" + delta[0]);
+			if (c.isInstance(event))
+				type.set(event, "" + delta[0]);
 		}
 	}
 	
@@ -216,7 +216,7 @@ public class ExprMessage extends SimpleExpression<String> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "the " + type.name + " message";
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprMetadata.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprMetadata.java
@@ -91,10 +91,10 @@ public class ExprMetadata<T> extends SimpleExpression<T> {
 
 	@Override
 	@Nullable
-	protected T[] get(Event e) {
+	protected T[] get(Event event) {
 		List<Object> values = new ArrayList<>();
-		for (String value : this.values.getArray(e)) {
-			for (Metadatable holder : holders.getArray(e)) {
+		for (String value : this.values.getArray(event)) {
+			for (Metadatable holder : holders.getArray(event)) {
 				List<MetadataValue> metadata = holder.getMetadata(value);
 				if (!metadata.isEmpty())
 					values.add(metadata.get(metadata.size() - 1).value()); // adds the most recent metadata value
@@ -116,9 +116,9 @@ public class ExprMetadata<T> extends SimpleExpression<T> {
 	}
 
 	@Override
-	public void change(Event e, @Nullable Object[] delta, Changer.ChangeMode mode) {
-		for (String value : values.getArray(e)) {
-			for (Metadatable holder : holders.getArray(e)) {
+	public void change(Event event, @Nullable Object[] delta, Changer.ChangeMode mode) {
+		for (String value : values.getArray(event)) {
+			for (Metadatable holder : holders.getArray(event)) {
 				switch (mode) {
 					case SET:
 						holder.setMetadata(value, new FixedMetadataValue(Skript.getInstance(), delta[0]));
@@ -151,8 +151,8 @@ public class ExprMetadata<T> extends SimpleExpression<T> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "metadata values " + values.toString(e, debug) + " of " + holders.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "metadata values " + values.toString(event, debug) + " of " + holders.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprMinecartDerailedFlyingVelocity.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprMinecartDerailedFlyingVelocity.java
@@ -80,18 +80,18 @@ public class ExprMinecartDerailedFlyingVelocity extends SimplePropertyExpression
 	}
 	
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		if (delta != null) {
 			if (flying) {
 				switch (mode) {
 					case SET:
-						for (Entity entity : getExpr().getArray(e)) {
+						for (Entity entity : getExpr().getArray(event)) {
 							if (entity instanceof Minecart)
 								((Minecart) entity).setFlyingVelocityMod((Vector) delta[0]);
 						}
 						break;
 					case ADD:
-						for (Entity entity : getExpr().getArray(e)) {
+						for (Entity entity : getExpr().getArray(event)) {
 							if (entity instanceof Minecart) {
 								Minecart minecart = (Minecart) entity;
 								minecart.setFlyingVelocityMod(((Vector) delta[0]).add(minecart.getFlyingVelocityMod()));
@@ -99,7 +99,7 @@ public class ExprMinecartDerailedFlyingVelocity extends SimplePropertyExpression
 						}
 						break;
 					case REMOVE:
-						for (Entity entity : getExpr().getArray(e)) {
+						for (Entity entity : getExpr().getArray(event)) {
 							if (entity instanceof Minecart) {
 								Minecart minecart = (Minecart) entity;
 								minecart.setFlyingVelocityMod(((Vector) delta[0]).subtract(minecart.getFlyingVelocityMod()));
@@ -112,13 +112,13 @@ public class ExprMinecartDerailedFlyingVelocity extends SimplePropertyExpression
 			} else {
 				switch (mode) {
 					case SET:
-						for (Entity entity : getExpr().getArray(e)) {
+						for (Entity entity : getExpr().getArray(event)) {
 							if (entity instanceof Minecart)
 								((Minecart) entity).setDerailedVelocityMod((Vector) delta[0]);
 						}
 						break;
 					case ADD:
-						for (Entity entity : getExpr().getArray(e)) {
+						for (Entity entity : getExpr().getArray(event)) {
 							if (entity instanceof Minecart) {
 								Minecart minecart = (Minecart) entity;
 								minecart.setDerailedVelocityMod(((Vector) delta[0]).add(minecart.getDerailedVelocityMod()));
@@ -126,7 +126,7 @@ public class ExprMinecartDerailedFlyingVelocity extends SimplePropertyExpression
 						}
 						break;
 					case REMOVE:
-						for (Entity entity : getExpr().getArray(e)) {
+						for (Entity entity : getExpr().getArray(event)) {
 							if (entity instanceof Minecart) {
 								Minecart minecart = (Minecart) entity;
 								minecart.setDerailedVelocityMod(((Vector) delta[0]).subtract(minecart.getDerailedVelocityMod()));

--- a/src/main/java/ch/njol/skript/expressions/ExprName.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprName.java
@@ -220,9 +220,9 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 	}
 
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		String name = delta != null ? (String) delta[0] : null;
-		for (Object o : getExpr().getArray(e)) {
+		for (Object o : getExpr().getArray(event)) {
 			if (o instanceof Player) {
 				switch (mark) {
 					case 2:

--- a/src/main/java/ch/njol/skript/expressions/ExprNamed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNamed.java
@@ -68,8 +68,8 @@ public class ExprNamed extends PropertyExpression<Object, Object> {
 	}
 	
 	@Override
-	protected Object[] get(final Event e, final Object[] source) {
-		String name = this.name.getSingle(e);
+	protected Object[] get(final Event event, final Object[] source) {
+		String name = this.name.getSingle(event);
 		if (name == null)
 			return get(source, obj -> obj); // No name provided, do nothing
 		return get(source, new Getter<Object, Object>() {
@@ -104,8 +104,8 @@ public class ExprNamed extends PropertyExpression<Object, Object> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return getExpr().toString(e, debug) + " named " + name;
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return getExpr().toString(event, debug) + " named " + name;
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprNoDamageTicks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNoDamageTicks.java
@@ -55,9 +55,9 @@ public class ExprNoDamageTicks extends SimplePropertyExpression<LivingEntity, Lo
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
 		int d = delta == null ? 0 : ((Number) delta[0]).intValue();
-		for (LivingEntity le : getExpr().getArray(e)) {
+		for (LivingEntity le : getExpr().getArray(event)) {
 			switch (mode) {
 				case ADD:
 					int r1 = le.getNoDamageTicks() + d;

--- a/src/main/java/ch/njol/skript/expressions/ExprNow.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNow.java
@@ -49,7 +49,7 @@ public class ExprNow extends SimpleExpression<Date> {
 	}
 	
 	@Override
-	protected Date[] get(final Event e) {
+	protected Date[] get(final Event event) {
 		return new Date[] {new Date()};
 	}
 	
@@ -64,7 +64,7 @@ public class ExprNow extends SimpleExpression<Date> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "now";
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprNumberOfCharacters.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNumberOfCharacters.java
@@ -65,8 +65,8 @@ public class ExprNumberOfCharacters extends SimpleExpression<Long> {
 	@Override
 	@SuppressWarnings("null")
 	@Nullable
-	protected Long[] get(Event e) {
-		String str = expr.getSingle(e);
+	protected Long[] get(Event event) {
+		String str = expr.getSingle(event);
 		if (str == null)
 			return null;
 		long size = 0;
@@ -97,7 +97,7 @@ public class ExprNumberOfCharacters extends SimpleExpression<Long> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		if (pattern == 0) {
 			return "number of uppercase characters";
 		} else if (pattern == 1) {

--- a/src/main/java/ch/njol/skript/expressions/ExprNumbers.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNumbers.java
@@ -177,8 +177,8 @@ public class ExprNumbers extends SimpleExpression<Number> {
 	}
 	
 	@Override
-	public boolean isLoopOf(final String s) {
-		return mode == 1 && (s.equalsIgnoreCase("integer") || s.equalsIgnoreCase("int"));
+	public boolean isLoopOf(final String string) {
+		return mode == 1 && (string.equalsIgnoreCase("integer") || string.equalsIgnoreCase("int"));
 	}
 	
 	@Override
@@ -192,9 +192,9 @@ public class ExprNumbers extends SimpleExpression<Number> {
 	}
 
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		final String modeString = mode == 0 ? "numbers" : (mode == 1 ? "integers" : "decimals");
-		return modeString + " from " + start.toString(e, debug) + " to " + end.toString(e, debug);
+		return modeString + " from " + start.toString(event, debug) + " to " + end.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprOnlinePlayersCount.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprOnlinePlayersCount.java
@@ -78,14 +78,14 @@ public class ExprOnlinePlayersCount extends SimpleExpression<Long> {
 
 	@Override
 	@Nullable
-	public Long[] get(Event e) {
-		if (!isReal && !(e instanceof PaperServerListPingEvent))
+	public Long[] get(Event event) {
+		if (!isReal && !(event instanceof PaperServerListPingEvent))
 			return null;
 
 		if (isReal)
 			return CollectionUtils.array((long) Bukkit.getOnlinePlayers().size());
 		else
-			return CollectionUtils.array((long) ((PaperServerListPingEvent) e).getNumPlayers());
+			return CollectionUtils.array((long) ((PaperServerListPingEvent) event).getNumPlayers());
 	}
 
 	@Override
@@ -142,7 +142,7 @@ public class ExprOnlinePlayersCount extends SimpleExpression<Long> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "the count of " + (isReal ? "real max players" : "max players");
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprParse.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprParse.java
@@ -230,8 +230,8 @@ public class ExprParse extends SimpleExpression<Object> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return text.toString(e, debug) + " parsed as " + (classInfo != null ? classInfo.toString(Language.F_INDEFINITE_ARTICLE) : pattern);
+	public String toString(@Nullable Event event, boolean debug) {
+		return text.toString(event, debug) + " parsed as " + (classInfo != null ? classInfo.toString(Language.F_INDEFINITE_ARTICLE) : pattern);
 	}
 
 	/**

--- a/src/main/java/ch/njol/skript/expressions/ExprParseError.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprParseError.java
@@ -55,7 +55,7 @@ public class ExprParseError extends SimpleExpression<String> {
 	}
 	
 	@Override
-	protected String[] get(final Event e) {
+	protected String[] get(final Event event) {
 		return ExprParse.lastError == null ? new String[0] : new String[] {ExprParse.lastError};
 	}
 	
@@ -70,7 +70,7 @@ public class ExprParseError extends SimpleExpression<String> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "the last parse error";
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprPassenger.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPassenger.java
@@ -72,17 +72,17 @@ public class ExprPassenger extends SimpleExpression<Entity> { // REMIND create '
 	
 	@Override
 	@Nullable
-	protected Entity[] get(Event e) {
-		Entity[] source = vehicle.getAll(e);
+	protected Entity[] get(Event event) {
+		Entity[] source = vehicle.getAll(event);
 		Converter<Entity, Entity[]> conv = new Converter<Entity, Entity[]>(){
 			@Override
 			@Nullable
 			public Entity[] convert(Entity v) {
-				if (getTime() >= 0 && e instanceof VehicleEnterEvent && v.equals(((VehicleEnterEvent) e).getVehicle()) && !Delay.isDelayed(e)) {
-					return new Entity[] {((VehicleEnterEvent) e).getEntered()};
+				if (getTime() >= 0 && event instanceof VehicleEnterEvent && v.equals(((VehicleEnterEvent) event).getVehicle()) && !Delay.isDelayed(event)) {
+					return new Entity[] {((VehicleEnterEvent) event).getEntered()};
 				}
-				if (getTime() >= 0 && e instanceof VehicleExitEvent && v.equals(((VehicleExitEvent) e).getVehicle()) && !Delay.isDelayed(e)) {
-					return new Entity[] {((VehicleExitEvent) e).getExited()};
+				if (getTime() >= 0 && event instanceof VehicleExitEvent && v.equals(((VehicleExitEvent) event).getVehicle()) && !Delay.isDelayed(event)) {
+					return new Entity[] {((VehicleExitEvent) event).getExited()};
 				}
 				return PassengerUtils.getPassenger(v);
 			}};
@@ -118,8 +118,8 @@ public class ExprPassenger extends SimpleExpression<Entity> { // REMIND create '
 
 	@SuppressWarnings("null")
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
-		Entity[] vehicles = this.vehicle.getArray(e);
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
+		Entity[] vehicles = this.vehicle.getArray(event);
 		if (!isSingle() || mode == ChangeMode.SET) {
 			for (Entity vehicle: vehicles){
 				if (vehicle == null)
@@ -161,7 +161,7 @@ public class ExprPassenger extends SimpleExpression<Entity> { // REMIND create '
 				}
 			}
 		} else {
-			super.change(e, delta, mode);
+			super.change(event, delta, mode);
 		}
 		
 	}
@@ -172,8 +172,8 @@ public class ExprPassenger extends SimpleExpression<Entity> { // REMIND create '
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "the passenger of " + vehicle.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "the passenger of " + vehicle.toString(event, debug);
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprPermissions.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPermissions.java
@@ -62,9 +62,9 @@ public class ExprPermissions extends SimpleExpression<String> {
 
 	@Override
 	@Nullable
-	protected String[] get(Event e) {
+	protected String[] get(Event event) {
 		final Set<String> permissions = new HashSet<>();
-		for (Player player : players.getArray(e))
+		for (Player player : players.getArray(event))
 			for (final PermissionAttachmentInfo permission : player.getEffectivePermissions())
 				permissions.add(permission.getPermission());
 		return permissions.toArray(new String[permissions.size()]);

--- a/src/main/java/ch/njol/skript/expressions/ExprPlain.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPlain.java
@@ -57,8 +57,8 @@ public class ExprPlain extends SimpleExpression<ItemType> {
 	
 	@Override
 	@Nullable
-	protected ItemType[] get(Event e) {
-		ItemType itemType = item.getSingle(e);
+	protected ItemType[] get(Event event) {
+		ItemType itemType = item.getSingle(event);
 		if (itemType == null)
 			return new ItemType[0];
 		ItemData data = new ItemData(itemType.getMaterial());
@@ -78,8 +78,8 @@ public class ExprPlain extends SimpleExpression<ItemType> {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "plain " + item.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "plain " + item.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprPlayerViewDistance.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPlayerViewDistance.java
@@ -57,7 +57,7 @@ public class ExprPlayerViewDistance extends PropertyExpression<Player, Long> {
 	}
 	
 	@Override
-	protected Long[] get(Event e, Player[] source) {
+	protected Long[] get(Event event, Player[] source) {
 		return get(source, player -> (long) player.getViewDistance());
 	}
 	
@@ -76,24 +76,24 @@ public class ExprPlayerViewDistance extends PropertyExpression<Player, Long> {
 	}
 	
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		int distance = delta == null ? 0 : ((Number) delta[0]).intValue();
 		switch (mode) {
 			case DELETE:
 			case SET:
-				for (Player player : getExpr().getArray(e))
+				for (Player player : getExpr().getArray(event))
 					player.setViewDistance(distance);
 				break;
 			case ADD:
-				for (Player player : getExpr().getArray(e))
+				for (Player player : getExpr().getArray(event))
 					player.setViewDistance(player.getViewDistance() + distance);
 				break;
 			case REMOVE:
-				for (Player player : getExpr().getArray(e))
+				for (Player player : getExpr().getArray(event))
 					player.setViewDistance(player.getViewDistance() - distance);
 				break;
 			case RESET:
-				for (Player player : getExpr().getArray(e))
+				for (Player player : getExpr().getArray(event))
 					player.setViewDistance(Bukkit.getServer().getViewDistance());
 			default:
 				assert false;
@@ -106,8 +106,8 @@ public class ExprPlayerViewDistance extends PropertyExpression<Player, Long> {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "the view distance of " + getExpr().toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "the view distance of " + getExpr().toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprPlayerWeather.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPlayerWeather.java
@@ -73,13 +73,13 @@ public class ExprPlayerWeather extends SimplePropertyExpression<Player, WeatherT
 
 	@SuppressWarnings("null")
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
 		if (delta == null) {
-			for (Player p : getExpr().getArray(e))
+			for (Player p : getExpr().getArray(event))
 				p.resetPlayerWeather();
 		} else {
 			WeatherType type = (WeatherType) delta[0];
-			for (Player p : getExpr().getArray(e))
+			for (Player p : getExpr().getArray(event))
 				type.setWeather(p);
 		}
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprPlayerlistHeaderFooter.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPlayerlistHeaderFooter.java
@@ -84,9 +84,9 @@ public class ExprPlayerlistHeaderFooter extends SimplePropertyExpression<Player,
 	}
 	
 	@Override
-	public void change(Event e, @Nullable Object[] delta, Changer.ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, Changer.ChangeMode mode) {
 		final String text = delta == null ? "" : (String) delta[0];
-		for (Player player : getExpr().getArray(e)) {
+		for (Player player : getExpr().getArray(event)) {
 			if (mark == HEADER) {
 				player.setPlayerListHeader(text);
 			} else if (mark == FOOTER) {

--- a/src/main/java/ch/njol/skript/expressions/ExprPlugins.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPlugins.java
@@ -57,7 +57,7 @@ public class ExprPlugins extends SimpleExpression<String> {
 
 	@Override
 	@Nullable
-	protected String[] get(Event e) {
+	protected String[] get(Event event) {
 		return Arrays.stream(Bukkit.getPluginManager().getPlugins())
 			.map(Plugin::getName)
 			.toArray(String[]::new);
@@ -74,7 +74,7 @@ public class ExprPlugins extends SimpleExpression<String> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "the loaded plugins";
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprPortal.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPortal.java
@@ -67,11 +67,11 @@ public class ExprPortal extends SimpleExpression<Block> {
 
 	@Nullable
 	@Override
-	protected Block[] get(Event e) {
-		if (!(e instanceof PortalCreateEvent))
+	protected Block[] get(Event event) {
+		if (!(event instanceof PortalCreateEvent))
 			return null;
 
-		List<?> blocks = ((PortalCreateEvent) e).getBlocks();
+		List<?> blocks = ((PortalCreateEvent) event).getBlocks();
 		if (USING_BLOCKSTATE)
 			return blocks.stream()
 					.map(block -> ((BlockState) block).getBlock())
@@ -83,11 +83,11 @@ public class ExprPortal extends SimpleExpression<Block> {
 
 	@Nullable
 	@Override
-	public Iterator<Block> iterator(Event e) {
-		if (!(e instanceof PortalCreateEvent))
+	public Iterator<Block> iterator(Event event) {
+		if (!(event instanceof PortalCreateEvent))
 			return null;
 
-		List<?> blocks = ((PortalCreateEvent) e).getBlocks();
+		List<?> blocks = ((PortalCreateEvent) event).getBlocks();
 		if (USING_BLOCKSTATE) 
 			return blocks.stream()
 					.map(block -> ((BlockState) block).getBlock())
@@ -111,7 +111,7 @@ public class ExprPortal extends SimpleExpression<Block> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "the portal blocks";
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprPotionEffect.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPotionEffect.java
@@ -71,19 +71,19 @@ public class ExprPotionEffect extends SimpleExpression<PotionEffect> {
 	
 	@Override
 	@Nullable
-	protected PotionEffect[] get(final Event e) {
-		PotionEffectType potionEffectType = this.potionEffectType.getSingle(e);
+	protected PotionEffect[] get(final Event event) {
+		PotionEffectType potionEffectType = this.potionEffectType.getSingle(event);
 		if (potionEffectType == null)
 			return null;
 		int tier = 0;
 		if (this.tier != null) {
-			Number n = this.tier.getSingle(e);
+			Number n = this.tier.getSingle(event);
 			if (n != null)
 				tier = n.intValue() - 1;
 		}
 		int ticks = 15 * 20; // 15 second default potion length
 		if (this.timespan != null) {
-			Timespan timespan = this.timespan.getSingle(e);
+			Timespan timespan = this.timespan.getSingle(event);
 			if (timespan != null)
 				ticks = (int) timespan.getTicks_i();
 		}
@@ -101,20 +101,20 @@ public class ExprPotionEffect extends SimpleExpression<PotionEffect> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		StringBuilder builder = new StringBuilder();
 		if (ambient)
 			builder.append("ambient ");
-		builder.append("potion of ").append(potionEffectType.toString(e, debug));
+		builder.append("potion of ").append(potionEffectType.toString(event, debug));
 		if (tier != null) {
-			String t = tier.toString(e, debug);
+			String t = tier.toString(event, debug);
 			builder.append(" of tier/amp ").append(t);
 		}
 		if (!particles)
 			builder.append(" without particles");
 		builder.append(" for ");
 		if (timespan != null)
-			builder.append(timespan.toString(e, debug));
+			builder.append(timespan.toString(event, debug));
 		else
 			builder.append("15 seconds");
 		return builder.toString();

--- a/src/main/java/ch/njol/skript/expressions/ExprPotionEffects.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPotionEffects.java
@@ -72,9 +72,9 @@ public class ExprPotionEffects extends SimpleExpression<PotionEffect> {
 	
 	@Nullable
 	@Override
-	protected PotionEffect[] get(Event e) {
+	protected PotionEffect[] get(Event event) {
 		List<PotionEffect> effects = new ArrayList<>();
-		for (Object object : this.objects.getArray(e)) {
+		for (Object object : this.objects.getArray(event)) {
 			if (object instanceof LivingEntity)
 				effects.addAll(((LivingEntity) object).getActivePotionEffects());
 			else if (object instanceof ItemType)
@@ -97,8 +97,8 @@ public class ExprPotionEffects extends SimpleExpression<PotionEffect> {
 	}
 	
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
-		for (Object object : this.objects.getArray(e)) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+		for (Object object : this.objects.getArray(event)) {
 			switch (mode) {
 				case DELETE:
 					if (object instanceof LivingEntity)
@@ -137,8 +137,8 @@ public class ExprPotionEffects extends SimpleExpression<PotionEffect> {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean d) {
-		return "active potion effects of " + objects.toString(e, d);
+	public String toString(@Nullable Event event, boolean d) {
+		return "active potion effects of " + objects.toString(event, d);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprProjectileBounceState.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprProjectileBounceState.java
@@ -55,10 +55,10 @@ public class ExprProjectileBounceState extends SimplePropertyExpression<Projecti
 	}
 	
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		if (delta == null) return;
 		boolean state = (Boolean) delta[0];
-		for (Projectile entity : getExpr().getArray(e))
+		for (Projectile entity : getExpr().getArray(event))
 			entity.setBounce(state);
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprProjectileCriticalState.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprProjectileCriticalState.java
@@ -63,10 +63,10 @@ public class ExprProjectileCriticalState extends SimplePropertyExpression<Projec
 	}
 	
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		if (delta == null) return;
 		boolean state = (Boolean) delta[0];
-		for (Projectile entity : getExpr().getAll(e)) {
+		for (Projectile entity : getExpr().getAll(event)) {
 			if (abstractArrowExists && entity instanceof AbstractArrow) {
 				((AbstractArrow) entity).setCritical(state);
 			} else if (entity instanceof Arrow) {

--- a/src/main/java/ch/njol/skript/expressions/ExprProtocolVersion.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprProtocolVersion.java
@@ -78,11 +78,11 @@ public class ExprProtocolVersion extends SimpleExpression<Long> {
 
 	@Override
 	@Nullable
-	public Long[] get(Event e) {
-		if (!(e instanceof PaperServerListPingEvent))
+	public Long[] get(Event event) {
+		if (!(event instanceof PaperServerListPingEvent))
 			return null;
 
-		return CollectionUtils.array((long) ((PaperServerListPingEvent) e).getProtocolVersion());
+		return CollectionUtils.array((long) ((PaperServerListPingEvent) event).getProtocolVersion());
 	}
 
 	@Override
@@ -99,11 +99,11 @@ public class ExprProtocolVersion extends SimpleExpression<Long> {
 
 	@SuppressWarnings("null")
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
-		if (!(e instanceof PaperServerListPingEvent))
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+		if (!(event instanceof PaperServerListPingEvent))
 			return;
 
-		((PaperServerListPingEvent) e).setProtocolVersion(((Number) delta[0]).intValue());
+		((PaperServerListPingEvent) event).setProtocolVersion(((Number) delta[0]).intValue());
 	}
 
 	@Override
@@ -117,7 +117,7 @@ public class ExprProtocolVersion extends SimpleExpression<Long> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "the protocol version";
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprPushedBlocks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPushedBlocks.java
@@ -59,12 +59,12 @@ public class ExprPushedBlocks extends SimpleExpression<Block> {
 	
 	@Override
 	@Nullable
-	protected Block[] get(Event e) {
-		if (!CollectionUtils.isAnyInstanceOf(e, BlockPistonExtendEvent.class, BlockPistonRetractEvent.class))
+	protected Block[] get(Event event) {
+		if (!CollectionUtils.isAnyInstanceOf(event, BlockPistonExtendEvent.class, BlockPistonRetractEvent.class))
 			return null;
 
-		return (e instanceof BlockPistonExtendEvent) ? ((BlockPistonExtendEvent) e).getBlocks().toArray(new Block[0])
-				: ((BlockPistonRetractEvent) e).getBlocks().toArray(new Block[0]);
+		return (event instanceof BlockPistonExtendEvent) ? ((BlockPistonExtendEvent) event).getBlocks().toArray(new Block[0])
+				: ((BlockPistonRetractEvent) event).getBlocks().toArray(new Block[0]);
 	}
 	
 	@Override
@@ -78,7 +78,7 @@ public class ExprPushedBlocks extends SimpleExpression<Block> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "moved blocks";
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprRandom.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprRandom.java
@@ -64,8 +64,8 @@ public class ExprRandom extends SimpleExpression<Object> {
 	}
 	
 	@Override
-	protected Object[] get(final Event e) {
-		final Object[] set = expr.getAll(e);
+	protected Object[] get(final Event event) {
+		final Object[] set = expr.getAll(event);
 		if (set.length <= 1)
 			return set;
 		final Object[] one = (Object[]) Array.newInstance(set.getClass().getComponentType(), 1);
@@ -79,8 +79,8 @@ public class ExprRandom extends SimpleExpression<Object> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "a random element out of " + expr.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "a random element out of " + expr.toString(event, debug);
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprRandomNumber.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprRandomNumber.java
@@ -68,9 +68,9 @@ public class ExprRandomNumber extends SimpleExpression<Number> {
 	
 	@Override
 	@Nullable
-	protected Number[] get(final Event e) {
-		final Number l = lower.getSingle(e);
-		final Number u = upper.getSingle(e);
+	protected Number[] get(final Event event) {
+		final Number l = lower.getSingle(event);
+		final Number u = upper.getSingle(event);
 		if (u == null || l == null)
 			return null;
 		final double ll = Math.min(l.doubleValue(), u.doubleValue());
@@ -88,8 +88,8 @@ public class ExprRandomNumber extends SimpleExpression<Number> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "a random " + (integer ? "integer" : "number") + " between " + lower.toString(e, debug) + " and " + upper.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "a random " + (integer ? "integer" : "number") + " between " + lower.toString(event, debug) + " and " + upper.toString(event, debug);
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprRandomUUID.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprRandomUUID.java
@@ -51,7 +51,7 @@ public class ExprRandomUUID extends SimpleExpression<String> {
 	
 	@Override
 	@Nullable
-	protected String[] get(Event e) {
+	protected String[] get(Event event) {
 		return new String[] {UUID.randomUUID().toString()};
 	}
 	
@@ -66,7 +66,7 @@ public class ExprRandomUUID extends SimpleExpression<String> {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "random uuid";
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprRawName.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprRawName.java
@@ -58,8 +58,8 @@ public class ExprRawName extends SimpleExpression<String> {
 	
 	@Override
 	@Nullable
-	protected String[] get(final Event e) {
-		return Arrays.stream(types.getAll(e))
+	protected String[] get(final Event event) {
+		return Arrays.stream(types.getAll(event))
 				.map(ItemType::getRawNames)
 				.flatMap(List::stream)
 				.toArray(String[]::new);
@@ -77,8 +77,8 @@ public class ExprRawName extends SimpleExpression<String> {
 	
 	@SuppressWarnings("null")
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "minecraft name of " + types.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "minecraft name of " + types.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprRawString.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprRawString.java
@@ -71,14 +71,14 @@ public class ExprRawString extends SimpleExpression<String> {
 	}
 
 	@Override
-	protected String[] get(Event e) {
+	protected String[] get(Event event) {
 		List<String> strings = new ArrayList<>();
 		for (Expression<? extends String> message : messages) {
 			if (message instanceof VariableString) {
-				strings.add(((VariableString) message).toUnformattedString(e));
+				strings.add(((VariableString) message).toUnformattedString(event));
 				continue;
 			}
-			strings.addAll(Arrays.asList(message.getArray(e)));
+			strings.addAll(Arrays.asList(message.getArray(event)));
 		}
 		return strings.toArray(new String[0]);
 	}
@@ -94,7 +94,7 @@ public class ExprRawString extends SimpleExpression<String> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "raw " + expr.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "raw " + expr.toString(event, debug);
 	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprReversedList.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprReversedList.java
@@ -64,8 +64,8 @@ public class ExprReversedList extends SimpleExpression<Object> {
 
 	@Override
 	@Nullable
-	protected Object[] get(Event e) {
-		Object[] inputArray = list.getArray(e).clone();
+	protected Object[] get(Event event) {
+		Object[] inputArray = list.getArray(event).clone();
 		Object[] array = (Object[]) Array.newInstance(getReturnType(), inputArray.length);
 		System.arraycopy(inputArray, 0, array, 0, inputArray.length);
 		reverse(array);
@@ -106,8 +106,8 @@ public class ExprReversedList extends SimpleExpression<Object> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "reversed " + list.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "reversed " + list.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprRound.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprRound.java
@@ -62,7 +62,7 @@ public class ExprRound extends PropertyExpression<Number, Long> {
 	}
 	
 	@Override
-	protected Long[] get(final Event e, final Number[] source) {
+	protected Long[] get(final Event event, final Number[] source) {
 		return get(source, n -> {
 			if (n instanceof Integer)
 				return n.longValue();
@@ -78,8 +78,8 @@ public class ExprRound extends PropertyExpression<Number, Long> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return (action == -1 ? "floor" : action == 0 ? "round" : "ceil") + "(" + getExpr().toString(e, debug) + ")";
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return (action == -1 ? "floor" : action == 0 ? "round" : "ceil") + "(" + getExpr().toString(event, debug) + ")";
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprSaturation.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSaturation.java
@@ -54,25 +54,25 @@ public class ExprSaturation extends SimplePropertyExpression<Player, Number> {
 
 	@SuppressWarnings("null")
 	@Override
-	public void change(Event e, @Nullable Object[] delta, Changer.ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, Changer.ChangeMode mode) {
 		Float value = delta != null ? ((Number)delta[0]).floatValue() : null;
 		switch (mode) {
 			case ADD:
-				for (Player player : getExpr().getArray(e))
+				for (Player player : getExpr().getArray(event))
 					player.setSaturation(player.getSaturation() + value);
 				break;
 			case REMOVE:
-				for (Player player : getExpr().getArray(e))
+				for (Player player : getExpr().getArray(event))
 					player.setSaturation(player.getSaturation() - value);
 				break;
 			case SET:
-				for (Player player : getExpr().getArray(e))
+				for (Player player : getExpr().getArray(event))
 					player.setSaturation(value);
 				break;
 			case DELETE:
 			case REMOVE_ALL:
 			case RESET:
-				for (Player player : getExpr().getArray(e))
+				for (Player player : getExpr().getArray(event))
 					player.setSaturation(0);
 				break;
 		}

--- a/src/main/java/ch/njol/skript/expressions/ExprScoreboardTags.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprScoreboardTags.java
@@ -75,8 +75,8 @@ public class ExprScoreboardTags extends SimpleExpression<String> {
 
 	@Override
 	@Nullable
-	public String[] get(Event e) {
-		return Stream.of(entities.getArray(e))
+	public String[] get(Event event) {
+		return Stream.of(entities.getArray(event))
 				.map(Entity::getScoreboardTags)
 				.flatMap(Set::stream)
 				.toArray(String[]::new);
@@ -98,8 +98,8 @@ public class ExprScoreboardTags extends SimpleExpression<String> {
 	}
 
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
-		for (Entity entity : entities.getArray(e)) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+		for (Entity entity : entities.getArray(event)) {
 			switch (mode) {
 				case SET:
 					assert delta != null;
@@ -135,8 +135,8 @@ public class ExprScoreboardTags extends SimpleExpression<String> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "the scoreboard tags of " + entities.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "the scoreboard tags of " + entities.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprScript.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprScript.java
@@ -65,7 +65,7 @@ public class ExprScript extends SimpleExpression<String> {
 	}
 	
 	@Override
-	protected String[] get(Event e) {
+	protected String[] get(Event event) {
 		return new String[]{name};
 	}
 	
@@ -80,7 +80,7 @@ public class ExprScript extends SimpleExpression<String> {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "the script's name";
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprScripts.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprScripts.java
@@ -103,7 +103,7 @@ public class ExprScripts extends SimpleExpression<String> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "scripts";
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprServerIcon.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprServerIcon.java
@@ -75,12 +75,12 @@ public class ExprServerIcon extends SimpleExpression<CachedServerIcon> {
 
 	@Override
 	@Nullable
-	public CachedServerIcon[] get(Event e) {
+	public CachedServerIcon[] get(Event event) {
 		CachedServerIcon icon = null;
 		if ((isServerPingEvent && !isDefault) && PAPER_EVENT_EXISTS) {
-			if (!(e instanceof PaperServerListPingEvent))
+			if (!(event instanceof PaperServerListPingEvent))
 				return null;
-			icon = ((PaperServerListPingEvent) e).getServerIcon();
+			icon = ((PaperServerListPingEvent) event).getServerIcon();
 		} else {
 			icon = Bukkit.getServerIcon();
 		}
@@ -130,7 +130,7 @@ public class ExprServerIcon extends SimpleExpression<CachedServerIcon> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "the " + (!isServerPingEvent || isDefault ? "default" : "shown") + " server icon";
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprSets.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSets.java
@@ -183,8 +183,8 @@ public class ExprSets extends SimpleExpression<Object> {
 	}
 	
 	@Override
-	public boolean isLoopOf(String s) {
-		return pattern == 4 && (s.equalsIgnoreCase("color") || s.equalsIgnoreCase("colour"))|| pattern >= 2 && s.equalsIgnoreCase("block") || pattern < 2 && s.equalsIgnoreCase("item");
+	public boolean isLoopOf(String string) {
+		return pattern == 4 && (string.equalsIgnoreCase("color") || string.equalsIgnoreCase("colour"))|| pattern >= 2 && string.equalsIgnoreCase("block") || pattern < 2 && string.equalsIgnoreCase("item");
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprShooter.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprShooter.java
@@ -57,7 +57,7 @@ public class ExprShooter extends PropertyExpression<Projectile, LivingEntity> {
 	}
 	
 	@Override
-	protected LivingEntity[] get(final Event e, final Projectile[] source) {
+	protected LivingEntity[] get(final Event event, final Projectile[] source) {
 		return get(source, new Converter<Projectile, LivingEntity>() {
 			@Override
 			@Nullable
@@ -79,15 +79,15 @@ public class ExprShooter extends PropertyExpression<Projectile, LivingEntity> {
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
 		if (mode == ChangeMode.SET) {
 			assert delta != null;
-			for (final Projectile p : getExpr().getArray(e)) {
+			for (final Projectile p : getExpr().getArray(event)) {
 				assert p != null : getExpr();
 				p.setShooter((ProjectileSource) delta[0]);
 			}
 		} else {
-			super.change(e, delta, mode);
+			super.change(event, delta, mode);
 		}
 	}
 	
@@ -97,8 +97,8 @@ public class ExprShooter extends PropertyExpression<Projectile, LivingEntity> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "the shooter" + (getExpr().isDefault() ? "" : " of " + getExpr().toString(e, debug));
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "the shooter" + (getExpr().isDefault() ? "" : " of " + getExpr().toString(event, debug));
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprShuffledList.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprShuffledList.java
@@ -67,8 +67,8 @@ public class ExprShuffledList extends SimpleExpression<Object> {
 
 	@Override
 	@Nullable
-	protected Object[] get(Event e) {
-		Object[] origin = list.getArray(e).clone();
+	protected Object[] get(Event event) {
+		Object[] origin = list.getArray(event).clone();
 		List<Object> shuffled = Arrays.asList(origin); // Not yet shuffled...
 		Collections.shuffle(shuffled);
 
@@ -101,8 +101,8 @@ public class ExprShuffledList extends SimpleExpression<Object> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "shuffled " + list.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "shuffled " + list.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprSignText.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSignText.java
@@ -86,17 +86,17 @@ public class ExprSignText extends SimpleExpression<String> {
 	
 	@Override
 	@Nullable
-	protected String[] get(final Event e) {
-		final Number l = line.getSingle(e);
+	protected String[] get(final Event event) {
+		final Number l = line.getSingle(event);
 		if (l == null)
 			return new String[0];
 		final int line = l.intValue() - 1;
 		if (line < 0 || line > 3)
 			return new String[0];
-		if (getTime() >= 0 && block.isDefault() && e instanceof SignChangeEvent && !Delay.isDelayed(e)) {
-			return new String[] {((SignChangeEvent) e).getLine(line)};
+		if (getTime() >= 0 && block.isDefault() && event instanceof SignChangeEvent && !Delay.isDelayed(event)) {
+			return new String[] {((SignChangeEvent) event).getLine(line)};
 		}
-		final Block b = block.getSingle(e);
+		final Block b = block.getSingle(event);
 		if (b == null)
 			return new String[0];
 		if (!sign.isOfType(b))
@@ -105,8 +105,8 @@ public class ExprSignText extends SimpleExpression<String> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "line " + line.toString(e, debug) + " of " + block.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "line " + line.toString(event, debug) + " of " + block.toString(event, debug);
 	}
 	
 	// TODO allow add, remove, and remove all (see ExprLore)
@@ -122,24 +122,24 @@ public class ExprSignText extends SimpleExpression<String> {
 	
 	@SuppressWarnings("incomplete-switch")
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
-		final Number l = line.getSingle(e);
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
+		final Number l = line.getSingle(event);
 		if (l == null)
 			return;
 		final int line = l.intValue() - 1;
 		if (line < 0 || line > 3)
 			return;
-		final Block b = block.getSingle(e);
+		final Block b = block.getSingle(event);
 		if (b == null)
 			return;
-		if (getTime() >= 0 && e instanceof SignChangeEvent && b.equals(((SignChangeEvent) e).getBlock()) && !Delay.isDelayed(e)) {
+		if (getTime() >= 0 && event instanceof SignChangeEvent && b.equals(((SignChangeEvent) event).getBlock()) && !Delay.isDelayed(event)) {
 			switch (mode) {
 				case DELETE:
-					((SignChangeEvent) e).setLine(line, "");
+					((SignChangeEvent) event).setLine(line, "");
 					break;
 				case SET:
 					assert delta != null;
-					((SignChangeEvent) e).setLine(line, (String) delta[0]);
+					((SignChangeEvent) event).setLine(line, (String) delta[0]);
 					break;
 			}
 		} else {

--- a/src/main/java/ch/njol/skript/expressions/ExprSortedList.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSortedList.java
@@ -67,8 +67,8 @@ public class ExprSortedList extends SimpleExpression<Object> {
 
 	@Override
 	@Nullable
-	protected Object[] get(Event e) {
-		Object[] unsorted = list.getArray(e);
+	protected Object[] get(Event event) {
+		Object[] unsorted = list.getArray(event);
 		Object[] sorted = (Object[]) Array.newInstance(getReturnType(), unsorted.length); // Not yet sorted...
 		
 		for (int i = 0; i < sorted.length; i++) {
@@ -115,8 +115,8 @@ public class ExprSortedList extends SimpleExpression<Object> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "sorted " + list.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "sorted " + list.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprSpawnReason.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSpawnReason.java
@@ -46,7 +46,7 @@ public class ExprSpawnReason extends EventValueExpression<SpawnReason> {
 	}
 
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "the spawning reason";
 	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprSpawnerType.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSpawnerType.java
@@ -68,8 +68,8 @@ public class ExprSpawnerType extends SimplePropertyExpression<Block, EntityData>
 	
 	@SuppressWarnings("null")
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
-		for (Block b : getExpr().getArray(e)) {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
+		for (Block b : getExpr().getArray(event)) {
 			if (b.getType() != MATERIAL_SPAWNER)
 				continue;
 			CreatureSpawner s = (CreatureSpawner) b.getState();

--- a/src/main/java/ch/njol/skript/expressions/ExprSpecialNumber.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSpecialNumber.java
@@ -55,7 +55,7 @@ public class ExprSpecialNumber extends SimpleExpression<Number> {
 	}
 
 	@Override
-	protected Number[] get(Event e) {
+	protected Number[] get(Event event) {
 		return new Number[]{value == 0 ? Double.NaN : value == 1 ? Double.POSITIVE_INFINITY : Double.NEGATIVE_INFINITY};
 	}
 
@@ -70,7 +70,7 @@ public class ExprSpecialNumber extends SimpleExpression<Number> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return value == 0 ? "NaN value" : value == 1 ? "infinity value" : "-infinity value";
 	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprSpeed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSpeed.java
@@ -72,10 +72,10 @@ public class ExprSpeed extends SimplePropertyExpression<Player, Number> {
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
 		float input = delta == null ? 0 : ((Number) delta[0]).floatValue();
 		
-		for (final Player p : getExpr().getArray(e)) {
+		for (final Player p : getExpr().getArray(event)) {
 			float oldSpeed = walk ? p.getWalkSpeed() : p.getFlySpeed();
 			
 			float newSpeed;

--- a/src/main/java/ch/njol/skript/expressions/ExprStringCase.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprStringCase.java
@@ -113,8 +113,8 @@ public class ExprStringCase extends SimpleExpression<String> {
 	@SuppressWarnings("null")
 	@Override
 	@Nullable
-	protected String[] get(Event e) {
-		String[] strs = expr.getArray(e);
+	protected String[] get(Event event) {
+		String[] strs = expr.getArray(event);
 		for (int i = 0; i < strs.length; i++) {
 			if (strs[i] != null) {
 				switch (type) {
@@ -153,7 +153,7 @@ public class ExprStringCase extends SimpleExpression<String> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		switch (type) {
 			case 0: // Basic Case Change 
 				return (casemode == 1) ? "uppercase" : "lowercase";

--- a/src/main/java/ch/njol/skript/expressions/ExprSubstring.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSubstring.java
@@ -75,22 +75,22 @@ public class ExprSubstring extends SimpleExpression<String> {
 	@Override
 	@Nullable
 	@SuppressWarnings("null")
-	protected String[] get(final Event e) {
+	protected String[] get(final Event event) {
 		final List<String> parts = new ArrayList<>();
-		final String[] strings = string.getArray(e);
+		final String[] strings = string.getArray(event);
 		if (strings == null)
 			return new String[0];
 		for (String string : strings) {
 			if (start != null && !start.isSingle()) {
-				Number[] i = start.getArray(e);
+				Number[] i = start.getArray(event);
 				if (i == null) return new String[0];
 				for (Number p : i) {
 					if (p.intValue() > string.length() || p.intValue() < 1) continue;
 					parts.add(string.substring(p.intValue() - 1, p.intValue()));
 				}
 			} else {
-				Number d1 = start != null ? start.getSingle(e) : 1;
-				Number d2 = end != null ? end.getSingle(e) : string.length();
+				Number d1 = start != null ? start.getSingle(event) : 1;
+				Number d2 = end != null ? end.getSingle(event) : string.length();
 				if (d1 == null || d2 == null) continue;
 				if (end == null) d1 = string.length() - d1.intValue() + 1;
 				int i1 = Math.max(d1.intValue() - 1, 0);
@@ -115,17 +115,17 @@ public class ExprSubstring extends SimpleExpression<String> {
 	
 	@Override
 	@SuppressWarnings("null")
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		if (start == null) {
 			assert end != null;
-			return "the first " + end.toString(e, debug) + " characters of " + string.toString(e, debug);
+			return "the first " + end.toString(event, debug) + " characters of " + string.toString(event, debug);
 		} else if (end == null) {
 			assert start != null;
-			return "the last " + start.toString(e, debug) + " characters of " + string.toString(e, debug);
+			return "the last " + start.toString(event, debug) + " characters of " + string.toString(event, debug);
 		} else if (usedSubstring) {
-			return "the substring of " + string.toString(e, debug) + " from index " + start.toString(e, debug) + " to " + end.toString(e, debug);
+			return "the substring of " + string.toString(event, debug) + " from index " + start.toString(event, debug) + " to " + end.toString(event, debug);
 		} else {
-			return "the character at " + (start.isSingle() ? "index " : "indexes ") + start.toString(e, debug) + " in " + string.toString(e, debug);
+			return "the character at " + (start.isSingle() ? "index " : "indexes ") + start.toString(event, debug) + " in " + string.toString(event, debug);
 		}
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprTPS.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTPS.java
@@ -65,7 +65,7 @@ public class ExprTPS extends SimpleExpression<Number> {
 	}
 
 	@Override
-	protected Number[] get(Event e) {
+	protected Number[] get(Event event) {
 		double[] tps = Bukkit.getServer().getTPS();
 		if (index != 3) {
 			return new Number[] { tps[index] };
@@ -84,7 +84,7 @@ public class ExprTPS extends SimpleExpression<Number> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return expr;
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprTamer.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTamer.java
@@ -56,11 +56,11 @@ public class ExprTamer extends SimpleExpression<Player> {
 	}
 	
 	@Override
-	protected Player[] get(final Event e) {
-		if (!(e instanceof EntityTameEvent))
+	protected Player[] get(final Event event) {
+		if (!(event instanceof EntityTameEvent))
 			return null;
 
-		return new Player[] {((EntityTameEvent) e).getOwner() instanceof Player ? (Player) ((EntityTameEvent) e).getOwner() : null};
+		return new Player[] {((EntityTameEvent) event).getOwner() instanceof Player ? (Player) ((EntityTameEvent) event).getOwner() : null};
 	}
 	
 	@Override
@@ -74,7 +74,7 @@ public class ExprTamer extends SimpleExpression<Player> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "the tamer";
 	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprTarget.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTarget.java
@@ -74,13 +74,13 @@ public class ExprTarget extends PropertyExpression<LivingEntity, Entity> {
 	}
 
 	@Override
-	protected Entity[] get(Event e, LivingEntity[] source) {
+	protected Entity[] get(Event event, LivingEntity[] source) {
 		return get(source, new Converter<LivingEntity, Entity>() {
 			@Override
 			@Nullable
 			public Entity convert(LivingEntity en) {
-				if (getTime() >= 0 && e instanceof EntityTargetEvent && en.equals(((EntityTargetEvent) e).getEntity()) && !Delay.isDelayed(e)) {
-					Entity target = ((EntityTargetEvent) e).getTarget();
+				if (getTime() >= 0 && event instanceof EntityTargetEvent && en.equals(((EntityTargetEvent) event).getEntity()) && !Delay.isDelayed(event)) {
+					Entity target = ((EntityTargetEvent) event).getTarget();
 					if (target == null || type != null && !type.isInstance(target))
 						return null;
 					return target;
@@ -96,10 +96,10 @@ public class ExprTarget extends PropertyExpression<LivingEntity, Entity> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		if (e == null)
-			return "the target" + (type == null ? "" : "ed " + type) + (getExpr().isDefault() ? "" : " of " + getExpr().toString(e, debug));
-		return Classes.getDebugMessage(getAll(e));
+	public String toString(@Nullable Event event, boolean debug) {
+		if (event == null)
+			return "the target" + (type == null ? "" : "ed " + type) + (getExpr().isDefault() ? "" : " of " + getExpr().toString(event, debug));
+		return Classes.getDebugMessage(getAll(event));
 	}
 
 	@Override
@@ -116,19 +116,19 @@ public class ExprTarget extends PropertyExpression<LivingEntity, Entity> {
 	}
 
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		if (mode == ChangeMode.SET || mode == ChangeMode.DELETE) {
 			LivingEntity target = delta == null ? null : (LivingEntity) delta[0];
-			for (LivingEntity entity : getExpr().getArray(e)) {
-				if (getTime() >= 0 && e instanceof EntityTargetEvent && entity.equals(((EntityTargetEvent) e).getEntity()) && !Delay.isDelayed(e)) {
-					((EntityTargetEvent) e).setTarget(target);
+			for (LivingEntity entity : getExpr().getArray(event)) {
+				if (getTime() >= 0 && event instanceof EntityTargetEvent && entity.equals(((EntityTargetEvent) event).getEntity()) && !Delay.isDelayed(event)) {
+					((EntityTargetEvent) event).setTarget(target);
 				} else if (entity instanceof Mob) {
 					((Mob) entity).setTarget(target);
 				}
 			}
 			return;
 		}
-		super.change(e, delta, mode);
+		super.change(event, delta, mode);
 	}
 
 	/**

--- a/src/main/java/ch/njol/skript/expressions/ExprTargetedBlock.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTargetedBlock.java
@@ -62,7 +62,7 @@ public class ExprTargetedBlock extends PropertyExpression<Player, Block> {
 	}
 
 	@Override
-	protected Block[] get(Event e, Player[] source) {
+	protected Block[] get(Event event, Player[] source) {
 		return get(source, p -> {
 			Block block = p.getTargetBlock(null, SkriptConfig.maxTargetBlockDistance.value());
 			if (block.getType() == Material.AIR)
@@ -83,8 +83,8 @@ public class ExprTargetedBlock extends PropertyExpression<Player, Block> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "the targeted block" + (getExpr().isSingle() ? "" : "s") + " of " + getExpr().toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "the targeted block" + (getExpr().isSingle() ? "" : "s") + " of " + getExpr().toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprTeleportCause.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTeleportCause.java
@@ -46,7 +46,7 @@ public class ExprTeleportCause extends EventValueExpression<TeleportCause> {
 	}
 
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "the teleport cause";
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprTernary.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTernary.java
@@ -92,8 +92,8 @@ public class ExprTernary<T> extends SimpleExpression<T> {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	protected T[] get(Event e) {
-		Object[] values = condition.check(e) ? ifTrue.getArray(e) : ifFalse.getArray(e);
+	protected T[] get(Event event) {
+		Object[] values = condition.check(event) ? ifTrue.getArray(event) : ifFalse.getArray(event);
 		try {
 			return Converters.convertArray(values, types, superType);
 		} catch (ClassCastException e1) {
@@ -122,8 +122,8 @@ public class ExprTernary<T> extends SimpleExpression<T> {
 	}
 
 	@Override
-	public String toString(Event e, boolean debug) {
-		return ifTrue.toString(e, debug) + " if " + condition + " otherwise " + ifFalse.toString(e, debug);
+	public String toString(Event event, boolean debug) {
+		return ifTrue.toString(event, debug) + " if " + condition + " otherwise " + ifFalse.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprTime.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTime.java
@@ -61,7 +61,7 @@ public class ExprTime extends PropertyExpression<World, Time> {
 	}
 	
 	@Override
-	protected Time[] get(final Event e, final World[] source) {
+	protected Time[] get(final Event event, final World[] source) {
 		return get(source, new Getter<Time, World>() {
 			@Override
 			public Time get(final World w) {
@@ -88,8 +88,8 @@ public class ExprTime extends PropertyExpression<World, Time> {
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
-		final World[] worlds = getExpr().getArray(e);
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
+		final World[] worlds = getExpr().getArray(event);
 		int mod = 1;
 		switch (mode) {
 			case SET:

--- a/src/main/java/ch/njol/skript/expressions/ExprTimeSince.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTimeSince.java
@@ -69,8 +69,8 @@ public class ExprTimeSince extends SimplePropertyExpression<Date, Timespan> {
 	}
 
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "the time since " + getExpr().toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "the time since " + getExpr().toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprTimeState.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTimeState.java
@@ -73,8 +73,8 @@ public class ExprTimeState extends WrapperExpression<Object> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "the " + (getTime() == -1 ? "past" : "future") + " state of " + getExpr().toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "the " + (getTime() == -1 ? "past" : "future") + " state of " + getExpr().toString(event, debug);
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprTimes.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTimes.java
@@ -85,8 +85,8 @@ public class ExprTimes extends SimpleExpression<Long> {
 
 	@Nullable
 	@Override
-	protected Long[] get(final Event e) {
-		Iterator<? extends Long> iter = iterator(e);
+	protected Long[] get(final Event event) {
+		Iterator<? extends Long> iter = iterator(event);
 		if (iter == null) {
 			return null;
 		}
@@ -95,8 +95,8 @@ public class ExprTimes extends SimpleExpression<Long> {
 
 	@Nullable
 	@Override
-	public Iterator<? extends Long> iterator(final Event e) {
-		Number end = this.end.getSingle(e);
+	public Iterator<? extends Long> iterator(final Event event) {
+		Number end = this.end.getSingle(event);
 		if (end == null)
 			return null;
 
@@ -114,8 +114,8 @@ public class ExprTimes extends SimpleExpression<Long> {
 	}
 
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return end.toString(e, debug) + " times";
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return end.toString(event, debug) + " times";
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprTool.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTool.java
@@ -129,9 +129,9 @@ public class ExprTool extends PropertyExpression<LivingEntity, Slot> {
 	}
 
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		String hand = offHand ? "off hand" : "";
-		return String.format("%s tool of %s", hand, getExpr().toString(e, debug));
+		return String.format("%s tool of %s", hand, getExpr().toString(event, debug));
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/ch/njol/skript/expressions/ExprUnbreakable.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprUnbreakable.java
@@ -69,7 +69,7 @@ public class ExprUnbreakable extends PropertyExpression<ItemType, ItemType> {
 	}
 	
 	@Override
-	protected ItemType[] get(final Event e, final ItemType[] source) {
+	protected ItemType[] get(final Event event, final ItemType[] source) {
 		return get(source, itemType -> {
 			ItemType clone = itemType.clone();
 
@@ -87,9 +87,9 @@ public class ExprUnbreakable extends PropertyExpression<ItemType, ItemType> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		if (e == null)
+	public String toString(@Nullable Event event, boolean debug) {
+		if (event == null)
 			return "unbreakable items";
-		return "unbreakable " + Arrays.toString(getExpr().getAll(e));
+		return "unbreakable " + Arrays.toString(getExpr().getAll(event));
 	}
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprValue.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprValue.java
@@ -53,8 +53,8 @@ public class ExprValue extends SimpleExpression<Unit> {
 	
 	@Override
 	@Nullable
-	protected Unit[] get(final Event e) {
-		final Number a = amount.getSingle(e);
+	protected Unit[] get(final Event event) {
+		final Number a = amount.getSingle(event);
 		if (a == null)
 			return null;
 		final Unit u = unit.clone();
@@ -75,8 +75,8 @@ public class ExprValue extends SimpleExpression<Unit> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return amount.toString(e, debug) + " " + unit.toString();
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return amount.toString(event, debug) + " " + unit.toString();
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorAngleBetween.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorAngleBetween.java
@@ -62,9 +62,9 @@ public class ExprVectorAngleBetween extends SimpleExpression<Number> {
 
 	@Override
 	@SuppressWarnings("null")
-	protected Number[] get(Event e) {
-		Vector v1 = first.getSingle(e);
-		Vector v2 = second.getSingle(e);
+	protected Number[] get(Event event) {
+		Vector v1 = first.getSingle(event);
+		Vector v2 = second.getSingle(event);
 		if (v1 == null || v2 == null)
 			return null;
 		return CollectionUtils.array(v1.angle(v2) * (float) VectorMath.RAD_TO_DEG);
@@ -81,8 +81,8 @@ public class ExprVectorAngleBetween extends SimpleExpression<Number> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "the angle between " + first.toString(e, debug) + " and " + second.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "the angle between " + first.toString(event, debug) + " and " + second.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorArithmetic.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorArithmetic.java
@@ -119,8 +119,8 @@ public class ExprVectorArithmetic extends SimpleExpression<Vector> {
 	}
 
 	@Override
-	protected Vector[] get(Event e) {
-		Vector v1 = first.getSingle(e), v2 = second.getSingle(e);
+	protected Vector[] get(Event event) {
+		Vector v1 = first.getSingle(event), v2 = second.getSingle(event);
 		if (v1 == null)
 			v1 = new Vector();
 		if (v2 == null)
@@ -139,8 +139,8 @@ public class ExprVectorArithmetic extends SimpleExpression<Vector> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return first.toString(e, debug) + " " + op +  " " + second.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return first.toString(event, debug) + " " + op +  " " + second.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorBetweenLocations.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorBetweenLocations.java
@@ -62,9 +62,9 @@ public class ExprVectorBetweenLocations extends SimpleExpression<Vector> {
 
 	@Override
 	@SuppressWarnings("null")
-	protected Vector[] get(Event e) {
-		Location l1 = from.getSingle(e);
-		Location l2 = to.getSingle(e);
+	protected Vector[] get(Event event) {
+		Location l1 = from.getSingle(event);
+		Location l2 = to.getSingle(event);
 		if (l1 == null || l2 == null)
 			return null;
 		return CollectionUtils.array(new Vector(l2.getX() - l1.getX(), l2.getY() - l1.getY(), l2.getZ() - l1.getZ()));
@@ -80,8 +80,8 @@ public class ExprVectorBetweenLocations extends SimpleExpression<Vector> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "vector from " + from.toString(e, debug) + " to " + to.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "vector from " + from.toString(event, debug) + " to " + to.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorCrossProduct.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorCrossProduct.java
@@ -60,9 +60,9 @@ public class ExprVectorCrossProduct extends SimpleExpression<Vector> {
 
 	@Override
 	@SuppressWarnings("null")
-	protected Vector[] get(Event e) {
-		Vector v1 = first.getSingle(e);
-		Vector v2 = second.getSingle(e);
+	protected Vector[] get(Event event) {
+		Vector v1 = first.getSingle(event);
+		Vector v2 = second.getSingle(event);
 		if (v1 == null || v2 == null)
 			return null;
 		return CollectionUtils.array(v1.clone().crossProduct(v2));
@@ -79,8 +79,8 @@ public class ExprVectorCrossProduct extends SimpleExpression<Vector> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return first.toString(e, debug) + " cross " + second.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return first.toString(event, debug) + " cross " + second.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorCylindrical.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorCylindrical.java
@@ -65,10 +65,10 @@ public class ExprVectorCylindrical extends SimpleExpression<Vector> {
 
 	@Override
 	@SuppressWarnings("null")
-	protected Vector[] get(Event e) {
-		Number r = radius.getSingle(e);
-		Number y = yaw.getSingle(e);
-		Number h = height.getSingle(e);
+	protected Vector[] get(Event event) {
+		Number r = radius.getSingle(event);
+		Number y = yaw.getSingle(event);
+		Number h = height.getSingle(event);
 		if (r == null || y == null || h == null)
 			return null;
 		return CollectionUtils.array(VectorMath.fromCylindricalCoordinates(r.doubleValue(), VectorMath.fromSkriptYaw(y.floatValue()), h.doubleValue()));
@@ -85,9 +85,9 @@ public class ExprVectorCylindrical extends SimpleExpression<Vector> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "cylindrical vector with radius " + radius.toString(e, debug) + ", yaw " +
-				yaw.toString(e, debug) + " and height " + height.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "cylindrical vector with radius " + radius.toString(event, debug) + ", yaw " +
+				yaw.toString(event, debug) + " and height " + height.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorDotProduct.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorDotProduct.java
@@ -67,9 +67,9 @@ public class ExprVectorDotProduct extends SimpleExpression<Number> {
 
 	@Override
 	@SuppressWarnings("null")
-	protected Number[] get(Event e) {
-		Vector v1 = first.getSingle(e);
-		Vector v2 = second.getSingle(e);
+	protected Number[] get(Event event) {
+		Vector v1 = first.getSingle(event);
+		Vector v2 = second.getSingle(event);
 		if (v1 == null || v2 == null)
 			return null;
 		return CollectionUtils.array(v1.getX() * v2.getX() + v1.getY() * v2.getY() + v1.getZ() * v2.getZ());
@@ -86,8 +86,8 @@ public class ExprVectorDotProduct extends SimpleExpression<Number> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return first.toString(e, debug) + " dot " + second.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return first.toString(event, debug) + " dot " + second.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorFromXYZ.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorFromXYZ.java
@@ -62,10 +62,10 @@ public class ExprVectorFromXYZ extends SimpleExpression<Vector> {
 
 	@Override
 	@SuppressWarnings("null")
-	protected Vector[] get(Event e) {
-		Number x = this.x.getSingle(e);
-		Number y = this.y.getSingle(e);
-		Number z = this.z.getSingle(e);
+	protected Vector[] get(Event event) {
+		Number x = this.x.getSingle(event);
+		Number y = this.y.getSingle(event);
+		Number z = this.z.getSingle(event);
 		if (x == null || y == null || z == null)
 			return null;
 		return CollectionUtils.array(new Vector(x.doubleValue(), y.doubleValue(), z.doubleValue()));
@@ -82,8 +82,8 @@ public class ExprVectorFromXYZ extends SimpleExpression<Vector> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "vector from x " + x.toString(e, debug) + ", y " + y.toString(e, debug) + ", z " + z.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "vector from x " + x.toString(event, debug) + ", y " + y.toString(event, debug) + ", z " + z.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorFromYawAndPitch.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorFromYawAndPitch.java
@@ -62,9 +62,9 @@ public class ExprVectorFromYawAndPitch extends SimpleExpression<Vector> {
 
 	@Override
 	@SuppressWarnings("null")
-	protected Vector[] get(Event e) {
-		Number y = yaw.getSingle(e);
-		Number p = pitch.getSingle(e);
+	protected Vector[] get(Event event) {
+		Number y = yaw.getSingle(event);
+		Number p = pitch.getSingle(event);
 		if (y == null || p == null)
 			return null;
 		float yaw = VectorMath.fromSkriptYaw(VectorMath.wrapAngleDeg(y.floatValue()));
@@ -83,8 +83,8 @@ public class ExprVectorFromYawAndPitch extends SimpleExpression<Vector> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "vector from yaw " + yaw.toString(e, debug) + " and pitch " + pitch.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "vector from yaw " + yaw.toString(event, debug) + " and pitch " + pitch.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorLength.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorLength.java
@@ -61,9 +61,9 @@ public class ExprVectorLength extends SimplePropertyExpression<Vector, Number> {
 	}
 
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		assert delta != null;
-		final Vector v = getExpr().getSingle(e);
+		final Vector v = getExpr().getSingle(event);
 		if (v == null)
 			return;
 		double n = ((Number) delta[0]).doubleValue();
@@ -75,7 +75,7 @@ public class ExprVectorLength extends SimplePropertyExpression<Vector, Number> {
 					double l = n + v.length();
 					v.normalize().multiply(l);
 				}
-				getExpr().change(e, new Vector[]{v}, ChangeMode.SET);
+				getExpr().change(event, new Vector[]{v}, ChangeMode.SET);
 				break;
 			case REMOVE:
 				n = -n;
@@ -85,7 +85,7 @@ public class ExprVectorLength extends SimplePropertyExpression<Vector, Number> {
 					v.zero();
 				else
 					v.normalize().multiply(n);
-				getExpr().change(e, new Vector[]{v}, ChangeMode.SET);
+				getExpr().change(event, new Vector[]{v}, ChangeMode.SET);
 				break;
 		}
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorNormalize.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorNormalize.java
@@ -61,8 +61,8 @@ public class ExprVectorNormalize extends SimpleExpression<Vector> {
 
 	@Override
 	@SuppressWarnings("null")
-	protected Vector[] get(Event e) {
-		Vector v = vector.getSingle(e);
+	protected Vector[] get(Event event) {
+		Vector v = vector.getSingle(event);
 		if (v == null)
 			return null;
 		return CollectionUtils.array(v.clone().normalize());
@@ -79,8 +79,8 @@ public class ExprVectorNormalize extends SimpleExpression<Vector> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "normalized " + vector.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "normalized " + vector.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorOfLocation.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorOfLocation.java
@@ -62,8 +62,8 @@ public class ExprVectorOfLocation extends SimpleExpression<Vector> {
 
 	@Override
 	@SuppressWarnings("null")
-	protected Vector[] get(Event e) {
-		Location l = location.getSingle(e);
+	protected Vector[] get(Event event) {
+		Location l = location.getSingle(event);
 		if (l == null)
 			return null;
 		return CollectionUtils.array(l.toVector());
@@ -80,8 +80,8 @@ public class ExprVectorOfLocation extends SimpleExpression<Vector> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "vector from " + location.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "vector from " + location.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorRandom.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorRandom.java
@@ -57,7 +57,7 @@ public class ExprVectorRandom extends SimpleExpression<Vector> {
 	}
 
 	@Override
-	protected Vector[] get(Event e) {
+	protected Vector[] get(Event event) {
 		return CollectionUtils.array(new Vector(randomSignedDouble(), randomSignedDouble(), randomSignedDouble()));
 	}
 
@@ -72,7 +72,7 @@ public class ExprVectorRandom extends SimpleExpression<Vector> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "random vector";
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorSpherical.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorSpherical.java
@@ -65,10 +65,10 @@ public class ExprVectorSpherical extends SimpleExpression<Vector> {
 
 	@Override
 	@SuppressWarnings("null")
-	protected Vector[] get(Event e) {
-		Number r = radius.getSingle(e);
-		Number y = yaw.getSingle(e);
-		Number p = pitch.getSingle(e);
+	protected Vector[] get(Event event) {
+		Number r = radius.getSingle(event);
+		Number y = yaw.getSingle(event);
+		Number p = pitch.getSingle(event);
 		if (r == null || y == null || p == null)
 			return null;
 		return CollectionUtils.array(VectorMath.fromSphericalCoordinates(r.doubleValue(), VectorMath.fromSkriptYaw(y.floatValue()), p.floatValue() + 90));
@@ -85,9 +85,9 @@ public class ExprVectorSpherical extends SimpleExpression<Vector> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "spherical vector with radius " + radius.toString(e, debug) + ", yaw " + yaw.toString(e, debug) +
-				" and pitch" + pitch.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "spherical vector with radius " + radius.toString(event, debug) + ", yaw " + yaw.toString(event, debug) +
+				" and pitch" + pitch.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorXYZ.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorXYZ.java
@@ -82,9 +82,9 @@ public class ExprVectorXYZ extends SimplePropertyExpression<Vector, Number> {
 	}
 	
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		assert delta != null;
-		final Vector v = getExpr().getSingle(e);
+		final Vector v = getExpr().getSingle(event);
 		if (v == null)
 			return;
 		double n = ((Number) delta[0]).doubleValue();
@@ -99,7 +99,7 @@ public class ExprVectorXYZ extends SimplePropertyExpression<Vector, Number> {
 					v.setY(v.getY() + n);
 				else
 					v.setZ(v.getZ() + n);
-				getExpr().change(e, new Vector[] {v}, ChangeMode.SET);
+				getExpr().change(event, new Vector[] {v}, ChangeMode.SET);
 				break;
 			case SET:
 				if (axis == 0)
@@ -108,7 +108,7 @@ public class ExprVectorXYZ extends SimplePropertyExpression<Vector, Number> {
 					v.setY(n);
 				else
 					v.setZ(n);
-				getExpr().change(e, new Vector[] {v}, ChangeMode.SET);
+				getExpr().change(event, new Vector[] {v}, ChangeMode.SET);
 		}
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprVehicle.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVehicle.java
@@ -55,23 +55,23 @@ public class ExprVehicle extends SimplePropertyExpression<Entity, Entity> {
 	}
 	
 	@Override
-	protected Entity[] get(final Event e, final Entity[] source) {
+	protected Entity[] get(final Event event, final Entity[] source) {
 		return get(source, new Converter<Entity, Entity>() {
 			@Override
 			@Nullable
 			public Entity convert(final Entity p) {
-				if (getTime() >= 0 && e instanceof VehicleEnterEvent && p.equals(((VehicleEnterEvent) e).getEntered()) && !Delay.isDelayed(e)) {
-					return ((VehicleEnterEvent) e).getVehicle();
+				if (getTime() >= 0 && event instanceof VehicleEnterEvent && p.equals(((VehicleEnterEvent) event).getEntered()) && !Delay.isDelayed(event)) {
+					return ((VehicleEnterEvent) event).getVehicle();
 				}
-				if (getTime() >= 0 && e instanceof VehicleExitEvent && p.equals(((VehicleExitEvent) e).getExited()) && !Delay.isDelayed(e)) {
-					return ((VehicleExitEvent) e).getVehicle();
+				if (getTime() >= 0 && event instanceof VehicleExitEvent && p.equals(((VehicleExitEvent) event).getExited()) && !Delay.isDelayed(event)) {
+					return ((VehicleExitEvent) event).getVehicle();
 				}
 				if (hasMountEvents) {
-					if (getTime() >= 0 && e instanceof EntityMountEvent && p.equals(((EntityMountEvent) e).getEntity()) && !Delay.isDelayed(e)) {
-						return ((EntityMountEvent) e).getMount();
+					if (getTime() >= 0 && event instanceof EntityMountEvent && p.equals(((EntityMountEvent) event).getEntity()) && !Delay.isDelayed(event)) {
+						return ((EntityMountEvent) event).getMount();
 					}
-					if (getTime() >= 0 && e instanceof EntityDismountEvent && p.equals(((EntityDismountEvent) e).getEntity()) && !Delay.isDelayed(e)) {
-						return ((EntityDismountEvent) e).getDismounted();
+					if (getTime() >= 0 && event instanceof EntityDismountEvent && p.equals(((EntityDismountEvent) event).getEntity()) && !Delay.isDelayed(event)) {
+						return ((EntityDismountEvent) event).getDismounted();
 					}
 				}
 				return p.getVehicle();
@@ -106,10 +106,10 @@ public class ExprVehicle extends SimplePropertyExpression<Entity, Entity> {
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
 		if (mode == ChangeMode.SET) {
 			assert delta != null;
-			final Entity[] ps = getExpr().getArray(e);
+			final Entity[] ps = getExpr().getArray(event);
 			if (ps.length == 0)
 				return;
 			final Object o = delta[0];
@@ -130,7 +130,7 @@ public class ExprVehicle extends SimplePropertyExpression<Entity, Entity> {
 				assert false;
 			}
 		} else {
-			super.change(e, delta, mode);
+			super.change(event, delta, mode);
 		}
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprVelocity.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVelocity.java
@@ -61,9 +61,9 @@ public class ExprVelocity extends SimplePropertyExpression<Entity, Vector> {
 
 	@Override
 	@SuppressWarnings("null")
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		assert mode == ChangeMode.DELETE || mode == ChangeMode.RESET || delta != null;
-		for (final Entity entity : getExpr().getArray(e)) {
+		for (final Entity entity : getExpr().getArray(event)) {
 			if (entity == null)
 				return;
 			switch (mode) {

--- a/src/main/java/ch/njol/skript/expressions/ExprVersion.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVersion.java
@@ -92,12 +92,12 @@ public class ExprVersion extends SimpleExpression<String> {
 	}
 	
 	@Override
-	protected String[] get(final Event e) {
+	protected String[] get(final Event event) {
 		return new String[] {type.get()};
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return type + " version";
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprVersionString.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVersionString.java
@@ -70,10 +70,10 @@ public class ExprVersionString extends SimpleExpression<String> {
 
 	@Override
 	@Nullable
-	public String[] get(Event e) {
-		if (!(e instanceof PaperServerListPingEvent))
+	public String[] get(Event event) {
+		if (!(event instanceof PaperServerListPingEvent))
 			return null;
-		return CollectionUtils.array(((PaperServerListPingEvent) e).getVersion());
+		return CollectionUtils.array(((PaperServerListPingEvent) event).getVersion());
 	}
 
 	@Override
@@ -90,11 +90,11 @@ public class ExprVersionString extends SimpleExpression<String> {
 
 	@SuppressWarnings("null")
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
-		if (!(e instanceof PaperServerListPingEvent))
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+		if (!(event instanceof PaperServerListPingEvent))
 			return;
 
-		((PaperServerListPingEvent) e).setVersion(((String) delta[0]));
+		((PaperServerListPingEvent) event).setVersion(((String) delta[0]));
 	}
 
 	@Override
@@ -108,7 +108,7 @@ public class ExprVersionString extends SimpleExpression<String> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "the version string";
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprWeather.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprWeather.java
@@ -64,12 +64,12 @@ public class ExprWeather extends PropertyExpression<World, WeatherType> {
 	}
 
 	@Override
-	protected WeatherType[] get(final Event e, final World[] source) {
+	protected WeatherType[] get(final Event event, final World[] source) {
 		return get(source, new Getter<WeatherType, World>() {
 			@Override
 			public WeatherType get(final World w) {
-				if (getTime() >= 0 && e instanceof WeatherEvent && w.equals(((WeatherEvent) e).getWorld()) && !Delay.isDelayed(e))
-					return WeatherType.fromEvent((WeatherEvent) e);
+				if (getTime() >= 0 && event instanceof WeatherEvent && w.equals(((WeatherEvent) event).getWorld()) && !Delay.isDelayed(event))
+					return WeatherType.fromEvent((WeatherEvent) event);
 				else
 					return WeatherType.fromWorld(w);
 			}
@@ -77,8 +77,8 @@ public class ExprWeather extends PropertyExpression<World, WeatherType> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "the weather in " + getExpr().toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "the weather in " + getExpr().toString(event, debug);
 	}
 	
 	@Override
@@ -90,21 +90,21 @@ public class ExprWeather extends PropertyExpression<World, WeatherType> {
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
 		final WeatherType t = delta == null ? WeatherType.CLEAR : (WeatherType) delta[0];
-		for (final World w : getExpr().getArray(e)) {
+		for (final World w : getExpr().getArray(event)) {
 			assert w != null : getExpr();
-			if (getTime() >= 0 && e instanceof WeatherEvent && w.equals(((WeatherEvent) e).getWorld()) && !Delay.isDelayed(e)) {
-				if (e instanceof WeatherChangeEvent) {
-					if (((WeatherChangeEvent) e).toWeatherState() && t == WeatherType.CLEAR)
-						((WeatherChangeEvent) e).setCancelled(true);
-					if (((WeatherChangeEvent) e).getWorld().isThundering() != (t == WeatherType.THUNDER))
-						((WeatherChangeEvent) e).getWorld().setThundering(t == WeatherType.THUNDER);
-				} else if (e instanceof ThunderChangeEvent) {
-					if (((ThunderChangeEvent) e).toThunderState() && t != WeatherType.THUNDER)
-						((ThunderChangeEvent) e).setCancelled(true);
-					if (((ThunderChangeEvent) e).getWorld().hasStorm() == (t == WeatherType.CLEAR))
-						((ThunderChangeEvent) e).getWorld().setStorm(t != WeatherType.CLEAR);
+			if (getTime() >= 0 && event instanceof WeatherEvent && w.equals(((WeatherEvent) event).getWorld()) && !Delay.isDelayed(event)) {
+				if (event instanceof WeatherChangeEvent) {
+					if (((WeatherChangeEvent) event).toWeatherState() && t == WeatherType.CLEAR)
+						((WeatherChangeEvent) event).setCancelled(true);
+					if (((WeatherChangeEvent) event).getWorld().isThundering() != (t == WeatherType.THUNDER))
+						((WeatherChangeEvent) event).getWorld().setThundering(t == WeatherType.THUNDER);
+				} else if (event instanceof ThunderChangeEvent) {
+					if (((ThunderChangeEvent) event).toThunderState() && t != WeatherType.THUNDER)
+						((ThunderChangeEvent) event).setCancelled(true);
+					if (((ThunderChangeEvent) event).getWorld().hasStorm() == (t == WeatherType.CLEAR))
+						((ThunderChangeEvent) event).getWorld().setStorm(t != WeatherType.CLEAR);
 				}
 			} else {
 				t.setWeather(w);

--- a/src/main/java/ch/njol/skript/expressions/ExprWhitelist.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprWhitelist.java
@@ -59,7 +59,7 @@ public class ExprWhitelist extends SimpleExpression<OfflinePlayer> {
 	
 	@Nullable
 	@Override
-	protected OfflinePlayer[] get(Event e) {
+	protected OfflinePlayer[] get(Event event) {
 		return Bukkit.getServer().getWhitelistedPlayers().toArray(new OfflinePlayer[0]);
 	}
 	
@@ -75,7 +75,7 @@ public class ExprWhitelist extends SimpleExpression<OfflinePlayer> {
 	}
 	
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		switch (mode) {
 			case SET:
 				if (delta != null)
@@ -113,7 +113,7 @@ public class ExprWhitelist extends SimpleExpression<OfflinePlayer> {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "whitelist";
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprWorld.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprWorld.java
@@ -71,7 +71,7 @@ public class ExprWorld extends PropertyExpression<Object, World> {
 	}
 	
 	@Override
-	protected World[] get(final Event e, final Object[] source) {
+	protected World[] get(final Event event, final Object[] source) {
 		if (source instanceof World[]) // event value (see init)
 			return (World[]) source;
 		return get(source, new Converter<Object, World>() {
@@ -79,8 +79,8 @@ public class ExprWorld extends PropertyExpression<Object, World> {
 			@Nullable
 			public World convert(final Object o) {
 				if (o instanceof Entity) {
-					if (getTime() > 0 && e instanceof PlayerTeleportEvent && o.equals(((PlayerTeleportEvent) e).getPlayer()) && !Delay.isDelayed(e))
-						return ((PlayerTeleportEvent) e).getTo().getWorld();
+					if (getTime() > 0 && event instanceof PlayerTeleportEvent && o.equals(((PlayerTeleportEvent) event).getPlayer()) && !Delay.isDelayed(event))
+						return ((PlayerTeleportEvent) event).getTo().getWorld();
 					else
 						return ((Entity) o).getWorld();
 				} else if (o instanceof Location) {
@@ -103,11 +103,11 @@ public class ExprWorld extends PropertyExpression<Object, World> {
 	}
 
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		if (delta == null)
 			return;
 
-		for (Object o : getExpr().getArray(e)) {
+		for (Object o : getExpr().getArray(event)) {
 			if (o instanceof Location) {
 				((Location) o).setWorld((World) delta[0]);
 			}
@@ -126,8 +126,8 @@ public class ExprWorld extends PropertyExpression<Object, World> {
 	}
 
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "the world" + (getExpr().isDefault() ? "" : " of " + getExpr().toString(e, debug));
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "the world" + (getExpr().isDefault() ? "" : " of " + getExpr().toString(event, debug));
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprWorldFromName.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprWorldFromName.java
@@ -56,8 +56,8 @@ public class ExprWorldFromName extends SimpleExpression<World> {
 
 	@Override
 	@Nullable
-	protected World[] get(Event e) {
-		String worldName = this.worldName.getSingle(e);
+	protected World[] get(Event event) {
+		String worldName = this.worldName.getSingle(event);
 		if (worldName == null)
 			return null;
 		World world = Bukkit.getWorld(worldName);
@@ -78,8 +78,8 @@ public class ExprWorldFromName extends SimpleExpression<World> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "the world with name " + worldName.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "the world with name " + worldName.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprWorlds.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprWorlds.java
@@ -67,18 +67,18 @@ public class ExprWorlds extends SimpleExpression<World> {
 	
 	@Override
 	@Nullable
-	protected World[] get(final Event e) {
+	protected World[] get(final Event event) {
 		return Bukkit.getWorlds().toArray(new World[0]);
 	}
 	
 	@Override
 	@Nullable
-	public Iterator<World> iterator(final Event e) {
+	public Iterator<World> iterator(final Event event) {
 		return Bukkit.getWorlds().iterator();
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "worlds";
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprXOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprXOf.java
@@ -59,8 +59,8 @@ public class ExprXOf extends PropertyExpression<Object, Object> {
 	}
 
 	@Override
-	protected Object[] get(Event e, Object[] source) {
-		Number a = amount.getSingle(e);
+	protected Object[] get(Event event, Object[] source) {
+		Number a = amount.getSingle(event);
 		if (a == null)
 			return new Object[0];
 
@@ -107,8 +107,8 @@ public class ExprXOf extends PropertyExpression<Object, Object> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return amount.toString(e, debug) + " of " + getExpr().toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return amount.toString(event, debug) + " of " + getExpr().toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprYawPitch.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprYawPitch.java
@@ -78,11 +78,11 @@ public class ExprYawPitch extends SimplePropertyExpression<Object, Number> {
 
 	@SuppressWarnings("null")
 	@Override
-	public void change(Event e, Object[] delta, ChangeMode mode) {
+	public void change(Event event, Object[] delta, ChangeMode mode) {
 		if (delta == null)
 			return;
 		float value = ((Number) delta[0]).floatValue();
-		for (Object single : getExpr().getArray(e)) {
+		for (Object single : getExpr().getArray(event)) {
 			if (single instanceof Location) {
 				changeLocation(((Location) single), value, mode);
 			} else if (single instanceof Vector) {

--- a/src/main/java/ch/njol/skript/expressions/LitAt.java
+++ b/src/main/java/ch/njol/skript/expressions/LitAt.java
@@ -49,7 +49,7 @@ public class LitAt extends SimpleLiteral<Direction> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "at";
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/LitConsole.java
+++ b/src/main/java/ch/njol/skript/expressions/LitConsole.java
@@ -60,7 +60,7 @@ public class LitConsole extends SimpleLiteral<ConsoleCommandSender> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "the console";
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/LitNewLine.java
+++ b/src/main/java/ch/njol/skript/expressions/LitNewLine.java
@@ -52,7 +52,7 @@ public class LitNewLine extends SimpleLiteral<String> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "newline";
 	}
 }

--- a/src/main/java/ch/njol/skript/expressions/arithmetic/ExprArithmetic.java
+++ b/src/main/java/ch/njol/skript/expressions/arithmetic/ExprArithmetic.java
@@ -160,10 +160,10 @@ public class ExprArithmetic extends SimpleExpression<Number> {
 	
 	@SuppressWarnings("null")
 	@Override
-	protected Number[] get(final Event e) {
+	protected Number[] get(final Event event) {
 		Number[] one = (Number[]) Array.newInstance(returnType, 1);
 		
-		one[0] = arithmeticGettable.get(e, returnType == Long.class);
+		one[0] = arithmeticGettable.get(event, returnType == Long.class);
 		
 		return one;
 	}
@@ -179,8 +179,8 @@ public class ExprArithmetic extends SimpleExpression<Number> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return first.toString(e, debug) + " " + op + " " + second.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return first.toString(event, debug) + " " + op + " " + second.toString(event, debug);
 	}
 	
 	@SuppressWarnings("null")

--- a/src/main/java/ch/njol/skript/expressions/base/EventValueExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/EventValueExpression.java
@@ -81,8 +81,8 @@ public class EventValueExpression<T> extends SimpleExpression<T> implements Defa
 	
 	@Override
 	@Nullable
-	protected T[] get(final Event e) {
-		final T o = getValue(e);
+	protected T[] get(final Event event) {
+		final T o = getValue(event);
 		if (o == null)
 			return null;
 		@SuppressWarnings("unchecked")
@@ -162,10 +162,10 @@ public class EventValueExpression<T> extends SimpleExpression<T> implements Defa
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		if (!debug || e == null)
+	public String toString(final @Nullable Event event, final boolean debug) {
+		if (!debug || event == null)
 			return "event-" + Classes.getSuperClassInfo(c).getName();
-		return Classes.getDebugMessage(getValue(e));
+		return Classes.getDebugMessage(getValue(event));
 	}
 	
 	@SuppressWarnings("unchecked")
@@ -179,11 +179,11 @@ public class EventValueExpression<T> extends SimpleExpression<T> implements Defa
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
 		final Changer<? super T> ch = changer;
 		if (ch == null)
 			throw new UnsupportedOperationException();
-		ChangerUtils.change(ch, getArray(e), delta, mode);
+		ChangerUtils.change(ch, getArray(event), delta, mode);
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/base/PropertyExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/PropertyExpression.java
@@ -69,13 +69,13 @@ public abstract class PropertyExpression<F, T> extends SimpleExpression<T> {
 	}
 	
 	@Override
-	protected final T[] get(final Event e) {
-		return get(e, expr.getArray(e));
+	protected final T[] get(final Event event) {
+		return get(event, expr.getArray(event));
 	}
 	
 	@Override
-	public final T[] getAll(final Event e) {
-		return get(e, expr.getAll(e));
+	public final T[] getAll(final Event event) {
+		return get(event, expr.getAll(event));
 	}
 	
 	/**
@@ -83,12 +83,12 @@ public abstract class PropertyExpression<F, T> extends SimpleExpression<T> {
 	 * <p>
 	 * Please note that the returned array must neither be null nor contain any null elements!
 	 * 
-	 * @param e
+	 * @param event
 	 * @param source
 	 * @return An array of the converted objects, which may contain less elements than the source array, but must not be null.
 	 * @see Converters#convert(Object[], Class, Converter)
 	 */
-	protected abstract T[] get(Event e, F[] source);
+	protected abstract T[] get(Event event, F[] source);
 	
 	/**
 	 * @param source

--- a/src/main/java/ch/njol/skript/expressions/base/SimplePropertyExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/SimplePropertyExpression.java
@@ -49,12 +49,12 @@ public abstract class SimplePropertyExpression<F, T> extends PropertyExpression<
 	public abstract T convert(F f);
 	
 	@Override
-	protected T[] get(final Event e, final F[] source) {
+	protected T[] get(final Event event, final F[] source) {
 		return super.get(source, this);
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "the " + getPropertyName() + " of " + getExpr().toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "the " + getPropertyName() + " of " + getExpr().toString(event, debug);
 	}
 }

--- a/src/main/java/ch/njol/skript/expressions/base/WrapperExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/WrapperExpression.java
@@ -75,10 +75,10 @@ public abstract class WrapperExpression<T> extends SimpleExpression<T> {
 				continue;
 			return new ConvertedExpression<T, R>(expr, c, conv) {
 				@Override
-				public String toString(final @Nullable Event e, final boolean debug) {
-					if (debug && e == null)
-						return "(" + WrapperExpression.this.toString(e, debug) + ")->" + to.getName();
-					return WrapperExpression.this.toString(e, debug);
+				public String toString(final @Nullable Event event, final boolean debug) {
+					if (debug && event == null)
+						return "(" + WrapperExpression.this.toString(event, debug) + ")->" + to.getName();
+					return WrapperExpression.this.toString(event, debug);
 				}
 			};
 		}
@@ -86,14 +86,14 @@ public abstract class WrapperExpression<T> extends SimpleExpression<T> {
 	}
 	
 	@Override
-	protected T[] get(final Event e) {
-		return expr.getArray(e);
+	protected T[] get(final Event event) {
+		return expr.getArray(event);
 	}
 	
 	@Override
 	@Nullable
-	public Iterator<? extends T> iterator(final Event e) {
-		return expr.iterator(e);
+	public Iterator<? extends T> iterator(final Event event) {
+		return expr.iterator(event);
 	}
 	
 	@Override
@@ -118,8 +118,8 @@ public abstract class WrapperExpression<T> extends SimpleExpression<T> {
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
-		expr.change(e, delta, mode);
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
+		expr.change(event, delta, mode);
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/hooks/chat/expressions/ExprPrefixSuffix.java
+++ b/src/main/java/ch/njol/skript/hooks/chat/expressions/ExprPrefixSuffix.java
@@ -81,10 +81,10 @@ public class ExprPrefixSuffix extends SimplePropertyExpression<Player, String> {
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
 		assert mode == ChangeMode.SET;
 		assert delta != null;
-		for (final Player p : getExpr().getArray(e)) {
+		for (final Player p : getExpr().getArray(event)) {
 			if (prefix)
 				VaultHook.chat.setPlayerPrefix(p, (String) delta[0]);
 			else

--- a/src/main/java/ch/njol/skript/hooks/permission/expressions/ExprAllGroups.java
+++ b/src/main/java/ch/njol/skript/hooks/permission/expressions/ExprAllGroups.java
@@ -58,7 +58,7 @@ public class ExprAllGroups extends SimpleExpression<String> {
 
 	@Override
 	@Nullable
-	protected String[] get(Event e) {
+	protected String[] get(Event event) {
 		return VaultHook.permission.getGroups();
 	}
 
@@ -73,7 +73,7 @@ public class ExprAllGroups extends SimpleExpression<String> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "all groups";
 	}
 

--- a/src/main/java/ch/njol/skript/hooks/permission/expressions/ExprGroup.java
+++ b/src/main/java/ch/njol/skript/hooks/permission/expressions/ExprGroup.java
@@ -73,9 +73,9 @@ public class ExprGroup extends SimpleExpression<String> {
 
 	@SuppressWarnings("null")
 	@Override
-	protected String[] get(Event e) {
+	protected String[] get(Event event) {
 		List<String> groups = new ArrayList<>();
-		for (OfflinePlayer player : players.getArray(e)) {
+		for (OfflinePlayer player : players.getArray(event)) {
 			if (primary)
 				groups.add(VaultHook.permission.getPrimaryGroup(null, player));
 			else
@@ -99,9 +99,9 @@ public class ExprGroup extends SimpleExpression<String> {
 
 	@Override
 	@SuppressWarnings("null")
-	public void change(Event e, @Nullable Object[] delta, Changer.ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, Changer.ChangeMode mode) {
 		Permission api = VaultHook.permission;
-		for (OfflinePlayer player : players.getArray(e)) {
+		for (OfflinePlayer player : players.getArray(event)) {
 			switch (mode) {
 				case ADD:
 					for (Object o : delta)
@@ -139,8 +139,8 @@ public class ExprGroup extends SimpleExpression<String> {
 
 	@SuppressWarnings("null")
 	@Override
-	public String toString(Event e, boolean debug) {
-		return "group" + (primary ? "" : "s") + " of " + players.toString(e, debug);
+	public String toString(Event event, boolean debug) {
+		return "group" + (primary ? "" : "s") + " of " + players.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/hooks/regions/conditions/CondCanBuild.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/conditions/CondCanBuild.java
@@ -87,8 +87,8 @@ public class CondCanBuild extends Condition {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return players.toString(e, debug) + " can build " + locations.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return players.toString(event, debug) + " can build " + locations.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/hooks/regions/conditions/CondIsMember.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/conditions/CondIsMember.java
@@ -85,7 +85,7 @@ public class CondIsMember extends Condition {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return players.toString(e, debug) + " " + (players.isSingle() ? "is" : "are") + (isNegated() ? " not" : "") + " " + (owner ? "owner" : "member") + (players.isSingle() ? "" : "s") + " of " + regions.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return players.toString(event, debug) + " " + (players.isSingle() ? "is" : "are") + (isNegated() ? " not" : "") + " " + (owner ? "owner" : "member") + (players.isSingle() ? "" : "s") + " of " + regions.toString(event, debug);
 	}
 }

--- a/src/main/java/ch/njol/skript/hooks/regions/conditions/CondRegionContains.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/conditions/CondRegionContains.java
@@ -88,8 +88,8 @@ public class CondRegionContains extends Condition {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return regions.toString(e, debug) + " contain" + (regions.isSingle() ? "s" : "") + " " + locs.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return regions.toString(event, debug) + " contain" + (regions.isSingle() ? "s" : "") + " " + locs.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/hooks/regions/events/EvtRegionBorder.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/events/EvtRegionBorder.java
@@ -87,9 +87,9 @@ public class EvtRegionBorder extends SelfRegisteringSkriptEvent {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		final Literal<Region> r = regions;
-		return (enter ? "enter" : "leave") + " of " + (r == null ? "a region" : r.toString(e, debug));
+		return (enter ? "enter" : "leave") + " of " + (r == null ? "a region" : r.toString(event, debug));
 	}
 	
 	private final static Collection<Trigger> triggers = new ArrayList<>();

--- a/src/main/java/ch/njol/skript/hooks/regions/expressions/ExprBlocksInRegion.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/expressions/ExprBlocksInRegion.java
@@ -68,8 +68,8 @@ public class ExprBlocksInRegion extends SimpleExpression<Block> {
 	
 	@SuppressWarnings("null")
 	@Override
-	protected Block[] get(final Event e) {
-		final Iterator<Block> iter = iterator(e);
+	protected Block[] get(final Event event) {
+		final Iterator<Block> iter = iterator(event);
 		final ArrayList<Block> r = new ArrayList<>();
 		while (iter.hasNext())
 			r.add(iter.next());
@@ -78,8 +78,8 @@ public class ExprBlocksInRegion extends SimpleExpression<Block> {
 	
 	@Override
 	@NonNull
-	public Iterator<Block> iterator(final Event e) {
-		final Region[] rs = regions.getArray(e);
+	public Iterator<Block> iterator(final Event event) {
+		final Region[] rs = regions.getArray(event);
 		if (rs.length == 0)
 			return EmptyIterator.get();
 		return new Iterator<Block>() {
@@ -122,8 +122,8 @@ public class ExprBlocksInRegion extends SimpleExpression<Block> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "all blocks in " + regions.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "all blocks in " + regions.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/hooks/regions/expressions/ExprMembersOfRegion.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/expressions/ExprMembersOfRegion.java
@@ -66,9 +66,9 @@ public class ExprMembersOfRegion extends SimpleExpression<OfflinePlayer> {
 	
 	@SuppressWarnings("null")
 	@Override
-	protected OfflinePlayer[] get(final Event e) {
+	protected OfflinePlayer[] get(final Event event) {
 		final ArrayList<OfflinePlayer> r = new ArrayList<>();
-		for (final Region region : regions.getArray(e)) {
+		for (final Region region : regions.getArray(event)) {
 			r.addAll(owners ? region.getOwners() : region.getMembers());
 		}
 		return r.toArray(new OfflinePlayer[r.size()]);
@@ -85,8 +85,8 @@ public class ExprMembersOfRegion extends SimpleExpression<OfflinePlayer> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "the " + (owners ? "owner" + (isSingle() ? "" : "s") : "members") + " of " + regions.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "the " + (owners ? "owner" + (isSingle() ? "" : "s") : "members") + " of " + regions.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/hooks/regions/expressions/ExprRegion.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/expressions/ExprRegion.java
@@ -50,7 +50,7 @@ public class ExprRegion extends EventValueExpression<Region> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "the region";
 	}
 	

--- a/src/main/java/ch/njol/skript/hooks/regions/expressions/ExprRegionsAt.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/expressions/ExprRegionsAt.java
@@ -73,8 +73,8 @@ public class ExprRegionsAt extends SimpleExpression<Region> {
 	@SuppressWarnings("null")
 	@Override
 	@Nullable
-	protected Region[] get(final Event e) {
-		final Location[] ls = locs.getArray(e);
+	protected Region[] get(final Event event) {
+		final Location[] ls = locs.getArray(event);
 		if (ls.length == 0)
 			return new Region[0];
 		final ArrayList<Region> r = new ArrayList<>();
@@ -94,8 +94,8 @@ public class ExprRegionsAt extends SimpleExpression<Region> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "the regions at " + locs.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return "the regions at " + locs.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/lang/Condition.java
+++ b/src/main/java/ch/njol/skript/lang/Condition.java
@@ -50,8 +50,8 @@ public abstract class Condition extends Statement {
 	public abstract boolean check(Event e);
 	
 	@Override
-	public final boolean run(Event e) {
-		return check(e);
+	public final boolean run(Event event) {
+		return check(event);
 	}
 	
 	/**

--- a/src/main/java/ch/njol/skript/lang/Debuggable.java
+++ b/src/main/java/ch/njol/skript/lang/Debuggable.java
@@ -27,11 +27,11 @@ import org.eclipse.jdt.annotation.Nullable;
 public interface Debuggable {
 	
 	/**
-	 * @param e The event to get information to. This is always null if debug == false.
+	 * @param event The event to get information to. This is always null if debug == false.
 	 * @param debug If true this should print more information, if false this should print what is shown to the end user
 	 * @return String representation of this object
 	 */
-	public String toString(@Nullable Event e, boolean debug);
+	public String toString(@Nullable Event event, boolean debug);
 	
 	/**
 	 * Should return <tt>{@link #toString(Event, boolean) toString}(null, false)</tt>

--- a/src/main/java/ch/njol/skript/lang/Effect.java
+++ b/src/main/java/ch/njol/skript/lang/Effect.java
@@ -41,13 +41,13 @@ public abstract class Effect extends Statement {
 	/**
 	 * Executes this effect.
 	 * 
-	 * @param e
+	 * @param event
 	 */
-	protected abstract void execute(Event e);
+	protected abstract void execute(Event event);
 	
 	@Override
-	public final boolean run(final Event e) {
-		execute(e);
+	public final boolean run(final Event event) {
+		execute(event);
 		return true;
 	}
 	

--- a/src/main/java/ch/njol/skript/lang/EffectSectionEffect.java
+++ b/src/main/java/ch/njol/skript/lang/EffectSectionEffect.java
@@ -37,11 +37,11 @@ public class EffectSectionEffect extends Effect {
 	}
 
 	@Override
-	protected void execute(Event e) { }
+	protected void execute(Event event) { }
 
 	@Override
-	protected @Nullable TriggerItem walk(Event e) {
-		return effectSection.walk(e);
+	protected @Nullable TriggerItem walk(Event event) {
+		return effectSection.walk(event);
 	}
 
 	@Override
@@ -65,8 +65,8 @@ public class EffectSectionEffect extends Effect {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return effectSection.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return effectSection.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/lang/Expression.java
+++ b/src/main/java/ch/njol/skript/lang/Expression.java
@@ -58,24 +58,24 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	 * <p>
 	 * Do not use this in conditions, use {@link #check(Event, Checker, boolean)} instead.
 	 * 
-	 * @param e The event
+	 * @param event The event
 	 * @return The value or null if this expression doesn't have any value for the event
 	 * @throws UnsupportedOperationException (optional) if this was called on a non-single expression
 	 */
 	@Nullable
-	T getSingle(Event e);
+	T getSingle(Event event);
 
 	/**
 	 * Get an optional of the single value of this expression.
 	 * <p>
 	 * Do not use this in conditions, use {@link #check(Event, Checker, boolean)} instead.
 	 *
-	 * @param e the event
+	 * @param event the event
 	 * @return an {@link Optional} containing the {@link #getSingle(Event) single value} of this expression for this event.
 	 * @see #getSingle(Event)
 	 */
-	default Optional<T> getOptionalSingle(Event e) {
-		return Optional.ofNullable(getSingle(e));
+	default Optional<T> getOptionalSingle(Event event) {
+		return Optional.ofNullable(getSingle(event));
 	}
 	
 	/**
@@ -85,28 +85,28 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	 * <p>
 	 * Do not use this in conditions, use {@link #check(Event, Checker, boolean)} instead.
 	 * 
-	 * @param e The event
+	 * @param event The event
 	 * @return An array of values of this expression which must neither be null nor contain nulls, and which must not be an internal array.
 	 */
-	public T[] getArray(final Event e);
+	public T[] getArray(final Event event);
 	
 	/**
 	 * Gets all possible return values of this expression, i.e. it returns the same as {@link #getArray(Event)} if {@link #getAnd()} is true, otherwise all possible values for
 	 * {@link #getSingle(Event)}.
 	 * 
-	 * @param e The event
+	 * @param event The event
 	 * @return An array of all possible values of this expression for the given event which must neither be null nor contain nulls, and which must not be an internal array.
 	 */
-	public T[] getAll(final Event e);
+	public T[] getAll(final Event event);
 	
 	/**
 	 * Gets a non-null stream of this expression's values.
 	 *
-	 * @param e The event
+	 * @param event The event
 	 * @return A non-null stream of this expression's values
 	 */
-	default public Stream<? extends T> stream(final Event e) {
-		Iterator<? extends T> iter = iterator(e);
+	default public Stream<? extends T> stream(final Event event) {
+		Iterator<? extends T> iter = iterator(event);
 		if (iter == null) {
 			return Stream.empty();
 		}
@@ -128,24 +128,24 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	 * return negated ^ {@link #check(Event, Checker)};
 	 * </pre>
 	 * 
-	 * @param e The event
-	 * @param c A checker
+	 * @param event The event
+	 * @param checker A checker
 	 * @param negated The checking condition's negated state. This is used to invert the output of the checker if set to true (i.e. <tt>negated ^ checker.check(...)</tt>)
 	 * @return Whether this expression matches or doesn't match the given checker depending on the condition's negated state.
 	 * @see SimpleExpression#check(Object[], Checker, boolean, boolean)
 	 */
-	public boolean check(final Event e, final Checker<? super T> c, final boolean negated);
+	public boolean check(final Event event, final Checker<? super T> checker, final boolean negated);
 	
 	/**
 	 * Checks this expression against the given checker. This method must only be used around other checks, use {@link #check(Event, Checker, boolean)} for a simple ckeck or the
 	 * innermost check of a nested check.
 	 * 
-	 * @param e The event
-	 * @param c A checker
+	 * @param event The event
+	 * @param checker A checker
 	 * @return Whether this expression matches the given checker
 	 * @see SimpleExpression#check(Object[], Checker, boolean, boolean)
 	 */
-	public boolean check(final Event e, final Checker<? super T> c);
+	public boolean check(final Event event, final Checker<? super T> checker);
 	
 	/**
 	 * Tries to convert this expression to the given type. This method can print an error prior to returning null to specify the cause.
@@ -220,11 +220,11 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	/**
 	 * Returns the same as {@link #getArray(Event)} but as an iterator. This method should be overriden by expressions intended to be looped to increase performance.
 	 * 
-	 * @param e The event
+	 * @param event The event
 	 * @return An iterator to iterate over all values of this expression which may be empty and/or null, but must not return null elements.
 	 */
 	@Nullable
-	public Iterator<? extends T> iterator(Event e);
+	public Iterator<? extends T> iterator(Event event);
 	
 	/**
 	 * Checks whether the given 'loop-...' expression should match this loop, e.g. loop-block matches any loops that loop through blocks and loop-argument matches an
@@ -232,10 +232,10 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	 * <p>
 	 * You should usually just return false as e.g. loop-block will automatically match the expression if its returnType is Block or a subtype of it.
 	 * 
-	 * @param s The entered string
+	 * @param string The entered string
 	 * @return Whether this loop matches the given string
 	 */
-	public boolean isLoopOf(String s);
+	public boolean isLoopOf(String string);
 	
 	/**
 	 * Returns the original expression that was parsed, i.e. without any conversions done.
@@ -281,13 +281,13 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	 * Changes the expression's value by the given amount. This will only be called on supported modes and with the desired <code>delta</code> type as returned by
 	 * {@link #acceptChange(ChangeMode)}
 	 * 
-	 * @param e
+	 * @param event
 	 * @param delta An array with one or more instances of one or more of the the classes returned by {@link #acceptChange(ChangeMode)} for the given change mode (null for
 	 *            {@link ChangeMode#DELETE} and {@link ChangeMode#RESET}). <b>This can be a Object[], thus casting is not allowed.</b>
 	 * @param mode
 	 * @throws UnsupportedOperationException (optional) - If this method was called on an unsupported ChangeMode.
 	 */
-	public void change(Event e, final @Nullable Object[] delta, final ChangeMode mode);
+	public void change(Event event, final @Nullable Object[] delta, final ChangeMode mode);
 	
 	/**
 	 * This method is called before this expression is set to another one.

--- a/src/main/java/ch/njol/skript/lang/ExpressionList.java
+++ b/src/main/java/ch/njol/skript/lang/ExpressionList.java
@@ -78,37 +78,37 @@ public class ExpressionList<T> implements Expression<T> {
 
 	@Override
 	@Nullable
-	public T getSingle(Event e) {
+	public T getSingle(Event event) {
 		if (!single)
 			throw new UnsupportedOperationException();
 		Expression<? extends T> expression = CollectionUtils.getRandom(expressions);
-		return expression != null ? expression.getSingle(e) : null;
+		return expression != null ? expression.getSingle(event) : null;
 	}
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public T[] getArray(Event e) {
+	public T[] getArray(Event event) {
 		if (and)
-			return getAll(e);
+			return getAll(event);
 		Expression<? extends T> expression = CollectionUtils.getRandom(expressions);
-		return expression != null ? expression.getArray(e) : (T[]) Array.newInstance(returnType, 0);
+		return expression != null ? expression.getArray(event) : (T[]) Array.newInstance(returnType, 0);
 	}
 
 	@SuppressWarnings({"null", "unchecked"})
 	@Override
-	public T[] getAll(Event e) {
+	public T[] getAll(Event event) {
 		ArrayList<T> r = new ArrayList<>();
 		for (Expression<? extends T> expr : expressions)
-			r.addAll(Arrays.asList(expr.getAll(e)));
+			r.addAll(Arrays.asList(expr.getAll(event)));
 		return r.toArray((T[]) Array.newInstance(returnType, r.size()));
 	}
 
 	@Override
 	@Nullable
-	public Iterator<? extends T> iterator(Event e) {
+	public Iterator<? extends T> iterator(Event event) {
 		if (!and) {
 			Expression<? extends T> expression = CollectionUtils.getRandom(expressions);
-			return expression != null ? expression.iterator(e) : null;
+			return expression != null ? expression.iterator(event) : null;
 		}
 		return new Iterator<T>() {
 			private int i = 0;
@@ -119,7 +119,7 @@ public class ExpressionList<T> implements Expression<T> {
 			public boolean hasNext() {
 				Iterator<? extends T> c = current;
 				while (i < expressions.length && (c == null || !c.hasNext()))
-					current = c = expressions[i++].iterator(e);
+					current = c = expressions[i++].iterator(event);
 				return c != null && c.hasNext();
 			}
 
@@ -148,14 +148,14 @@ public class ExpressionList<T> implements Expression<T> {
 	}
 
 	@Override
-	public boolean check(Event e, Checker<? super T> c, boolean negated) {
-		return negated ^ check(e, c);
+	public boolean check(Event event, Checker<? super T> checker, boolean negated) {
+		return negated ^ check(event, checker);
 	}
 
 	@Override
-	public boolean check(Event e, Checker<? super T> c) {
+	public boolean check(Event event, Checker<? super T> checker) {
 		for (Expression<? extends T> expr : expressions) {
-			boolean b = expr.check(e, c);
+			boolean b = expr.check(event, checker);
 			if (and && !b)
 				return false;
 			if (!and && b)
@@ -223,9 +223,9 @@ public class ExpressionList<T> implements Expression<T> {
 	}
 
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) throws UnsupportedOperationException {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) throws UnsupportedOperationException {
 		for (Expression<?> expr : expressions) {
-			expr.change(e, delta, mode);
+			expr.change(event, delta, mode);
 		}
 	}
 
@@ -253,9 +253,9 @@ public class ExpressionList<T> implements Expression<T> {
 	}
 
 	@Override
-	public boolean isLoopOf(String s) {
+	public boolean isLoopOf(String string) {
 		for (Expression<?> e : expressions)
-			if (e.isLoopOf(s))
+			if (e.isLoopOf(string))
 				return true;
 		return false;
 	}
@@ -267,7 +267,7 @@ public class ExpressionList<T> implements Expression<T> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		StringBuilder b = new StringBuilder("(");
 		for (int i = 0; i < expressions.length; i++) {
 			if (i != 0) {
@@ -276,7 +276,7 @@ public class ExpressionList<T> implements Expression<T> {
 				else
 					b.append(", ");
 			}
-			b.append(expressions[i].toString(e, debug));
+			b.append(expressions[i].toString(event, debug));
 		}
 		b.append(")");
 		if (debug)

--- a/src/main/java/ch/njol/skript/lang/SectionSkriptEvent.java
+++ b/src/main/java/ch/njol/skript/lang/SectionSkriptEvent.java
@@ -66,7 +66,7 @@ public class SectionSkriptEvent extends SkriptEvent {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return name;
 	}
 

--- a/src/main/java/ch/njol/skript/lang/Trigger.java
+++ b/src/main/java/ch/njol/skript/lang/Trigger.java
@@ -71,13 +71,13 @@ public class Trigger extends TriggerSection {
 	
 	@Override
 	@Nullable
-	protected TriggerItem walk(final Event e) {
-		return walk(e, true);
+	protected TriggerItem walk(final Event event) {
+		return walk(event, true);
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return name + " (" + event.toString(e, debug) + ")";
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return name + " (" + this.event.toString(event, debug) + ")";
 	}
 	
 	/**

--- a/src/main/java/ch/njol/skript/lang/TriggerItem.java
+++ b/src/main/java/ch/njol/skript/lang/TriggerItem.java
@@ -54,16 +54,16 @@ public abstract class TriggerItem implements Debuggable {
 	 * <p>
 	 * Overriding classes must call {@link #debug(Event, boolean)}. If this method is overridden, {@link #run(Event)} is not used anymore and can be ignored.
 	 * 
-	 * @param e
+	 * @param event
 	 * @return The next item to run or null to stop execution
 	 */
 	@Nullable
-	protected TriggerItem walk(final Event e) {
-		if (run(e)) {
-			debug(e, true);
+	protected TriggerItem walk(final Event event) {
+		if (run(event)) {
+			debug(event, true);
 			return next;
 		} else {
-			debug(e, false);
+			debug(event, false);
 			final TriggerSection parent = this.parent;
 			return parent == null ? null : parent.getNext();
 		}
@@ -72,22 +72,22 @@ public abstract class TriggerItem implements Debuggable {
 	/**
 	 * Executes this item.
 	 * 
-	 * @param e
+	 * @param event
 	 * @return True if the next item should be run, or false for the item following this item's parent.
 	 */
-	protected abstract boolean run(Event e);
+	protected abstract boolean run(Event event);
 	
 	/**
 	 * @param start
-	 * @param e
+	 * @param event
 	 * @return false if an exception occurred
 	 */
-	public static boolean walk(final TriggerItem start, final Event e) {
-		assert start != null && e != null;
+	public static boolean walk(final TriggerItem start, final Event event) {
+		assert start != null && event != null;
 		TriggerItem i = start;
 		try {
 			while (i != null)
-				i = i.walk(e);
+				i = i.walk(event);
 			
 			return true;
 		} catch (final StackOverflowError err) {
@@ -135,10 +135,10 @@ public abstract class TriggerItem implements Debuggable {
 		return ind;
 	}
 	
-	protected final void debug(final Event e, final boolean run) {
+	protected final void debug(final Event event, final boolean run) {
 		if (!Skript.debug())
 			return;
-		Skript.debug(SkriptColor.replaceColorChar(getIndentation() + (run ? "" : "-") + toString(e, true)));
+		Skript.debug(SkriptColor.replaceColorChar(getIndentation() + (run ? "" : "-") + toString(event, true)));
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/lang/TriggerSection.java
+++ b/src/main/java/ch/njol/skript/lang/TriggerSection.java
@@ -95,17 +95,17 @@ public abstract class TriggerSection extends TriggerItem {
 	}
 	
 	@Override
-	protected final boolean run(Event e) {
+	protected final boolean run(Event event) {
 		throw new UnsupportedOperationException();
 	}
 	
 	@Override
 	@Nullable
-	protected abstract TriggerItem walk(Event e);
+	protected abstract TriggerItem walk(Event event);
 	
 	@Nullable
-	protected final TriggerItem walk(Event e, boolean run) {
-		debug(e, run);
+	protected final TriggerItem walk(Event event, boolean run) {
+		debug(event, run);
 		if (run && first != null) {
 			return first;
 		} else {

--- a/src/main/java/ch/njol/skript/lang/UnparsedLiteral.java
+++ b/src/main/java/ch/njol/skript/lang/UnparsedLiteral.java
@@ -239,7 +239,7 @@ public class UnparsedLiteral implements Literal<Object> {
 //	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "'" + data + "'";
 	}
 	
@@ -278,7 +278,7 @@ public class UnparsedLiteral implements Literal<Object> {
 	}
 	
 	@Override
-	public Object[] getAll(final Event e) {
+	public Object[] getAll(final Event event) {
 		throw invalidAccessException();
 	}
 	
@@ -288,7 +288,7 @@ public class UnparsedLiteral implements Literal<Object> {
 	}
 	
 	@Override
-	public Object[] getArray(final Event e) {
+	public Object[] getArray(final Event event) {
 		throw invalidAccessException();
 	}
 	
@@ -298,17 +298,17 @@ public class UnparsedLiteral implements Literal<Object> {
 	}
 	
 	@Override
-	public Object getSingle(final Event e) {
+	public Object getSingle(final Event event) {
 		throw invalidAccessException();
 	}
 	
 	@Override
-	public NonNullIterator<Object> iterator(final Event e) {
+	public NonNullIterator<Object> iterator(final Event event) {
 		throw invalidAccessException();
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
 		throw invalidAccessException();
 	}
 	
@@ -318,12 +318,12 @@ public class UnparsedLiteral implements Literal<Object> {
 	}
 	
 	@Override
-	public boolean check(final Event e, final Checker<? super Object> c) {
+	public boolean check(final Event event, final Checker<? super Object> checker) {
 		throw invalidAccessException();
 	}
 	
 	@Override
-	public boolean check(final Event e, final Checker<? super Object> c, final boolean negated) {
+	public boolean check(final Event event, final Checker<? super Object> checker, final boolean negated) {
 		throw invalidAccessException();
 	}
 	
@@ -343,7 +343,7 @@ public class UnparsedLiteral implements Literal<Object> {
 	}
 	
 	@Override
-	public boolean isLoopOf(final String s) {
+	public boolean isLoopOf(final String string) {
 		throw invalidAccessException();
 	}
 	

--- a/src/main/java/ch/njol/skript/lang/VariableString.java
+++ b/src/main/java/ch/njol/skript/lang/VariableString.java
@@ -532,7 +532,7 @@ public class VariableString implements Expression<String> {
 	 * Use {@link #toString(Event)} to get the actual string
 	 */
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		if (isSimple) {
 			assert simple != null;
 			return '"' + simple + '"';
@@ -542,7 +542,7 @@ public class VariableString implements Expression<String> {
 		StringBuilder b = new StringBuilder("\"");
 		for (Object o : string) {
 			if (o instanceof Expression) {
-				b.append("%").append(((Expression<?>) o).toString(e, debug)).append("%");
+				b.append("%").append(((Expression<?>) o).toString(event, debug)).append("%");
 			} else {
 				b.append(o);
 			}
@@ -601,18 +601,18 @@ public class VariableString implements Expression<String> {
 	}
 	
 	@Override
-	public String getSingle(Event e) {
-		return toString(e);
+	public String getSingle(Event event) {
+		return toString(event);
 	}
 	
 	@Override
-	public String[] getArray(Event e) {
-		return new String[] {toString(e)};
+	public String[] getArray(Event event) {
+		return new String[] {toString(event)};
 	}
 	
 	@Override
-	public String[] getAll(Event e) {
-		return new String[] {toString(e)};
+	public String[] getAll(Event event) {
+		return new String[] {toString(event)};
 	}
 	
 	@Override
@@ -621,13 +621,13 @@ public class VariableString implements Expression<String> {
 	}
 	
 	@Override
-	public boolean check(Event e, Checker<? super String> c, boolean negated) {
-		return SimpleExpression.check(getAll(e), c, negated, false);
+	public boolean check(Event event, Checker<? super String> checker, boolean negated) {
+		return SimpleExpression.check(getAll(event), checker, negated, false);
 	}
 	
 	@Override
-	public boolean check(Event e, Checker<? super String> c) {
-		return SimpleExpression.check(getAll(e), c, false, false);
+	public boolean check(Event event, Checker<? super String> checker) {
+		return SimpleExpression.check(getAll(event), checker, false, false);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -651,7 +651,7 @@ public class VariableString implements Expression<String> {
 	}
 	
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) throws UnsupportedOperationException {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) throws UnsupportedOperationException {
 		throw new UnsupportedOperationException();
 	}
 	
@@ -676,12 +676,12 @@ public class VariableString implements Expression<String> {
 	}
 	
 	@Override
-	public Iterator<? extends String> iterator(Event e) {
-		return new SingleItemIterator<>(toString(e));
+	public Iterator<? extends String> iterator(Event event) {
+		return new SingleItemIterator<>(toString(event));
 	}
 	
 	@Override
-	public boolean isLoopOf(String s) {
+	public boolean isLoopOf(String string) {
 		return false;
 	}
 	

--- a/src/main/java/ch/njol/skript/lang/function/EffFunctionCall.java
+++ b/src/main/java/ch/njol/skript/lang/function/EffFunctionCall.java
@@ -48,14 +48,14 @@ public class EffFunctionCall extends Effect {
 	}
 	
 	@Override
-	protected void execute(final Event e) {
-		function.execute(e);
+	protected void execute(final Event event) {
+		function.execute(event);
 		function.resetReturnValue(); // Function might have return value that we're ignoring
 	}
 	
 	@Override
-	public String toString(@Nullable final Event e, final boolean debug) {
-		return function.toString(e, debug);
+	public String toString(@Nullable final Event event, final boolean debug) {
+		return function.toString(event, debug);
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/lang/function/ExprFunctionCall.java
+++ b/src/main/java/ch/njol/skript/lang/function/ExprFunctionCall.java
@@ -56,8 +56,8 @@ public class ExprFunctionCall<T> extends SimpleExpression<T> {
 
 	@Override
 	@Nullable
-	protected T[] get(Event e) {
-		Object[] returnValue = function.execute(e);
+	protected T[] get(Event event) {
+		Object[] returnValue = function.execute(event);
 		function.resetReturnValue();
 		return Converters.convertArray(returnValue, returnTypes, returnType);
 	}
@@ -86,8 +86,8 @@ public class ExprFunctionCall<T> extends SimpleExpression<T> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return function.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return function.toString(event, debug);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/lang/util/ContainerExpression.java
+++ b/src/main/java/ch/njol/skript/lang/util/ContainerExpression.java
@@ -43,14 +43,14 @@ public class ContainerExpression extends SimpleExpression<Object> {
 	}
 	
 	@Override
-	protected Object[] get(final Event e) {
+	protected Object[] get(final Event event) {
 		throw new UnsupportedOperationException("ContanerExpression must only be used by Loops");
 	}
 	
 	@Override
 	@Nullable
-	public Iterator<Object> iterator(final Event e) {
-		final Iterator<? extends Container<?>> iter = expr.iterator(e);
+	public Iterator<Object> iterator(final Event event) {
+		final Iterator<? extends Container<?>> iter = expr.iterator(event);
 		if (iter == null)
 			return null;
 		return new Iterator<Object>() {
@@ -101,8 +101,8 @@ public class ContainerExpression extends SimpleExpression<Object> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return expr.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		return expr.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/lang/util/ConvertedExpression.java
+++ b/src/main/java/ch/njol/skript/lang/util/ConvertedExpression.java
@@ -92,11 +92,11 @@ public class ConvertedExpression<F, T> implements Expression<T> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		if (debug && e == null)
-			return "(" + source.toString(e, debug) + " >> " + conv + ": "
-				+ converterInfo.toString(e, true) + ")";
-		return source.toString(e, debug);
+	public String toString(final @Nullable Event event, final boolean debug) {
+		if (debug && event == null)
+			return "(" + source.toString(event, debug) + " >> " + conv + ": "
+				+ converterInfo.toString(event, true) + ")";
+		return source.toString(event, debug);
 	}
 	
 	@Override
@@ -140,51 +140,51 @@ public class ConvertedExpression<F, T> implements Expression<T> {
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
 		final ClassInfo<? super T> rti = returnTypeInfo;
 		if (rti != null) {
 			final Changer<? super T> c = rti.getChanger();
 			if (c != null)
-				c.change(getArray(e), delta, mode);
+				c.change(getArray(event), delta, mode);
 		} else {
-			source.change(e, delta, mode);
+			source.change(event, delta, mode);
 		}
 	}
 	
 	@Override
 	@Nullable
-	public T getSingle(final Event e) {
-		final F f = source.getSingle(e);
+	public T getSingle(final Event event) {
+		final F f = source.getSingle(event);
 		if (f == null)
 			return null;
 		return conv.convert(f);
 	}
 	
 	@Override
-	public T[] getArray(final Event e) {
-		return Converters.convert(source.getArray(e), to, conv);
+	public T[] getArray(final Event event) {
+		return Converters.convert(source.getArray(event), to, conv);
 	}
 	
 	@Override
-	public T[] getAll(final Event e) {
-		return Converters.convert(source.getAll(e), to, conv);
+	public T[] getAll(final Event event) {
+		return Converters.convert(source.getAll(event), to, conv);
 	}
 	
 	@Override
-	public boolean check(final Event e, final Checker<? super T> c, final boolean negated) {
-		return negated ^ check(e, c);
+	public boolean check(final Event event, final Checker<? super T> checker, final boolean negated) {
+		return negated ^ check(event, checker);
 	}
 	
 	@Override
-	public boolean check(final Event e, final Checker<? super T> c) {
-		return source.check(e, new Checker<F>() {
+	public boolean check(final Event event, final Checker<? super T> checker) {
+		return source.check(event, new Checker<F>() {
 			@Override
 			public boolean check(final F f) {
 				final T t = conv.convert(f);
 				if (t == null) {
 					return false;
 				}
-				return c.check(t);
+				return checker.check(t);
 			}
 		});
 	}
@@ -210,14 +210,14 @@ public class ConvertedExpression<F, T> implements Expression<T> {
 	}
 	
 	@Override
-	public boolean isLoopOf(final String s) {
+	public boolean isLoopOf(final String string) {
 		return false;// A loop does not convert the expression to loop
 	}
 	
 	@Override
 	@Nullable
-	public Iterator<T> iterator(final Event e) {
-		final Iterator<? extends F> iter = source.iterator(e);
+	public Iterator<T> iterator(final Event event) {
+		final Iterator<? extends F> iter = source.iterator(event);
 		if (iter == null)
 			return null;
 		return new Iterator<T>() {

--- a/src/main/java/ch/njol/skript/lang/util/ConvertedLiteral.java
+++ b/src/main/java/ch/njol/skript/lang/util/ConvertedLiteral.java
@@ -65,7 +65,7 @@ public class ConvertedLiteral<F, T> extends ConvertedExpression<F, T> implements
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return Classes.toString(data, getAnd());
 	}
 	
@@ -80,7 +80,7 @@ public class ConvertedLiteral<F, T> extends ConvertedExpression<F, T> implements
 	}
 	
 	@Override
-	public T[] getArray(final Event e) {
+	public T[] getArray(final Event event) {
 		return getArray();
 	}
 	
@@ -93,24 +93,24 @@ public class ConvertedLiteral<F, T> extends ConvertedExpression<F, T> implements
 	}
 	
 	@Override
-	public T getSingle(final Event e) {
+	public T getSingle(final Event event) {
 		return getSingle();
 	}
 	
 	@Override
 	@Nullable
-	public Iterator<T> iterator(final Event e) {
+	public Iterator<T> iterator(final Event event) {
 		return new ArrayIterator<>(data);
 	}
 	
 	@Override
-	public boolean check(final Event e, final Checker<? super T> c) {
-		return SimpleExpression.check(data, c, false, getAnd());
+	public boolean check(final Event event, final Checker<? super T> checker) {
+		return SimpleExpression.check(data, checker, false, getAnd());
 	}
 	
 	@Override
-	public boolean check(final Event e, final Checker<? super T> c, final boolean negated) {
-		return SimpleExpression.check(data, c, negated, getAnd());
+	public boolean check(final Event event, final Checker<? super T> checker, final boolean negated) {
+		return SimpleExpression.check(data, checker, negated, getAnd());
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/lang/util/SimpleEvent.java
+++ b/src/main/java/ch/njol/skript/lang/util/SimpleEvent.java
@@ -48,7 +48,7 @@ public class SimpleEvent extends SkriptEvent {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		return "simple event";
 	}
 	

--- a/src/main/java/ch/njol/skript/lang/util/SimpleExpression.java
+++ b/src/main/java/ch/njol/skript/lang/util/SimpleExpression.java
@@ -54,8 +54,8 @@ public abstract class SimpleExpression<T> implements Expression<T> {
 	
 	@Override
 	@Nullable
-	public final T getSingle(final Event e) {
-		final T[] all = getArray(e);
+	public final T getSingle(final Event event) {
+		final T[] all = getArray(event);
 		if (all.length == 0)
 			return null;
 		if (all.length > 1)
@@ -70,8 +70,8 @@ public abstract class SimpleExpression<T> implements Expression<T> {
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public T[] getAll(final Event e) {
-		final T[] all = get(e);
+	public T[] getAll(final Event event) {
+		final T[] all = get(event);
 		if (all == null) {
 			final T[] r = (T[]) Array.newInstance(getReturnType(), 0);
 			assert r != null;
@@ -96,8 +96,8 @@ public abstract class SimpleExpression<T> implements Expression<T> {
 	
 	@SuppressWarnings("unchecked")
 	@Override
-	public final T[] getArray(final Event e) {
-		final T[] all = get(e);
+	public final T[] getArray(final Event event) {
+		final T[] all = get(event);
 		if (all == null) {
 			final T[] r = (T[]) Array.newInstance(getReturnType(), 0);
 			assert r != null;
@@ -143,24 +143,24 @@ public abstract class SimpleExpression<T> implements Expression<T> {
 	 * This is the internal method to get an expression's values.<br>
 	 * To get the expression's value from the outside use {@link #getSingle(Event)} or {@link #getArray(Event)}.
 	 * 
-	 * @param e The event
+	 * @param event The event
 	 * @return An array of values for this event. May not contain nulls.
 	 */
 	@Nullable
-	protected abstract T[] get(Event e);
+	protected abstract T[] get(Event event);
 	
 	@Override
-	public final boolean check(final Event e, final Checker<? super T> c) {
-		return check(e, c, false);
+	public final boolean check(final Event event, final Checker<? super T> checker) {
+		return check(event, checker, false);
 	}
 	
 	@Override
-	public final boolean check(final Event e, final Checker<? super T> c, final boolean negated) {
-		return check(get(e), c, negated, getAnd());
+	public final boolean check(final Event event, final Checker<? super T> checker, final boolean negated) {
+		return check(get(event), checker, negated, getAnd());
 	}
 	
 	// TODO return a kleenean (UNKNOWN if 'all' is null or empty)
-	public static <T> boolean check(final @Nullable T[] all, final Checker<? super T> c, final boolean invert, final boolean and) {
+	public static <T> boolean check(final @Nullable T[] all, final Checker<? super T> checker, final boolean invert, final boolean and) {
 		if (all == null)
 			return invert;
 		boolean hasElement = false;
@@ -168,7 +168,7 @@ public abstract class SimpleExpression<T> implements Expression<T> {
 			if (t == null)
 				continue;
 			hasElement = true;
-			final boolean b = c.check(t);
+			final boolean b = checker.check(t);
 			if (and && !b)
 				return invert;
 			if (!and && b)
@@ -231,14 +231,14 @@ public abstract class SimpleExpression<T> implements Expression<T> {
 	
 	@SuppressWarnings("unchecked")
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) {
 		final ClassInfo<?> rti = returnTypeInfo;
 		if (rti == null)
 			throw new UnsupportedOperationException();
 		final Changer<?> c = rti.getChanger();
 		if (c == null)
 			throw new UnsupportedOperationException();
-		((Changer<T>) c).change(getArray(e), delta, mode);
+		((Changer<T>) c).change(getArray(event), delta, mode);
 	}
 
 	/**
@@ -329,14 +329,14 @@ public abstract class SimpleExpression<T> implements Expression<T> {
 	}
 	
 	@Override
-	public boolean isLoopOf(final String s) {
+	public boolean isLoopOf(final String string) {
 		return false;
 	}
 	
 	@Override
 	@Nullable
-	public Iterator<? extends T> iterator(final Event e) {
-		return new ArrayIterator<>(getArray(e));
+	public Iterator<? extends T> iterator(final Event event) {
+		return new ArrayIterator<>(getArray(event));
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/lang/util/SimpleLiteral.java
+++ b/src/main/java/ch/njol/skript/lang/util/SimpleLiteral.java
@@ -103,7 +103,7 @@ public class SimpleLiteral<T> implements Literal<T>, DefaultExpression<T> {
 	}
 	
 	@Override
-	public T[] getArray(final Event e) {
+	public T[] getArray(final Event event) {
 		return data;
 	}
 	
@@ -113,7 +113,7 @@ public class SimpleLiteral<T> implements Literal<T>, DefaultExpression<T> {
 	}
 	
 	@Override
-	public T[] getAll(final Event e) {
+	public T[] getAll(final Event event) {
 		return data;
 	}
 	
@@ -124,7 +124,7 @@ public class SimpleLiteral<T> implements Literal<T>, DefaultExpression<T> {
 	}
 	
 	@Override
-	public T getSingle(final Event e) {
+	public T getSingle(final Event event) {
 		return getSingle();
 	}
 	
@@ -146,7 +146,7 @@ public class SimpleLiteral<T> implements Literal<T>, DefaultExpression<T> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		if (debug)
 			return "[" + Classes.toString(data, getAnd(), StringMode.DEBUG) + "]";
 		return Classes.toString(data, getAnd());
@@ -168,13 +168,13 @@ public class SimpleLiteral<T> implements Literal<T>, DefaultExpression<T> {
 	}
 	
 	@Override
-	public boolean check(final Event e, final Checker<? super T> c, final boolean negated) {
-		return SimpleExpression.check(data, c, negated, getAnd());
+	public boolean check(final Event event, final Checker<? super T> checker, final boolean negated) {
+		return SimpleExpression.check(data, checker, negated, getAnd());
 	}
 	
 	@Override
-	public boolean check(final Event e, final Checker<? super T> c) {
-		return SimpleExpression.check(data, c, false, getAnd());
+	public boolean check(final Event event, final Checker<? super T> checker) {
+		return SimpleExpression.check(data, checker, false, getAnd());
 	}
 	
 	@Nullable
@@ -191,7 +191,7 @@ public class SimpleLiteral<T> implements Literal<T>, DefaultExpression<T> {
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
+	public void change(final Event event, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
 		final ClassInfo<? super T> rti = returnTypeInfo;
 		if (rti == null)
 			throw new UnsupportedOperationException();
@@ -217,7 +217,7 @@ public class SimpleLiteral<T> implements Literal<T>, DefaultExpression<T> {
 	}
 	
 	@Override
-	public NonNullIterator<T> iterator(final Event e) {
+	public NonNullIterator<T> iterator(final Event event) {
 		return new NonNullIterator<T>() {
 			private int i = 0;
 			
@@ -232,7 +232,7 @@ public class SimpleLiteral<T> implements Literal<T>, DefaultExpression<T> {
 	}
 	
 	@Override
-	public boolean isLoopOf(final String s) {
+	public boolean isLoopOf(final String string) {
 		return false;
 	}
 	

--- a/src/main/java/ch/njol/skript/sections/SecLoop.java
+++ b/src/main/java/ch/njol/skript/sections/SecLoop.java
@@ -87,30 +87,30 @@ public class SecLoop extends Section {
 
 	@Override
 	@Nullable
-	protected TriggerItem walk(Event e) {
-		Iterator<?> iter = currentIter.get(e);
+	protected TriggerItem walk(Event event) {
+		Iterator<?> iter = currentIter.get(event);
 		if (iter == null) {
-			iter = expr instanceof Variable ? ((Variable<?>) expr).variablesIterator(e) : expr.iterator(e);
+			iter = expr instanceof Variable ? ((Variable<?>) expr).variablesIterator(event) : expr.iterator(event);
 			if (iter != null) {
 				if (iter.hasNext())
-					currentIter.put(e, iter);
+					currentIter.put(event, iter);
 				else
 					iter = null;
 			}
 		}
 		if (iter == null || !iter.hasNext()) {
-			exit(e);
-			debug(e, false);
+			exit(event);
+			debug(event, false);
 			return actualNext;
 		} else {
-			current.put(e, iter.next());
-			return walk(e, true);
+			current.put(event, iter.next());
+			return walk(event, true);
 		}
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "loop " + expr.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "loop " + expr.toString(event, debug);
 	}
 
 	@Nullable

--- a/src/main/java/ch/njol/skript/sections/SecWhile.java
+++ b/src/main/java/ch/njol/skript/sections/SecWhile.java
@@ -68,13 +68,13 @@ public class SecWhile extends Section {
 
 	@Nullable
 	@Override
-	protected TriggerItem walk(Event e) {
-		if ((doWhile && !ranDoWhile) || condition.check(e)) {
+	protected TriggerItem walk(Event event) {
+		if ((doWhile && !ranDoWhile) || condition.check(event)) {
 			ranDoWhile = true;
-			return walk(e, true);
+			return walk(event, true);
 		} else {
 			reset();
-			debug(e, false);
+			debug(event, false);
 			return actualNext;
 		}
 	}
@@ -91,8 +91,8 @@ public class SecWhile extends Section {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return (doWhile ? "do " : "") + "while " + condition.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return (doWhile ? "do " : "") + "while " + condition.toString(event, debug);
 	}
 
 	public void reset() {

--- a/src/main/java/ch/njol/skript/structures/StructAliases.java
+++ b/src/main/java/ch/njol/skript/structures/StructAliases.java
@@ -76,7 +76,7 @@ public class StructAliases extends Structure {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "aliases";
 	}
 

--- a/src/main/java/ch/njol/skript/structures/StructCommand.java
+++ b/src/main/java/ch/njol/skript/structures/StructCommand.java
@@ -347,7 +347,7 @@ public class StructCommand extends Structure {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "command";
 	}
 

--- a/src/main/java/ch/njol/skript/structures/StructFunction.java
+++ b/src/main/java/ch/njol/skript/structures/StructFunction.java
@@ -123,7 +123,7 @@ public class StructFunction extends Structure {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return (local ? "local " : "") + "function";
 	}
 

--- a/src/main/java/ch/njol/skript/structures/StructOptions.java
+++ b/src/main/java/ch/njol/skript/structures/StructOptions.java
@@ -109,7 +109,7 @@ public class StructOptions extends Structure {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "options";
 	}
 

--- a/src/main/java/ch/njol/skript/structures/StructVariables.java
+++ b/src/main/java/ch/njol/skript/structures/StructVariables.java
@@ -160,7 +160,7 @@ public class StructVariables extends Structure {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "variables";
 	}
 

--- a/src/main/java/ch/njol/skript/tests/runner/CondMinecraftVersion.java
+++ b/src/main/java/ch/njol/skript/tests/runner/CondMinecraftVersion.java
@@ -60,8 +60,8 @@ public class CondMinecraftVersion extends Condition {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "is running minecraft " + version.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "is running minecraft " + version.toString(event, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/tests/runner/EffAssert.java
+++ b/src/main/java/ch/njol/skript/tests/runner/EffAssert.java
@@ -82,17 +82,17 @@ public class EffAssert extends Effect  {
 	}
 
 	@Override
-	protected void execute(Event e) {}
+	protected void execute(Event event) {}
 	
 	@Nullable
 	@Override
-	public TriggerItem walk(Event e) {
+	public TriggerItem walk(Event event) {
 		if (shouldFail && condition == null) {
 			return getNext();
 		}
 		
-		if (condition.check(e) == shouldFail) {
-			String msg = errorMsg.getSingle(e);
+		if (condition.check(event) == shouldFail) {
+			String msg = errorMsg.getSingle(event);
 			TestTracker.testFailed(msg != null ? msg : "assertation failed");
 			return null;
 		}
@@ -100,7 +100,7 @@ public class EffAssert extends Effect  {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "assert " + condition.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "assert " + condition.toString(event, debug);
 	}
 }

--- a/src/main/java/ch/njol/skript/tests/runner/EvtTestCase.java
+++ b/src/main/java/ch/njol/skript/tests/runner/EvtTestCase.java
@@ -72,9 +72,9 @@ public class EvtTestCase extends SkriptEvent {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		if (e != null)
-			return "test " + name.getSingle(e);
+	public String toString(@Nullable Event event, boolean debug) {
+		if (event != null)
+			return "test " + name.getSingle(event);
 		return "test case";
 	}
 }

--- a/src/main/java/ch/njol/skript/util/AsyncEffect.java
+++ b/src/main/java/ch/njol/skript/util/AsyncEffect.java
@@ -43,11 +43,11 @@ public abstract class AsyncEffect extends Effect {
 	
 	@Override
 	@Nullable
-	protected TriggerItem walk(Event e) {
-		debug(e, true);
+	protected TriggerItem walk(Event event) {
+		debug(event, true);
 		
-		Delay.addDelayedEvent(e); // Mark this event as delayed
-		Object localVars = Variables.removeLocals(e); // Back up local variables
+		Delay.addDelayedEvent(event); // Mark this event as delayed
+		Object localVars = Variables.removeLocals(event); // Back up local variables
 
 		if (!Skript.getInstance().isEnabled()) // See https://github.com/SkriptLang/Skript/issues/3702
 			return null;
@@ -55,9 +55,9 @@ public abstract class AsyncEffect extends Effect {
 		Bukkit.getScheduler().runTaskAsynchronously(Skript.getInstance(), () -> {
 			// Re-set local variables
 			if (localVars != null)
-				Variables.setLocalVariables(e, localVars);
+				Variables.setLocalVariables(event, localVars);
 			
-			execute(e); // Execute this effect
+			execute(event); // Execute this effect
 			
 			if (getNext() != null) {
 				Bukkit.getScheduler().runTask(Skript.getInstance(), () -> { // Walk to next item synchronously
@@ -69,14 +69,14 @@ public abstract class AsyncEffect extends Effect {
 						}
 					}
 					
-					TriggerItem.walk(getNext(), e);
+					TriggerItem.walk(getNext(), event);
 					
-					Variables.removeLocals(e); // Clean up local vars, we may be exiting now
+					Variables.removeLocals(event); // Clean up local vars, we may be exiting now
 					
 					SkriptTimings.stop(timing); // Stop timing if it was even started
 				});
 			} else {
-				Variables.removeLocals(e);
+				Variables.removeLocals(event);
 			}
 		});
 		return null;

--- a/src/main/java/ch/njol/skript/util/Direction.java
+++ b/src/main/java/ch/njol/skript/util/Direction.java
@@ -373,9 +373,9 @@ public class Direction implements YggdrasilRobustSerializable {
 		return new SimpleExpression<Location>() {
 			@SuppressWarnings("null")
 			@Override
-			protected Location[] get(final Event e) {
-				final Direction[] ds = dirs.getArray(e);
-				final Location[] ls = locs.getArray(e);
+			protected Location[] get(final Event event) {
+				final Direction[] ds = dirs.getArray(event);
+				final Location[] ls = locs.getArray(event);
 				final Location[] r = ls; //ds.length == 1 ? ls : new Location[ds.length * ls.length];
 				for (int i = 0; i < ds.length; i++) {
 					for (int j = 0; j < ls.length; j++) {
@@ -388,9 +388,9 @@ public class Direction implements YggdrasilRobustSerializable {
 			
 			@SuppressWarnings("null")
 			@Override
-			public Location[] getAll(final Event e) {
-				final Direction[] ds = dirs.getAll(e);
-				final Location[] ls = locs.getAll(e);
+			public Location[] getAll(final Event event) {
+				final Direction[] ds = dirs.getAll(event);
+				final Location[] ls = locs.getAll(event);
 				final Location[] r = ls; //ds.length == 1 ? ls : new Location[ds.length * ls.length];
 				for (int i = 0; i < ds.length; i++) {
 					for (int j = 0; j < ls.length; j++) {
@@ -424,8 +424,8 @@ public class Direction implements YggdrasilRobustSerializable {
 			}
 			
 			@Override
-			public String toString(final @Nullable Event e, final boolean debug) {
-				return dirs.toString(e, debug) + " " + locs.toString(e, debug);
+			public String toString(final @Nullable Event event, final boolean debug) {
+				return dirs.toString(event, debug) + " " + locs.toString(event, debug);
 			}
 			
 			@Override

--- a/src/main/java/ch/njol/skript/util/slot/CursorSlot.java
+++ b/src/main/java/ch/njol/skript/util/slot/CursorSlot.java
@@ -71,7 +71,7 @@ public class CursorSlot extends Slot {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "cursor slot of " + Classes.toString(player);
 	}
 	

--- a/src/main/java/ch/njol/skript/util/slot/DroppedItemSlot.java
+++ b/src/main/java/ch/njol/skript/util/slot/DroppedItemSlot.java
@@ -64,7 +64,7 @@ public class DroppedItemSlot extends Slot {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return Classes.toString(getItem());
 	}
 	

--- a/src/main/java/ch/njol/skript/util/slot/InventorySlot.java
+++ b/src/main/java/ch/njol/skript/util/slot/InventorySlot.java
@@ -89,7 +89,7 @@ public class InventorySlot extends SlotWithIndex {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		InventoryHolder holder = invi != null ? invi.getHolder() : null;
 		
 		if (holder instanceof BlockState)

--- a/src/main/java/ch/njol/skript/util/slot/ItemFrameSlot.java
+++ b/src/main/java/ch/njol/skript/util/slot/ItemFrameSlot.java
@@ -63,7 +63,7 @@ public class ItemFrameSlot extends Slot {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return Classes.toString(getItem());
 	}
 	

--- a/src/main/java/ch/njol/skript/util/slot/ThrowableProjectileSlot.java
+++ b/src/main/java/ch/njol/skript/util/slot/ThrowableProjectileSlot.java
@@ -61,7 +61,7 @@ public class ThrowableProjectileSlot extends Slot {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return Classes.toString(getItem());
 	}
 	


### PR DESCRIPTION
### Description
This PR aims to convert all `Event e` to `Event event` in classes that will be extended from (ie: Expression/Effect/Section/Condition)
This makes sure that future PRs, when users are extending from classes, for example SimplePropertyExpression, that they don't have to manually change e -> event.
Also makes the code look more consistent when users are referring to other classes for inspiration. 

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
