### PR TITLE
Fix unrelated default variables

### DIFF
--- a/src/main/java/ch/njol/skript/structures/StructVariables.java
+++ b/src/main/java/ch/njol/skript/structures/StructVariables.java
@@ -95,8 +95,14 @@ public class StructVariables extends Structure {
 		public void add(String variable, Class<?>... hints) {
 			if (hints == null || hints.length <= 0)
 				return;
-			if (CollectionUtils.containsAll(hints, Object.class)) // Ignore useless type hint
+			if (CollectionUtils.containsAll(hints, Object.class)) // Ignore useless type hint.
 				return;
+			// DefaultVariables can only be added when called from Variable.getRaw(event) and not somewhere else.
+			// This means that the scope has not been entered.
+			if (this.hints.isEmpty()) {
+				System.out.println("VARIABLE NOT MATCH, THIS IS GOOD " + variable);
+				return;
+			}
 			this.hints.getFirst().put(variable, hints);
 		}
 

--- a/src/main/java/ch/njol/skript/structures/StructVariables.java
+++ b/src/main/java/ch/njol/skript/structures/StructVariables.java
@@ -158,8 +158,10 @@ public class StructVariables extends Structure {
 				name = name.substring(1, name.length() - 1);
 			} else {
 				// TODO deprecated, remove this ability soon.
-				Skript.warning("The variables: section suggests using brackets around the name {example::%player%} = 5\n" +
-						"Not using brackets is considered deprecated, and will disallow no bracket definitions in the future.");
+				Skript.warning(
+						"It is suggested to use brackets around the name of a variable. Example: {example::%player%} = 5\n" +
+						"Excluding brackets is deprecated, meaning this warning will become an error in the future."
+				);
 			}
 
 			if (name.startsWith(Variable.LOCAL_VARIABLE_TOKEN)) {

--- a/src/main/java/ch/njol/skript/structures/StructVariables.java
+++ b/src/main/java/ch/njol/skript/structures/StructVariables.java
@@ -154,8 +154,13 @@ public class StructVariables extends Structure {
 			}
 
 			String name = n.getKey().toLowerCase(Locale.ENGLISH);
-			if (name.startsWith("{") && name.endsWith("}"))
+			if (name.startsWith("{") && name.endsWith("}")) {
 				name = name.substring(1, name.length() - 1);
+			} else {
+				// TODO deprecated, remove this ability soon.
+				Skript.warning("The variables: section suggests using brackets around the name {example::%player%} = 5\n" +
+						"Not using brackets is considered deprecated, and will disallow no bracket definitions in the future.");
+			}
 
 			if (name.startsWith(Variable.LOCAL_VARIABLE_TOKEN)) {
 				Skript.error("'" + name + "' cannot be a local variable in default variables structure");

--- a/src/main/java/ch/njol/skript/structures/StructVariables.java
+++ b/src/main/java/ch/njol/skript/structures/StructVariables.java
@@ -97,12 +97,9 @@ public class StructVariables extends Structure {
 				return;
 			if (CollectionUtils.containsAll(hints, Object.class)) // Ignore useless type hint.
 				return;
-			// DefaultVariables can only be added when called from Variable.getRaw(event) and not somewhere else.
-			// This means that the scope has not been entered.
-			if (this.hints.isEmpty()) {
-				System.out.println("VARIABLE NOT MATCH, THIS IS GOOD " + variable);
+			// This important empty check ensures that the variable type hint came from a defined DefaultVariable.
+			if (this.hints.isEmpty())
 				return;
-			}
 			this.hints.getFirst().put(variable, hints);
 		}
 

--- a/src/test/skript/tests/misc/default variables.sk
+++ b/src/test/skript/tests/misc/default variables.sk
@@ -23,6 +23,7 @@ on test "default variables":
 	set {_player} to "Njol" parsed as offlineplayer
 	assert {regression::%{_player}%} is 1337 with "default variable 6 failed: Value with player and double"
 
+	# If this fails, the scope of the default variables was not set, and it shouldn't be set for undefined, unrelated default variables.
 	set {unrelated::%{_player}%} to true
 	assert {unrelated::%{_player}%} is true with "unrelated variable to default variables conflict"
 

--- a/src/test/skript/tests/misc/default variables.sk
+++ b/src/test/skript/tests/misc/default variables.sk
@@ -1,37 +1,38 @@
 
 variables:
-	{testing variables1::%entity%} = 1337
-	{testing variables2::%object%} = 1337
-	{testing variables3::%entity%::%object%} = 1337
-	testing no brackets::%living entity% = "String"
-	testing = 1.6900000000001
-	{regression::%offlineplayer%} = 1337
+	{testing::variables1::%entity%} = 1337
+	{testing::variables2::%object%} = 1337
+	{testing::variables3::%entity%::%object%} = 1337
+	testing::no brackets::%living entity% = "String"
+	testing::variables4 = 1.6900000000001
+	{testing::regression::%offlineplayer%} = 1337
 
 on test "default variables":
 	spawn a pig at spawn of world "world"
-	assert {testing variables1::%last spawned pig%} is 1337 with "default variable 1 failed"
+	assert {testing::variables1::%last spawned pig%} is 1337 with "default variable 1 failed"
 
 	set {_string} to "empty string"
 	set {_local} to {_string}
 	assert {_local} is {_string} with "Local variable failed to copy another local variable"
 
-	assert {testing variables2::%{_string}%} is 1337 with "default variable 2 failed: Value with string"
-	assert {testing variables3::%last spawned pig%::%{_string}%} is 1337 with "default variable 3 failed: Value with entity and string"
-	assert {testing no brackets::%last spawned pig%} is "String" with "default variable 4 failed: Value with entity and string"
-	assert {testing} is 1.6900000000001 with "default variable 5 failed: Value with no entity and double"
+	assert {testing::variables2::%{_string}%} is 1337 with "default variable 2 failed: Value with string"
+	assert {testing::variables3::%last spawned pig%::%{_string}%} is 1337 with "default variable 3 failed: Value with entity and string"
+	assert {testing::no brackets::%last spawned pig%} is "String" with "default variable 4 failed: Value with entity and string"
+	assert {testing::variables4} is 1.6900000000001 with "default variable 5 failed: Value with no entity and double"
 
 	set {_player} to "Njol" parsed as offlineplayer
-	assert {regression::%{_player}%} is 1337 with "default variable 6 failed: Value with player and double"
+	assert {testing::regression::%{_player}%} is 1337 with "default variable 6 failed: Value with player and double"
 
 	# If this fails, the scope of the default variables was not set, and it shouldn't be set for undefined, unrelated default variables.
-	set {unrelated::%{_player}%} to true
-	assert {unrelated::%{_player}%} is true with "unrelated variable to default variables conflict"
+	set {testing::unrelated::%{_player}%} to true
+	assert {testing::unrelated::%{_player}%} is true with "unrelated variable to default variables conflict"
 
-	delete {regression::*}, {testing}, {testing no brackets::*}, {testing variables1::*}, {testing variables2::*} and {testing variables3::*}
-	assert {regression::*}, {testing}, {testing no brackets::*}, {testing variables1::*}, {testing variables2::*} and {testing variables3::*} are not set with "Failed to delete default variables"
+	delete {testing::*}
+	assert {testing::*} is not set with "Failed to delete default variables"
 
 	delete last spawned pig
 	clear all entities
 
+# Fail over if something happens.
 on script unload:
-	delete {testing}, {testing no brackets::*}, {testing variables1::*}, {testing variables2::*} and {testing variables3::*}
+	delete {testing::*}

--- a/src/test/skript/tests/misc/default variables.sk
+++ b/src/test/skript/tests/misc/default variables.sk
@@ -3,26 +3,34 @@ variables:
 	{testing variables1::%entity%} = 1337
 	{testing variables2::%object%} = 1337
 	{testing variables3::%entity%::%object%} = 1337
+	testing no brackets::%living entity% = "String"
+	testing = 1.6900000000001
+	{regression::%offlineplayer%} = 1337
 
 on test "default variables":
 	spawn a pig at spawn of world "world"
-	assert {testing variables1::%last spawned pig%} is set with "default variable 1 was not set"
-	assert {testing variables1::%last spawned pig%} is 1337 with "default variable 1 failed: Value with pig = %{testing variables1::%last spawned pig%}%"
+	assert {testing variables1::%last spawned pig%} is 1337 with "default variable 1 failed"
 
 	set {_string} to "empty string"
 	set {_local} to {_string}
-	assert {_local} is {_string} with "Local variable failed to copy another local variable."
+	assert {_local} is {_string} with "Local variable failed to copy another local variable"
 
-	assert {testing variables2::%{_string}%} is set with "default variable 2 was not set"
-	assert {testing variables2::%{_string}%} is 1337 with "default variable 2 failed: Value with string = %{testing variables2::%{_string}%}%"
+	assert {testing variables2::%{_string}%} is 1337 with "default variable 2 failed: Value with string"
+	assert {testing variables3::%last spawned pig%::%{_string}%} is 1337 with "default variable 3 failed: Value with entity and string"
+	assert {testing no brackets::%last spawned pig%} is "String" with "default variable 4 failed: Value with entity and string"
+	assert {testing} is 1.6900000000001 with "default variable 5 failed: Value with no entity and double"
 
-	assert {testing variables3::%last spawned pig%::%{_string}%} is set with "default variable 3 was not set"
-	assert {testing variables3::%last spawned pig%::%{_string}%} is 1337 with "default variable 3 failed: Value with entity and string = %{testing variables3::%last spawned pig%::%{_string}%}%"
+	set {_player} to "Njol" parsed as offlineplayer
+	assert {regression::%{_player}%} is 1337 with "default variable 6 failed: Value with player and double"
+
+	set {unrelated::%{_player}%} to true
+	assert {unrelated::%{_player}%} is true with "unrelated variable to default variables conflict"
+
+	delete {regression::*}, {testing}, {testing no brackets::*}, {testing variables1::*}, {testing variables2::*} and {testing variables3::*}
+	assert {regression::*}, {testing}, {testing no brackets::*}, {testing variables1::*}, {testing variables2::*} and {testing variables3::*} are not set with "Failed to delete default variables"
 
 	delete last spawned pig
-	delete {testing variables1::*}, {testing variables2::*} and {testing variables3::*}
-
-	assert {testing variables1::*}, {testing variables2::*} and {testing variables3::*} are not set with "Failed to delete default variables."
+	clear all entities
 
 on script unload:
-	delete {testing variables1::*}, {testing variables2::*} and {testing variables3::*}
+	delete {testing}, {testing no brackets::*}, {testing variables1::*}, {testing variables2::*} and {testing variables3::*}


### PR DESCRIPTION
### Description
Fixes a bug where Skript attempts to add type hints to the default variables data of a variable that was not defined in the default variables, causing Skript to critical internal error. This is only present on scripts that utilize the default variables section.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** https://github.com/SkriptLang/Skript/issues/5510
