### PR TITLE
EvtPlayerChunkEnter - Make 'player' Keyword Optional

### DIFF
--- a/src/main/java/ch/njol/skript/events/EvtPlayerChunkEnter.java
+++ b/src/main/java/ch/njol/skript/events/EvtPlayerChunkEnter.java
@@ -31,7 +31,7 @@ import org.eclipse.jdt.annotation.Nullable;
 public class EvtPlayerChunkEnter extends SkriptEvent {
 
 	static {
-		Skript.registerEvent("Player Chunk Enters", EvtPlayerChunkEnter.class, PlayerMoveEvent.class, "player (enter[s] [a] chunk|chunk enter[ing])")
+		Skript.registerEvent("Player Chunk Enters", EvtPlayerChunkEnter.class, PlayerMoveEvent.class, "[player] (enter[s] [a] chunk|chunk enter[ing])")
 				.description("Called when a player enters a chunk. Note that this event is based on 'player move' event, and may be called frequent internally.")
 				.examples(
 						"on player enters a chunk:",


### PR DESCRIPTION
### Description
This PR makes the keyword 'player' in the pattern of EvtPlayerChunkEnter as optional, which I should have done it in my previous PR on implementing this event.

---
**Target Minecraft Versions:** any
**Requirements:** -
**Related Issues:** -
