### PR TITLE
Fix Converter compatibility for Property Expressions

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprChunk.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprChunk.java
@@ -18,14 +18,8 @@
  */
 package ch.njol.skript.expressions;
 
-import org.bukkit.Chunk;
-import org.bukkit.Location;
-import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
-import org.skriptlang.skript.lang.converter.Converter;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -36,6 +30,10 @@ import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.Direction;
 import ch.njol.util.Kleenean;
+import org.bukkit.Chunk;
+import org.bukkit.Location;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * @author Peter Güttinger
@@ -69,12 +67,7 @@ public class ExprChunk extends PropertyExpression<Location, Chunk> {
 	
 	@Override
 	protected Chunk[] get(final Event e, final Location[] source) {
-		return get(source, new Converter<Location, Chunk>() {
-			@Override
-			public Chunk convert(final Location l) {
-				return l.getChunk();
-			}
-		});
+		return get(source, Location::getChunk);
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprColoured.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprColoured.java
@@ -18,11 +18,7 @@
  */
 package ch.njol.skript.expressions;
 
-import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
-
 import ch.njol.skript.Skript;
-import org.skriptlang.skript.lang.converter.Converter;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -34,6 +30,8 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.Utils;
 import ch.njol.skript.util.chat.ChatMessages;
 import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
 
 @Name("Colored / Uncolored")
 @Description({"Parses &lt;color&gt;s and, optionally, chat styles in a message or removes",
@@ -78,12 +76,7 @@ public class ExprColoured extends PropertyExpression<String, String> {
 	
 	@Override
 	protected String[] get(final Event e, final String[] source) {
-		return get(source, new Converter<String, String>() {
-			@Override
-			public String convert(final String s) {
-				return color ? Utils.replaceChatStyles(s) : "" + ChatMessages.stripStyles(s);
-			}
-		});
+		return get(source, s -> color ? Utils.replaceChatStyles(s) : "" + ChatMessages.stripStyles(s));
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprGameMode.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprGameMode.java
@@ -18,17 +18,8 @@
  */
 package ch.njol.skript.expressions;
 
-import org.bukkit.Bukkit;
-import org.bukkit.GameMode;
-import org.bukkit.entity.Player;
-import org.bukkit.event.Event;
-import org.bukkit.event.player.PlayerGameModeChangeEvent;
-import org.eclipse.jdt.annotation.Nullable;
-
-import ch.njol.skript.ScriptLoader;
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
-import org.skriptlang.skript.lang.converter.Converter;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -40,6 +31,12 @@ import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.player.PlayerGameModeChangeEvent;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * @author Peter Güttinger
@@ -64,14 +61,10 @@ public class ExprGameMode extends PropertyExpression<Player, GameMode> {
 	
 	@Override
 	protected GameMode[] get(final Event e, final Player[] source) {
-		return get(source, new Converter<Player, GameMode>() {
-			@Override
-			@Nullable
-			public GameMode convert(final Player p) {
-				if (getTime() >= 0 && e instanceof PlayerGameModeChangeEvent && ((PlayerGameModeChangeEvent) e).getPlayer() == p && !Delay.isDelayed(e))
-					return ((PlayerGameModeChangeEvent) e).getNewGameMode();
-				return p.getGameMode();
-			}
+		return get(source, player -> {
+			if (getTime() >= 0 && e instanceof PlayerGameModeChangeEvent && ((PlayerGameModeChangeEvent) e).getPlayer() == player && !Delay.isDelayed(e))
+				return ((PlayerGameModeChangeEvent) e).getNewGameMode();
+			return player.getGameMode();
 		});
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprLightLevel.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLightLevel.java
@@ -18,13 +18,7 @@
  */
 package ch.njol.skript.expressions;
 
-import org.bukkit.Location;
-import org.bukkit.block.Block;
-import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
-
 import ch.njol.skript.Skript;
-import org.skriptlang.skript.lang.converter.Converter;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -35,6 +29,10 @@ import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.Direction;
 import ch.njol.util.Kleenean;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * @author Peter Güttinger
@@ -72,12 +70,10 @@ public class ExprLightLevel extends PropertyExpression<Location, Byte> {
 	
 	@Override
 	protected Byte[] get(final Event e, final Location[] source) {
-		return get(source, new Converter<Location, Byte>() {
-			@Override
-			public Byte convert(final Location l) {
-				final Block b = l.getBlock();
-				return whatLight == ANY ? b.getLightLevel() : whatLight == BLOCK ? b.getLightFromBlocks() : b.getLightFromSky();
-			}
+		return get(source, location -> {
+			Block block = location.getBlock();
+			return whatLight == ANY ? block.getLightLevel()
+				: whatLight == BLOCK ? block.getLightFromBlocks() : block.getLightFromSky();
 		});
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprShooter.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprShooter.java
@@ -18,15 +18,8 @@
  */
 package ch.njol.skript.expressions;
 
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Projectile;
-import org.bukkit.projectiles.ProjectileSource;
-import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
-import org.skriptlang.skript.lang.converter.Converter;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -36,6 +29,11 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.Event;
+import org.bukkit.projectiles.ProjectileSource;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * @author Peter Güttinger
@@ -58,15 +56,11 @@ public class ExprShooter extends PropertyExpression<Projectile, LivingEntity> {
 	
 	@Override
 	protected LivingEntity[] get(final Event e, final Projectile[] source) {
-		return get(source, new Converter<Projectile, LivingEntity>() {
-			@Override
-			@Nullable
-			public LivingEntity convert(final Projectile p) {
-				final Object o = p != null ? p.getShooter() : null;
-				if (o instanceof LivingEntity)
-					return (LivingEntity) o;
-				return null;
-			}
+		return get(source, projectile -> {
+			Object shooter = projectile != null ? projectile.getShooter() : null;
+			if (shooter instanceof LivingEntity)
+				return (LivingEntity) shooter;
+			return null;
 		});
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprTarget.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTarget.java
@@ -18,19 +18,8 @@
  */
 package ch.njol.skript.expressions;
 
-import java.util.List;
-
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Mob;
-import org.bukkit.event.Event;
-import org.bukkit.event.entity.EntityTargetEvent;
-import org.bukkit.util.Vector;
-import org.eclipse.jdt.annotation.Nullable;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
-import org.skriptlang.skript.lang.converter.Converter;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -44,6 +33,15 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Mob;
+import org.bukkit.event.Event;
+import org.bukkit.event.entity.EntityTargetEvent;
+import org.bukkit.util.Vector;
+import org.eclipse.jdt.annotation.Nullable;
+
+import java.util.List;
 
 /**
  * @author Peter Güttinger
@@ -75,18 +73,14 @@ public class ExprTarget extends PropertyExpression<LivingEntity, Entity> {
 
 	@Override
 	protected Entity[] get(Event e, LivingEntity[] source) {
-		return get(source, new Converter<LivingEntity, Entity>() {
-			@Override
-			@Nullable
-			public Entity convert(LivingEntity en) {
-				if (getTime() >= 0 && e instanceof EntityTargetEvent && en.equals(((EntityTargetEvent) e).getEntity()) && !Delay.isDelayed(e)) {
-					Entity target = ((EntityTargetEvent) e).getTarget();
-					if (target == null || type != null && !type.isInstance(target))
-						return null;
-					return target;
-				}
-				return getTarget(en, type);
+		return get(source, en -> {
+			if (getTime() >= 0 && e instanceof EntityTargetEvent && en.equals(((EntityTargetEvent) e).getEntity()) && !Delay.isDelayed(e)) {
+				Entity target = ((EntityTargetEvent) e).getTarget();
+				if (target == null || type != null && !type.isInstance(target))
+					return null;
+				return target;
 			}
+			return getTarget(en, type);
 		});
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVehicle.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVehicle.java
@@ -56,26 +56,22 @@ public class ExprVehicle extends SimplePropertyExpression<Entity, Entity> {
 	
 	@Override
 	protected Entity[] get(final Event e, final Entity[] source) {
-		return get(source, new Converter<Entity, Entity>() {
-			@Override
-			@Nullable
-			public Entity convert(final Entity p) {
-				if (getTime() >= 0 && e instanceof VehicleEnterEvent && p.equals(((VehicleEnterEvent) e).getEntered()) && !Delay.isDelayed(e)) {
-					return ((VehicleEnterEvent) e).getVehicle();
-				}
-				if (getTime() >= 0 && e instanceof VehicleExitEvent && p.equals(((VehicleExitEvent) e).getExited()) && !Delay.isDelayed(e)) {
-					return ((VehicleExitEvent) e).getVehicle();
-				}
-				if (hasMountEvents) {
-					if (getTime() >= 0 && e instanceof EntityMountEvent && p.equals(((EntityMountEvent) e).getEntity()) && !Delay.isDelayed(e)) {
-						return ((EntityMountEvent) e).getMount();
-					}
-					if (getTime() >= 0 && e instanceof EntityDismountEvent && p.equals(((EntityDismountEvent) e).getEntity()) && !Delay.isDelayed(e)) {
-						return ((EntityDismountEvent) e).getDismounted();
-					}
-				}
-				return p.getVehicle();
+		return get(source, entity -> {
+			if (getTime() >= 0 && e instanceof VehicleEnterEvent && entity.equals(((VehicleEnterEvent) e).getEntered()) && !Delay.isDelayed(e)) {
+				return ((VehicleEnterEvent) e).getVehicle();
 			}
+			if (getTime() >= 0 && e instanceof VehicleExitEvent && entity.equals(((VehicleExitEvent) e).getExited()) && !Delay.isDelayed(e)) {
+				return ((VehicleExitEvent) e).getVehicle();
+			}
+			if (hasMountEvents) {
+				if (getTime() >= 0 && e instanceof EntityMountEvent && entity.equals(((EntityMountEvent) e).getEntity()) && !Delay.isDelayed(e)) {
+					return ((EntityMountEvent) e).getMount();
+				}
+				if (getTime() >= 0 && e instanceof EntityDismountEvent && entity.equals(((EntityDismountEvent) e).getEntity()) && !Delay.isDelayed(e)) {
+					return ((EntityDismountEvent) e).getDismounted();
+				}
+			}
+			return entity.getVehicle();
 		});
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprWorld.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprWorld.java
@@ -74,23 +74,19 @@ public class ExprWorld extends PropertyExpression<Object, World> {
 	protected World[] get(final Event e, final Object[] source) {
 		if (source instanceof World[]) // event value (see init)
 			return (World[]) source;
-		return get(source, new Converter<Object, World>() {
-			@Override
-			@Nullable
-			public World convert(final Object o) {
-				if (o instanceof Entity) {
-					if (getTime() > 0 && e instanceof PlayerTeleportEvent && o.equals(((PlayerTeleportEvent) e).getPlayer()) && !Delay.isDelayed(e))
-						return ((PlayerTeleportEvent) e).getTo().getWorld();
-					else
-						return ((Entity) o).getWorld();
-				} else if (o instanceof Location) {
-					return ((Location) o).getWorld();
-				} else if (o instanceof Chunk) {
-					return ((Chunk) o).getWorld();
-				}
-				assert false : o;
-				return null;
+		return get(source, obj -> {
+			if (obj instanceof Entity) {
+				if (getTime() > 0 && e instanceof PlayerTeleportEvent && obj.equals(((PlayerTeleportEvent) e).getPlayer()) && !Delay.isDelayed(e))
+					return ((PlayerTeleportEvent) e).getTo().getWorld();
+				else
+					return ((Entity) obj).getWorld();
+			} else if (obj instanceof Location) {
+				return ((Location) obj).getWorld();
+			} else if (obj instanceof Chunk) {
+				return ((Chunk) obj).getWorld();
 			}
+			assert false : obj;
+			return null;
 		});
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/base/PropertyExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/PropertyExpression.java
@@ -112,10 +112,11 @@ public abstract class PropertyExpression<F, T> extends SimpleExpression<T> {
 	 * @return An array containing the converted values
 	 * @throws ArrayStoreException if the converter returned invalid values
 	 */
-	protected T[] get(final F[] source, final Converter<? super F, ? extends T> converter) {
+	@SuppressWarnings("deprecation") // for backwards compatibility
+	protected T[] get(final F[] source, final ch.njol.skript.classes.Converter<? super F, ? extends T> converter) {
 		assert source != null;
 		assert converter != null;
-		return Converters.convertUnsafe(source, getReturnType(), converter);
+		return ch.njol.skript.registrations.Converters.convertUnsafe(source, getReturnType(), converter);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/base/SimplePropertyExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/SimplePropertyExpression.java
@@ -18,10 +18,10 @@
  */
 package ch.njol.skript.expressions.base;
 
+import ch.njol.skript.classes.Converter;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
-import org.skriptlang.skript.lang.converter.Converter;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
@@ -33,6 +33,7 @@ import ch.njol.util.Kleenean;
  * @see PropertyExpression
  * @see PropertyExpression#register(Class, Class, String, String)
  */
+@SuppressWarnings("deprecation") // for backwards compatibility
 public abstract class SimplePropertyExpression<F, T> extends PropertyExpression<F, T> implements Converter<F, T> {
 	
 	@SuppressWarnings({"unchecked", "null"})

--- a/src/main/java/ch/njol/skript/util/Getter.java
+++ b/src/main/java/ch/njol/skript/util/Getter.java
@@ -18,9 +18,8 @@
  */
 package ch.njol.skript.util;
 
+import ch.njol.skript.classes.Converter;
 import org.eclipse.jdt.annotation.Nullable;
-
-import org.skriptlang.skript.lang.converter.Converter;
 
 /**
  * Used to get a specific value from instances of some type.
@@ -29,6 +28,7 @@ import org.skriptlang.skript.lang.converter.Converter;
  * @param <A> the type which holds the value
  * @author Peter Güttinger
  */
+@SuppressWarnings("deprecation") // for backwards compatibility
 public abstract class Getter<R, A> implements Converter<A, R> {
 	
 	/**


### PR DESCRIPTION
### Description
Currently, addons making use of PropertyExpression will error with a NoSuchMethodError, like this one:
![image](https://user-images.githubusercontent.com/29044720/224467409-b693359d-6350-4cd9-8323-4e3c2d328aae.png)
This is because these classes were made to require usage of the new Converter class. Of course, we can easily rectify this issue by having the method make use of the old Converter class. This also makes SimplePropertyExpression and Getter implement/extend (respectively) the old Converter class. This should have a minimal impact internally while allowing these addons to function. Some syntax classes have been updated so that they are using lambdas (allowing this to easily work regardless of which Converter class is required).

Since old Converter extends new Converter, Getter and SimplePropertyExpression are still both new Converters as well (they are just also old ones again too).


---
**Target Minecraft Versions:** Any
**Requirements:** N/A
**Related Issues:** N/A (reported on Discord)
