### PR TITLE
ExprVectorRandom - Fix Vectors not Unit & Not True Random Generations

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprVectorRandom.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorRandom.java
@@ -41,7 +41,7 @@ import java.util.Random;
 @Since("2.2-dev28, 2.7 (signed components)")
 public class ExprVectorRandom extends SimpleExpression<Vector> {
 
-	private static final Random random = new Random();
+	private static final Random RANDOM = new Random();
 	
 	static {
 		Skript.registerExpression(ExprVectorRandom.class, Vector.class, ExpressionType.SIMPLE, "[a] random vector");
@@ -56,7 +56,7 @@ public class ExprVectorRandom extends SimpleExpression<Vector> {
 	protected Vector[] get(Event event) {
 		// Generating uniform random numbers leads to bias towards the corners of the cube.
 		// Gaussian distribution is radially symmetric, so it avoids this bias.
-		return CollectionUtils.array(new Vector(random.nextGaussian(), random.nextGaussian(), random.nextGaussian()).normalize());
+		return CollectionUtils.array(new Vector(RANDOM.nextGaussian(), RANDOM.nextGaussian(), RANDOM.nextGaussian()).normalize());
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorRandom.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorRandom.java
@@ -18,12 +18,6 @@
  */
 package ch.njol.skript.expressions;
 
-import java.util.Random;
-
-import org.bukkit.event.Event;
-import org.bukkit.util.Vector;
-import org.eclipse.jdt.annotation.Nullable;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -35,6 +29,11 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.event.Event;
+import org.bukkit.util.Vector;
+import org.eclipse.jdt.annotation.Nullable;
+
+import java.util.Random;
 
 @Name("Vectors - Random Vector")
 @Description("Creates a random unit vector.")
@@ -55,7 +54,9 @@ public class ExprVectorRandom extends SimpleExpression<Vector> {
 
 	@Override
 	protected Vector[] get(Event event) {
-		return CollectionUtils.array(new Vector(randomSignedDouble(), randomSignedDouble(), randomSignedDouble()).normalize());
+		// Generating uniform random numbers leads to bias towards the corners of the cube.
+		// Gaussian distribution is radially symmetric, so it avoids this bias.
+		return CollectionUtils.array(new Vector(random.nextGaussian(), random.nextGaussian(), random.nextGaussian()).normalize());
 	}
 
 	@Override
@@ -71,10 +72,6 @@ public class ExprVectorRandom extends SimpleExpression<Vector> {
 	@Override
 	public String toString(@Nullable Event event, boolean debug) {
 		return "random vector";
-	}
-	
-	private static double randomSignedDouble() {
-		return random.nextDouble() * (random.nextBoolean() ? 1 : -1);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorRandom.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorRandom.java
@@ -37,7 +37,7 @@ import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 
 @Name("Vectors - Random Vector")
-@Description("Creates a random vector with the magnitude of 1.")
+@Description("Creates a random unit vector.")
 @Examples("set {_v} to a random vector")
 @Since("2.2-dev28, 2.7 (signed components)")
 public class ExprVectorRandom extends SimpleExpression<Vector> {

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorRandom.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorRandom.java
@@ -38,7 +38,7 @@ import ch.njol.util.coll.CollectionUtils;
 
 @Name("Vectors - Random Vector")
 @Description("Creates a random vector with the magnitude of 1.")
-@Examples({"set {_v} to a random vector"})
+@Examples("set {_v} to a random vector")
 @Since("2.2-dev28, 2.7 (signed components)")
 public class ExprVectorRandom extends SimpleExpression<Vector> {
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorRandom.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorRandom.java
@@ -36,11 +36,8 @@ import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 
-/**
- * @author bi0qaw
- */
 @Name("Vectors - Random Vector")
-@Description("Creates a random vector.")
+@Description("Creates a random vector with the magnitude of 1.")
 @Examples({"set {_v} to a random vector"})
 @Since("2.2-dev28, 2.7 (signed components)")
 public class ExprVectorRandom extends SimpleExpression<Vector> {
@@ -57,8 +54,8 @@ public class ExprVectorRandom extends SimpleExpression<Vector> {
 	}
 
 	@Override
-	protected Vector[] get(Event e) {
-		return CollectionUtils.array(new Vector(randomSignedDouble(), randomSignedDouble(), randomSignedDouble()));
+	protected Vector[] get(Event event) {
+		return CollectionUtils.array(new Vector(randomSignedDouble(), randomSignedDouble(), randomSignedDouble()).normalize());
 	}
 
 	@Override
@@ -72,7 +69,7 @@ public class ExprVectorRandom extends SimpleExpression<Vector> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return "random vector";
 	}
 	


### PR DESCRIPTION
### Description
This PR fixes ExprVectorRandom to strictly returning vectors with magnitude of 1.

#### EDIT (24 April)
Permission was granted to change the way vectors are generated within this PR scope.

---
**Target Minecraft Versions:** any
**Requirements:** -
**Related Issues:** -
