### PR TITLE
Revert "Allow literal-only string parsing"

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/JavaClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/JavaClasses.java
@@ -565,9 +565,11 @@ public class JavaClasses {
 					@Nullable
 					public String parse(String s, ParseContext context) {
 						switch (context) {
+							case DEFAULT: // in DUMMY, parsing is handled by VariableString
+								assert false;
+								return null;
 							case CONFIG: // duh
 								return s;
-							case DEFAULT:
 							case SCRIPT:
 							case EVENT:
 								if (VariableString.isQuotedCorrectly(s, true))
@@ -582,7 +584,7 @@ public class JavaClasses {
 					
 					@Override
 					public boolean canParse(ParseContext context) {
-						return true;
+						return context != ParseContext.DEFAULT;
 					}
 					
 					@Override


### PR DESCRIPTION
Reverts SkriptLang/Skript#4667 This is currently unstable at the moment and needs further improvements see https://github.com/SkriptLang/Skript/issues/5635