### PR TITLE
Fixes IllegalArgumentException throwing with unloaded worlds in location serialization

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -28,18 +28,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import ch.njol.util.coll.iterator.ArrayIterator;
-import ch.njol.skript.classes.ClassInfo;
-import ch.njol.skript.classes.ConfigurationSerializer;
-import ch.njol.skript.classes.EnumClassInfo;
-import ch.njol.skript.classes.Parser;
-import ch.njol.skript.classes.Serializer;
-import ch.njol.skript.lang.util.SimpleLiteral;
-import ch.njol.skript.util.BlockUtils;
-import ch.njol.skript.util.EnchantmentType;
-import ch.njol.skript.util.PotionEffectUtils;
-import ch.njol.skript.util.StringMode;
-import io.papermc.paper.world.MoonPhase;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Difficulty;
@@ -92,14 +80,25 @@ import ch.njol.skript.aliases.Aliases;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.bukkitutil.EnchantmentUtils;
 import ch.njol.skript.bukkitutil.ItemUtils;
+import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.classes.ConfigurationSerializer;
+import ch.njol.skript.classes.EnumClassInfo;
+import ch.njol.skript.classes.Parser;
+import ch.njol.skript.classes.Serializer;
 import ch.njol.skript.entity.EntityData;
 import ch.njol.skript.expressions.ExprDamageCause;
 import ch.njol.skript.expressions.base.EventValueExpression;
 import ch.njol.skript.lang.ParseContext;
+import ch.njol.skript.lang.util.SimpleLiteral;
 import ch.njol.skript.localization.Language;
 import ch.njol.skript.registrations.Classes;
+import ch.njol.skript.util.BlockUtils;
+import ch.njol.skript.util.EnchantmentType;
+import ch.njol.skript.util.PotionEffectUtils;
+import ch.njol.skript.util.StringMode;
 import ch.njol.util.StringUtils;
 import ch.njol.yggdrasil.Fields;
+import io.papermc.paper.world.MoonPhase;
 
 /**
  * @author Peter Güttinger
@@ -390,15 +389,22 @@ public class BukkitClasses {
 					}
 				}).serializer(new Serializer<Location>() {
 					@Override
-					public Fields serialize(final Location l) {
-						final Fields f = new Fields();
-						f.putObject("world", l.getWorld());
-						f.putPrimitive("x", l.getX());
-						f.putPrimitive("y", l.getY());
-						f.putPrimitive("z", l.getZ());
-						f.putPrimitive("yaw", l.getYaw());
-						f.putPrimitive("pitch", l.getPitch());
-						return f;
+					public Fields serialize(Location location) {
+						Fields fields = new Fields();
+						World world = null;
+						try {
+							world = location.getWorld();
+						} catch (IllegalArgumentException exception) {
+							if (Skript.logHigh())
+								Skript.warning("A location failed to serilize with it's defined world, as the world was unloaded.");
+						}
+						fields.putObject("world", world);
+						fields.putPrimitive("x", location.getX());
+						fields.putPrimitive("y", location.getY());
+						fields.putPrimitive("z", location.getZ());
+						fields.putPrimitive("yaw", location.getYaw());
+						fields.putPrimitive("pitch", location.getPitch());
+						return fields;
 					}
 					
 					@Override

--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -395,7 +395,7 @@ public class BukkitClasses {
 						try {
 							world = location.getWorld();
 						} catch (IllegalArgumentException exception) {
-							Skript.warning("A location failed to serilize with it's defined world, as the world was unloaded.");
+							Skript.warning("A location failed to serialize with its defined world, as the world was unloaded.");
 						}
 						fields.putObject("world", world);
 						fields.putPrimitive("x", location.getX());

--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -395,8 +395,7 @@ public class BukkitClasses {
 						try {
 							world = location.getWorld();
 						} catch (IllegalArgumentException exception) {
-							if (Skript.logHigh())
-								Skript.warning("A location failed to serilize with it's defined world, as the world was unloaded.");
+							Skript.warning("A location failed to serilize with it's defined world, as the world was unloaded.");
 						}
 						fields.putObject("world", world);
 						fields.putPrimitive("x", location.getX());


### PR DESCRIPTION
### Description
```
05.05 00:29:27 [Server] ERROR #!#! Stack trace:
05.05 00:29:27 [Server] ERROR #!#! java.lang.IllegalArgumentException: World unloaded
05.05 00:29:27 [Server] ERROR #!#!     at com.google.common.base.Preconditions.checkArgument(Preconditions.java:141)
05.05 00:29:27 [Server] ERROR #!#!     at org.bukkit.Location.getWorld(Location.java:112)
05.05 00:29:27 [Server] ERROR #!#!     at Skript-2.6.4.jar//ch.njol.skript.classes.data.BukkitClasses$6.serialize(BukkitClasses.java:398)
05.05 00:29:27 [Server] ERROR #!#!     at Skript-2.6.4.jar//ch.njol.skript.classes.data.BukkitClasses$6.serialize(BukkitClasses.java:394)
05.05 00:29:27 [Server] ERROR #!#!     at Skript-2.6.4.jar//ch.njol.yggdrasil.YggdrasilOutputStream.writeGenericObject(YggdrasilOutputStream.java:178)
05.05 00:29:27 [Server] ERROR #!#!     at Skript-2.6.4.jar//ch.njol.yggdrasil.YggdrasilOutputStream.writeObject(YggdrasilOutputStream.java:249)
05.05 00:29:27 [Server] ERROR #!#!     at Skript-2.6.4.jar//ch.njol.skript.registrations.Classes.serialize(Classes.java:724)
05.05 00:29:27 [Server] ERROR #!#!     at Skript-2.6.4.jar//ch.njol.skript.variables.FlatFileStorage.save(FlatFileStorage.java:438)
05.05 00:29:27 [Server] ERROR #!#!     at Skript-2.6.4.jar//ch.njol.skript.variables.FlatFileStorage.save(FlatFileStorage.java:432)
05.05 00:29:27 [Server] ERROR #!#!     at Skript-2.6.4.jar//ch.njol.skript.variables.FlatFileStorage.saveVariables(FlatFileStorage.java:386)
05.05 00:29:27 [Server] ERROR #!#!     at Skript-2.6.4.jar//ch.njol.skript.variables.FlatFileStorage.close(FlatFileStorage.java:339)
05.05 00:29:27 [Server] ERROR #!#!     at Skript-2.6.4.jar//ch.njol.skript.Skript.onDisable(Skript.java:1135)
05.05 00:29:27 [Server] ERROR #!#!     at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:266)
05.05 00:29:27 [Server] ERROR #!#!     at org.bukkit.plugin.java.JavaPluginLoader.disablePlugin(JavaPluginLoader.java:399)
05.05 00:29:27 [Server] ERROR #!#!     at org.bukkit.plugin.SimplePluginManager.disablePlugin(SimplePluginManager.java:537)
05.05 00:29:27 [Server] ERROR #!#!     at org.bukkit.plugin.SimplePluginManager.disablePlugins(SimplePluginManager.java:514)
05.05 00:29:27 [Server] ERROR #!#!     at org.bukkit.craftbukkit.v1_17_R1.CraftServer.disablePlugins(CraftServer.java:495)
05.05 00:29:27 [Server] ERROR #!#!     at net.minecraft.server.MinecraftServer.stop(MinecraftServer.java:1053)
05.05 00:29:27 [Server] ERROR #!#!     at net.minecraft.server.dedicated.DedicatedServer.stop(DedicatedServer.java:817)
05.05 00:29:27 [Server] ERROR #!#!     at net.minecraft.server.MinecraftServer.close(MinecraftServer.java:1013)
```
- Fixes an IllegalArgumentException from being thrown when attempting to serialize a location with a world that is unloaded.
- It'll warn and save without the world.
- The getWorld can already be null aswell.
- Fields support getting and setting null values.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none