### PR TITLE
SimpleEntityData - Display should be super entity

### DIFF
--- a/src/main/java/ch/njol/skript/entity/SimpleEntityData.java
+++ b/src/main/java/ch/njol/skript/entity/SimpleEntityData.java
@@ -307,7 +307,7 @@ public class SimpleEntityData extends EntityData<Entity> {
 			addSimpleEntity("item display", ItemDisplay.class);
 			addSimpleEntity("block display", BlockDisplay.class);
 			addSimpleEntity("interaction", Interaction.class);
-			addSimpleEntity("display", Display.class);
+			addSuperEntity("display", Display.class);
 		}
 
 		// Register zombie after Husk and Drowned to make sure both work


### PR DESCRIPTION
### Description
This PR aims to fix an issue with display entities.
Spawning 1 of each display entity type, then doing 
`send size of all displays` returns 0.
This is due to Display.class incorrectly being registered as a simple entity, which it should have been a super type.

---
**Target Minecraft Versions:** 1.19.4+
**Requirements:** none
**Related Issues:** none
