### PR TITLE
Gradle auto apply correct JDK version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,9 +41,6 @@ dependencies {
 	testShadow group: 'org.easymock', name: 'easymock', version: '5.1.0'
 }
 
-compileJava.options.encoding = 'UTF-8'
-compileTestJava.options.encoding = 'UTF-8'
-
 task checkAliases {
 	description 'Checks for the existence of the aliases.'
 	doLast {
@@ -233,9 +230,17 @@ def latestEnv = 'java17/paper-1.19.3.json'
 def latestJava = 17
 def oldestJava = 8
 
+java {
+    toolchain.languageVersion.set(JavaLanguageVersion.of(latestJava))
+}
+
 tasks.withType(JavaCompile).configureEach {
 	options.compilerArgs += ['-source', '' + oldestJava, '-target', '' + oldestJava]
 }
+
+compileJava.options.encoding = 'UTF-8'
+compileTestJava.options.encoding = 'UTF-8'
+
 // Register different Skript testing tasks
 String environments = 'src/test/skript/environments/';
 String env = project.property('testEnv') == null ? latestEnv : project.property('testEnv') + '.json'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,6 @@
+
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.4.0'
+}
+
 rootProject.name = 'Skript'


### PR DESCRIPTION
### Description
Adds the Gradle suggested toolchain downloader for whatever latest Java version we support. https://docs.gradle.org/current/userguide/toolchains.html

This allows any new contributor to start building Skript without having to need Java 17 installed. Gradle will do this automatically by applying Java 17 for them. This means when the IDE goes to compile Skript/Spigot for usage, it ensures it's set to Java 17 as that is what Paper 1.17+ requires.

Tested on a Java 8 machine with Eclipse.

Labeling as a bug as a few users have had issues and asked for support before in the development Discord channels of SkUnity.

Notes:
- Skript still compiles down to Java 8 target.
- This does not impact the Skript runner tests. They still run on Java 8 and Java 17 respectively.
