### PR TITLE
Line of sight

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondHasLineOfSight.java
+++ b/src/main/java/ch/njol/skript/conditions/CondHasLineOfSight.java
@@ -1,6 +1,28 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
 package ch.njol.skript.conditions;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -11,6 +33,14 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
+@Name("Has Line of Sight")
+@Description("Checks whether living entities have an unobstructed line of sight to other entities or locations.")
+@Examples({
+		"player has direct line of sight to location 5 blocks to the right of player",
+		"victim has line of sight to attacker",
+		"player has no line of sight to location 100 blocks in front of player"
+})
+@Since("INSERT VERSION")
 public class CondHasLineOfSight extends Condition {
 
 	static {
@@ -35,18 +65,18 @@ public class CondHasLineOfSight extends Condition {
 	public boolean check(Event event) {
 		return targets.check(event, (target) -> {
 			if (target instanceof Entity) {
-				return viewers.check(event, (viewer) -> viewer.hasLineOfSight((Entity) target), isNegated());
+				return viewers.check(event, (viewer) -> viewer.hasLineOfSight((Entity) target));
 			} else if (target instanceof Location) {
-				return viewers.check(event, (viewer) -> viewer.hasLineOfSight((Location) target), isNegated());
+				return viewers.check(event, (viewer) -> viewer.hasLineOfSight((Location) target));
 			} else {
-				return isNegated();
+				return false;
 			}
-		});
+		}, isNegated());
 	}
 
 	@Override
 	public String toString(@Nullable Event event, boolean debug) {
-		return viewers.toString(event, debug) + " has " + (isNegated() ? "no" : "")+ " line of sight to " + targets.toString(event,debug);
+		return viewers.toString(event, debug) + " has " + (isNegated() ? "no" : "") + " line of sight to " + targets.toString(event,debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/conditions/CondHasLineOfSight.java
+++ b/src/main/java/ch/njol/skript/conditions/CondHasLineOfSight.java
@@ -1,0 +1,52 @@
+package ch.njol.skript.conditions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.Condition;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+public class CondHasLineOfSight extends Condition {
+
+	static {
+		Skript.registerCondition(CondHasLineOfSight.class,
+				"%livingentities% (has|have) [a] [direct] line of sight to %entities/locations%",
+				"%livingentities% does(n't| not) have [a] [direct] line of sight to %entities/locations%",
+				"%livingentities% has no [direct] line of sight to %entities/locations%");
+	}
+
+	private Expression<LivingEntity> viewers;
+	private Expression<?> targets;
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		viewers = (Expression<LivingEntity>) exprs[0];
+		targets = exprs[1];
+		if (matchedPattern > 0) setNegated(true);
+		return true;
+	}
+
+	@Override
+	public boolean check(Event event) {
+		return targets.check(event, (target) -> {
+			if (target instanceof Entity) {
+				return viewers.check(event, (viewer) -> viewer.hasLineOfSight((Entity) target), isNegated());
+			} else if (target instanceof Location) {
+				return viewers.check(event, (viewer) -> viewer.hasLineOfSight((Location) target), isNegated());
+			} else {
+				return isNegated();
+			}
+		});
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return viewers.toString(event, debug) + " has " + (isNegated() ? "no" : "")+ " line of sight to " + targets.toString(event,debug);
+	}
+
+}

--- a/src/test/skript/tests/syntaxes/conditions/CondHasLineOfSight.sk
+++ b/src/test/skript/tests/syntaxes/conditions/CondHasLineOfSight.sk
@@ -1,0 +1,16 @@
+test "line of sight":
+	loop blocks between (spawn of world "world") and (spawn of world "world" ~ vector(0, 10, 0)):
+		set {_block::%loop-block%} to type of loop-block
+		set loop-block to air
+	spawn pig at spawn of world "world"
+	set {_pig1} to last spawned entity
+	spawn pig at ((spawn of world "world") ~ vector(0, 10, 0)):
+		assert pig has line of sight to {_pig1} with "Pigs should have line of sight to each other 1"
+		assert {_pig1} has line of sight to pig with "Pigs should have line of sight to each other 2"
+		set block at ((spawn of world "world") ~ vector(0, 5, 0)) to stone
+		assert pig has no line of sight to {_pig1} with "Pigs should not have line of sight to each other 1"
+		assert {_pig1} has no line of sight to pig with "Pigs should not have line of sight to each other 2"
+		delete pig
+	delete random entity out of {_pig1}
+	loop blocks between (spawn of world "world") and (spawn of world "world" ~ vector(0, 10, 0)):
+		set loop-block to {_block::%loop-block%}


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Adds CondHasLineOfSight. Checks if one or more living entities have unobstructed lines of sight to the target entities/locations.

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** #4185 <!-- Links to related issues -->
