### PR TITLE
Disable Timings for 1.19.4+

### DIFF
--- a/src/main/java/ch/njol/skript/SkriptConfig.java
+++ b/src/main/java/ch/njol/skript/SkriptConfig.java
@@ -41,6 +41,7 @@ import ch.njol.skript.util.Version;
 import ch.njol.skript.util.chat.ChatMessages;
 import ch.njol.skript.util.chat.LinkParseMode;
 import ch.njol.skript.variables.Variables;
+import co.aikar.timings.Timings;
 import org.bukkit.event.EventPriority;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -196,13 +197,13 @@ public class SkriptConfig {
 	
 	public static final Option<Boolean> enableTimings = new Option<>("enable timings", false)
 			.setter(t -> {
-				if (!Skript.classExists("co.aikar.timings.Timings")) { // Check for Paper server
+				if (!Skript.classExists("co.aikar.timings.Timings")) { // Check for Timings
 					if (t) // Warn the server admin that timings won't work
 						Skript.warning("Timings cannot be enabled! You are running Bukkit/Spigot, but Paper is required.");
 					SkriptTimings.setEnabled(false); // Just to be sure, deactivate timings support completely
 					return;
 				}
-				if (Skript.isRunningMinecraft(1, 19, 4)) { // check for valid paper version (<1.19.4)
+				if (Timings.class.isAnnotationPresent(Deprecated.class)) { // check for deprecated Timings
 					if (t) // Warn the server admin that timings won't work
 						Skript.warning("Timings cannot be enabled! Paper no longer supports Timings as of 1.19.4.");
 					SkriptTimings.setEnabled(false); // Just to be sure, deactivate timings support completely

--- a/src/main/java/ch/njol/skript/SkriptConfig.java
+++ b/src/main/java/ch/njol/skript/SkriptConfig.java
@@ -196,15 +196,22 @@ public class SkriptConfig {
 	
 	public static final Option<Boolean> enableTimings = new Option<>("enable timings", false)
 			.setter(t -> {
-				if (Skript.classExists("co.aikar.timings.Timings")) { // Check for Paper server
-					if (t)
-						Skript.info("Timings support enabled!");
-					SkriptTimings.setEnabled(t); // Config option will be used
-				} else { // Not running Paper
+				if (!Skript.classExists("co.aikar.timings.Timings")) { // Check for Paper server
 					if (t) // Warn the server admin that timings won't work
 						Skript.warning("Timings cannot be enabled! You are running Bukkit/Spigot, but Paper is required.");
 					SkriptTimings.setEnabled(false); // Just to be sure, deactivate timings support completely
+					return;
 				}
+				if (Skript.isRunningMinecraft(1, 19, 4)) { // check for valid paper version (<1.19.4)
+					if (t) // Warn the server admin that timings won't work
+						Skript.warning("Timings cannot be enabled! Paper no longer supports Timings as of 1.19.4.");
+					SkriptTimings.setEnabled(false); // Just to be sure, deactivate timings support completely
+					return;
+				}
+				// If we get here, we can safely enable timings
+				if (t)
+					Skript.info("Timings support enabled!");
+				SkriptTimings.setEnabled(t); // Config option will be used
 			});
 	
 	public static final Option<String> parseLinks = new Option<>("parse links in chat messages", "disabled")

--- a/src/main/resources/config.sk
+++ b/src/main/resources/config.sk
@@ -159,7 +159,8 @@ soft api exceptions: false
 
 enable timings: false
 # When enabled, triggers in scripts will be present in timings reports.
-# Note that this requires Paper (https://paper.readthedocs.io/en/paper-1.11/) to work; on Bukkit/Spigot this option has no effect.
+# Note that this requires Paper (https://papermc.io/downloads/paper) to work; on Bukkit/Spigot this option has no effect.
+# Warning: Paper no longer supports Timings as of 1.19.4. This option has no effect on versions 1.19.4 and above.
 # When false, timings are not enabled for scripts even if you're running Paper.
 
 parse links in chat messages: disabled


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Prevents Skript from enabling Timings support for Paper versions 1.19.4 or greater. 
Fixes #5726

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** #5726  <!-- Links to related issues -->
