### PR TITLE
Define import sorting rule

### DIFF
--- a/code-conventions.md
+++ b/code-conventions.md
@@ -119,7 +119,7 @@ If we need to remove or alter contributed code due to a licensing issue we will 
   - Section: init -> walk -> toString
   - Structure: init -> (preLoad) -> load -> (postLoad) -> unload -> (postUnload) -> (getPriority) -> toString
 
-* To avoid sorting of imports every pull request between different IDE's we sort imports by the following format; java.* imports come before every other import sorted in alphabetical order followed by two optional line break between different package groups (Intellij is currently not capable of automatic line breaks). Example:
+* To avoid sorting of imports every pull request between different IDE's we sort imports by the following format; java.* imports come before every other import sorted in alphabetical order followed by two optional line break between different package groups (Intellij is currently not capable of automatic line breaks). Most popular IDE's have a configuration option to allow for these rules. Example:
 ```java
 package ...;
 

--- a/code-conventions.md
+++ b/code-conventions.md
@@ -119,6 +119,17 @@ If we need to remove or alter contributed code due to a licensing issue we will 
   - Section: init -> walk -> toString
   - Structure: init -> (preLoad) -> load -> (postLoad) -> unload -> (postUnload) -> (getPriority) -> toString
 
+* To avoid sorting of imports every pull request between different IDE's we sort imports by the following format; java.* imports come before every other import sorted in alphabetical order followed by two optional line break between different package groups (Intellij is currently not capable of automatic line breaks). Example:
+```java
+package ...;
+
+import java.*;
+
+import ch.njol.*;
+import ch.njol.skript.another;
+
+import org.skriptlang.*;
+```
 
 ### Naming
 * Class names are written in `UpperCamelCase`


### PR DESCRIPTION
### Description
Define import sorting rule. This is to avoid having different people update the import list every pull request ultimately making rebasing of pull requests that much harder. This is due to different IDE's having different rules. Most popular IDE's have a configuration option to allow for these rules.

### Preview

<img width="814" alt="Untitled" src="https://user-images.githubusercontent.com/16087552/235281684-6e2a8a7d-1482-49a6-ae62-48d3722f7593.png">
