### PR TITLE
Apply entity data changes before calling consumer

### DIFF
--- a/src/main/java/ch/njol/skript/entity/EntityData.java
+++ b/src/main/java/ch/njol/skript/entity/EntityData.java
@@ -434,23 +434,25 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		return spawn(loc, null);
 	}
 
-	@SuppressWarnings("unchecked")
-	@Nullable
-	public E spawn(Location loc, @Nullable Consumer<E> consumer) {
-		assert loc != null;
-		try {
-			E e;
-			if (consumer != null)
-				e = loc.getWorld().spawn(loc, (Class<E>) getType(), consumer);
-			else
-				e = loc.getWorld().spawn(loc, getType());
+	private E apply(E entity) {
+		if (baby.isTrue())
+			EntityUtils.setBaby(entity);
+		else if (baby.isFalse())
+			EntityUtils.setAdult(entity);
+		set(entity);
+		return entity;
+	}
 
-			if (baby.isTrue())
-				EntityUtils.setBaby(e);
-			else if (baby.isFalse())
-				EntityUtils.setAdult(e);
-			set(e);
-			return e;
+	@Nullable
+	@SuppressWarnings("unchecked")
+	public E spawn(Location location, @Nullable Consumer<E> consumer) {
+		assert location != null;
+		try {
+			if (consumer != null) {
+				return location.getWorld().spawn(location, (Class<E>) getType(), e -> consumer.accept(apply(e)));
+			} else {
+				return apply(location.getWorld().spawn(location, getType()));
+			}
 		} catch (IllegalArgumentException e) {
 			if (Skript.testing())
 				Skript.error("Can't spawn " + getType().getName());

--- a/src/main/java/ch/njol/skript/entity/EntityData.java
+++ b/src/main/java/ch/njol/skript/entity/EntityData.java
@@ -435,10 +435,11 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	}
 
 	private E apply(E entity) {
-		if (baby.isTrue())
+		if (baby.isTrue()) {
 			EntityUtils.setBaby(entity);
-		else if (baby.isFalse())
+		} else if (baby.isFalse()) {
 			EntityUtils.setAdult(entity);
+		}
 		set(entity);
 		return entity;
 	}

--- a/src/test/skript/tests/syntaxes/expressions/ExprTotalExperience.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprTotalExperience.sk
@@ -1,6 +1,6 @@
 test "total experience":
 	spawn 10 xp at spawn of world "world":
-		assert experience of entity is 0 with "spawned orb should have 0 experience in section"
+		assert experience of entity is 10 with "spawned orb should have 10 experience in section"
 		set experience of entity to 100
 		assert experience of entity is 100 with "set experience of entity did not work"
 		reset experience of entity
@@ -11,5 +11,5 @@ test "total experience":
 		assert experience of entity is 25 with "remove experience from entity did not work"
 		remove 50 from experience of entity
 		assert experience of entity is 0 with "remove too much experience from entity did not work"
-	assert experience of last spawned entity is 10 with "entity should have 10 experience after section"
+	assert experience of last spawned entity is 0 with "entity should have 0 experience after section"
 	delete last spawned entity


### PR DESCRIPTION
### Description
Apply EntityData#set before calling the consumer, so the changes are properly reflected in the section of the EffSecSpawn syntax.

Breaking change because people might have adapted to this weird behavior, although very low chance as it requires an expression in the entity data.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** https://github.com/SkriptLang/Skript/issues/5711
