### PR TITLE
Add support for keybind components

### DIFF
--- a/src/main/java/ch/njol/skript/util/chat/BungeeConverter.java
+++ b/src/main/java/ch/njol/skript/util/chat/BungeeConverter.java
@@ -25,6 +25,7 @@ import ch.njol.skript.Skript;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.KeybindComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.chat.TranslatableComponent;
 
@@ -42,11 +43,10 @@ public class BungeeConverter {
 		if (origin.translation != null) {
 			String[] strings = origin.translation.split(":");
 			String key = strings[0];
-			if (strings.length > 1) {
-				base = new TranslatableComponent(key, Arrays.copyOfRange(strings, 1, strings.length, Object[].class));
-			} else {
-				base = new TranslatableComponent(key);
-			}
+			base = new TranslatableComponent(key, Arrays.copyOfRange(strings, 1, strings.length, Object[].class));
+			base.addExtra(new TextComponent(origin.text));
+		} else if (origin.keybind != null) {
+			base = new KeybindComponent(origin.keybind);
 			base.addExtra(new TextComponent(origin.text));
 		} else {
 			base = new TextComponent(origin.text);

--- a/src/main/java/ch/njol/skript/util/chat/ChatMessages.java
+++ b/src/main/java/ch/njol/skript/util/chat/ChatMessages.java
@@ -538,6 +538,8 @@ public class ChatMessages {
 			to.insertion = from.insertion;
 		if (to.hoverEvent == null)
 			to.hoverEvent = from.hoverEvent;
+		if (to.font == null)
+			to.font = from.font;
 	}
 
 	public static void shareStyles(MessageComponent[] components) {
@@ -591,6 +593,10 @@ public class ChatMessages {
 			List<MessageComponent> components = parse(result);
 			StringBuilder builder = new StringBuilder();
 			for (MessageComponent component : components) { // This also strips bracket tags ex. <red> <ttp:..> etc.
+				if (component.translation != null)
+					builder.append(component.translation);
+				if (component.keybind != null)
+					builder.append(component.keybind);
 				builder.append(component.text);
 			}
 			String plain = builder.toString();

--- a/src/main/java/ch/njol/skript/util/chat/MessageComponent.java
+++ b/src/main/java/ch/njol/skript/util/chat/MessageComponent.java
@@ -92,7 +92,10 @@ public class MessageComponent {
 
 	@Nullable
 	public String translation;
-	
+
+	@Nullable
+	public String keybind;
+
 	public static class ClickEvent {
 		public ClickEvent(ClickEvent.Action action, String value) {
 			this.action = action;
@@ -176,6 +179,8 @@ public class MessageComponent {
 		messageComponent.clickEvent = this.clickEvent;
 		messageComponent.font = this.font;
 		messageComponent.hoverEvent = this.hoverEvent;
+		messageComponent.translation = translation;
+		messageComponent.keybind = keybind;
 		return messageComponent;
 	}
 

--- a/src/main/java/ch/njol/skript/util/chat/SkriptChatCode.java
+++ b/src/main/java/ch/njol/skript/util/chat/SkriptChatCode.java
@@ -163,6 +163,13 @@ public enum SkriptChatCode implements ChatCode {
         public void updateComponent(MessageComponent component, String param) {
 			component.translation = param;
 		}
+    },
+
+    keybind(true) {
+	    @Override
+        public void updateComponent(MessageComponent component, String param) {
+			component.keybind = param;
+		}
     };
 
 	private boolean hasParam;

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -412,6 +412,7 @@ chat styles:
 	font: font, f
 	insertion: insertion, insert, ins
 	translate: translate, tr, lang
+	keybind: keybind, key
 
 # -- Directions --
 directions:


### PR DESCRIPTION
### Description
This PR implements keybind tags in Skript's formatting system. The syntax is `<keybind:value>`, where `value` is the node for the keybind

An example of how a keybind component looks like:
![image](https://github.com/SkriptLang/Skript/assets/98935832/ce9b510b-70e4-4a1f-a000-2ffe868a2638)

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
