### PR TITLE
Update the return function regex

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffReturn.java
+++ b/src/main/java/ch/njol/skript/effects/EffReturn.java
@@ -44,6 +44,9 @@ import org.eclipse.jdt.annotation.Nullable;
 @Examples({
 	"function double(i: number) :: number:",
 		"\treturn 2 * {_i}"
+	"",
+	"function divide(i: number) :: number:",
+		"\treturn {_i} / 2"
 })
 @Since("2.2")
 public class EffReturn extends Effect {

--- a/src/main/java/ch/njol/skript/effects/EffReturn.java
+++ b/src/main/java/ch/njol/skript/effects/EffReturn.java
@@ -45,7 +45,7 @@ import org.eclipse.jdt.annotation.Nullable;
 	"function double(i: number) :: number:",
 		"\treturn 2 * {_i}",
 	"",
-	"function divide(i: number) :: number:",
+	"function divide(i: number) returns number:",
 		"\treturn {_i} / 2"
 })
 @Since("2.2")

--- a/src/main/java/ch/njol/skript/effects/EffReturn.java
+++ b/src/main/java/ch/njol/skript/effects/EffReturn.java
@@ -43,7 +43,7 @@ import org.eclipse.jdt.annotation.Nullable;
 @Description("Makes a function return a value")
 @Examples({
 	"function double(i: number) :: number:",
-		"\treturn 2 * {_i}"
+		"\treturn 2 * {_i}",
 	"",
 	"function divide(i: number) :: number:",
 		"\treturn {_i} / 2"

--- a/src/main/java/ch/njol/skript/effects/EffReturn.java
+++ b/src/main/java/ch/njol/skript/effects/EffReturn.java
@@ -48,7 +48,7 @@ import org.eclipse.jdt.annotation.Nullable;
 	"function divide(i: number) returns number:",
 		"\treturn {_i} / 2"
 })
-@Since("2.2")
+@Since("2.2, INSERT VERSION (returns aliases)")
 public class EffReturn extends Effect {
 	
 	static {

--- a/src/main/java/ch/njol/skript/structures/StructFunction.java
+++ b/src/main/java/ch/njol/skript/structures/StructFunction.java
@@ -59,7 +59,7 @@ public class StructFunction extends Structure {
 
 	static {
 		Skript.registerStructure(StructFunction.class,
-			"[:local] function <(" + Functions.functionNamePattern + "\)\\((.*)\\)(?:\\s*(?:::| returns )\\s*(.+))?>"
+			"[:local] function <(" + Functions.functionNamePattern + ")\\((.*)\\)(?:\\s*(?:::| returns )\\s*(.+))?>"
 		);
 	}
 

--- a/src/main/java/ch/njol/skript/structures/StructFunction.java
+++ b/src/main/java/ch/njol/skript/structures/StructFunction.java
@@ -50,7 +50,7 @@ import java.util.regex.MatchResult;
 	"local function giveApple(amount: number) :: item:",
 	"\treturn {_amount} of apple",
 	"",
-	"function getPoints(p: player) returns object:",
+	"function getPoints(p: player) returns number:",
 	"\treturn {points::%{_p}%}"
 })
 @Since("2.2, 2.7 (local functions)")

--- a/src/main/java/ch/njol/skript/structures/StructFunction.java
+++ b/src/main/java/ch/njol/skript/structures/StructFunction.java
@@ -48,7 +48,7 @@ import java.util.regex.MatchResult;
 	"\tbroadcast {_message} # our message argument is available in '{_message}'",
 	"",
 	"local function giveApple(amount: number) :: item:",
-	"\treturn {_amount} of apple"
+	"\treturn {_amount} of apple",
 	"",
 	"function getPoints(p: player) returns object:",
 	"\treturn {points::%{_p}%}"

--- a/src/main/java/ch/njol/skript/structures/StructFunction.java
+++ b/src/main/java/ch/njol/skript/structures/StructFunction.java
@@ -59,7 +59,7 @@ public class StructFunction extends Structure {
 
 	static {
 		Skript.registerStructure(StructFunction.class,
-			"[:local] function <(" + Functions.functionNamePattern + ")\\((.*)\\)(?:\\s*::\\s*(.+))?>"
+			"[:local] function <(" + Functions.functionNamePattern + "\)\\((.*)\\)(?:\\s*(?:::| returns )\\s*(.+))?>"
 		);
 	}
 

--- a/src/main/java/ch/njol/skript/structures/StructFunction.java
+++ b/src/main/java/ch/njol/skript/structures/StructFunction.java
@@ -49,6 +49,9 @@ import java.util.regex.MatchResult;
 	"",
 	"local function giveApple(amount: number) :: item:",
 	"\treturn {_amount} of apple"
+	"",
+	"function getPoints(p: player) returns object:",
+	"\treturn {points::%{_p}%}"
 })
 @Since("2.2, 2.7 (local functions)")
 public class StructFunction extends Structure {


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
There was a need for cleaner return functions instead of the old one, because the `::` is so confusing for people who learn by looking at codes

``function getScore(player: player) :: number: `` old 
``function getScore(player: player) returns number:`` new 


---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->
any
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** <!-- Links to related issues -->
