### PR TITLE
Add MIT release clause

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,3 +5,10 @@
 **Target Minecraft Versions:** <!-- 'any' means all supported versions -->
 **Requirements:** <!-- Required plugins, Minecraft versions, server software... -->
 **Related Issues:** <!-- Links to related issues -->
+
+<!-- To foster a better open-source community, we ask contributors to release their code under the MIT license -->
+<!-- This license is less restrictive than Skript's current license (GPL) -->
+<!-- However, it provides us and other developers with greater flexibility when making use of your code -->
+<!-- Please replace this with 'No' if you do not wish to release your code under the MIT license -->
+<!-- You can read more about the MIT License at https://choosealicense.com/licenses/mit/ -->
+**Release Code Under MIT License:** Yes


### PR DESCRIPTION
### Description
In the interest of promoting a better open-source community I am proposing adding a clause to the PR template for contributors to release their code under the MIT license. To (hopefully) get people to participate, this would be an opt-out system.

---
**Target Minecraft Versions:** any
**Requirements:** n/a
**Related Issues:** none?
