### PR TITLE
Fix ExprAttacker not working in damage events

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprAttacker.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAttacker.java
@@ -22,6 +22,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Projectile;
 import org.bukkit.event.Event;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.vehicle.VehicleDamageEvent;
 import org.bukkit.event.vehicle.VehicleDestroyEvent;
@@ -61,7 +62,7 @@ public class ExprAttacker extends SimpleExpression<Entity> {
 	
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parser) {
-		if (!getParser().isCurrentEvent(EntityDamageByEntityEvent.class, EntityDeathEvent.class, VehicleDamageEvent.class, VehicleDestroyEvent.class)) {
+		if (!getParser().isCurrentEvent(EntityDamageEvent.class, EntityDeathEvent.class, VehicleDamageEvent.class, VehicleDestroyEvent.class)) {
 			Skript.error("Cannot use 'attacker' outside of a damage/death/destroy event", ErrorQuality.SEMANTIC_ERROR);
 			return false;
 		}


### PR DESCRIPTION
### Description
This PR fixes ExprAttacker not working in damage events. See the issue below:
![image](https://user-images.githubusercontent.com/29044720/224471216-a57576c8-193c-4617-a53a-f34a14277ef6.png)
This error occurred because the isCurrentEvent check was broken, but I recently fixed it.
EvtDamage is based on the EntityDamageEvent, but ExprAttacker requires EntityDamageByEntityEvent, thus the error. This simple fix restores previous behavior. No additional checks are needed since the `get` method already has instanceof checks.

---
**Target Minecraft Versions:** Any
**Requirements:** N/A
**Related Issues:** N/A (reported on Discord)
