### PR TITLE
Change loading order for BukkitClasses

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -476,6 +476,7 @@ public final class Skript extends JavaPlugin implements Listener {
 		Throwable classLoadError = null;
 		try {
 			new SkriptClasses();
+			new BukkitClasses();
 		} catch (Throwable e) {
 			classLoadError = e;
 		}
@@ -530,7 +531,6 @@ public final class Skript extends JavaPlugin implements Listener {
 		skriptCommand.setTabCompleter(new SkriptCommandTabCompleter());
 		
 		// Load Bukkit stuff. It is done after platform check, because something might be missing!
-		new BukkitClasses();
 		new BukkitEventValues();
 		
 		new DefaultComparators();

--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -471,7 +471,14 @@ public final class Skript extends JavaPlugin implements Listener {
 		
 		// Load classes which are always safe to use
 		new JavaClasses(); // These may be needed in configuration
-		
+
+		// Check server software, Minecraft version, etc.
+		if (!checkServerPlatform()) {
+			disabled = true; // Nothing was loaded, nothing needs to be unloaded
+			setEnabled(false); // Cannot continue; user got errors in console to tell what happened
+			return;
+		}
+
 		// And then not-so-safe classes
 		Throwable classLoadError = null;
 		try {
@@ -488,13 +495,6 @@ public final class Skript extends JavaPlugin implements Listener {
 		// Now override the verbosity if test mode is enabled
 		if (TestMode.VERBOSITY != null)
 			SkriptLogger.setVerbosity(Verbosity.valueOf(TestMode.VERBOSITY));
-		
-		// Check server software, Minecraft version, etc.
-		if (!checkServerPlatform()) {
-			disabled = true; // Nothing was loaded, nothing needs to be unloaded
-			setEnabled(false); // Cannot continue; user got errors in console to tell what happened
-			return;
-		}
 		
 		// Use the updater, now that it has been configured to (not) do stuff
 		if (updater != null) {


### PR DESCRIPTION
### Description
You currently cannot use any classinfo registered in the BukkitClasses inside any .lang file. This fix changes the loading order of BukkitClasses to also be registered with SkriptClasses. No issues from my testing, but could use testing from users with many scripts.

- Moves the platform version check higher. (I dont know why this isn't the first thing to check)
- Moves BukkitClasses higher to load with SkriptClasses.