### PR TITLE
Enhance Effect Send Block Change

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/ItemType.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemType.java
@@ -393,11 +393,13 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 	}
 
 	/**
-	 * Send a block change to a player
-	 * <p>This will send a fake block change to the player, and will not change the block on the server.</p>
+	 * Send a multi-block change to a player.
+	 * <p>This will send a packet for each chunk modified to the player, and will not change the block on the server.</p>
+	 * Requires MC 1.19.
 	 *
 	 * @param player Player to send change to
-	 * @param location Location of block to change
+	 * @param locations Array of locations of blocks to change
+	 * @param suppressLightUpdates Whether to suppress light updates.
 	 */
 	public void sendBlockChanges(Player player, Location[] locations, boolean suppressLightUpdates) {
 		for (int i = random.nextInt(types.size()); i < types.size(); i++) {

--- a/src/main/java/ch/njol/skript/aliases/ItemType.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemType.java
@@ -391,7 +391,24 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 			BlockUtils.sendBlockChange(player, location, blockType, d.getBlockValues());
 		}
 	}
-	
+
+	/**
+	 * Send a block change to a player
+	 * <p>This will send a fake block change to the player, and will not change the block on the server.</p>
+	 *
+	 * @param player Player to send change to
+	 * @param location Location of block to change
+	 */
+	public void sendBlockChanges(Player player, Location[] locations, boolean suppressLightUpdates) {
+		for (int i = random.nextInt(types.size()); i < types.size(); i++) {
+			ItemData d = types.get(i);
+			Material blockType = ItemUtils.asBlock(d.type);
+			if (blockType == null) // Ignore items which cannot be placed
+				continue;
+			BlockUtils.sendBlockChanges(player, locations, blockType, d.getBlockValues(), suppressLightUpdates);
+		}
+	}
+
 	/**
 	 * Intersects all ItemDatas with all ItemDatas of the given ItemType, returning an ItemType with at most n*m ItemDatas, where n = #ItemDatas of this ItemType, and m =
 	 * #ItemDatas of the argument.

--- a/src/main/java/ch/njol/skript/bukkitutil/block/BlockSetter.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/block/BlockSetter.java
@@ -78,5 +78,7 @@ public interface BlockSetter {
 	 * @param values Additional block data, such as block states.
 	 */
 	void sendBlockChange(Player player, Location location, Material type, @Nullable BlockValues values);
-	
+
+	void sendBlockChanges(Player player, Location[] locations, Material type, @Nullable BlockValues values, boolean suppressLightUpdates);
+
 }

--- a/src/main/java/ch/njol/skript/bukkitutil/block/BlockSetter.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/block/BlockSetter.java
@@ -79,6 +79,17 @@ public interface BlockSetter {
 	 */
 	void sendBlockChange(Player player, Location location, Material type, @Nullable BlockValues values);
 
+	/**
+	 * Send a multi-block change to a player.
+	 * <p>This will send a packet for each chunk modified to the player, and will not change the block on the server.</p>
+	 * Requires MC 1.19.
+	 *
+	 * @param player Player to send change to
+	 * @param locations Array of locations of blocks to change
+	 * @param type Material of change
+	 * @param values Additional block data, such as block states.
+	 * @param suppressLightUpdates Whether to suppress light updates.
+	 */
 	void sendBlockChanges(Player player, Location[] locations, Material type, @Nullable BlockValues values, boolean suppressLightUpdates);
 
 }

--- a/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
@@ -42,6 +42,8 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
 import java.io.StreamCorruptedException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -315,13 +317,30 @@ public class NewBlockCompat implements BlockCompat {
 			
 			return null; // Can't place torch here legally
 		}
-		
+
 		@Override
 		public void sendBlockChange(Player player, Location location, Material type, @Nullable BlockValues values) {
 			BlockData blockData = values != null ? ((NewBlockValues) values).data : type.createBlockData();
 			player.sendBlockChange(location, blockData);
 		}
-		
+
+		@Override
+		public void sendBlockChanges(Player player, Location[] locations, Material type, @Nullable BlockValues values, boolean suppressLightUpdates) {
+			BlockData blockData = values != null ? ((NewBlockValues) values).data : type.createBlockData();
+			if (true) {
+				Collection<BlockState> newBlockStates = new ArrayList<>();
+				for (Location location : locations) {
+					BlockState state = location.getBlock().getState();
+					state.setBlockData(blockData);
+					newBlockStates.add(state);
+				}
+				player.sendBlockChanges(newBlockStates, suppressLightUpdates);
+				return;
+			}
+			for (Location location : locations)
+				sendBlockChange(player, location, type, values);
+		}
+
 	}
 	
 	private NewBlockSetter setter = new NewBlockSetter();

--- a/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
@@ -23,6 +23,7 @@ import ch.njol.skript.aliases.Aliases;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.aliases.MatchQuality;
 import ch.njol.skript.variables.Variables;
+import ch.njol.util.coll.CollectionUtils;
 import ch.njol.yggdrasil.Fields;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -143,7 +144,8 @@ public class NewBlockCompat implements BlockCompat {
 	}
 	
 	private static class NewBlockSetter implements BlockSetter {
-		
+
+		private static final boolean SUPPORT_MULTIBLOCK_CHANGE = Skript.methodExists(Player.class, "sendBlockChanges", CollectionUtils.array(Collection.class, boolean.class));
 		private ItemType floorTorch;
 		private ItemType wallTorch;
 		
@@ -327,7 +329,7 @@ public class NewBlockCompat implements BlockCompat {
 		@Override
 		public void sendBlockChanges(Player player, Location[] locations, Material type, @Nullable BlockValues values, boolean suppressLightUpdates) {
 			BlockData blockData = values != null ? ((NewBlockValues) values).data : type.createBlockData();
-			if (true) {
+			if (SUPPORT_MULTIBLOCK_CHANGE) {
 				Collection<BlockState> newBlockStates = new ArrayList<>();
 				for (Location location : locations) {
 					BlockState state = location.getBlock().getState();
@@ -335,10 +337,10 @@ public class NewBlockCompat implements BlockCompat {
 					newBlockStates.add(state);
 				}
 				player.sendBlockChanges(newBlockStates, suppressLightUpdates);
-				return;
+			} else {
+				for (Location location : locations)
+					sendBlockChange(player, location, type, values);
 			}
-			for (Location location : locations)
-				sendBlockChange(player, location, type, values);
 		}
 
 	}

--- a/src/main/java/ch/njol/skript/effects/EffSendBlockChange.java
+++ b/src/main/java/ch/njol/skript/effects/EffSendBlockChange.java
@@ -55,8 +55,6 @@ import org.eclipse.jdt.annotation.Nullable;
 @Since("2.2-dev37c, 2.5.1 (block data support)")
 public class EffSendBlockChange extends Effect {
 
-	private static final Random random = new Random();
-	
 	private static final boolean SUPPORT_MULTI_BLOCKS = Skript.methodExists(Player.class, "sendBlockChanges", CollectionUtils.array(Collection.class, boolean.class));
 
 	static {
@@ -81,13 +79,12 @@ public class EffSendBlockChange extends Effect {
 
 	@Override
 	protected void execute(Event event) {
-		Object object = this.as.getSingle(event);
+		Object object = as.getSingle(event);
 		Block[] blocks = this.blocks.getArray(event);
 		if (object instanceof ItemType) {
 			ItemType itemType = (ItemType) object;
 			if (SUPPORT_MULTI_BLOCKS && blocks.length > 1) {
 				for (Player player : players.getArray(event)) {
-					System.out.println("chunk packet"); // debug
 					Location[] locations = Arrays.stream(blocks).map(Block::getLocation).toArray(Location[]::new);
 					itemType.sendBlockChanges(player, locations, lightUpdates);
 				}
@@ -108,7 +105,6 @@ public class EffSendBlockChange extends Effect {
 					newBlockStates.add(state);
 				}
 				for (Player player : players.getArray(event)) {
-					System.out.println("chunk packet"); // debug
 					player.sendBlockChanges(newBlockStates, lightUpdates);
 				}
 			} else {

--- a/src/main/java/ch/njol/skript/effects/EffSendBlockChange.java
+++ b/src/main/java/ch/njol/skript/effects/EffSendBlockChange.java
@@ -18,14 +18,6 @@
  */
 package ch.njol.skript.effects;
 
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.block.Block;
-import org.bukkit.block.data.BlockData;
-import org.bukkit.entity.Player;
-import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.doc.Description;
@@ -34,8 +26,13 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
 
 @Name("Send Block Change")
 @Description("Makes a player see a block as something it really isn't. BlockData support is only for MC 1.13+")
@@ -44,20 +41,8 @@ import ch.njol.util.Kleenean;
 @Since("2.2-dev37c, 2.5.1 (block data support)")
 public class EffSendBlockChange extends Effect {
 
-	private static final boolean BLOCK_DATA_SUPPORT = Skript.classExists("org.bukkit.block.data.BlockData");
-	private static final boolean SUPPORTED =
-			Skript.methodExists(
-					Player.class,
-					"sendBlockChange",
-					Location.class,
-					Material.class,
-					byte.class
-			);
-
 	static {
-		Skript.registerEffect(EffSendBlockChange.class,
-				BLOCK_DATA_SUPPORT ? "make %players% see %blocks% as %itemtype/blockdata%" : "make %players% see %blocks% as %itemtype%"
-		);
+		Skript.registerEffect(EffSendBlockChange.class, "make %players% see %blocks% as %itemtype/blockdata%");
 	}
 
 	@SuppressWarnings("null")
@@ -71,14 +56,7 @@ public class EffSendBlockChange extends Effect {
 	
 	@Override
 	@SuppressWarnings("unchecked")
-	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
-		if (!SUPPORTED) {
-			Skript.error("The send block change effect is not supported on this version. " +
-				"If Spigot has added a replacement method without magic values " +
-				"please open an issue at https://github.com/SkriptLang/Skript/issues " +
-				"and support will be added for it.");
-			return false;
-		}
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		players = (Expression<Player>) exprs[0];
 		blocks = (Expression<Block>) exprs[1];
 		as = (Expression<Object>) exprs[2];
@@ -86,19 +64,19 @@ public class EffSendBlockChange extends Effect {
 	}
 
 	@Override
-	protected void execute(Event e) {
-		Object object = this.as.getSingle(e);
+	protected void execute(Event event) {
+		Object object = this.as.getSingle(event);
 		if (object instanceof ItemType) {
 			ItemType itemType = (ItemType) object;
-			for (Player player : players.getArray(e)) {
-				for (Block block : blocks.getArray(e)) {
+			for (Player player : players.getArray(event)) {
+				for (Block block : blocks.getArray(event)) {
 					itemType.sendBlockChange(player, block.getLocation());
 				}
 			}
-		} else if (BLOCK_DATA_SUPPORT && object instanceof BlockData) {
+		} else if (object instanceof BlockData) {
 			BlockData blockData = (BlockData) object;
-			for (Player player : players.getArray(e)) {
-				for (Block block : blocks.getArray(e)) {
+			for (Player player : players.getArray(event)) {
+				for (Block block : blocks.getArray(event)) {
 					player.sendBlockChange(block.getLocation(), blockData);
 				}
 			}
@@ -106,12 +84,12 @@ public class EffSendBlockChange extends Effect {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return String.format(
 				"make %s see %s as %s",
-				players.toString(e, debug),
-				blocks.toString(e, debug),
-				as.toString(e, debug)
+				players.toString(event, debug),
+				blocks.toString(event, debug),
+				as.toString(event, debug)
 		);
 	}
 

--- a/src/main/java/ch/njol/skript/effects/EffSendBlockChange.java
+++ b/src/main/java/ch/njol/skript/effects/EffSendBlockChange.java
@@ -35,9 +35,14 @@ import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
 @Name("Send Block Change")
-@Description("Makes a player see a block as something it really isn't. BlockData support is only for MC 1.13+")
-@Examples({"make player see block at player as dirt",
-		"make player see target block as campfire[facing=south]"})
+@Description({
+	"Makes a player see a block as something it really isn't.",
+	"The chunk where the fake block change occur must be loaded to the player in order to take effect."
+})
+@Examples({
+	"make player see block at player as dirt",
+	"make player see target block as campfire[facing=south]"
+})
 @Since("2.2-dev37c, 2.5.1 (block data support)")
 public class EffSendBlockChange extends Effect {
 

--- a/src/main/java/ch/njol/skript/effects/EffSendBlockChange.java
+++ b/src/main/java/ch/njol/skript/effects/EffSendBlockChange.java
@@ -28,6 +28,7 @@ import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.RequiredPlugins;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
@@ -46,13 +47,15 @@ import org.eclipse.jdt.annotation.Nullable;
 @Description({
 	"Makes a player see a block as something it really isn't.",
 	"The chunk where the fake block change occur must be loaded to the player in order to take effect.",
-	"The 'without light updates' option is available for use when you are changing multiple blocks at once."
+	"The 'without light updates' option is available for use when you are changing multiple blocks at once in MC 1.19+"
 })
 @Examples({
 	"make player see block at player as dirt",
-	"make player see target block as campfire[facing=south]"
+	"make player see target block as campfire[facing=south]",
+	"make player see {_blocks::*} as obsidian without light updates"
 })
-@Since("2.2-dev37c, 2.5.1 (block data support)")
+@Since("2.2-dev37c, 2.5.1 (block data support), INSERT VERSION (multi-block method)")
+@RequiredPlugins("MC 1.19+ (multi-block method)")
 public class EffSendBlockChange extends Effect {
 
 	private static final boolean SUPPORT_MULTI_BLOCKS = Skript.methodExists(Player.class, "sendBlockChanges", CollectionUtils.array(Collection.class, boolean.class));

--- a/src/main/java/ch/njol/skript/expressions/ExprBlocks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBlocks.java
@@ -116,7 +116,8 @@ public class ExprBlocks extends SimpleExpression<Block> {
 			return from.stream(event)
 					.filter(Location.class::isInstance)
 					.map(Location.class::cast)
-					.map(location -> direction.getRelative(location))
+					.map(direction::getRelative)
+					.map(Location::getBlock)
 					.toArray(Block[]::new);
 		}
 		Iterator<Block> iterator = iterator(event);

--- a/src/main/java/ch/njol/skript/util/BlockUtils.java
+++ b/src/main/java/ch/njol/skript/util/BlockUtils.java
@@ -60,11 +60,15 @@ public class BlockUtils {
 	public static boolean set(Block block, ItemData type, boolean applyPhysics) {
 		return set(block, type.getType(), type.getBlockValues(), applyPhysics);
 	}
-	
+
 	public static void sendBlockChange(Player player, Location location, Material type, @Nullable BlockValues blockValues) {
 		BlockCompat.SETTER.sendBlockChange(player, location, type, blockValues);
 	}
-	
+
+	public static void sendBlockChanges(Player player, Location[] locations, Material type, @Nullable BlockValues blockValues, boolean suppressLightUpdates) {
+		BlockCompat.SETTER.sendBlockChanges(player, locations, type, blockValues, suppressLightUpdates);
+	}
+
 	@SuppressWarnings("null")
 	public static Iterable<Block> getBlocksAround(Block b) {
 		return Arrays.asList(b.getRelative(BlockFace.NORTH), b.getRelative(BlockFace.EAST), b.getRelative(BlockFace.SOUTH), b.getRelative(BlockFace.WEST));


### PR DESCRIPTION
### Description
This PR removes legacy code as Skript has dropped its support, and adds support of [Player#sendBlockChanges(....)](https://jd.papermc.io/paper/1.19/org/bukkit/entity/Player.html#sendBlockChanges(java.util.Collection,boolean)) method when using this effect with more than 1 block.

---
**Target Minecraft Versions:** MC 1.19 (multi-block method)
**Requirements:** MC 1.19 (multi-block method)
**Related Issues:** -

~~### Notes
*Awaiting #5660 to be merged due to a bug and prevent conflicts*~~
