### PR TITLE
Remove getters from event values

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -73,7 +73,6 @@ import ch.njol.skript.util.Date;
 import ch.njol.skript.util.EmptyStacktraceException;
 import ch.njol.skript.util.ExceptionUtils;
 import ch.njol.skript.util.FileUtils;
-import ch.njol.skript.util.Getter;
 import ch.njol.skript.util.Task;
 import ch.njol.skript.util.Utils;
 import ch.njol.skript.util.Version;
@@ -164,13 +163,12 @@ import java.util.zip.ZipFile;
  * Once you made sure that Skript is loaded you can use <code>Skript.getInstance()</code> whenever you need a reference to the plugin, but you likely won't need it since all API
  * methods are static.
  * 
- * @author Peter Güttinger
  * @see #registerAddon(JavaPlugin)
  * @see #registerCondition(Class, String...)
  * @see #registerEffect(Class, String...)
  * @see #registerExpression(Class, Class, ExpressionType, String...)
  * @see #registerEvent(String, Class, Class, String...)
- * @see EventValues#registerEventValue(Class, Class, Getter, int)
+ * @see EventValues#registerEventValue(Class, Class, Converter, int)
  * @see Classes#registerClass(ClassInfo)
  * @see Comparators#registerComparator(Class, Class, Comparator)
  * @see Converters#registerConverter(Class, Class, Converter)

--- a/src/main/java/ch/njol/skript/expressions/base/EventValueExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/EventValueExpression.java
@@ -135,7 +135,7 @@ public class EventValueExpression<T> extends SimpleExpression<T> implements Defa
 			return one;
 		}
 		T[] dataArray = (T[]) value;
-		T[] array = (T[]) Array.newInstance(c.getComponentType(), ((T[]) value).length);
+		T[] array = (T[]) Array.newInstance(c.getComponentType(), dataArray.length);
 		System.arraycopy(dataArray, 0, array, 0, array.length);
 		return array;
 	}

--- a/src/main/java/ch/njol/skript/registrations/EventValues.java
+++ b/src/main/java/ch/njol/skript/registrations/EventValues.java
@@ -173,7 +173,7 @@ public class EventValues {
 	 * @param converter The converter that will extract the value from the event.
 	 * @param time The time state of this event value. Use {@link EventValues#TIME_PAST} if this value was before the event.
 	 * 		or use {@link EventValues#TIME_FUTURE} if this value is after the event. {@link EventValues#TIME_NOW} is the default neutral state.
-	 * 		If the provided time was not {@link EventValues#TIME_NOW} and it's time wasn't found, Skript will default to {@link EventValues#TIME_NOW}.
+	 * 		If the provided time was not {@link EventValues#TIME_NOW} and its time wasn't found, Skript will default to {@link EventValues#TIME_NOW}.
 	 * 		Use {@link EventValues#TIME_NOW} if this event value has no distinct states, and always register a default state {@link EventValues#TIME_NOW} for each return type of the event.
 	 */
 	public static <T, E extends Event> void registerEventValue(Class<E> event, Class<T> c, Converter<E, T> converter, int time) {

--- a/src/main/java/ch/njol/skript/registrations/EventValues.java
+++ b/src/main/java/ch/njol/skript/registrations/EventValues.java
@@ -151,7 +151,7 @@ public class EventValues {
 			return defaultEventValues;
 		if (time == TIME_FUTURE)
 			return futureEventValues;
-		throw new IllegalArgumentException("time must be TIME_PAST, TIME_NOW, or TIME_FUTURE");
+		throw new IllegalArgumentException("time must be " + TIME_PAST + ", " + TIME_NOW + ", or " + TIME_FUTURE);
 	}
 
 	/**

--- a/src/main/java/ch/njol/skript/registrations/EventValues.java
+++ b/src/main/java/ch/njol/skript/registrations/EventValues.java
@@ -63,7 +63,7 @@ public class EventValues {
 
 		/**
 		 * Get the classes that are excluded for this event value.
-		 * If the event values is used in any of these events, Skript will error.
+		 * If the event values are used in any of these events, Skript will error.
 		 * Example being command sender or a player in a damage event, they should be using attacker/victim.
 		 * 
 		 * @return The classes of the excluded events for this event value.

--- a/src/main/java/ch/njol/skript/registrations/EventValues.java
+++ b/src/main/java/ch/njol/skript/registrations/EventValues.java
@@ -24,301 +24,351 @@ import java.util.List;
 
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.ApiStatus.ScheduledForRemoval;
 
 import com.google.common.collect.ImmutableList;
 import ch.njol.skript.Skript;
 import org.skriptlang.skript.lang.converter.Converter;
 import org.skriptlang.skript.lang.converter.Converters;
 import ch.njol.skript.expressions.base.EventValueExpression;
-import ch.njol.skript.util.Getter;
 
-/**
- * @author Peter Güttinger
- */
 public class EventValues {
-	
+
 	private EventValues() {}
-	
+
 	private final static class EventValueInfo<E extends Event, T> {
-		
-		public final Class<E> event;
-		public final Class<T> c;
-		public final Getter<T, E> getter;
+
 		@Nullable
-		public final Class<? extends E>[] excludes;
+		private final Class<? extends E>[] excludes;
+
 		@Nullable
-		public final String excludeErrorMessage;
-		
-		public EventValueInfo(Class<E> event, Class<T> c, Getter<T, E> getter, @Nullable String excludeErrorMessage, @Nullable Class<? extends E>[] excludes) {
+		private final String excludeErrorMessage;
+
+		private final Converter<E, T> converter;
+		private final Class<E> event;
+		private final Class<T> c;
+
+		@SafeVarargs
+		public EventValueInfo(Class<E> event, Class<T> c, Converter<E, T> converter, @Nullable String excludeErrorMessage, @Nullable Class<? extends E>... excludes) {
+			assert converter != null;
 			assert event != null;
 			assert c != null;
-			assert getter != null;
+
+			this.excludeErrorMessage = excludeErrorMessage;
+			this.converter = converter;
+			this.excludes = excludes;
 			this.event = event;
 			this.c = c;
-			this.getter = getter;
-			this.excludes = excludes;
-			this.excludeErrorMessage = excludeErrorMessage;
 		}
-		
+
 		/**
-		 * Get the class that represents the Event.
-		 * @return The class of the Event associated with this event value
+		 * Get the classes that are excluded for this event value.
+		 * If the event values is used in any of these events, Skript will error.
+		 * Example being command sender or a player in a damage event, they should be using attacker/victim.
+		 * 
+		 * @return The classes of the excluded events for this event value.
 		 */
-		public Class<E> getEventClass() {
-			return event;
-		}
-		
-		/**
-		 * Get the class that represents Value.
-		 * @return The class of the Value associated with this event value
-		 */
-		public Class<T> getValueClass() {
-			return c;
-		}
-		
-		/**
-		 * Get the classes that represent the excluded for this Event value.
-		 * @return The classes of the Excludes associated with this event value
-		 */
-		@Nullable
-		@SuppressWarnings("null")
-		public Class<? extends E>[] getExcludes() {
-			if (excludes != null)
+		@SuppressWarnings("unchecked")
+		public Class<? extends E>[] getExcludedEvents() {
+			if (excludes != null && excludes.length > 0)
 				return Arrays.copyOf(excludes, excludes.length);
 			return new Class[0];
 		}
-		
+
 		/**
-		 * Get the error message used when encountering an exclude value.
-		 * @return The error message to use when encountering an exclude
+		 * Get the error message used when encountering an exclude event.
+		 * 
+		 * @return The error message to use when encountering an exclude event.
 		 */
 		@Nullable
-		public String getExcludeErrorMessage() {
+		String getExcludeErrorMessage() {
 			return excludeErrorMessage;
 		}
+
+		/**
+		 * Get the converter that will collect the value from the event.
+		 * 
+		 * @return The converter that will collect the value from the event.
+		 */
+		Converter<E, T> getConverter() {
+			return converter;
+		}
+
+		/**
+		 * Get the class that represents the Event.
+		 * 
+		 * @return The class of the Event associated with this event value.
+		 */
+		Class<E> getEventClass() {
+			return event;
+		}
+
+		/**
+		 * Get the class that represents the value.
+		 * 
+		 * @return The class of the value associated with this event value.
+		 */
+		Class<T> getValueClass() {
+			return c;
+		}
+
 	}
-	
-	private final static List<EventValueInfo<?, ?>> defaultEventValues = new ArrayList<>(30);
+
+	private final static List<EventValueInfo<?, ?>> defaultEventValues = new ArrayList<>();
 	private final static List<EventValueInfo<?, ?>> futureEventValues = new ArrayList<>();
 	private final static List<EventValueInfo<?, ?>> pastEventValues = new ArrayList<>();
-	
+
 	/**
-	 * The past time of an event value. Represented by "past" or "former".
+	 * The past time of an event value. Represented when using "past" or "was".
 	 */
 	public static final int TIME_PAST = -1;
-	
+
 	/**
 	 * The current time of an event value.
 	 */
 	public static final int TIME_NOW = 0;
-	
+
 	/**
-	 * The future time of an event value.
+	 * The future time of an event value. Represented when using "future" or "will be".
 	 */
 	public static final int TIME_FUTURE = 1;
-	
+
 	/**
-	 * Get Event Values list for the specified time
+	 * Get event values list for the specified time.
+	 * 
 	 * @param time The time of the event values. One of
-	 * {@link EventValues#TIME_PAST}, {@link EventValues#TIME_NOW} or {@link EventValues#TIME_FUTURE}.
-	 * @return An immutable copy of the event values list for the specified time
+	 * 		{@link EventValues#TIME_PAST}, {@link EventValues#TIME_NOW} or {@link EventValues#TIME_FUTURE}.
+	 * @return An immutable copy of the event values list for the specified time.
 	 */
 	public static List<EventValueInfo<?, ?>> getEventValuesListForTime(int time) {
 		return ImmutableList.copyOf(getEventValuesList(time));
 	}
-	
+
 	private static List<EventValueInfo<?, ?>> getEventValuesList(int time) {
-		if (time == -1)
+		if (time == TIME_PAST)
 			return pastEventValues;
-		if (time == 0)
+		if (time == TIME_NOW)
 			return defaultEventValues;
-		if (time == 1)
+		if (time == TIME_FUTURE)
 			return futureEventValues;
 		throw new IllegalArgumentException("time must be -1, 0, or 1");
 	}
-	
+
 	/**
-	 * Registers an event value.
+	 * Register an event value. Defaults the time state to {@link EventValues#TIME_NOW}.
 	 * 
-	 * @param e the event type
-	 * @param c the type of the default value
-	 * @param g the getter to get the value
-	 * @param time -1 if this is the value before the event, 1 if after, and 0 if it's the default or this value doesn't have distinct states.
-	 *            <b>Always register a default state!</b> You can leave out one of the other states instead, e.g. only register a default and a past state. The future state will
-	 *            default to the default state in this case.
+	 * @param event The event class this event value is coming from.
+	 * @param c The return type of the event value.
+	 * @param converter The converter that will extract the value from the event.
 	 */
-	public static <T, E extends Event> void registerEventValue(Class<E> e, Class<T> c, Getter<T, E> g, int time) {
-		registerEventValue(e, c, g, time, null, (Class<? extends E>[]) null);
+	public static <T, E extends Event> void registerEventValue(Class<E> event, Class<T> c, Converter<E, T> converter) {
+		registerEventValue(event, c, converter, TIME_NOW, null);
 	}
-	
+
 	/**
-	 * Same as {@link #registerEventValue(Class, Class, Getter, int)}
+	 * Register an event value.
 	 * 
-	 * @param e
-	 * @param c
-	 * @param g
-	 * @param time -1 if this is the value before the event, 1 if after, and 0 if it's the default or this value doesn't have distinct states.
-	 *            <b>Always register a default state!</b> You can leave out one of the other states instead, e.g. only register a default and a past state. The future state will
-	 *            default to the default state in this case.
-	 * @param excludes Subclasses of the event for which this event value should not be registered for
+	 * @param event The event class this event value is coming from.
+	 * @param c The return type of the event value.
+	 * @param converter The converter that will extract the value from the event.
+	 * @param time The time state of this event value. Use {@link EventValues#TIME_PAST} if this value was before the event.
+	 * 		or use {@link EventValues#TIME_FUTURE} if this value is after the event. {@link EventValues#TIME_NOW} is the default neutral state.
+	 * 		If the provided time was not {@link EventValues#TIME_NOW} and it's time wasn't found, Skript will default to {@link EventValues#TIME_NOW}.
+	 * 		Use {@link EventValues#TIME_NOW} if this event value has no distinct states, and always register a default state {@link EventValues#TIME_NOW} for each return type of the event.
+	 */
+	public static <T, E extends Event> void registerEventValue(Class<E> event, Class<T> c, Converter<E, T> converter, int time) {
+		registerEventValue(event, c, converter, time, null);
+	}
+
+	/**
+	 * Register an event value with events that should be excluded for this event value.
+	 * Some event values you may want to not opperate in specific events.
+	 * <p>
+	 * An example would be Skript's player event value not being allowed in a damage event.
+	 * This is because there can be multiple players in a damage event and Skript would be defaulting to
+	 * one of the players when the end user may want the other player. So Skript will print an error stating to use victim/attacker.
+	 * 
+	 * @param event The event class this event value is coming from.
+	 * @param c The return type of the event value.
+	 * @param converter The converter that will extract the value from the event.
+	 * @param time The time state of this event value. Use {@link EventValues#TIME_PAST} if this value was before the event.
+	 * 		or use {@link EventValues#TIME_FUTURE} if this value is after the event. {@link EventValues#TIME_NOW} is the default neutral state.
+	 * 		If the provided time was not {@link EventValues#TIME_NOW} and it's time wasn't found, Skript will default to {@link EventValues#TIME_NOW}.
+	 * 		Use {@link EventValues#TIME_NOW} if this event value has no distinct states, and always register a default state {@link EventValues#TIME_NOW} for each return type of the event.
+	 * @param excludeErrorMessage The error message to print when an excluded event is used with this event value.
+	 * @param excludes Subclasses of the event for which this event value should not be registered for.
 	 */
 	@SafeVarargs
-	public static <T, E extends Event> void registerEventValue(Class<E> e, Class<T> c, Getter<T, E> g, int time, @Nullable String excludeErrorMessage, @Nullable Class<? extends E>... excludes) {
+	public static <T, E extends Event> void registerEventValue(Class<E> e, Class<T> c, Converter<E, T> g, int time, @Nullable String excludeErrorMessage, @Nullable Class<? extends E>... excludes) {
 		Skript.checkAcceptRegistrations();
 		List<EventValueInfo<?, ?>> eventValues = getEventValuesList(time);
 		for (int i = 0; i < eventValues.size(); i++) {
 			EventValueInfo<?, ?> info = eventValues.get(i);
-			if (info.event != e ? info.event.isAssignableFrom(e) : info.c.isAssignableFrom(c)) {
+			if (info.getEventClass() != e ? info.getEventClass().isAssignableFrom(e) : info.getValueClass().isAssignableFrom(c)) {
 				eventValues.add(i, new EventValueInfo<>(e, c, g, excludeErrorMessage, excludes));
 				return;
 			}
 		}
 		eventValues.add(new EventValueInfo<>(e, c, g, excludeErrorMessage, excludes));
 	}
-	
+
 	/**
 	 * Gets a specific value from an event. Returns null if the event doesn't have such a value (conversions are done to try and get the desired value).
 	 * <p>
 	 * It is recommended to use {@link EventValues#getEventValueGetter(Class, Class, int)} or {@link EventValueExpression#EventValueExpression(Class)} instead of invoking this
 	 * method repeatedly.
 	 * 
-	 * @param e event
-	 * @param c return type of getter
-	 * @param time -1 if this is the value before the event, 1 if after, and 0 if it's the default or this value doesn't have distinct states.
-	 *            <b>Always register a default state!</b> You can leave out one of the other states instead, e.g. only register a default and a past state. The future state will
-	 *            default to the default state in this case.
-	 * @return The event's value
+	 * @param event The event to grab the value from.
+	 * @param c The return type of the converter.
+	 * @param time The time state of this event value. Use {@link EventValues#TIME_PAST} if this value was before the event.
+	 * 		or use {@link EventValues#TIME_FUTURE} if this value is after the event. {@link EventValues#TIME_NOW} is the default neutral state.
+	 * 		If the provided time was not {@link EventValues#TIME_NOW} and it's time wasn't found, Skript will default to {@link EventValues#TIME_NOW}.
+	 * @return The value found from possible event values.
 	 * @see #registerEventValue(Class, Class, Getter, int)
 	 */
 	@Nullable
-	public static <T, E extends Event> T getEventValue(E e, Class<T> c, int time) {
+	public static <T, E extends Event> T getEventValue(E event, Class<T> c, int time) {
 		@SuppressWarnings("unchecked")
-		Getter<? extends T, ? super E> getter = getEventValueGetter((Class<E>) e.getClass(), c, time);
-		if (getter == null)
+		Converter<? super E, ? extends T> converter = getEventValueConverter((Class<E>) event.getClass(), c, time);
+		if (converter == null)
 			return null;
-		return getter.get(e);
+		return converter.convert(event);
 	}
-	
+
 	/**
-	 * Returns a getter to get a value from in an event.
+	 * @deprecated API name change. Scheduled for removal. Use {@link #getEventValueConverter(Class, Class, int)}
+	 */
+	@Nullable
+	@Deprecated
+	@ScheduledForRemoval
+	public static <T, E extends Event> Converter<? super E, ? extends T> getEventValueGetter(Class<E> event, Class<T> c, int time) {
+		return getEventValueConverter(event, c, time, true);
+	}
+
+	/**
+	 * Returns a converter to get a value from the defined event. Otherwise null if not possible.
+	 * Skript will attempt to convert the type and check subclasses to see if converting is possible.
 	 * <p>
-	 * Can print an error if the event value is blocked for the given event.
+	 * Can print an error if the event value is excluded for the given event.
 	 * 
-	 * @param event the event class the getter will be getting from
-	 * @param c type of getter
-	 * @param time the event-value's time
-	 * @return A getter to get values for a given type of events
+	 * @param event The event class the converter will be getting from.
+	 * @param c The return type of the converter.
+	 * @param time The event-value's time state.
+	 * 		If the provided time was not {@link EventValues#TIME_NOW} and it's time wasn't found, Skript will default to {@link EventValues#TIME_NOW}.
+	 * @return A converter that is used to extract values from the given event class.
 	 * @see #registerEventValue(Class, Class, Getter, int)
 	 * @see EventValueExpression#EventValueExpression(Class)
 	 */
 	@Nullable
-	public static <T, E extends Event> Getter<? extends T, ? super E> getEventValueGetter(Class<E> event, Class<T> c, int time) {
-		return getEventValueGetter(event, c, time, true);
+	public static <T, E extends Event> Converter<? super E, ? extends T> getEventValueConverter(Class<E> event, Class<T> c, int time) {
+		return getEventValueConverter(event, c, time, true);
 	}
-	
-	@SuppressWarnings("unchecked")
+
 	@Nullable
-	private static <T, E extends Event> Getter<? extends T, ? super E> getEventValueGetter(Class<E> event, Class<T> c, int time, boolean allowDefault) {
+	@SuppressWarnings("unchecked")
+	private static <T, E extends Event> Converter<? super E, ? extends T> getEventValueConverter(Class<E> event, Class<T> c, int time, boolean allowDefault) {
 		List<EventValueInfo<?, ?>> eventValues = getEventValuesList(time);
+
 		// First check for exact classes matching the parameters.
 		for (EventValueInfo<?, ?> eventValueInfo : eventValues) {
-			if (!c.equals(eventValueInfo.c))
+			if (!c.equals(eventValueInfo.getValueClass()))
 				continue;
 			if (!checkExcludes(eventValueInfo, event))
 				return null;
-			if (eventValueInfo.event.isAssignableFrom(event))
-				return (Getter<? extends T, ? super E>) eventValueInfo.getter;
+			if (eventValueInfo.getEventClass().isAssignableFrom(event))
+				return (Converter<? super E, ? extends T>) eventValueInfo.getConverter();
 		}
+
 		// Second check for assignable subclasses.
 		for (EventValueInfo<?, ?> eventValueInfo : eventValues) {
-			if (!c.isAssignableFrom(eventValueInfo.c))
+			if (!c.isAssignableFrom(eventValueInfo.getValueClass()))
 				continue;
 			if (!checkExcludes(eventValueInfo, event))
 				return null;
-			if (eventValueInfo.event.isAssignableFrom(event))
-				return (Getter<? extends T, ? super E>) eventValueInfo.getter;
-			if (!event.isAssignableFrom(eventValueInfo.event))
+			if (eventValueInfo.getEventClass().isAssignableFrom(event))
+				return (Converter<? super E, ? extends T>) eventValueInfo.getConverter();
+			if (!event.isAssignableFrom(eventValueInfo.getEventClass()))
 				continue;
-			return new Getter<T, E>() {
+			return new Converter<E, T>() {
 				@Override
 				@Nullable
-				public T get(E event) {
-					if (!eventValueInfo.event.isInstance(event))
+				public T convert(E event) {
+					if (!eventValueInfo.getEventClass().isInstance(event))
 						return null;
-					return ((Getter<? extends T, E>) eventValueInfo.getter).get(event);
+					return ((Converter<E, ? extends T>) eventValueInfo.getConverter()).convert(event);
 				}
 			};
 		}
-		// Most checks have returned before this below is called, but Skript will attempt to convert or find an alternative.
+
+		// Most checks have returned before this below is called, Skript will now attempt to convert or find an alternative.
 		// Third check is if the returned object matches the class.
 		for (EventValueInfo<?, ?> eventValueInfo : eventValues) {
-			if (!eventValueInfo.c.isAssignableFrom(c))
+			if (!eventValueInfo.getValueClass().isAssignableFrom(c))
 				continue;
-			boolean checkInstanceOf = !eventValueInfo.event.isAssignableFrom(event);
-			if (checkInstanceOf && !event.isAssignableFrom(eventValueInfo.event))
+			boolean checkInstanceOf = !eventValueInfo.getEventClass().isAssignableFrom(event);
+			if (checkInstanceOf && !event.isAssignableFrom(eventValueInfo.getEventClass()))
 				continue;
 			if (!checkExcludes(eventValueInfo, event))
 				return null;
-			return new Getter<T, E>() {
+			return new Converter<E, T>() {
 				@Override
 				@Nullable
-				public T get(E event) {
-					if (checkInstanceOf && !eventValueInfo.event.isInstance(event))
+				public T convert(E event) {
+					if (checkInstanceOf && !eventValueInfo.getEventClass().isInstance(event))
 						return null;
-					Object object = ((Getter<? super T, ? super E>) eventValueInfo.getter).get(event);
+					Object object = ((Converter<? super E, ? super T>) eventValueInfo.getConverter()).convert(event);
 					if (c.isInstance(object))
 						return (T) object;
 					return null;
 				}
 			};
 		}
+
 		// Fourth check will attempt to convert the event value to the requesting type.
 		// This first for loop will check that the events are exact. See issue #5016
 		for (EventValueInfo<?, ?> eventValueInfo : eventValues) {
-			if (!event.equals(eventValueInfo.event))
+			if (!event.equals(eventValueInfo.getEventClass()))
 				continue;
-			
-			Getter<? extends T, ? super E> getter = (Getter<? extends T, ? super E>) getConvertedGetter(eventValueInfo, c, false);
-			if (getter == null)
+			Converter<? super E, ? extends T> converter = (Converter<? super E, ? extends T>) getConvertedConverter(eventValueInfo, c, false);
+			if (converter == null)
 				continue;
-			
 			if (!checkExcludes(eventValueInfo, event))
 				return null;
-			return getter;
+			return converter;
 		}
+
 		// This loop will attempt to look for converters assignable to the class of the provided event.
 		for (EventValueInfo<?, ?> eventValueInfo : eventValues) {
 			// The requesting event must be assignable to the event value's event. Otherwise it'll throw an error.
-			if (!event.isAssignableFrom(eventValueInfo.event))
+			if (!event.isAssignableFrom(eventValueInfo.getEventClass()))
 				continue;
-			
-			Getter<? extends T, ? super E> getter = (Getter<? extends T, ? super E>) getConvertedGetter(eventValueInfo, c, true);
-			if (getter == null)
+			Converter<? super E, ? extends T> converter = (Converter<? super E, ? extends T>) getConvertedConverter(eventValueInfo, c, true);
+			if (converter == null)
 				continue;
-			
 			if (!checkExcludes(eventValueInfo, event))
 				return null;
-			return getter;
+			return converter;
 		}
-		// If the check should try again matching event values with a 0 time (most event values).
-		if (allowDefault && time != 0)
-			return getEventValueGetter(event, c, 0, false);
+
+		// If the check should try again matching event values with TIME_NOW (most event values) if it's not already.
+		if (allowDefault && time != TIME_NOW)
+			return getEventValueConverter(event, c, TIME_NOW, false);
 		return null;
 	}
 
 	/**
-	 * Check if the event value states to exclude events.
+	 * Check if the provided event class is excluded in the event value.
 	 * 
-	 * @param info The event value info that will be used to grab the value from
+	 * @param info The event value info that will be used to grab the value from.
 	 * @param event The event class to check the excludes against.
-	 * @return boolean if true the event value passes for the events.
+	 * @return boolean true if the event value passes for the events.
 	 */
 	private static boolean checkExcludes(EventValueInfo<?, ?> info, Class<? extends Event> event) {
-		if (info.excludes == null)
+		if (info.getExcludedEvents() == null)
 			return true;
-		for (Class<? extends Event> ex : (Class<? extends Event>[]) info.excludes) {
-			if (ex.isAssignableFrom(event)) {
-				Skript.error(info.excludeErrorMessage);
+		for (Class<? extends Event> excluded : info.getExcludedEvents()) {
+			if (excluded.isAssignableFrom(event)) {
+				Skript.error(info.getExcludeErrorMessage());
 				return false;
 			}
 		}
@@ -326,34 +376,41 @@ public class EventValues {
 	}
 
 	/**
-	 * Return a converter wrapped in a getter that will grab the requested value by converting from the given event value info.
+	 * Return a converter wrapped in a converter that will extract the requested value by converting from the given event value info.
 	 * 
-	 * @param info The event value info that will be used to grab the value from
-	 * @param to The class that the converter will look for to convert the type from the event value to
+	 * @param info The event value info that will be used to grab the value from.
+	 * @param to The class that the converter will look for to convert the type from the event value to.
 	 * @param checkInstanceOf If the event must be an exact instance of the event value info's event or not.
-	 * @return The found Converter wrapped in a Getter object, or null if no Converter was found.
+	 * @return A Converter that will convert the event value to the corresponding type, or null if no Converter was possible.
 	 */
 	@Nullable
-	private static <E extends Event, F, T> Getter<? extends T, ? super E> getConvertedGetter(EventValueInfo<E, F> info, Class<T> to, boolean checkInstanceOf) {
-		Converter<? super F, ? extends T> converter = Converters.getConverter(info.c, to);
+	private static <E extends Event, F, T> Converter<? super E, ? extends T> getConvertedConverter(EventValueInfo<E, F> info, Class<T> to, boolean checkInstanceOf) {
+		Converter<? super F, ? extends T> converter = Converters.getConverter(info.getValueClass(), to);
 		if (converter == null)
 			return null;
-		return new Getter<T, E>() {
+		return new Converter<E, T>() {
 			@Override
 			@Nullable
-			public T get(E e) {
-				if (checkInstanceOf && !info.event.isInstance(e))
+			public T convert(E e) {
+				if (checkInstanceOf && !info.getEventClass().isInstance(e))
 					return null;
-				F f = info.getter.get(e);
-				if (f == null)
+				F value = info.getConverter().convert(e);
+				if (value == null)
 					return null;
-				return converter.convert(f);
+				return converter.convert(value);
 			}
 		};
 	}
-	
-	public static boolean doesEventValueHaveTimeStates(Class<? extends Event> e, Class<?> c) {
-		return getEventValueGetter(e, c, -1, false) != null || getEventValueGetter(e, c, 1, false) != null;
+
+	/**
+	 * Check if an event has event values in the past or future time states based on the provided return type.
+	 * 
+	 * @param event The event to check for event values against.
+	 * @param c The return type to check against event values for.
+	 * @return boolean true if there are event values present of the provided return type and in the future or past time states.
+	 */
+	public static boolean doesEventValueHaveTimeStates(Class<? extends Event> event, Class<?> c) {
+		return getEventValueConverter(event, c, TIME_PAST, false) != null || getEventValueConverter(event, c, TIME_FUTURE, false) != null;
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/registrations/EventValues.java
+++ b/src/main/java/ch/njol/skript/registrations/EventValues.java
@@ -64,7 +64,7 @@ public class EventValues {
 		/**
 		 * Get the classes that are excluded for this event value.
 		 * If the event values are used in any of these events, Skript will error.
-		 * Example being command sender or a player in a damage event, they should be using attacker/victim.
+		 * Example: command sender or a player in a damage event will error, they should be using attacker/victim.
 		 * 
 		 * @return The classes of the excluded events for this event value.
 		 */
@@ -151,7 +151,7 @@ public class EventValues {
 			return defaultEventValues;
 		if (time == TIME_FUTURE)
 			return futureEventValues;
-		throw new IllegalArgumentException("time must be -1, 0, or 1");
+		throw new IllegalArgumentException("time must be TIME_PAST, TIME_NOW, or TIME_FUTURE");
 	}
 
 	/**
@@ -199,17 +199,17 @@ public class EventValues {
 	 * @param excludes Subclasses of the event for which this event value should not be registered for.
 	 */
 	@SafeVarargs
-	public static <T, E extends Event> void registerEventValue(Class<E> e, Class<T> c, Converter<E, T> g, int time, @Nullable String excludeErrorMessage, @Nullable Class<? extends E>... excludes) {
+	public static <T, E extends Event> void registerEventValue(Class<E> event, Class<T> c, Converter<E, T> converter, int time, @Nullable String excludeErrorMessage, @Nullable Class<? extends E>... excludes) {
 		Skript.checkAcceptRegistrations();
 		List<EventValueInfo<?, ?>> eventValues = getEventValuesList(time);
 		for (int i = 0; i < eventValues.size(); i++) {
 			EventValueInfo<?, ?> info = eventValues.get(i);
-			if (info.getEventClass() != e ? info.getEventClass().isAssignableFrom(e) : info.getValueClass().isAssignableFrom(c)) {
-				eventValues.add(i, new EventValueInfo<>(e, c, g, excludeErrorMessage, excludes));
+			if (info.getEventClass() != event ? info.getEventClass().isAssignableFrom(event) : info.getValueClass().isAssignableFrom(c)) {
+				eventValues.add(i, new EventValueInfo<>(event, c, converter, excludeErrorMessage, excludes));
 				return;
 			}
 		}
-		eventValues.add(new EventValueInfo<>(e, c, g, excludeErrorMessage, excludes));
+		eventValues.add(new EventValueInfo<>(event, c, converter, excludeErrorMessage, excludes));
 	}
 
 	/**
@@ -391,10 +391,10 @@ public class EventValues {
 		return new Converter<E, T>() {
 			@Override
 			@Nullable
-			public T convert(E e) {
-				if (checkInstanceOf && !info.getEventClass().isInstance(e))
+			public T convert(E event) {
+				if (checkInstanceOf && !info.getEventClass().isInstance(event))
 					return null;
-				F value = info.getConverter().convert(e);
+				F value = info.getConverter().convert(event);
 				if (value == null)
 					return null;
 				return converter.convert(value);

--- a/src/main/java/ch/njol/skript/registrations/EventValues.java
+++ b/src/main/java/ch/njol/skript/registrations/EventValues.java
@@ -182,7 +182,7 @@ public class EventValues {
 
 	/**
 	 * Register an event value with events that should be excluded for this event value.
-	 * Some event values you may want to not opperate in specific events.
+	 * Some event values you may want to not operate in specific events.
 	 * <p>
 	 * An example would be Skript's player event value not being allowed in a damage event.
 	 * This is because there can be multiple players in a damage event and Skript would be defaulting to
@@ -193,7 +193,7 @@ public class EventValues {
 	 * @param converter The converter that will extract the value from the event.
 	 * @param time The time state of this event value. Use {@link EventValues#TIME_PAST} if this value was before the event.
 	 * 		or use {@link EventValues#TIME_FUTURE} if this value is after the event. {@link EventValues#TIME_NOW} is the default neutral state.
-	 * 		If the provided time was not {@link EventValues#TIME_NOW} and it's time wasn't found, Skript will default to {@link EventValues#TIME_NOW}.
+	 * 		If the provided time was not {@link EventValues#TIME_NOW} and its time wasn't found, Skript will default to {@link EventValues#TIME_NOW}.
 	 * 		Use {@link EventValues#TIME_NOW} if this event value has no distinct states, and always register a default state {@link EventValues#TIME_NOW} for each return type of the event.
 	 * @param excludeErrorMessage The error message to print when an excluded event is used with this event value.
 	 * @param excludes Subclasses of the event for which this event value should not be registered for.
@@ -222,7 +222,7 @@ public class EventValues {
 	 * @param c The return type of the converter.
 	 * @param time The time state of this event value. Use {@link EventValues#TIME_PAST} if this value was before the event.
 	 * 		or use {@link EventValues#TIME_FUTURE} if this value is after the event. {@link EventValues#TIME_NOW} is the default neutral state.
-	 * 		If the provided time was not {@link EventValues#TIME_NOW} and it's time wasn't found, Skript will default to {@link EventValues#TIME_NOW}.
+	 * 		If the provided time was not {@link EventValues#TIME_NOW} and its time wasn't found, Skript will default to {@link EventValues#TIME_NOW}.
 	 * @return The value found from possible event values.
 	 * @see #registerEventValue(Class, Class, Getter, int)
 	 */
@@ -254,7 +254,7 @@ public class EventValues {
 	 * @param event The event class the converter will be getting from.
 	 * @param c The return type of the converter.
 	 * @param time The event-value's time state.
-	 * 		If the provided time was not {@link EventValues#TIME_NOW} and it's time wasn't found, Skript will default to {@link EventValues#TIME_NOW}.
+	 * 		If the provided time was not {@link EventValues#TIME_NOW} and its time wasn't found, Skript will default to {@link EventValues#TIME_NOW}.
 	 * @return A converter that is used to extract values from the given event class.
 	 * @see #registerEventValue(Class, Class, Getter, int)
 	 * @see EventValueExpression#EventValueExpression(Class)

--- a/src/main/java/ch/njol/skript/util/Getter.java
+++ b/src/main/java/ch/njol/skript/util/Getter.java
@@ -19,7 +19,7 @@
 package ch.njol.skript.util;
 
 import org.eclipse.jdt.annotation.Nullable;
-
+import org.jetbrains.annotations.ApiStatus.ScheduledForRemoval;
 import org.skriptlang.skript.lang.converter.Converter;
 
 /**
@@ -27,8 +27,10 @@ import org.skriptlang.skript.lang.converter.Converter;
  * 
  * @param <R> the returned value type
  * @param <A> the type which holds the value
- * @author Peter Güttinger
+ * @deprecated Use {@link org.skriptlang.skript.lang.converter.Converter}
  */
+@Deprecated
+@ScheduledForRemoval
 public abstract class Getter<R, A> implements Converter<A, R> {
 	
 	/**


### PR DESCRIPTION
### Description
A rebase of pull request https://github.com/SkriptLang/Skript/pull/5013 the amount of changes was not worth the time dealing with conflicts.

Change Getter to Converter in EventValues.
Getter doesn't allow for Java lambdas, and most Skript classes use Converter directly.
I've also added a registerEventValue method without the time integer, which will default to TIME_NOW. As it's the most used time state.

This will allow for
```java
EventValues.registerEventValue(PlayerEggThrowEvent.class, Egg.class, PlayerEggThrowEvent::getEgg);
EventValues.registerEventValue(PlayerEggThrowEvent.class, Egg.class, PlayerEggThrowEvent::getEgg, EventValues.TIME_NOW);
```

Also code cleaned my main domain the EventValues, and added all JavaDocs with over the top explanation.
Changed all raw field references in EventValueInfo to be using the getters that have never been used. Security.
I will change all the BukkitEventValues in another pull request. There will be too many conflict resolving for it to be contained in this pull request.

---
**Related Issues:** https://github.com/SkriptLang/Skript/issues/5006