### PR TITLE
Disable JUnit in build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,12 @@ task build(overwrite: true, type: ShadowJar) {
 	from sourceSets.main.output
 }
 
+// Excludes the tests for the build task. Should be using junit, junitJava17, junitJava8, skriptTest, quickTest.
+// We do not want tests to run for building. That's time consuming and annoying. Especially in development.
+test {
+	exclude '**/*'
+}
+
 task relocateShadowJar(type: ConfigureShadowRelocation) {
 	target = tasks.shadowJar
 }


### PR DESCRIPTION
### Description
Disables the JUnit test from running when building. The build task does not start up a test runner server instance, so it'll throw errors as the JUnit tests are expecting a server to be running. This will disable that for the build task, which should be just like gradlew assemble. Use the provided test tasks for testing specific traits of Skript.
