### PR TITLE
Add warning to notify the user about using teleport in the spawn section

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffTeleport.java
+++ b/src/main/java/ch/njol/skript/effects/EffTeleport.java
@@ -19,6 +19,7 @@
 package ch.njol.skript.effects;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.sections.EffSecSpawn;
 import ch.njol.skript.bukkitutil.EntityUtils;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -43,12 +44,16 @@ import org.bukkit.event.player.PlayerRespawnEvent;
 import org.eclipse.jdt.annotation.Nullable;
 
 @Name("Teleport")
-@Description({"Teleport an entity to a specific location. ",
-		"This effect is delayed by default on Paper, meaning certain syntax such as the return effect for functions cannot be used after this effect.",
-		"The keyword 'force' indicates this effect will not be delayed, ",
-		"which may cause lag spikes or server crashes when using this effect to teleport entities to unloaded chunks."})
-@Examples({"teleport the player to {homes.%player%}",
-		"teleport the attacker to the victim"})
+@Description({
+	"Teleport an entity to a specific location. ",
+	"This effect is delayed by default on Paper, meaning certain syntax such as the return effect for functions cannot be used after this effect.",
+	"The keyword 'force' indicates this effect will not be delayed, ",
+	"which may cause lag spikes or server crashes when using this effect to teleport entities to unloaded chunks."
+})
+@Examples({
+	"teleport the player to {homes.%player%}",
+	"teleport the attacker to the victim"
+})
 @Since("1.0")
 public class EffTeleport extends Effect {
 
@@ -65,8 +70,8 @@ public class EffTeleport extends Effect {
 
 	private boolean isAsync;
 
-	@SuppressWarnings({"unchecked", "null"})
 	@Override
+	@SuppressWarnings("unchecked")
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		entities = (Expression<Entity>) exprs[0];
 		location = Direction.combine((Expression<? extends Direction>) exprs[1], (Expression<? extends Location>) exprs[2]);
@@ -74,9 +79,14 @@ public class EffTeleport extends Effect {
 
 		if (isAsync)
 			getParser().setHasDelayBefore(Kleenean.UNKNOWN); // UNKNOWN because it isn't async if the chunk is already loaded.
+
+		if (getParser().getCurrentSection(EffSecSpawn.class) != null) {
+			Skript.error("You cannot be teleporting an entity that hasn't spawned yet. Ensure you're using the location expression from the spawn section pattern.");
+			return false;
+		}
 		return true;
 	}
-	
+
 	@Nullable
 	@Override
 	protected TriggerItem walk(Event e) {

--- a/src/main/java/ch/njol/skript/effects/EffTeleport.java
+++ b/src/main/java/ch/njol/skript/effects/EffTeleport.java
@@ -20,6 +20,7 @@ package ch.njol.skript.effects;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.sections.EffSecSpawn;
+import ch.njol.skript.sections.EffSecSpawn.SpawnEvent;
 import ch.njol.skript.bukkitutil.EntityUtils;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -30,6 +31,7 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.Trigger;
 import ch.njol.skript.lang.TriggerItem;
+import ch.njol.skript.lang.TriggerSection;
 import ch.njol.skript.timings.SkriptTimings;
 import ch.njol.skript.util.Direction;
 import ch.njol.skript.variables.Variables;
@@ -77,13 +79,13 @@ public class EffTeleport extends Effect {
 		location = Direction.combine((Expression<? extends Direction>) exprs[1], (Expression<? extends Location>) exprs[2]);
 		isAsync = CAN_RUN_ASYNC && parseResult.mark == 0;
 
-		if (isAsync)
-			getParser().setHasDelayBefore(Kleenean.UNKNOWN); // UNKNOWN because it isn't async if the chunk is already loaded.
-
-		if (getParser().getCurrentSection(EffSecSpawn.class) != null) {
+		if (getParser().isCurrentEvent(SpawnEvent.class)) {
 			Skript.error("You cannot be teleporting an entity that hasn't spawned yet. Ensure you're using the location expression from the spawn section pattern.");
 			return false;
 		}
+
+		if (isAsync)
+			getParser().setHasDelayBefore(Kleenean.UNKNOWN); // UNKNOWN because it isn't async if the chunk is already loaded.
 		return true;
 	}
 


### PR DESCRIPTION
### Description
Add warning to notify the user about using teleport in the spawn section.

getParser().getCurrentSection(EffSecSpawn.class) did not work. Probably something @APickledWalrus could look at fixing. Used the custom SpawnEvent as it works just as fine.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** https://github.com/SkriptLang/Skript/issues/5717
