### PR TITLE
EffFireworkLaunch: Fix Power 0

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffFireworkLaunch.java
+++ b/src/main/java/ch/njol/skript/effects/EffFireworkLaunch.java
@@ -80,6 +80,8 @@ public class EffFireworkLaunch extends Effect {
 			meta.addEffects(effects);
 			meta.setPower(power);
 			firework.setFireworkMeta(meta);
+			if (power == 0)
+				firework.detonate();
 			lastSpawned = firework;
 		}
 	}


### PR DESCRIPTION
### Description
This PR adds a workaround to when spawning a firework with power 0. Currently, spawning with power 0 still detonates itself after 1 second (which is power 1), and this is a Bukkit side issue.

---
**Target Minecraft Versions:** any
**Requirements:** -
**Related Issues:** -
