### PR TITLE
Script handling improvements

### DIFF
--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -599,6 +599,8 @@ public class ScriptLoader {
 	 */
 	// Whenever you call this method, make sure to also call PreScriptLoadEvent
 	private static NonNullPair<Script, List<Structure>> loadScript(Config config) {
+		if (config.getFile() == null)
+			throw new IllegalArgumentException("A config must have a file to be loaded.");
 
 		ParserInstance parser = getParser();
 		List<Structure> structures = new ArrayList<>();
@@ -791,14 +793,15 @@ public class ScriptLoader {
 	 *         This data is calculated by using {@link ScriptInfo#add(ScriptInfo)}.
 	 */
 	public static ScriptInfo unloadScripts(Set<Script> scripts) {
-		ParserInstance parser = getParser();
-		ScriptInfo info = new ScriptInfo();
-
-		// ensure unloaded scripts are not being loaded
+		// ensure unloaded scripts are not being unloaded
 		for (Script script : scripts) {
 			if (!loadedScripts.contains(script))
 				throw new SkriptAPIException("The script at '" + script.getConfig().getPath() + "' is not loaded!");
+			if (script.getConfig().getFile() == null)
+				throw new IllegalArgumentException("A script must have a file to be unloaded.");
 		}
+
+		ParserInstance parser = getParser();
 
 		// initial unload stage
 		for (Script script : scripts) {
@@ -810,6 +813,7 @@ public class ScriptLoader {
 		parser.setInactive();
 
 		// finish unloading + data collection
+		ScriptInfo info = new ScriptInfo();
 		for (Script script : scripts) {
 			List<Structure> structures = script.getStructures();
 

--- a/src/main/java/ch/njol/skript/command/Commands.java
+++ b/src/main/java/ch/njol/skript/command/Commands.java
@@ -158,7 +158,7 @@ public abstract class Commands {
 		public void onServerCommand(final ServerCommandEvent e) {
 			if (e.getCommand() == null || e.getCommand().isEmpty() || e.isCancelled())
 				return;
-			if (SkriptConfig.enableEffectCommands.value() && e.getCommand().startsWith(SkriptConfig.effectCommandToken.value())) {
+			if ((Skript.testing() || SkriptConfig.enableEffectCommands.value()) && e.getCommand().startsWith(SkriptConfig.effectCommandToken.value())) {
 				if (handleEffectCommand(e.getSender(), e.getCommand())) {
 					e.setCancelled(true);
 				}

--- a/src/main/java/ch/njol/skript/expressions/ExprScript.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprScript.java
@@ -26,6 +26,7 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.parser.ParserInstance;
 import org.skriptlang.skript.lang.script.Script;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
@@ -52,12 +53,17 @@ public class ExprScript extends SimpleExpression<String> {
 		);
 	}
 	
-	@SuppressWarnings("NotNullFieldNotIntialized")
+	@SuppressWarnings("NotNullFieldNotInitialized")
 	private String name;
 	
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		String name = getParser().getCurrentScript().getConfig().getFileName();
+		ParserInstance parser = getParser();
+		if (!parser.isActive()) {
+			Skript.error("You can't use the script expression outside of scripts!");
+			return false;
+		}
+		String name = parser.getCurrentScript().getConfig().getFileName();
 		if (name.contains("."))
 			name = name.substring(0, name.lastIndexOf('.'));
 		this.name = name;
@@ -65,7 +71,7 @@ public class ExprScript extends SimpleExpression<String> {
 	}
 	
 	@Override
-	protected String[] get(Event e) {
+	protected String[] get(Event event) {
 		return new String[]{name};
 	}
 	
@@ -80,7 +86,7 @@ public class ExprScript extends SimpleExpression<String> {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "the script's name";
 	}
 	

--- a/src/main/java/ch/njol/skript/lang/parser/ParserInstance.java
+++ b/src/main/java/ch/njol/skript/lang/parser/ParserInstance.java
@@ -39,6 +39,7 @@ import org.skriptlang.skript.lang.script.Script;
 import org.skriptlang.skript.lang.script.ScriptEvent;
 import org.skriptlang.skript.lang.structure.Structure;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -532,8 +533,10 @@ public final class ParserInstance {
 	public void setCurrentScript(@Nullable Config currentScript) {
 		if (currentScript == null)
 			return;
-		//noinspection ConstantConditions - shouldn't be null
-		Script script = ScriptLoader.getScript(currentScript.getFile());
+		File file = currentScript.getFile();
+		if (file == null)
+			return;
+		Script script = ScriptLoader.getScript(file);
 		if (script != null)
 			setActive(script);
 	}

--- a/src/main/java/org/skriptlang/skript/lang/script/Script.java
+++ b/src/main/java/org/skriptlang/skript/lang/script/Script.java
@@ -20,6 +20,7 @@ package org.skriptlang.skript.lang.script;
 
 import ch.njol.skript.config.Config;
 import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Unmodifiable;
 import org.skriptlang.skript.lang.structure.Structure;
 
@@ -38,6 +39,7 @@ import java.util.stream.Collectors;
  * Every script also has its own internal information, such as
  *  custom data, suppressed warnings, and associated event handlers.
  */
+@ApiStatus.Internal
 public final class Script {
 
 	private final Config config;
@@ -65,6 +67,7 @@ public final class Script {
 	/**
 	 * @return An unmodifiable list of all Structures within this Script.
 	 */
+	@Unmodifiable
 	public List<Structure> getStructures() {
 		return Collections.unmodifiableList(structures);
 	}

--- a/src/main/java/org/skriptlang/skript/lang/script/Script.java
+++ b/src/main/java/org/skriptlang/skript/lang/script/Script.java
@@ -39,7 +39,6 @@ import java.util.stream.Collectors;
  * Every script also has its own internal information, such as
  *  custom data, suppressed warnings, and associated event handlers.
  */
-@ApiStatus.Internal
 public final class Script {
 
 	private final Config config;
@@ -52,6 +51,7 @@ public final class Script {
 	 * @param config The Config containing the contents of this Script.
 	 * @param structures The list of Structures contained in this Script.
 	 */
+	@ApiStatus.Internal
 	public Script(Config config, List<Structure> structures) {
 		this.config = config;
 		this.structures = structures;

--- a/src/test/skript/tests/misc/effect commands.sk
+++ b/src/test/skript/tests/misc/effect commands.sk
@@ -1,0 +1,4 @@
+test "effect commands":
+
+	# assume if something goes wrong we'll get an exception
+	execute console command "!broadcast ""effect commands test"""


### PR DESCRIPTION
### Description
This PR adds some safety checks and corrects some usages of Script that may result in an error occurring during the usage of effect commands (or other runtime parsing mechanisms).

I've also added in a rough test. This means that effect commands are **always** enabled for console during **tests**.

---
**Target Minecraft Versions:** Any
**Requirements:** N/A
**Related Issues:**