### PR TITLE
Fix bugs in the random number expression

### DIFF
--- a/src/test/skript/tests/regressions/pull-5748-fix bugs in the random number expression.sk
+++ b/src/test/skript/tests/regressions/pull-5748-fix bugs in the random number expression.sk
@@ -1,0 +1,8 @@
+
+# Test not related to a made issue. Details at pull request.
+test "random integer test":
+	assert random integer between 1 and 1 is 1 with "Random integer between 1 and 1 should be 1"
+	assert random integer between 1.2 and 1.2 is not set with "Random integer between 1.2 and 1.2 shouldn't return anything"
+	assert random integer between 1.2 and 1.3 is not set with "Random integer between 1.2 and 1.3 shouldn't return anything"
+	assert random integer between 1.9 and 2.1 is 2 with "Random integer between 1.9 and 2.1 should be 2"
+	assert random integer between 1.5 and 2 is 2 with "Random integer between 1 and 2 should be 2"


### PR DESCRIPTION
### Description
This PR fixes a variety of bugs and weird behaviors of the random number expression. Like:
```vb
random integer between 1 and 1 # Returns nothing. Should return 1
random integer between 1.9 and 2.1 # Returns nothing. Should return 2
random integer between 1 and 1.5 # Returns nothing. Should return 1
random integer between 1.5 and 2 # Returns nothing. Should return 2
```

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
https://github.com/SkriptLang/Skript/pull/5443
