### PR TITLE
Fix ExprVersionString Unusable in Server List Ping Event

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprVersionString.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVersionString.java
@@ -18,11 +18,6 @@
  */
 package ch.njol.skript.expressions;
 
-import org.bukkit.event.Event;
-import org.bukkit.event.server.ServerListPingEvent;
-import org.eclipse.jdt.annotation.Nullable;
-
-import com.destroystokyo.paper.event.server.PaperServerListPingEvent;
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
@@ -37,32 +32,38 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
+import com.destroystokyo.paper.event.server.PaperServerListPingEvent;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
 
 @Name("Version String")
-@Description({"The text to show if the protocol version of the server doesn't match with protocol version of the client. " +
-		"You can check the <a href='#ExprProtocolVersion'>protocol version</a> expression for more information about this.",
-		"This can only be set in a <a href='events.html#server_list_ping'>server list ping</a> event."})
-@Examples({"on server list ping:",
-		"	set the protocol version to 0 # 13w41a (1.7), so it will show the version string always",
-		"	set the version string to \"&lt;light green&gt;Version: &lt;orange&gt;%minecraft version%\""})
+@Description({
+	"The text to show if the protocol version of the server doesn't match with protocol version of the client. " +
+	"You can check the <a href='#ExprProtocolVersion'>protocol version</a> expression for more information about this.",
+	"This can only be set in a <a href='events.html#server_list_ping'>server list ping</a> event."})
+@Examples({
+	"on server list ping:",
+	"	\tset the protocol version to 0 # 13w41a (1.7), so it will show the version string always",
+	"	\tset the version string to \"&lt;light green&gt;Version: &lt;orange&gt;%minecraft version%\""
+})
 @Since("2.3")
-@RequiredPlugins("Paper 1.12.2 or newer")
-@Events("server list ping")
+@RequiredPlugins("Paper 1.12.2+")
+@Events("Server List Ping")
 public class ExprVersionString extends SimpleExpression<String> {
+
+	private static final boolean PAPER_EVENT_EXISTS = Skript.classExists("com.destroystokyo.paper.event.server.PaperServerListPingEvent");
 
 	static {
 		Skript.registerExpression(ExprVersionString.class, String.class, ExpressionType.SIMPLE, "[the] [(shown|custom)] version [(string|text)]");
 	}
 
-	private static final boolean PAPER_EVENT_EXISTS = Skript.classExists("com.destroystokyo.paper.event.server.PaperServerListPingEvent");
-
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		if (getParser().isCurrentEvent(ServerListPingEvent.class)) {
-			Skript.error("The version string expression requires Paper 1.12.2 or newer");
+		if (!PAPER_EVENT_EXISTS) {
+			Skript.error("The version string expression requires Paper 1.12.2+");
 			return false;
-		} else if (!(PAPER_EVENT_EXISTS && getParser().isCurrentEvent(PaperServerListPingEvent.class))) {
-			Skript.error("The version string expression can't be used outside of a server list ping event");
+		} else if (!getParser().isCurrentEvent(PaperServerListPingEvent.class)) {
+			Skript.error("The version string expression can't be used outside of 'server list ping' event");
 			return false;
 		}
 		return true;
@@ -70,10 +71,10 @@ public class ExprVersionString extends SimpleExpression<String> {
 
 	@Override
 	@Nullable
-	public String[] get(Event e) {
-		if (!(e instanceof PaperServerListPingEvent))
-			return null;
-		return CollectionUtils.array(((PaperServerListPingEvent) e).getVersion());
+	public String[] get(Event event) {
+		if (!(event instanceof PaperServerListPingEvent))
+			return new String[0];
+		return CollectionUtils.array(((PaperServerListPingEvent) event).getVersion());
 	}
 
 	@Override
@@ -88,13 +89,13 @@ public class ExprVersionString extends SimpleExpression<String> {
 		return null;
 	}
 
-	@SuppressWarnings("null")
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
-		if (!(e instanceof PaperServerListPingEvent))
+	@SuppressWarnings("null")
+	public void change(Event event, Object @Nullable [] delta, ChangeMode mode) {
+		if (!(event instanceof PaperServerListPingEvent))
 			return;
-
-		((PaperServerListPingEvent) e).setVersion(((String) delta[0]));
+		if (delta != null)
+			((PaperServerListPingEvent) event).setVersion(((String) delta[0]));
 	}
 
 	@Override
@@ -108,7 +109,7 @@ public class ExprVersionString extends SimpleExpression<String> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "the version string";
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVersionString.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVersionString.java
@@ -40,11 +40,12 @@ import org.jetbrains.annotations.Nullable;
 @Description({
 	"The text to show if the protocol version of the server doesn't match with protocol version of the client. " +
 	"You can check the <a href='#ExprProtocolVersion'>protocol version</a> expression for more information about this.",
-	"This can only be set in a <a href='events.html#server_list_ping'>server list ping</a> event."})
+	"This can only be set in a <a href='events.html#server_list_ping'>server list ping</a> event."
+})
 @Examples({
 	"on server list ping:",
-	"	\tset the protocol version to 0 # 13w41a (1.7), so it will show the version string always",
-	"	\tset the version string to \"&lt;light green&gt;Version: &lt;orange&gt;%minecraft version%\""
+		"\tset the protocol version to 0 # 13w41a (1.7), so it will show the version string always",
+		"\tset the version string to \"&lt;light green&gt;Version: &lt;orange&gt;%minecraft version%\""
 })
 @Since("2.3")
 @RequiredPlugins("Paper 1.12.2+")
@@ -63,7 +64,7 @@ public class ExprVersionString extends SimpleExpression<String> {
 			Skript.error("The 'version string' expression requires Paper 1.12.2+");
 			return false;
 		} else if (!getParser().isCurrentEvent(PaperServerListPingEvent.class)) {
-			Skript.error("The 'version string' expression can't be used outside of 'server list ping' event");
+			Skript.error("The 'version string' expression can't be used outside of a 'server list ping' event");
 			return false;
 		}
 		return true;
@@ -94,8 +95,7 @@ public class ExprVersionString extends SimpleExpression<String> {
 	public void change(Event event, Object @Nullable [] delta, ChangeMode mode) {
 		if (!(event instanceof PaperServerListPingEvent))
 			return;
-		if (delta != null)
-			((PaperServerListPingEvent) event).setVersion(((String) delta[0]));
+		((PaperServerListPingEvent) event).setVersion(((String) delta[0]));
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprVersionString.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVersionString.java
@@ -54,16 +54,16 @@ public class ExprVersionString extends SimpleExpression<String> {
 	private static final boolean PAPER_EVENT_EXISTS = Skript.classExists("com.destroystokyo.paper.event.server.PaperServerListPingEvent");
 
 	static {
-		Skript.registerExpression(ExprVersionString.class, String.class, ExpressionType.SIMPLE, "[the] [(shown|custom)] version [(string|text)]");
+		Skript.registerExpression(ExprVersionString.class, String.class, ExpressionType.SIMPLE, "[the] [shown|custom] version [string|text]");
 	}
 
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		if (!PAPER_EVENT_EXISTS) {
-			Skript.error("The version string expression requires Paper 1.12.2+");
+			Skript.error("The 'version string' expression requires Paper 1.12.2+");
 			return false;
 		} else if (!getParser().isCurrentEvent(PaperServerListPingEvent.class)) {
-			Skript.error("The version string expression can't be used outside of 'server list ping' event");
+			Skript.error("The 'version string' expression can't be used outside of 'server list ping' event");
 			return false;
 		}
 		return true;


### PR DESCRIPTION
### Description
This PR fixes a bug introduced in Skript 2.7, in ExprVersionString where the expression can't be used in 'server list ping' event, where it should, and performed class cleanup to follow latest code convention.

---
**Target Minecraft Versions:** any
**Requirements:** Paper 1.12.2+
**Related Issues:** #5597
