### PR TITLE
🛠 Fix docs examples non HTML tags not escaped 

### DIFF
--- a/src/main/java/ch/njol/skript/doc/Documentation.java
+++ b/src/main/java/ch/njol/skript/doc/Documentation.java
@@ -476,16 +476,23 @@ public class Documentation {
 		return html;
 	}
 
-	private static String escapeSQL(final String s) {
-		return "" + s.replace("'", "\\'").replace("\"", "\\\"");
+	private static String escapeSQL(String value) {
+		return "" + value.replace("'", "\\'").replace("\"", "\\\"");
 	}
 
-	public static String escapeHTML(final @Nullable String s) {
-		if (s == null) {
+	public static String escapeHTML(@Nullable String value) {
+		if (value == null) {
 			assert false;
 			return "";
 		}
-		return "" + s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;");
+		return "" + value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+	}
+
+	public static String[] escapeHTML(@Nullable String[] values) {
+		for (int i = 0; i < values.length; i++) {
+			values[i] = escapeHTML(values[i]);
+		}
+		return values;
 	}
 
 }

--- a/src/main/java/ch/njol/skript/doc/HTMLGenerator.java
+++ b/src/main/java/ch/njol/skript/doc/HTMLGenerator.java
@@ -466,8 +466,8 @@ public class HTMLGenerator {
 
 		// Examples
 		Examples examples = c.getAnnotation(Examples.class);
-		desc = desc.replace("${element.examples}", Joiner.on("<br>").join(getDefaultIfNullOrEmpty((examples != null ? examples.value() : null), "Missing examples.")));
-		desc = desc.replace("${element.examples-safe}", Joiner.on("\\n").join(getDefaultIfNullOrEmpty((examples != null ? examples.value() : null), "Missing examples."))
+		desc = desc.replace("${element.examples}", Joiner.on("<br>").join(getDefaultIfNullOrEmpty((examples != null ? Documentation.escapeHTML(examples.value()) : null), "Missing examples.")));
+		desc = desc.replace("${element.examples-safe}", Joiner.on("\\n").join(getDefaultIfNullOrEmpty((examples != null ? Documentation.escapeHTML(examples.value()) : null), "Missing examples."))
 				.replace("\\", "\\\\").replace("\"", "\\\"").replace("\t", "    "));
 
 		// Documentation ID
@@ -595,7 +595,7 @@ public class HTMLGenerator {
 
 		// Examples
 		String[] examples = getDefaultIfNullOrEmpty(info.getExamples(), "Missing examples.");
-		desc = desc.replace("${element.examples}", Joiner.on("\n<br>").join(examples));
+		desc = desc.replace("${element.examples}", Joiner.on("\n<br>").join(Documentation.escapeHTML(examples)));
 		desc = desc
 				.replace("${element.examples-safe}", Joiner.on("\\n").join(examples)
 				.replace("\\", "\\\\").replace("\"", "\\\"").replace("\t", "    "));
@@ -703,8 +703,8 @@ public class HTMLGenerator {
 
 		// Examples
 		String[] examples = getDefaultIfNullOrEmpty(info.getExamples(), "Missing examples.");
-		desc = desc.replace("${element.examples}", Joiner.on("\n<br>").join(examples));
-		desc = desc.replace("${element.examples-safe}", Joiner.on("\\n").join(examples)
+		desc = desc.replace("${element.examples}", Joiner.on("\n<br>").join(Documentation.escapeHTML(examples)));
+		desc = desc.replace("${element.examples-safe}", Joiner.on("\\n").join(Documentation.escapeHTML(examples))
 				.replace("\\", "\\\\").replace("\"", "\\\"").replace("\t", "    "));
 
 		// Documentation ID
@@ -808,7 +808,7 @@ public class HTMLGenerator {
 
 		// Examples
 		String[] examples = getDefaultIfNullOrEmpty(info.getExamples(), "Missing examples.");
-		desc = desc.replace("${element.examples}", Joiner.on("\n<br>").join(examples));
+		desc = desc.replace("${element.examples}", Joiner.on("\n<br>").join(Documentation.escapeHTML(examples)));
 		desc = desc
 				.replace("${element.examples-safe}", Joiner.on("\\n").join(examples)
 				.replace("\\", "\\\\").replace("\"", "\\\"").replace("\t", "    "));


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
- Fixed docs examples non HTML tags not escaped (HTML tags have no use cases in skript examples)
- Also removed escaping quotes as that's only needed in attribute values which we don't use and it was causing problems as not appearing as quote symbol in HTML element content, see https://stackoverflow.com/a/25918549

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** <!-- Links to related issues -->
- closes https://github.com/SkriptLang/skript-docs/issues/30
