### PR TITLE
🚀 Add event values to events in docs

### DIFF
--- a/src/main/java/ch/njol/skript/doc/HTMLGenerator.java
+++ b/src/main/java/ch/njol/skript/doc/HTMLGenerator.java
@@ -636,7 +636,7 @@ public class HTMLGenerator {
 				}
 			}
 		}
-		List<String> eventValues = new ArrayList<>(0);
+		List<String> eventValues = new ArrayList<>();
 		for (String value : eventValuesSet)
 			eventValues.add("<span class='event-value'>" + value + "</span>");
 		desc = handleIf(desc, "${if event-values}", eventValues.size() > 0);

--- a/src/main/java/ch/njol/skript/registrations/EventValues.java
+++ b/src/main/java/ch/njol/skript/registrations/EventValues.java
@@ -400,7 +400,7 @@ public class EventValues {
 	 */
 	public static Map<Class<? extends Event>, List<EventValueInfo<?, ?>>> getPerEventEventValues() {
 		Map<Class<? extends Event>, List<EventValues.EventValueInfo<?, ?>>> eventValuesCache = new HashMap<>();
-		for (int i = -1; i < 2; i++) {
+		for (int i = TIME_PAST; i <= TIME_FUTURE; i++) {
 			for (EventValues.EventValueInfo<?, ?> eventValueInfo : EventValues.getEventValuesListForTime(i)) {
 				List<EventValueInfo<?, ?>> list = new ArrayList<>(0);
 				List<EventValueInfo<?, ?>> oldList = eventValuesCache.get(eventValueInfo.event);

--- a/src/main/java/ch/njol/skript/registrations/EventValues.java
+++ b/src/main/java/ch/njol/skript/registrations/EventValues.java
@@ -127,11 +127,10 @@ public class EventValues {
 		 * @return Either {@link #TIME_PAST}, {@link #TIME_NOW} or {@link #TIME_FUTURE}
 		 */
 		public boolean isEventExcluded(Class<? extends Event> c) {
-			if (excludes != null)
-				for (Class<? extends Event> exclude : excludes) {
-					if (exclude.isAssignableFrom(c))
-						return true;
-				}
+			for (Class<? extends Event> exclude : excludes) {
+				if (exclude.isAssignableFrom(c))
+					return true;
+			}
 			return false;
 		}
 


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
- Added event values to events in docs
- Added `EventValueInfo#getTime()`
- Added `EventValueInfo#isEventExcluded(Class)`
- Overloaded `EventValueInfo` constructor and deprecated the old one due to `time` param
- Added `EventValues#getPerEventEventValues()` for getting all events values per event -- useful for docs

_Preview_
![image](https://github.com/SkriptLang/Skript/assets/20037329/c897e1cd-23b6-43c4-af50-ed7455f458a5)
_nvm about the broken if condition, that's from my side_

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** <!-- Links to related issues -->
- closes https://github.com/SkriptLang/skript-docs/issues/9
