### PR TITLE
Fix EvtPlayerChunkEnter Comparison & Cleanup

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -845,6 +845,30 @@ public final class BukkitEventValues {
 				return event.getTo().clone().subtract(0, 0.5, 0).getBlock();
 			}
 		}, EventValues.TIME_NOW);
+		EventValues.registerEventValue(PlayerMoveEvent.class, Location.class, new Getter<Location, PlayerMoveEvent>() {
+			@Override
+			public Location get(PlayerMoveEvent event) {
+				return event.getFrom();
+			}
+		}, EventValues.TIME_PAST);
+		EventValues.registerEventValue(PlayerMoveEvent.class, Location.class, new Getter<Location, PlayerMoveEvent>() {
+			@Override
+			public Location get(PlayerMoveEvent event) {
+				return event.getTo();
+			}
+		}, EventValues.TIME_NOW);
+		EventValues.registerEventValue(PlayerMoveEvent.class, Chunk.class, new Getter<Chunk, PlayerMoveEvent>() {
+			@Override
+			public Chunk get(PlayerMoveEvent event) {
+				return event.getFrom().getChunk();
+			}
+		}, EventValues.TIME_PAST);
+		EventValues.registerEventValue(PlayerMoveEvent.class, Chunk.class, new Getter<Chunk, PlayerMoveEvent>() {
+			@Override
+			public Chunk get(PlayerMoveEvent event) {
+				return event.getTo().getChunk();
+			}
+		}, EventValues.TIME_NOW);
 		// PlayerItemDamageEvent
 		EventValues.registerEventValue(PlayerItemDamageEvent.class, ItemStack.class, new Getter<ItemStack, PlayerItemDamageEvent>() {
 			@Override
@@ -1425,21 +1449,6 @@ public final class BukkitEventValues {
 				return e.getCause();
 			}
 		}, 0);
-		//PlayerMoveEvent
-		EventValues.registerEventValue(PlayerMoveEvent.class, Location.class, new Getter<Location, PlayerMoveEvent>() {
-			@Override
-			@Nullable
-			public Location get(PlayerMoveEvent e) {
-				return e.getFrom();
-			}
-		}, EventValues.TIME_PAST);
-		EventValues.registerEventValue(PlayerMoveEvent.class, Location.class, new Getter<Location, PlayerMoveEvent>() {
-			@Override
-			@Nullable
-			public Location get(PlayerMoveEvent e) {
-				return e.getTo();
-			}
-		}, EventValues.TIME_NOW);
 		//EntityMoveEvent
 		if (Skript.classExists("io.papermc.paper.event.entity.EntityMoveEvent")) {
 			EventValues.registerEventValue(EntityMoveEvent.class, Location.class, new Getter<Location, EntityMoveEvent>() {

--- a/src/main/java/ch/njol/skript/events/EvtPlayerChunkEnter.java
+++ b/src/main/java/ch/njol/skript/events/EvtPlayerChunkEnter.java
@@ -22,11 +22,9 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptEvent;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
-
 import org.bukkit.event.Event;
 import org.bukkit.event.player.PlayerMoveEvent;
-
-import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public class EvtPlayerChunkEnter extends SkriptEvent {
 
@@ -46,7 +44,8 @@ public class EvtPlayerChunkEnter extends SkriptEvent {
 
 	@Override
 	public boolean check(Event event) {
-		return ((PlayerMoveEvent) event).getFrom().getChunk() != ((PlayerMoveEvent) event).getTo().getChunk();
+		PlayerMoveEvent moveEvent = ((PlayerMoveEvent) event);
+		return !moveEvent.getFrom().getChunk().equals(moveEvent.getTo().getChunk());
 	}
 
 	@Override


### PR DESCRIPTION
### Description
This PR cleans up and fixes EvtPlayerChunkEnter for:
- Fix potential comparison issue
- Explicitly specify event chunk values from event locations to prevent unexpected conflicts from Converters
- Minor general cleanup

---
**Target Minecraft Versions:** any
**Requirements:** -
**Related Issues:** -
