### PR TITLE
🛠 Removes 1.13 code from ItemUtils.isAir

### DIFF
--- a/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
@@ -99,17 +99,11 @@ public class ItemUtils {
 
 	// Only 1.15 and versions after have Material#isAir method
 	private static final boolean IS_AIR_EXISTS = Skript.methodExists(Material.class, "isAir");
-	// Version 1.14 have multiple air types but no Material#isAir method
-	private static final boolean OTHER_AIR_EXISTS = Skript.isRunningMinecraft(1, 14);
 
 	public static boolean isAir(Material type) {
-		if (IS_AIR_EXISTS) {
+		if (IS_AIR_EXISTS)
 			return type.isAir();
-		} else if (OTHER_AIR_EXISTS) {
-			return type == Material.AIR || type == Material.CAVE_AIR || type == Material.VOID_AIR;
-		}
-		// All versions prior to 1.14 only have 1 air type
-		return type == Material.AIR;
+		return type == Material.AIR || type == Material.CAVE_AIR || type == Material.VOID_AIR;
 	}
 	
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Skript no longer supports 1.12- and `OTHER_AIR_EXISTS` is actually since 1.13 not since 1.14

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->1.13+
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->None
**Related Issues:** <!-- Links to related issues -->None
