### PR TITLE
ExprBlocks: Fix ArrayStoreException

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprBlocks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBlocks.java
@@ -116,7 +116,8 @@ public class ExprBlocks extends SimpleExpression<Block> {
 			return from.stream(event)
 					.filter(Location.class::isInstance)
 					.map(Location.class::cast)
-					.map(location -> direction.getRelative(location))
+					.map(direction::getRelative)
+					.map(Location::getBlock)
 					.toArray(Block[]::new);
 		}
 		Iterator<Block> iterator = iterator(event);


### PR DESCRIPTION
### Description
This PR fixes ArrayStoreException thrown in ExprBlocks introduced in #5566, caused by when getting blocks from a list of locations.
![image](https://user-images.githubusercontent.com/72163224/235367233-9d5377b5-3f7f-41e4-a87d-19e36fb4e835.png)
![image](https://user-images.githubusercontent.com/72163224/235367204-bf1554f5-734a-49f0-921b-280441849f41.png)

---
**Target Minecraft Versions:** any
**Requirements:** -
**Related Issues:** #5566 
