### PR TITLE
Fix event-item not being present in book sign

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -1373,7 +1373,7 @@ public final class BukkitEventValues {
 				book.setItemMeta(event.getNewBookMeta());
 				return book;
 			}
-		}, EventValues.TIME_FUTURE);
+		}, EventValues.TIME_NOW);
 		EventValues.registerEventValue(PlayerEditBookEvent.class, String[].class, new Getter<String[], PlayerEditBookEvent>() {
 			@Override
 			public String[] get(PlayerEditBookEvent event) {
@@ -1385,7 +1385,7 @@ public final class BukkitEventValues {
 			public String[] get(PlayerEditBookEvent event) {
 				return event.getNewBookMeta().getPages().toArray(new String[0]);
 			}
-		}, EventValues.TIME_FUTURE);
+		}, EventValues.TIME_NOW);
 		//ItemDespawnEvent
 		EventValues.registerEventValue(ItemDespawnEvent.class, Item.class, new Getter<Item, ItemDespawnEvent>() {
 			@Override


### PR DESCRIPTION
### Description
There was no present time event-value registered for the book sign event. As stated in the JavaDoc of the `EventValues#registerEventValue` method that a default for present time must always be defined.
https://github.com/SkriptLang/Skript/blob/7632dd8fb367778bf9f28b59e4f147f091d37302/src/main/java/ch/njol/skript/registrations/EventValues.java#L187-L189

*Example script that now works.*
```vb
on book sign:
	broadcast "%event-item%" # Did not work
	if event-item will be a writable book: # Still works
		broadcast "yes"
```

### Other
Original pull request adding this https://github.com/SkriptLang/Skript/pull/813

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** https://github.com/SkriptLang/Skript/issues/5671
