### PR TITLE
Add defending for simple property expressions

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/base/SimplePropertyExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/SimplePropertyExpression.java
@@ -58,7 +58,7 @@ public abstract class SimplePropertyExpression<F, T> extends PropertyExpression<
 
 	/**
 	 * Used to collect the property type used in the register method.
-	 * This is used to create the toString for the SimplePropertyExpression.
+	 * This forms the toString of this SimplePropertyExpression.
 	 * 
 	 * @return The name of the type used when registering this SimplePropertyExpression.
 	 */

--- a/src/main/java/ch/njol/skript/expressions/base/SimplePropertyExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/SimplePropertyExpression.java
@@ -24,38 +24,49 @@ import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.util.LiteralUtils;
 import ch.njol.util.Kleenean;
 
 /**
  * A base class for property expressions that requires only few overridden methods
  * 
- * @author Peter Güttinger
  * @see PropertyExpression
  * @see PropertyExpression#register(Class, Class, String, String)
  */
 @SuppressWarnings("deprecation") // for backwards compatibility
 public abstract class SimplePropertyExpression<F, T> extends PropertyExpression<F, T> implements Converter<F, T> {
-	
-	@SuppressWarnings({"unchecked", "null"})
+
 	@Override
-	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
+	@SuppressWarnings("unchecked")
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		if (LiteralUtils.hasUnparsedLiteral(exprs[0])) {
+			setExpr(LiteralUtils.defendExpression(exprs[0]));
+			return LiteralUtils.canInitSafely(getExpr());
+		}
 		setExpr((Expression<? extends F>) exprs[0]);
 		return true;
 	}
-	
-	protected abstract String getPropertyName();
-	
+
 	@Override
 	@Nullable
 	public abstract T convert(F f);
-	
+
 	@Override
-	protected T[] get(final Event e, final F[] source) {
+	protected T[] get(Event event, F[] source) {
 		return super.get(source, this);
 	}
-	
+
+	/**
+	 * Used to collect the property type used in the register method.
+	 * This is used to create the toString for the SimplePropertyExpression.
+	 * 
+	 * @return The name of the type used when registering this SimplePropertyExpression.
+	 */
+	protected abstract String getPropertyName();
+
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "the " + getPropertyName() + " of " + getExpr().toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return getPropertyName() + " of " + getExpr().toString(event, debug);
 	}
+
 }


### PR DESCRIPTION
### Description
Add defending for simple property expressions for %objects%

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** https://github.com/SkriptLang/Skript/issues/5452
