### PR TITLE
Add missing .lang values for 1.19.4

### DIFF
--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -1221,6 +1221,25 @@ entities:
 	camel:
 		name: camel¦s
 		pattern: camel(|1¦s)
+	# 1.19.4 Entities
+	sniffer:
+		name: sniffer¦s
+		pattern: sniffer(|1¦s)
+	interaction:
+		name: interaction¦s
+		pattern: interaction(|1¦s)
+	display:
+		name: display¦s
+		pattern: display(|1¦s)
+	block display:
+		name: block display¦s
+		pattern: block display(|1¦s)
+	item display:
+		name: item display¦s
+		pattern: item display(|1¦s)
+	text display:
+		name: text display¦s
+		pattern: text display(|1¦s)
 
 # -- Heal Reasons --
 heal reasons:


### PR DESCRIPTION
### Description
Adds missing .lang values for 1.19.4

```
[21:07:46 INFO]: [Skript] Line 41: (combat.sk)
[21:07:46 INFO]:     Missing entry 'entities.sniffer.name' in the default/english language file
[21:07:46 INFO]:     Line: spectral arrowªs = minecraft:spectral_arrow[relatedEntity=spectral arrow]
[21:07:46 INFO]:
[21:07:46 INFO]: [Skript] Line 41: (combat.sk)
[21:07:46 INFO]:     Missing entry 'entities.text display.name' in the default/english language file
[21:07:46 INFO]:     Line: spectral arrowªs = minecraft:spectral_arrow[relatedEntity=spectral arrow]
[21:07:46 INFO]:
[21:07:46 INFO]: [Skript] Line 41: (combat.sk)
[21:07:46 INFO]:     Missing entry 'entities.item display.name' in the default/english language file
[21:07:46 INFO]:     Line: spectral arrowªs = minecraft:spectral_arrow[relatedEntity=spectral arrow]
[21:07:46 INFO]:
[21:07:46 INFO]: [Skript] Line 41: (combat.sk)
[21:07:46 INFO]:     Missing entry 'entities.block display.name' in the default/english language file
[21:07:46 INFO]:     Line: spectral arrowªs = minecraft:spectral_arrow[relatedEntity=spectral arrow]
[21:07:46 INFO]:
[21:07:46 INFO]: [Skript] Line 41: (combat.sk)
[21:07:46 INFO]:     Missing entry 'entities.interaction.name' in the default/english language file
[21:07:46 INFO]:     Line: spectral arrowªs = minecraft:spectral_arrow[relatedEntity=spectral arrow]
[21:07:46 INFO]:
[21:07:46 INFO]: [Skript] Line 41: (combat.sk)
[21:07:46 INFO]:     Missing entry 'entities.display.name' in the default/english language file
[21:07:46 INFO]:     Line: spectral arrowªs = minecraft:spectral_arrow[relatedEntity=spectral arrow]
[21:07:46 INFO]:
[21:07:46 INFO]: [Skript] Line 41: (combat.sk)
[21:07:46 INFO]:     Missing entry 'entities.sniffer.pattern' in the default/english language file
[21:07:46 INFO]:     Line: spectral arrowªs = minecraft:spectral_arrow[relatedEntity=spectral arrow]
[21:07:46 INFO]:
[21:07:46 INFO]: [Skript] Line 41: (combat.sk)
[21:07:46 INFO]:     Missing entry 'entities.text display.pattern' in the default/english language file
[21:07:46 INFO]:     Line: spectral arrowªs = minecraft:spectral_arrow[relatedEntity=spectral arrow]
[21:07:46 INFO]:
[21:07:46 INFO]: [Skript] Line 41: (combat.sk)
[21:07:46 INFO]:     Missing entry 'entities.item display.pattern' in the default/english language file
[21:07:46 INFO]:     Line: spectral arrowªs = minecraft:spectral_arrow[relatedEntity=spectral arrow]
[21:07:46 INFO]:
[21:07:46 INFO]: [Skript] Line 41: (combat.sk)
[21:07:46 INFO]:     Missing entry 'entities.block display.pattern' in the default/english language file
[21:07:46 INFO]:     Line: spectral arrowªs = minecraft:spectral_arrow[relatedEntity=spectral arrow]
[21:07:46 INFO]:
[21:07:46 INFO]: [Skript] Line 41: (combat.sk)
[21:07:46 INFO]:     Missing entry 'entities.interaction.pattern' in the default/english language file
[21:07:46 INFO]:     Line: spectral arrowªs = minecraft:spectral_arrow[relatedEntity=spectral arrow]
[21:07:46 INFO]:
[21:07:46 INFO]: [Skript] Line 41: (combat.sk)
[21:07:46 INFO]:     Missing entry 'entities.display.pattern' in the default/english language file
[21:07:46 INFO]:     Line: spectral arrowªs = minecraft:spectral_arrow[relatedEntity=spectral arrow]
```

---
**Target Minecraft Versions:** 1.19.4+
**Requirements:** none
**Related Issues:** none
