### PR TITLE
Include the Adventure API BungeeComponentSerializer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ allprojects {
 dependencies {
 	shadow group: 'io.papermc', name: 'paperlib', version: '1.0.8'
 	shadow group: 'org.bstats', name: 'bstats-bukkit', version: '3.0.2'
+	shadow group: 'net.kyori', name: 'adventure-text-serializer-bungeecord', version: '4.3.0'
+
 	implementation group: 'io.papermc.paper', name: 'paper-api', version: '1.19.4-R0.1-SNAPSHOT'
 	implementation group: 'org.eclipse.jdt', name: 'org.eclipse.jdt.annotation', version: '2.2.700'
 	implementation group: 'com.google.code.findbugs', name: 'findbugs', version: '3.0.1'
@@ -87,6 +89,7 @@ tasks.withType(ShadowJar) {
 		include(dependency('io.papermc:paperlib'))
 		include(dependency('org.bstats:bstats-bukkit'))
 		include(dependency('org.bstats:bstats-base'))
+		include(dependency('net.kyori:adventure-text-serializer-bungeecord'))
 	}
 	relocate 'io.papermc.lib', 'ch.njol.skript.paperlib'
 	relocate 'org.bstats', 'ch.njol.skript.bstats'


### PR DESCRIPTION
### Description
Adds in the Adventure API serializer for the Bungeecord Chat API.
This allows us to use the Component classes that Paper has been deprecated in Spigot in favor of the Adventure API methods using Adventure API components. The BungeeComponentSerializer converts BaseComponents to Adventure API Components.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Pull Requests:** https://github.com/SkriptLang/Skript/pull/5601 and https://github.com/SkriptLang/Skript/pull/5622
