### PR TITLE
Fix expression list checking

### DIFF
--- a/src/main/java/ch/njol/skript/lang/ExpressionList.java
+++ b/src/main/java/ch/njol/skript/lang/ExpressionList.java
@@ -148,20 +148,20 @@ public class ExpressionList<T> implements Expression<T> {
 	}
 
 	@Override
-	public boolean check(Event e, Checker<? super T> c, boolean negated) {
-		return negated ^ check(e, c);
-	}
-
-	@Override
-	public boolean check(Event e, Checker<? super T> c) {
+	public boolean check(Event event, Checker<? super T> checker, boolean negated) {
 		for (Expression<? extends T> expr : expressions) {
-			boolean b = expr.check(e, c);
-			if (and && !b)
+			boolean result = expr.check(event, checker) ^ negated;
+			if (and && !result)
 				return false;
-			if (!and && b)
+			if (!and && result)
 				return true;
 		}
 		return and;
+	}
+
+	@Override
+	public boolean check(Event event, Checker<? super T> checker) {
+		return check(event, checker, false);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/test/skript/tests/misc/expression list checking.sk
+++ b/src/test/skript/tests/misc/expression list checking.sk
@@ -1,0 +1,3 @@
+test "expression list checking":
+	assert "" or {_empty} is empty with "both values aren't empty, but one should be"
+	assert "" or {_empty} is not empty with "both values are empty, but one shouldn't be"


### PR DESCRIPTION
### Description
This PR aims to fix an issue with negating the result of a condition used with an expression list. See image below and test for an explanation:
![image](https://user-images.githubusercontent.com/29044720/216433233-3bc56f0b-09a9-4466-b24a-0d9c0a689b8c.png)
Both should print, but this is not currently the case. This is because the negation was applied at the end, when it should likely be applied to each expression's result.

---
**Target Minecraft Versions:** Any
**Requirements:** N/A
**Related Issues:** None?
