### PR TITLE
Make aliases faster

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/AliasesParser.java
+++ b/src/main/java/ch/njol/skript/aliases/AliasesParser.java
@@ -742,9 +742,11 @@ public class AliasesParser {
 				final int oldLastWhitespace = lastWhitespace;
 				lastWhitespace = i;
 
-				if ((oldLastWhitespace != -1 && oldLastWhitespace == i - 1)
-					|| (i < name.length() - 1 && name.charAt(i + 1) == '¦')) {
-					++stripped;
+				if (
+					(oldLastWhitespace != -1 && oldLastWhitespace == i - 1)
+					|| (i < name.length() - 1 && name.charAt(i + 1) == '¦')
+				) {
+					stripped++;
 					continue;
 				}
 			}

--- a/src/main/java/ch/njol/skript/aliases/AliasesParser.java
+++ b/src/main/java/ch/njol/skript/aliases/AliasesParser.java
@@ -722,7 +722,7 @@ public class AliasesParser {
 		 * so that our indices for those characters aren't misaligned.
 		 * */
 
-		final StringBuilder sb = new StringBuilder(name.length());
+		StringBuilder sb = new StringBuilder(name.length());
 
 		int firstNonWhitespace = -1;
 		int lastNonWhitespace = -1;
@@ -730,16 +730,16 @@ public class AliasesParser {
 		int stripped = 0;
 
 		for (int i = 0; i < name.length(); ++i) {
-			final char c = name.charAt(i);
+			char c = name.charAt(i);
 			if (c > ' ') {
 				// The index will be off by the number of characters we've stripped so far
-				final int adjustedIndex = i - stripped;
+				int adjustedIndex = i - stripped;
 
 				if (firstNonWhitespace == -1)
 					firstNonWhitespace = adjustedIndex;
 				lastNonWhitespace = adjustedIndex;
 			} else {
-				final int oldLastWhitespace = lastWhitespace;
+				int oldLastWhitespace = lastWhitespace;
 				lastWhitespace = i;
 
 				if (

--- a/src/main/java/ch/njol/skript/aliases/AliasesParser.java
+++ b/src/main/java/ch/njol/skript/aliases/AliasesParser.java
@@ -702,18 +702,56 @@ public class AliasesParser {
 	
 	/**
 	 * Fixes an alias name by trimming it and removing all extraneous spaces
-	 * between the words.
+	 * between the words or before broken pipe characters (¦).
 	 * @param name Name to be fixed.
 	 * @return Name fixed.
 	 */
 	protected String fixName(String name) {
-		String result = org.apache.commons.lang.StringUtils.normalizeSpace(name);
-		
-		int i = result.indexOf('¦');
-		
-		if (i != -1 && Character.isWhitespace(result.codePointBefore(i)))
-			result = result.substring(0, i - 1) + result.substring(i);
-		return result;
+		/*
+		 * General logic:
+		 *
+		 * We rebuild the string from scratch, but skip any whitespace if
+		 * 	1. The previous character was also whitespace
+		 * 	2. The next character is a broken pipe (¦)
+		 *        - The broken pipe is used to separate the singular and plural forms of the alias
+		 *        - We want to allow a space before it for readability
+		 *        - We also don't want to literally include the space in the alias
+		 *
+		 * We also keep track of the first and last non-whitespace characters to trim the string manually.
+		 * Since we're also skipping whitespace, we need to keep track of how many characters we've skipped
+		 * so that our indices for those characters aren't misaligned.
+		 * */
+
+		final StringBuilder sb = new StringBuilder(name.length());
+
+		int firstNonWhitespace = -1;
+		int lastNonWhitespace = -1;
+		int lastWhitespace = -1;
+		int stripped = 0;
+
+		for (int i = 0; i < name.length(); ++i) {
+			final char c = name.charAt(i);
+			if (c > ' ') {
+				// The index will be off by the number of characters we've stripped so far
+				final int adjustedIndex = i - stripped;
+
+				if (firstNonWhitespace == -1) firstNonWhitespace = adjustedIndex;
+				lastNonWhitespace = adjustedIndex;
+			} else {
+				final int oldLastWhitespace = lastWhitespace;
+				lastWhitespace = i;
+
+				if ((oldLastWhitespace != -1 && oldLastWhitespace == i - 1)
+					|| (i < name.length() - 1 && name.charAt(i + 1) == '¦')) {
+					++stripped;
+					continue;
+				}
+			}
+
+			sb.append(c);
+		}
+
+		return sb.substring(firstNonWhitespace, lastNonWhitespace + 1);
 	}
 	
 	public void registerCondition(String name, Function<String, Boolean> condition) {

--- a/src/main/java/ch/njol/skript/aliases/AliasesParser.java
+++ b/src/main/java/ch/njol/skript/aliases/AliasesParser.java
@@ -735,7 +735,8 @@ public class AliasesParser {
 				// The index will be off by the number of characters we've stripped so far
 				final int adjustedIndex = i - stripped;
 
-				if (firstNonWhitespace == -1) firstNonWhitespace = adjustedIndex;
+				if (firstNonWhitespace == -1)
+					firstNonWhitespace = adjustedIndex;
 				lastNonWhitespace = adjustedIndex;
 			} else {
 				final int oldLastWhitespace = lastWhitespace;

--- a/src/main/java/ch/njol/skript/aliases/AliasesProvider.java
+++ b/src/main/java/ch/njol/skript/aliases/AliasesProvider.java
@@ -21,9 +21,11 @@ package ch.njol.skript.aliases;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Set;
 import java.util.List;
 import java.util.Map;
 
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.eclipse.jdt.annotation.Nullable;
@@ -56,7 +58,7 @@ public class AliasesProvider {
 	/**
 	 * All materials that are currently loaded by this provider.
 	 */
-	private final List<Material> materials;
+	private final Set<Material> materials;
 	
 	/**
 	 * Tags are in JSON format. We may need GSON when merging tags
@@ -171,7 +173,7 @@ public class AliasesProvider {
 		this.aliases = new HashMap<>(expectedCount);
 		this.variations = new HashMap<>(expectedCount / 20);
 		this.aliasesMap = new AliasesMap();
-		this.materials = new ArrayList<>();
+		this.materials = new ObjectOpenHashSet<>();
 		
 		this.gson = new Gson();
 	}
@@ -265,8 +267,8 @@ public class AliasesProvider {
 			if (material == null) { // If server doesn't recognize id, do not proceed
 				throw new InvalidMinecraftIdException(id);
 			}
-			if (!materials.contains(material))
-				materials.add(material);
+
+			materials.add(material);
 			
 			// Hacky: get related entity from block states
 			String entityName = blockStates.remove("relatedEntity");

--- a/src/main/java/ch/njol/skript/aliases/ItemData.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemData.java
@@ -419,7 +419,6 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 		first = first.clone();
 		second = second.clone();
 
-
 		first.setDisplayName(null);
 		second.setDisplayName(null);
 

--- a/src/main/java/ch/njol/skript/aliases/ItemData.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemData.java
@@ -303,6 +303,13 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 		if (isAnything || item.isAnything) {
 			return MatchQuality.EXACT; // TODO different match quality?
 		}
+
+		if (item.type == this.type
+			&& Objects.equals(item.stack.getItemMeta(), this.stack.getItemMeta())
+			&& Objects.equals(item.blockValues, this.blockValues)
+		) {
+			return MatchQuality.EXACT;
+		}
 		
 		// Ensure that both items share the material
 		if (item.getType() != getType()) {

--- a/src/main/java/ch/njol/skript/aliases/ItemData.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemData.java
@@ -342,7 +342,7 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 		}
 		
 		// See if we need to compare item metas (excluding durability)
-		if (quality.isAtLeast(MatchQuality.SAME_ITEM)) { // Item meta checks could lower this
+		if (quality.isAtLeast(MatchQuality.SAME_ITEM) && stack.hasItemMeta() || item.stack.hasItemMeta()) { // Item meta checks could lower this
 			MatchQuality metaQuality = compareItemMetas(getItemMeta(), item.getItemMeta());
 			
 			// If given item doesn't care about meta, promote to SAME_ITEM

--- a/src/main/java/ch/njol/skript/aliases/ItemData.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemData.java
@@ -303,18 +303,16 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 		if (isAnything || item.isAnything) {
 			return MatchQuality.EXACT; // TODO different match quality?
 		}
-
-		if (item.type == this.type
-			&& Objects.equals(item.stack.getItemMeta(), this.stack.getItemMeta())
-			&& Objects.equals(item.blockValues, this.blockValues)
-		) {
-			return MatchQuality.EXACT;
-		}
 		
 		// Ensure that both items share the material
 		if (item.getType() != getType()) {
 			return MatchQuality.DIFFERENT;
+		} else if (Objects.equals(item.stack.getItemMeta(), this.stack.getItemMeta())
+				   && Objects.equals(item.getBlockValues(), this.getBlockValues())) {
+			// Items are identical
+			return MatchQuality.EXACT;
 		}
+
 		BlockValues values = blockValues;
 		// Items (held in inventories) don't have block values
 		// If this is an item, given item must not have them either

--- a/src/main/java/ch/njol/skript/aliases/ItemData.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemData.java
@@ -307,10 +307,6 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 		// Ensure that both items share the material
 		if (item.getType() != getType()) {
 			return MatchQuality.DIFFERENT;
-		} else if (Objects.equals(item.stack.getItemMeta(), this.stack.getItemMeta())
-				   && Objects.equals(item.getBlockValues(), this.getBlockValues())) {
-			// Items are identical
-			return MatchQuality.EXACT;
 		}
 
 		BlockValues values = blockValues;
@@ -422,6 +418,7 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 		// clone to avoid affecting user
 		first = first.clone();
 		second = second.clone();
+
 
 		first.setDisplayName(null);
 		second.setDisplayName(null);


### PR DESCRIPTION
### Description

- Switched `AliasesProvider.materials` set implementation from Java SE `HashSet` to FastUtil `ObjectOpenHashSet`.
- Re-wrote `AliasesParser#fixName(String)`.
    > **Note**  
    > The re-written method is stricter about which kinds of whitespace it strips. This doesn't affect any of our aliases, as the spaces are never used.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** n/a<!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** n/a<!-- Links to related issues -->
