### PR TITLE
Fix an issue with creating a non creatable inventory from ExprNamed and fix array store exception

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprNamed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNamed.java
@@ -35,60 +35,84 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.PropertyExpression;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.Getter;
 import ch.njol.util.Kleenean;
 
-/**
- * @author Peter Güttinger
- */
 @Name("Named Item/Inventory")
-@Description("Directly names an item/inventory, useful for defining a named item/inventory in a script. " +
-		"If you want to (re)name existing items/inventories you can either use this expression or use <code>set <a href='#ExprName'>name of &lt;item/inventory&gt;</a> to &lt;text&gt;</code>.")
-@Examples({"give a diamond sword of sharpness 100 named \"&lt;gold&gt;Excalibur\" to the player",
-		"set tool of player to the player's tool named \"&lt;gold&gt;Wand\"",
-		"set the name of the player's tool to \"&lt;gold&gt;Wand\"",
-		"open hopper inventory named \"Magic Hopper\" to player"})
+@Description({
+	"Directly names an item/inventory, useful for defining a named item/inventory in a script.",
+	"If you want to (re)name existing items/inventories you can either use this expression " +
+			"or use <code>set <a href='#ExprName'>name of &lt;item/inventory&gt;</a> to &lt;text&gt;</code>."
+})
+@Examples({
+	"give a diamond sword of sharpness 100 named \"&lt;gold&gt;Excalibur\" to the player",
+	"set tool of player to the player's tool named \"&lt;gold&gt;Wand\"",
+	"set the name of the player's tool to \"&lt;gold&gt;Wand\"",
+	"open hopper inventory named \"Magic Hopper\" to player"
+})
 @Since("2.0, 2.2-dev34 (inventories)")
 public class ExprNamed extends PropertyExpression<Object, Object> {
+
 	static {
-		Skript.registerExpression(ExprNamed.class, Object.class, ExpressionType.PROPERTY,
+		Skript.registerExpression(ExprNamed.class, Object.class, ExpressionType.COMBINED,
 				"%itemtype/inventorytype% (named|with name[s]) %string%");
 	}
-	
-	@SuppressWarnings("null")
+
 	private Expression<String> name;
-	
-	@SuppressWarnings({"unchecked", "null"})
+
 	@Override
-	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
-		setExpr(exprs[0]);
+	@SuppressWarnings("unchecked")
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		// See issue #1822 as to why this convert is required.
+		if (exprs[0].getReturnType().equals(ItemStack.class)) {
+			setExpr(exprs[0].getConvertedExpression(ItemType.class));
+		} else {
+			setExpr(exprs[0]);
+		}
 		name = (Expression<String>) exprs[1];
+		if (getExpr() instanceof Literal) {
+			Literal<?> literal = (Literal<?>) getExpr();
+			Object object = literal.getSingle();
+			if (object instanceof InventoryType && !((InventoryType) object).isCreatable()) {
+				// Spigot forgot to label some InventoryType's as non creatable in some versions < 1.19.4
+				// So this throws NullPointerException aswell ontop of the IllegalArgumentException.
+				// See https://hub.spigotmc.org/jira/browse/SPIGOT-7301
+				Skript.error("You can't create a '" + literal.toString() + "' inventory. It's not creatable!");
+				return false;
+			}
+		}
 		return true;
 	}
-	
+
 	@Override
-	protected Object[] get(final Event e, final Object[] source) {
-		String name = this.name.getSingle(e);
+	protected Object[] get(Event event, Object[] source) {
+		String name = this.name.getSingle(event);
 		if (name == null)
-			return get(source, obj -> obj); // No name provided, do nothing
+			return get(source, object -> {
+				if (object instanceof InventoryType) {
+					try {
+						return Bukkit.createInventory(null, (InventoryType) object);
+					} catch (NullPointerException | IllegalArgumentException e) {
+						return null;
+					}
+				}
+				return object; // Return the same ItemType they passed without applying a name.
+			});
 		return get(source, new Getter<Object, Object>() {
 			@Override
 			@Nullable
-			public Object get(Object obj) {
-				if (obj instanceof InventoryType)
-					return Bukkit.createInventory(null, (InventoryType) obj, name);
-				if (obj instanceof ItemStack) {
-					ItemStack stack = (ItemStack) obj;
-					stack = stack.clone();
-					ItemMeta meta = stack.getItemMeta();
-					if (meta != null) {
-						meta.setDisplayName(name);
-						stack.setItemMeta(meta);
+			public Object get(Object object) {
+				if (object instanceof InventoryType) {
+					try {
+						return Bukkit.createInventory(null, (InventoryType) object, name);
+					} catch (NullPointerException | IllegalArgumentException e) {
+						return null;
 					}
-					return new ItemType(stack);
 				}
-				ItemType item = (ItemType) obj;
+				assert object instanceof ItemType;
+				ItemType item = (ItemType) object;
 				item = item.clone();
 				ItemMeta meta = item.getItemMeta();
 				meta.setDisplayName(name);
@@ -97,15 +121,15 @@ public class ExprNamed extends PropertyExpression<Object, Object> {
 			}
 		});
 	}
-	
+
 	@Override
 	public Class<? extends Object> getReturnType() {
 		return getExpr().getReturnType() == InventoryType.class ? Inventory.class : ItemType.class;
 	}
-	
+
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return getExpr().toString(e, debug) + " named " + name;
+	public String toString(@Nullable Event event, boolean debug) {
+		return getExpr().toString(event, debug) + " named " + name.toString(event, debug);
 	}
-	
+
 }


### PR DESCRIPTION
### Description
Fix an issue with creating a non creatable inventory from ExprNamed and fix array store exception.
- See https://github.com/SkriptLang/Skript/issues/5495 and solution pull request for it at https://github.com/SkriptLang/Skript/pull/5531 about the issue with creating non creatable inventories. This also affects ExprNamed which is what this pull request fixes, where as the referenced pull request is for EffOpenInventory.
- ExprNamed takes in an inventory type or an item type, and the array that PropertyExpression builds is of the type the implementing property expression class returns. So ExprNamed was returning Inventory.class from it's getReturnType method making the required array for the converters to be an Inventory[]. If the String of the ExprNamed was null, the get method would just return the getExpr(), so it was return an InventoryType, and you cannot store that in an Inventory[] array, so an exception was being thrown.
- The solution for the for mentioned was to make it return a new Bukkit#createInventory without a name.
---

- Changed the ExpressionType to a COMBINED as it combines multiple expressions to make one, but utilizes the PropertyExpression class.
- Cleaned up the examples and the class to follow modern code standards.
- Added event and debug boolean reference to the name expression for the toString method of ExprNamed.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** https://github.com/SkriptLang/Skript/issues/5495 and https://github.com/SkriptLang/Skript/issues/5923
