### PR TITLE
Fix Comparison Mistake in CondIsWithin

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondIsWithin.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsWithin.java
@@ -135,12 +135,12 @@ public class CondIsWithin extends Condition {
 
 		// Chunks
 		if (area instanceof Chunk) {
-			return locsToCheck.check(event, (loc) -> loc.getChunk() == area, isNegated());
+			return locsToCheck.check(event, (loc) -> loc.getChunk().equals(area), isNegated());
 		}
 
 		// Worlds
 		if (area instanceof World) {
-			return locsToCheck.check(event, (loc) -> loc.getWorld() == area, isNegated());
+			return locsToCheck.check(event, (loc) -> loc.getWorld().equals(area), isNegated());
 		}
 
 		// fall-back


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

I mistakenly used == to compare chunks and worlds in CondIsWithin, leading to failing tests in 1.19.4. 
This PR corrects that mistake and uses .equals() instead.

---
**Target Minecraft Versions:** any<!-- 'any' means all supported versions -->
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** #5371 <!-- Links to related issues -->
