### PR TITLE
🛠 Fix fireworkeffect classinfo doesn't have usage

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -1347,14 +1347,17 @@ public class BukkitClasses {
 		Classes.registerClass(new ClassInfo<>(FireworkEffect.class, "fireworkeffect")
 				.user("firework ?effects?")
 				.name("Firework Effect")
-				.description("A configuration of effects that defines the firework when exploded",
+				.usage("See <a href='/classes.html#FireworkType'>Firework Types</a>")
+				.description(
+					"A configuration of effects that defines the firework when exploded",
 					"which can be used in the <a href='effects.html#EffFireworkLaunch'>launch firework</a> effect.",
-					"See the <a href='expressions.html#ExprFireworkEffect'>firework effect</a> expression for detailed patterns.")
-				.defaultExpression(new EventValueExpression<>(FireworkEffect.class))
-				.examples("launch flickering trailing burst firework colored blue and green at player",
+					"See the <a href='expressions.html#ExprFireworkEffect'>firework effect</a> expression for detailed patterns."
+				).defaultExpression(new EventValueExpression<>(FireworkEffect.class))
+				.examples(
+					"launch flickering trailing burst firework colored blue and green at player",
 					"launch trailing flickering star colored purple, yellow, blue, green and red fading to pink at target entity",
-					"launch ball large colored red, purple and white fading to light green and black at player's location with duration 1")
-				.since("2.4")
+					"launch ball large colored red, purple and white fading to light green and black at player's location with duration 1"
+				).since("2.4")
 				.parser(new Parser<FireworkEffect>() {
 					@Override
 					@Nullable


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Fix fireworkeffect classinfo doesn't have usage

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** <!-- Links to related issues -->
- closes https://github.com/SkriptLang/skript-docs/issues/32
