### PR TITLE
Fix null pointer exception in ExprBlocks when using the ExprDirection without a number defined.

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprBlocks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBlocks.java
@@ -151,9 +151,11 @@ public class ExprBlocks extends SimpleExpression<Block> {
 				int distance = SkriptConfig.maxTargetBlockDistance.value();
 				if (this.direction instanceof ExprDirection) {
 					Expression<Number> numberExpression = ((ExprDirection) this.direction).amount;
-					Number number = numberExpression.getSingle(event);
-					if (numberExpression != null && number != null)
-						distance = number.intValue();
+					if (numberExpression != null) {
+						Number number = numberExpression.getSingle(event);
+						if (number != null)
+							distance = number.intValue();
+					}
 				}
 				return new BlockLineIterator(location, vector, distance);
 			} else {


### PR DESCRIPTION
### Description

Fix null pointer exception in ExprBlocks when using the ExprDirection without a number defined.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** https://github.com/SkriptLang/Skript/issues/5787
#5566
