### PR TITLE
Adds ExprPercent

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprPercent.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPercent.java
@@ -1,0 +1,90 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+@Name("Percent of")
+@Description("Returns a percentage of one or more numbers.")
+@Examples({
+	"set damage to 10% of victim's health",
+	"set damage to 125 percent of damage",
+	"set {_result} to {_percent} percent of 999",
+	"set {_result::*} to 10% of {_numbers::*}",
+	"set experience to 50% of player's total experience"
+})
+@Since("INSERT VERSION")
+public class ExprPercent extends SimpleExpression<Number> {
+
+	static {
+		Skript.registerExpression(ExprPercent.class, Number.class, ExpressionType.COMBINED, "%number%(\\%| percent) of %numbers%");
+	}
+
+	private Expression<Number> percent;
+	private Expression<Number> numbers;
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		percent = (Expression<Number>) exprs[0];
+		numbers = (Expression<Number>) exprs[1];
+		return true;
+	}
+
+	@Override
+	protected @Nullable Number[] get(Event event) {
+		Number percent = this.percent.getSingle(event);
+		Number[] numbers = this.numbers.getArray(event);
+		if (percent == null || numbers.length == 0)
+			return null;
+
+		Number[] results = new Number[numbers.length];
+		for (int i = 0; i < numbers.length; i++) {
+			results[i] = numbers[i].doubleValue() * percent.doubleValue() / 100;
+		}
+
+		return results;
+	}
+
+	@Override
+	public boolean isSingle() {
+		return numbers.isSingle();
+	}
+
+	@Override
+	public Class<? extends Number> getReturnType() {
+		return Number.class;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return percent.toString(event, debug) + " percent of " + numbers.toString(event, debug);
+	}
+
+}

--- a/src/test/skript/tests/syntaxes/expressions/ExprPercent.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprPercent.sk
@@ -1,0 +1,17 @@
+test "percent of":
+	assert 5% of 100 is 5 with "5%% of 100 is 5"
+	assert 0 percent of 100 is 0 with "0%% of 100 is 0"
+	assert -5% of 100 is -5 with "-5%% of 100 is -5"
+	assert infinity value% of 100 is infinity value with "infinity%% of 100 is infinity"
+	assert 20 percent of 0 is 0 with "20%% of 0 is 0"
+	assert 110% of 100 is 110 with "110%% of 100 is 110"
+
+	set {_a::*} to 50% of (100, 50, 0, and infinity value)
+	assert {_a::1} is 50 with "50%% of 100 is 50 (list)"
+	assert {_a::2} is 25 with "50%% of 50 is 25 (list)"
+	assert {_a::3} is 0 with "50%% of 0 is 0 (list)"
+	assert {_a::4} is infinity value with "50%% of infinity is infinity (list)"
+
+	assert {_none}% of 10 is not set with "none%% of 10 is none"
+	assert {_none}% of {_none} is not set with "none%% of none is none"
+	assert 10% of {_none} is not set with "10%% of none is none"


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Adds `%number%(\\%| percent) of %numbers%`, as requested by #2692.
Arguably does not complete the issue, but I'm of the opinion that `500 + 1%` does not make much sense and should not equal 505.

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** #2692 <!-- Links to related issues -->
