### PR TITLE
Fix cast throwing if existing variable for command storage exists

### DIFF
--- a/src/main/java/ch/njol/skript/command/ScriptCommand.java
+++ b/src/main/java/ch/njol/skript/command/ScriptCommand.java
@@ -477,7 +477,7 @@ public class ScriptCommand implements TabExecutor {
 			Object variable = Variables.getVariable(name, null, false);
 			if (!(variable instanceof Date)) {
 				Skript.warning("Variable {" + name + "} was not a date! You may be using this variable elsewhere. " +
-						"This warning is letting you know that this variable is now overriden for the command storage.");
+						"This warning is letting you know that this variable is now overridden for the command storage.");
 				return null;
 			}
 			return (Date) variable;

--- a/src/main/java/ch/njol/skript/command/ScriptCommand.java
+++ b/src/main/java/ch/njol/skript/command/ScriptCommand.java
@@ -474,7 +474,13 @@ public class ScriptCommand implements TabExecutor {
 		} else {
 			String name = getStorageVariableName(event);
 			assert name != null;
-			return (Date) Variables.getVariable(name, null, false);
+			Object variable = Variables.getVariable(name, null, false);
+			if (!(variable instanceof Date)) {
+				Skript.warning("Variable {" + name + "} was not a date! You may be using this variable elsewhere. " +
+						"This warning is letting you know that this variable is now overriden for the command storage.");
+				return null;
+			}
+			return (Date) variable;
 		}
 	}
 


### PR DESCRIPTION
### Description
Fix cast throwing if existing variable for command storage exists.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** https://github.com/SkriptLang/Skript/issues/5935
