### PR TITLE
Allow using alises when parsing BlockData

### DIFF
--- a/src/main/java/ch/njol/skript/util/BlockUtils.java
+++ b/src/main/java/ch/njol/skript/util/BlockUtils.java
@@ -111,7 +111,7 @@ public class BlockUtils {
 				int finalOpeningBracket = data.lastIndexOf('[');
 				// we use the original dataString param here as we want the alias before modifications
 				String alias = dataString.substring(0, finalOpeningBracket);
-				data = data.substring(data.lastIndexOf("["), finalOpeningBracket);
+				data = data.substring(finalOpeningBracket, dataString.length());
 				ItemType type = Aliases.parseItemType(alias);
 				if (type == null)
 					return null;

--- a/src/main/java/ch/njol/skript/util/BlockUtils.java
+++ b/src/main/java/ch/njol/skript/util/BlockUtils.java
@@ -24,7 +24,6 @@ import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.bukkitutil.block.BlockCompat;
 import ch.njol.skript.bukkitutil.block.BlockSetter;
 import ch.njol.skript.bukkitutil.block.BlockValues;
-import ch.njol.skript.log.BlockingLogHandler;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -109,9 +108,10 @@ public class BlockUtils {
 			return Bukkit.createBlockData(data.startsWith("minecraft:") ? data : "minecraft:" + data);
 		} catch (IllegalArgumentException ignored) {
 			try {
+				int finalOpeningBracket = data.lastIndexOf('[');
 				// we use the original dataString param here as we want the alias before modifications
-				String alias = dataString.substring(0, data.lastIndexOf("["));
-				data = data.substring(data.lastIndexOf("["), dataString.length());
+				String alias = dataString.substring(0, finalOpeningBracket);
+				data = data.substring(data.lastIndexOf("["), finalOpeningBracket);
 				ItemType type = Aliases.parseItemType(alias);
 				if (type == null)
 					return null;

--- a/src/main/java/ch/njol/skript/util/BlockUtils.java
+++ b/src/main/java/ch/njol/skript/util/BlockUtils.java
@@ -108,10 +108,9 @@ public class BlockUtils {
 			return Bukkit.createBlockData(data.startsWith("minecraft:") ? data : "minecraft:" + data);
 		} catch (IllegalArgumentException ignored) {
 			try {
-				int finalOpeningBracket = data.lastIndexOf('[');
 				// we use the original dataString param here as we want the alias before modifications
-				String alias = dataString.substring(0, finalOpeningBracket);
-				data = data.substring(finalOpeningBracket, dataString.length());
+				String alias = dataString.substring(0, dataString.lastIndexOf("["));
+				data = data.substring(data.lastIndexOf("["));
 				ItemType type = Aliases.parseItemType(alias);
 				if (type == null)
 					return null;

--- a/src/main/java/ch/njol/skript/util/BlockUtils.java
+++ b/src/main/java/ch/njol/skript/util/BlockUtils.java
@@ -108,7 +108,7 @@ public class BlockUtils {
 		try {
 			return Bukkit.createBlockData(data.startsWith("minecraft:") ? data : "minecraft:" + data);
 		} catch (IllegalArgumentException ignored) {
-			try (BlockingLogHandler ignoredHandler = new BlockingLogHandler().start()) {
+			try {
 				// we use the original dataString param here as we want the alias before modifications
 				String alias = dataString.substring(0, data.lastIndexOf("["));
 				data = data.substring(data.lastIndexOf("["), dataString.length());

--- a/src/test/skript/tests/misc/blockdata parser.sk
+++ b/src/test/skript/tests/misc/blockdata parser.sk
@@ -1,0 +1,5 @@
+aliases:
+	test alias = wheat
+
+test "blockdata parser using aliases":
+	assert wheat[age=7] is test alias[age=7] with "Parsing blockdata using an alias gave a different result"


### PR DESCRIPTION
### Description
This change allows using aliases instead of minecraft names when parsing blockdata

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** N/A