### PR TITLE
Fix Item Comparisons For "Base" ItemTypes

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/ItemData.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemData.java
@@ -593,6 +593,8 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 		if (stack.hasItemMeta()) {
 			ItemMeta meta = stack.getItemMeta(); // Creates a copy
 			meta.setDisplayName(null); // Clear display name
+			if (!itemFactory.getItemMeta(type).equals(meta)) // there may be different tags (e.g. potions)
+				data.itemFlags |= ItemFlags.CHANGED_TAGS;
 			data.stack.setItemMeta(meta);
 		}
 		ItemUtils.setDamage(data.stack, 0); // Set to undamaged
@@ -601,34 +603,6 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 		data.blockValues = blockValues;
 		data.itemForm = itemForm;
 		return data;
-	}
-
-	/**
-	 * Applies an item meta to this item. Currently, it copies the following,
-	 * provided that they exist in given meta:
-	 * <ul>
-	 * <li>Lore
-	 * <li>Display name
-	 * <li>Enchantments
-	 * <li>Item flags
-	 * </ul>
-	 * @param meta Item meta.
-	 */
-	public void applyMeta(ItemMeta meta) {
-		ItemMeta our = getItemMeta();
-		if (meta.hasLore())
-			our.setLore(meta.getLore());
-		if (meta.hasDisplayName())
-			our.setDisplayName(meta.getDisplayName());
-		if (meta.hasEnchants()) {
-			for (Map.Entry<Enchantment, Integer> entry : meta.getEnchants().entrySet()) {
-				our.addEnchant(entry.getKey(), entry.getValue(), true);
-			}
-		}
-		for (ItemFlag flag : meta.getItemFlags()) {
-			our.addItemFlags(flag);
-		}
-		setItemMeta(meta);
 	}
 	
 	/**

--- a/src/main/java/ch/njol/skript/aliases/ItemType.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemType.java
@@ -165,7 +165,7 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 			this.block = block;
 		}
 	}
-	
+
 	public ItemType() {}
 	
 	public ItemType(Material id) {
@@ -1298,7 +1298,7 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 		
 		// Apply new meta to all datas
 		for (ItemData data : types) {
-			data.applyMeta(meta);
+			data.setItemMeta(meta);
 		}
 	}
 	
@@ -1326,7 +1326,7 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 	public ItemType getBaseType() {
 		ItemType copy = new ItemType();
 		for (ItemData data : types) {
-			copy.add(data.aliasCopy());
+			copy.add_(data.aliasCopy());
 		}
 		return copy;
 	}

--- a/src/test/skript/tests/regressions/3419-item comparisons.sk
+++ b/src/test/skript/tests/regressions/3419-item comparisons.sk
@@ -151,3 +151,13 @@ test "item comparisons":
 
 	remove all items from {_inventory}
 	set block at spawn of world "world" to air
+
+	# type comparisons (see https://github.com/SkriptLang/Skript/issues/5693)
+
+	set {_fire-resist} to type of potion of fire resistance
+	set {_water-breathing} to type of water breathing potion
+	set {_water-bottle} to type of water bottle
+	assert {_fire-resist} is {_fire-resist} with "fire resist is not fire resist"
+	assert {_fire-resist} is not {_water-breathing} with "fire resist is water breathing"
+	assert {_fire-resist} is not {_water-bottle} with "fire resist is water bottle"
+	assert {_water-bottle} is not {_water-breathing} with "water bottle is water breathing"


### PR DESCRIPTION
### Description
This PR aims to fix item comparisons for ItemTypes created through `type of <itemtype>`. The issue is rather simple, which is that ItemFlags (specifically for having non-default tags) is not correctly applied. This causes the related issue, since items like potions and goat horns do not have non-default tags.

Also, while slightly odd given the name, aliasCopy does *not* return a "default" item, and this is specifically mentioned in the method's javadoc. Thus, it needs to be handling this "CHANGED_TAGS" flag even for items that aren't potions or goat horns (since properties like lore are kept).

I have also gone ahead and removed some useless code that didn't actually do anything except add overhead.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:**
- https://github.com/SkriptLang/Skript/issues/5693
