### PR TITLE
🚀 Add `Change Modes` to expressions in docs

### DIFF
--- a/src/main/java/ch/njol/skript/doc/AcceptedChangeModes.java
+++ b/src/main/java/ch/njol/skript/doc/AcceptedChangeModes.java
@@ -1,0 +1,40 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.doc;
+
+import ch.njol.skript.classes.Changer;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Provides a list of accepted {@link ch.njol.skript.classes.Changer.ChangeMode}s to be used in documentation for annotated
+ * elements.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface AcceptedChangeModes {
+	
+	public Changer.ChangeMode[] value();
+
+}

--- a/src/main/java/ch/njol/skript/doc/HTMLGenerator.java
+++ b/src/main/java/ch/njol/skript/doc/HTMLGenerator.java
@@ -517,6 +517,7 @@ public class HTMLGenerator {
 		desc = handleIf(desc, "${if by-addon}", false);
 
 		// Accepted Changers
+		// TODO grab the accepted data type as well (find a way to include that in annotation as well)
 		if (info instanceof ExpressionInfo<?,?>) {
 			List<Changer.ChangeMode> acceptedChangeModes = new ArrayList<>(4); // 4 is common, SET/ADD/REMOVE/DELETE
 			AcceptedChangeModes annotation = c.getAnnotation(AcceptedChangeModes.class);

--- a/src/main/java/ch/njol/skript/lang/Expression.java
+++ b/src/main/java/ch/njol/skript/lang/Expression.java
@@ -295,14 +295,12 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	default Map<ChangeMode, Class<?>[]> getAcceptedChangeModes() {
 		LogHandler logHandler = SkriptLogger.startLogHandler(new BlockingLogHandler());
 		Map<ChangeMode, Class<?>[]> map = new HashMap<>();
-		try {
+		try (LogHandler logHandler = new BlockingLogHandler()) {
 			for (ChangeMode cm : ChangeMode.values()) {
 				Class<?>[] ac = acceptChange(cm);
 				if (ac != null)
 					map.put(cm, ac);
 			}
-		} finally {
-			logHandler.stop();
 		}
 		return map;
 	}


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Currently this only implements getting the ChangeMode but not the accepted data type until a good way for implementing that in annotation is suggested/found.


- Enhancements: Pre-Compile some regex patterns
- Enhancement: Removed some duplicated null checks
- Ignore Skript errors in getAcceptedChangeModes method

_Preview_
![image](https://github.com/SkriptLang/Skript/assets/20037329/a1810ccb-1d70-4165-ad52-db034010f8a6)


---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** <!-- Links to related issues -->
- closes https://github.com/SkriptLang/skript-docs/issues/15
