### PR TITLE
Update security guidelines to point to new reporting page

### DIFF
--- a/security.md
+++ b/security.md
@@ -3,13 +3,10 @@ See also [code conventions](code-conventions.md); there are a few guidelines
 about security of added code there.
 
 ## Reporting security issues
-Security issues may be reported to core team members privately e.g. on Discord.
-Note that this applies *only* to security issues; everything else should still
-be posted to issue tracker.
+Security issues may be reported via the GitHub private vulnerability reporting feature [here](https://github.com/SkriptLang/Skript/security/advisories/new).
+Note that this applies *only* to security issues; everything else should still be posted to issue tracker.
 
-Publicly posting security issues is also allowed, because not everyone has or
-wants a Discord account. We may add other channels for private reports in
-future.
+Please avoid publicly posting or discussing security issues that don't have a fix available yet.
 
 ## Team guidelines
 Everyone with push access must use two-factor authentication for their Github


### PR DESCRIPTION
### Description
Updates the security document to recommend that security issues are privately reported via the security advisory page on github.

---
**Target Minecraft Versions:** N/A
**Requirements:** N/A
**Related Issues:** N/A