### PR TITLE
[2.7.0 target] Fix null pointer exception in ExprBlocks when using the ExprDirection without a number defined

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprBlocks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBlocks.java
@@ -151,9 +151,11 @@ public class ExprBlocks extends SimpleExpression<Block> {
 				int distance = SkriptConfig.maxTargetBlockDistance.value();
 				if (this.direction instanceof ExprDirection) {
 					Expression<Number> numberExpression = ((ExprDirection) this.direction).amount;
-					Number number = numberExpression.getSingle(event);
-					if (numberExpression != null && number != null)
-						distance = number.intValue();
+					if (numberExpression != null) {
+						Number number = numberExpression.getSingle(event);
+						if (number != null)
+							distance = number.intValue();
+					}
 				}
 				return new BlockLineIterator(location, vector, distance);
 			} else {


### PR DESCRIPTION
Fix null pointer exception in ExprBlocks when using the ExprDirection without a number defined.

2.7.0 target for https://github.com/SkriptLang/Skript/pull/5790

(cherry picked from commit 549ebc380b34dd544c760d7a2c23faa8973a12f7)

**Related Issues:** https://github.com/SkriptLang/Skript/issues/5787
