### PR TITLE
[2.7.0 target] Update 2.7.0 to Spigot 1.20.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 	shadow group: 'org.bstats', name: 'bstats-bukkit', version: '3.0.2'
 	shadow group: 'net.kyori', name: 'adventure-text-serializer-bungeecord', version: '4.3.0'
 
-	implementation group: 'io.papermc.paper', name: 'paper-api', version: '1.19.4-R0.1-SNAPSHOT'
+	implementation group: 'io.papermc.paper', name: 'paper-api', version: '1.20.1-R0.1-SNAPSHOT'
 	implementation group: 'org.eclipse.jdt', name: 'org.eclipse.jdt.annotation', version: '2.2.700'
 	implementation group: 'com.google.code.findbugs', name: 'findbugs', version: '3.0.1'
 	implementation group: 'com.sk89q.worldguard', name: 'worldguard-legacy', version: '7.0.0-SNAPSHOT'
@@ -254,7 +254,7 @@ void createTestTask(String name, String desc, String environments, int javaVersi
 	}
 }
 
-def latestEnv = 'java17/paper-1.19.4.json'
+def latestEnv = 'java17/paper-1.20.1.json'
 def latestJava = 17
 def oldestJava = 8
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,5 +2,5 @@ groupid=ch.njol
 name=skript
 version=2.7.0
 jarName=Skript.jar
-testEnv=java17/paper-1.19.4
+testEnv=java17/paper-1.20.1
 testEnvJavaVersion=17

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -1299,6 +1299,8 @@ damage causes:
 	dryout: dryout
 	custom: unknown, custom, plugin, a plugin
 	sonic_boom: sonic boom
+	kill: kill, killed
+	world_border: world border
 
 # -- Teleport Causes --
 teleport causes:

--- a/src/test/skript/environments/java17/paper-1.20.1.json
+++ b/src/test/skript/environments/java17/paper-1.20.1.json
@@ -1,11 +1,11 @@
 {
-	"name": "paper-1.19.3",
+	"name": "paper-1.20.1",
 	"resources": [
 		{"source": "server.properties.generic", "target": "server.properties"}
 	],
 	"paperDownloads": [
 		{
-			"version": "1.19.3",
+			"version": "1.20.1",
 			"target": "paperclip.jar"
 		}
 	],


### PR DESCRIPTION
### Description
Update 2.7.0 to Spigot 1.20.1

There is a warning present https://github.com/SkriptLang/Skript/issues/5740