### PR TITLE
add event value for BlockSpreadEvent.getSource();

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -1428,14 +1428,5 @@ public final class BukkitEventValues {
 				return event.getEgg();
 			}
 		}, EventValues.TIME_NOW);
-
-		// BlockSpreadEvent
-		EventValues.registerEventValue(BlockSpreadEvent.class, Block.class, new Getter<Block, BlockSpreadEvent>() {
-			@Override
-			@Nullable
-			public Block get(BlockSpreadEvent event) {
-				return event.getSource();
-			}
-		}, EventValues.TIME_NOW);
 	}
 }

--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -73,7 +73,6 @@ import org.bukkit.event.block.BlockFromToEvent;
 import org.bukkit.event.block.BlockGrowEvent;
 import org.bukkit.event.block.BlockIgniteEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
-import org.bukkit.event.block.BlockSpreadEvent;
 import org.bukkit.event.block.SignChangeEvent;
 import org.bukkit.event.enchantment.EnchantItemEvent;
 import org.bukkit.event.enchantment.PrepareItemEnchantEvent;

--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -73,6 +73,7 @@ import org.bukkit.event.block.BlockFromToEvent;
 import org.bukkit.event.block.BlockGrowEvent;
 import org.bukkit.event.block.BlockIgniteEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.block.BlockSpreadEvent;
 import org.bukkit.event.block.SignChangeEvent;
 import org.bukkit.event.enchantment.EnchantItemEvent;
 import org.bukkit.event.enchantment.PrepareItemEnchantEvent;
@@ -1425,6 +1426,15 @@ public final class BukkitEventValues {
 			@Nullable
 			public Egg get(PlayerEggThrowEvent event) {
 				return event.getEgg();
+			}
+		}, EventValues.TIME_NOW);
+
+		// BlockSpreadEvent
+		EventValues.registerEventValue(BlockSpreadEvent.class, Block.class, new Getter<Block, BlockSpreadEvent>() {
+			@Override
+			@Nullable
+			public Block get(BlockSpreadEvent event) {
+				return event.getSource();
 			}
 		}, EventValues.TIME_NOW);
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprSourceBlock.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSourceBlock.java
@@ -1,3 +1,22 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+
 package ch.njol.skript.expressions;
 
 import ch.njol.skript.Skript;

--- a/src/main/java/ch/njol/skript/expressions/ExprSourceBlock.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSourceBlock.java
@@ -20,7 +20,11 @@
 package ch.njol.skript.expressions;
 
 import ch.njol.skript.Skript;
-import ch.njol.skript.doc.*;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Events;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/ch/njol/skript/expressions/ExprSourceBlock.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSourceBlock.java
@@ -1,0 +1,61 @@
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.*;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import org.bukkit.block.Block;
+import org.bukkit.event.Event;
+import org.bukkit.event.block.BlockSpreadEvent;
+import org.eclipse.jdt.annotation.Nullable;
+
+@Name("Source Block")
+@Description("The source block in a spread event.")
+@Events("Spread")
+@Examples({
+	"on spread:",
+		"\tif the source block is a grass block:",
+			"\t\tset the source block to a dirt block"
+})
+@Since("INSERT VERSION")
+public class ExprSourceBlock extends SimpleExpression<Block> {
+
+	static {
+		Skript.registerExpression(ExprSourceBlock.class, Block.class, ExpressionType.SIMPLE, "[the] source block");
+	}
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		if (!getParser().isCurrentEvent(BlockSpreadEvent.class)) {
+			Skript.error("The 'source block' is only usable in a spread event");
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	protected Block[] get(Event event) {
+		if (!(event instanceof BlockSpreadEvent))
+			return new Block[0];
+		return new Block[]{((BlockSpreadEvent) event).getSource()};
+	}
+
+	@Override
+	public boolean isSingle() {
+		return true;
+	}
+
+	@Override
+	public Class<? extends Block> getReturnType() {
+		return Block.class;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "the source block";
+	}
+
+}


### PR DESCRIPTION
### Description
Added a way to get the source block in BlockSpreadEvent

---
**Target Minecraft Versions:** any
**Requirements:** No requirements
**Related Issues:** https://github.com/SkriptLang/Skript/issues/5346
