### PR TITLE
Enhance EffFeed

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffFeed.java
+++ b/src/main/java/ch/njol/skript/effects/EffFeed.java
@@ -25,7 +25,7 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
@@ -33,44 +33,47 @@ import org.eclipse.jdt.annotation.Nullable;
 
 @Name("Feed")
 @Description("Feeds the specified players.")
-@Examples({"feed all players", "feed the player by 5 beefs"})
+@Examples({
+	"feed all players",
+	"feed the player by 5 beefs"
+})
 @Since("2.2-dev34")
 public class EffFeed extends Effect {
 
     static {
-        Skript.registerEffect(EffFeed.class, "feed [the] %players% [by %-number% [beef[s]]]");
+        Skript.registerEffect(EffFeed.class, "feed [the] %players% [by %-number% [beef[s]|hunger]]");
     }
 
-    @SuppressWarnings("null")
+	@SuppressWarnings("NotNullFieldNotInitialized")
     private Expression<Player> players;
     @Nullable
-    private Expression<Number> beefs;
+    private Expression<Number> hunger;
 
     @Override
-    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+	@SuppressWarnings("unchecked")
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
         players = (Expression<Player>) exprs[0];
-        beefs = (Expression<Number>) exprs[1];
+        hunger = (Expression<Number>) exprs[1];
         return true;
     }
 
     @Override
-    protected void execute(Event e) {
+    protected void execute(Event event) {
         int level = 20;
-
-        if (beefs != null) {
-            Number n = beefs.getSingle(e);
-            if (n == null)
+        if (hunger != null) {
+            Number number = hunger.getSingle(event);
+            if (number == null)
                 return;
-            level = n.intValue();
+            level = number.intValue();
         }
-        for (Player player : players.getArray(e)) {
-            player.setFoodLevel(player.getFoodLevel() + level);
+        for (Player player : players.getArray(event)) {
+            player.setFoodLevel(Math.min(20, player.getFoodLevel() + level));
         }
     }
 
     @Override
-    public String toString(@Nullable Event e, boolean debug) {
-        return "feed " + players.toString(e, debug) + (beefs != null ? " by " + beefs.toString(e, debug) : "");
+    public String toString(@Nullable Event event, boolean debug) {
+        return "feed " + players.toString(event, debug) + (hunger != null ? " by " + hunger.toString(event, debug) : "");
     }
 
 


### PR DESCRIPTION
### Description
This PR does the following:
- Fix where the effect will overfed player. -- Technically "feeding" a person should not exceed the maximum level of the hunger, but the current behaviour allows overfeeding the player. I have changed it to re-adjust down back to 20 if any value exceeding 20 is used. Anyone wishes to exceed this value shall use `set player's food level to 999`.
- Added an optional keyword, `hunger` -> `feed the player by 5 hunger` -- This is how we refer to the amount of hunger left, hence I believe this change is more logical to have.
- Class cleanup to follow the latest code convention

Retaining the `beef` keyword as there's 0.01% chance someone is using it for unknown reasons.

---
**Target Minecraft Versions:** any
**Requirements:** -
**Related Issues:** -
