### PR TITLE
Improve hashCode of Pair

### DIFF
--- a/src/main/java/ch/njol/util/Pair.java
+++ b/src/main/java/ch/njol/util/Pair.java
@@ -20,6 +20,7 @@ package ch.njol.util;
 
 import java.io.Serializable;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -96,9 +97,7 @@ public class Pair<T1, T2> implements Entry<T1, T2>, Cloneable, Serializable {
 	 */
 	@Override
 	public final int hashCode() {
-		final T1 first = this.first;
-		final T2 second = this.second;
-		return (first == null ? 0 : first.hashCode()) ^ (second == null ? 0 : second.hashCode());
+		return Objects.hash(first, second);
 	}
 	
 	@Override


### PR DESCRIPTION
### Description
(originated from https://github.com/SkriptLang/Skript/pull/5403#discussion_r1088771469)

The previous implementation will return 0 if the `hashCode` of the objects equal due to the XOR operation. Therefore, a pair with equal objects will always have the same `hashCode`, which can be efficient if a data structure like a `HashMap` or `HashSet` contains pairs of possibly equal objects.

See also the contract of `hashCode`: https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#hashCode--

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
