### PR TITLE
🛠 Fix docs returntype check inverted

### DIFF
--- a/src/main/java/ch/njol/skript/doc/HTMLGenerator.java
+++ b/src/main/java/ch/njol/skript/doc/HTMLGenerator.java
@@ -914,7 +914,7 @@ public class HTMLGenerator {
 		if (returnType == null)
 			return handleIf(desc, "${if return-type}", false);
 
-		boolean noDoc = returnType.hasDocs();
+		boolean noDoc = !returnType.hasDocs();
 		String returnTypeName = noDoc ? returnType.getCodeName() : returnType.getDocName();
 		String returnTypeLink = noDoc ? "" : "$1" + getDefaultIfNullOrEmpty(returnType.getDocumentationID(), returnType.getCodeName());
 


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
- Fix docs returntype check inverted 🤦
- This fixes 2 issues
  - Java classinfos not appearing (related issue)
  - Other classinfos have no links

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** <!-- Links to related issues -->
- closes https://github.com/SkriptLang/skript-docs/issues/24
