### PR TITLE
Adds ability to listen to cancelled events

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -1471,7 +1471,7 @@ public final class Skript extends JavaPlugin implements Listener {
 
 		String[] transformedPatterns = new String[patterns.length];
 		for (int i = 0; i < patterns.length; i++)
-			transformedPatterns[i] = "[on] " + SkriptEvent.fixPattern(patterns[i]) + SkriptEventInfo.EVENT_PRIORITY_SYNTAX;
+			transformedPatterns[i] = "[on] [all] " + SkriptEvent.fixPattern(patterns[i]) + SkriptEventInfo.EVENT_PRIORITY_SYNTAX;
 
 		SkriptEventInfo<E> r = new SkriptEventInfo<>(name, transformedPatterns, c, originClassPath, events);
 		structures.add(r);

--- a/src/main/java/ch/njol/skript/lang/SkriptEvent.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptEvent.java
@@ -56,6 +56,7 @@ public abstract class SkriptEvent extends Structure {
 	@Nullable
 	protected EventPriority eventPriority;
 	private SkriptEventInfo<?> skriptEventInfo;
+	protected boolean ignoreCancelled = true;
 
 	/**
 	 * The Trigger containing this SkriptEvent's code.
@@ -65,8 +66,12 @@ public abstract class SkriptEvent extends Structure {
 	@Override
 	public final boolean init(Literal<?>[] args, int matchedPattern, ParseResult parseResult, EntryContainer entryContainer) {
 		String expr = parseResult.expr;
-		if (StringUtils.startsWithIgnoreCase(expr, "on "))
+		if (StringUtils.startsWithIgnoreCase(expr, "on all ")) {
+			expr = expr.substring("on all ".length());
+			ignoreCancelled = false;
+		} else if (StringUtils.startsWithIgnoreCase(expr, "on ")) {
 			expr = expr.substring("on ".length());
+		}
 
 		String[] split = expr.split(" with priority ");
 		if (split.length != 1) {
@@ -214,6 +219,13 @@ public abstract class SkriptEvent extends Structure {
 	 */
 	public boolean isEventPrioritySupported() {
 		return true;
+	}
+
+	/**
+	 * @return whether this SkriptEvent will ignore cancelled events
+	 */
+	public boolean shouldIgnoreCancelled() {
+		return ignoreCancelled;
 	}
 
 	/**


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Adds the ability to listen to events cancelled by other plugins by using `on all <event>`.
Previously, Skript would simply return before executing any triggers if the event was cancelled. Now it checks each trigger to see if each one is ignoring or listening to cancelled events via SkriptEvent#shouldIgnoreCancelled(). 

Also cleans up SkriptEventHandler#check() a bit more.

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** #5891 <!-- Links to related issues -->
