### PR TITLE
Update ExprFormatDate.java

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprFormatDate.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFormatDate.java
@@ -47,7 +47,7 @@ import ch.njol.util.Kleenean;
 	"command /date:",
 	"\ttrigger:",
 	"\t\tsend \"Full date: %now formatted human-readable%\" to sender",
-	"\t\tsend \"Short date: %now formatted as \"\"yyyy-MM-dd\"\"%\" to sender"
+	"\t\tsend \"Short date: %now formatted as \"yyyy-MM-dd\"%\" to sender"
 })
 @Since("2.2-dev31, INSERT VERSION (support variables in format)")
 public class ExprFormatDate extends PropertyExpression<Date, String> {


### PR DESCRIPTION
### Description
This PR adds nothing new to skript just fixed a outdated example for the expression.
Skript no longer required `""` within strings, this example wasn't updated in the last PR related to it

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions --> ANY
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->  NONE
**Related Issues:** <!-- Links to related issues --> NONE
