### PR TITLE
Bump version to 2.7.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 groupid=ch.njol
 name=skript
-version=2.7.0-beta2
+version=2.7.0
 jarName=Skript.jar
 testEnv=java17/paper-1.19.4
 testEnvJavaVersion=17


### PR DESCRIPTION
### Description
2.7.0-beta3 should be the last beta for 2.7.0. Then master branch gets placed into dev/2.7 where 2.7.x builds are handled and master becomes 2.8.0-dev

waiting on 2.7.0-beta3 before https://github.com/SkriptLang/Skript/pull/5574

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** <!-- Links to related issues -->
