### PR TITLE
Fix double space in toString of ExprPermissions

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprPermissions.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPermissions.java
@@ -82,7 +82,7 @@ public class ExprPermissions extends SimpleExpression<String> {
 	
 	@Override
 	public String toString(@Nullable Event event, boolean debug) {
-		return "permissions " + " of " + players.toString(event, debug);
+		return "permissions of " + players.toString(event, debug);
 	}
 
 }


### PR DESCRIPTION
### Description
Fixes a useless concatenation and double space in the toString of ExprPermissions.

---
**Target Minecraft Versions:** any
**Requirements:** N/A
**Related Issues:** N/A
