### PR TITLE
Fixes error not properly being caught

### DIFF
--- a/src/main/java/ch/njol/skript/util/Utils.java
+++ b/src/main/java/ch/njol/skript/util/Utils.java
@@ -199,7 +199,7 @@ public abstract class Utils {
 			for (String c : classNames) {
 				try {
 					classes.add(Class.forName(c, true, plugin.getClass().getClassLoader()));
-				} catch (ClassNotFoundException ex) {
+				} catch (ClassNotFoundException | NoClassDefFoundError ex) {
 					Skript.exception(ex, "Cannot load class " + c);
 				} catch (ExceptionInInitializerError err) {
 					Skript.exception(err.getCause(), "class " + c + " generated an exception while loading");


### PR DESCRIPTION
### Description
Since we're using the class loader of a provided plugin, the error if no class being found gets sent through NoClassDefFoundError and not ClassNotFoundException because NoClassDefFoundError refers to the class loader not being able to find the class.

This resulted in Skript critical hard failing, disabling itself and being unresponsive, becoming a pain to task manager end task for the testing environment and addons. Now it errors without crashing itself.