### PR TITLE
Async Safety API (Feedback Wanted)

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffAsyncTest.java
+++ b/src/main/java/ch/njol/skript/effects/EffAsyncTest.java
@@ -1,0 +1,55 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.ThreadSafety;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+public class EffAsyncTest extends Effect {
+
+	static {
+		Skript.registerEffect(EffAsyncTest.class, "my async-only effect [using %-object%]");
+	}
+
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		return "async effect";
+	}
+
+	@Override
+	protected void execute(Event e) {
+
+	}
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		return true;
+	}
+
+	@Override
+	public ThreadSafety getThreadSafety() {
+		return ThreadSafety.ASYNC_THREAD_ONLY;
+	}
+}

--- a/src/main/java/ch/njol/skript/effects/EffAsyncTest.java
+++ b/src/main/java/ch/njol/skript/effects/EffAsyncTest.java
@@ -22,7 +22,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
-import ch.njol.skript.lang.ThreadSafety;
+import ch.njol.skript.lang.ThreadConstraint;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
@@ -49,7 +49,7 @@ public class EffAsyncTest extends Effect {
 	}
 
 	@Override
-	public ThreadSafety getThreadSafety() {
-		return ThreadSafety.ASYNC_THREAD_ONLY;
+	public ThreadConstraint getThreadConstraint() {
+		return ThreadConstraint.ASYNC_THREAD_ONLY;
 	}
 }

--- a/src/main/java/ch/njol/skript/events/SimpleEvents.java
+++ b/src/main/java/ch/njol/skript/events/SimpleEvents.java
@@ -682,6 +682,7 @@ public class SimpleEvents {
 				"\t\tset chat format to \"&lt;orange&gt;[player]&lt;light gray&gt;: &lt;white&gt;[message]\""
 			)
 			.since("1.4.1");
+
 		if (Skript.classExists("org.bukkit.event.world.LootGenerateEvent")) {
 			Skript.registerEvent("Loot Generate", SimpleEvent.class, LootGenerateEvent.class, "loot generat(e|ing)")
 					.description(

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -265,13 +265,13 @@ public class SkriptParser {
 							for (Expression<?> expr : res.exprs) {
 								if (expr == null)
 									continue;
-								if (!expr.getThreadSafety().isSafe(getParser().getThreadContext())) {
-									Skript.error("A " + expr.getThreadSafety() + " element cannot be used in a " + getParser().getThreadContext() + " context");
+								if (!expr.getThreadConstraint().isSafe(getParser().getThreadContext())) {
+									Skript.error("A " + expr.getThreadConstraint() + " element cannot be used in a " + getParser().getThreadContext() + " context");
 									continue patternsLoop;
 								}
 							}
-							if (!t.getThreadSafety().isSafe(getParser().getThreadContext())) {
-								Skript.error("A " + t.getThreadSafety() + " element cannot be used in a " + getParser().getThreadContext() + " context");
+							if (!t.getThreadConstraint().isSafe(getParser().getThreadContext())) {
+								Skript.error("A " + t.getThreadConstraint() + " element cannot be used in a " + getParser().getThreadContext() + " context");
 								continue;
 							}
 							if (t.init(res.exprs, i, getParser().getHasDelayBefore(), res)) {

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -48,7 +48,6 @@ import ch.njol.util.NonNullPair;
 import ch.njol.util.StringUtils;
 import ch.njol.util.coll.CollectionUtils;
 import com.google.common.primitives.Booleans;
-import org.bukkit.event.EventPriority;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.eclipse.jdt.annotation.Nullable;
 import org.skriptlang.skript.lang.script.Script;
@@ -263,6 +262,18 @@ public class SkriptParser {
 								x = x2;
 							}
 							T t = info.c.newInstance();
+							for (Expression<?> expr : res.exprs) {
+								if (expr == null)
+									continue;
+								if (!expr.getThreadSafety().isSafe(getParser().getThreadContext())) {
+									Skript.error("A " + expr.getThreadSafety() + " element cannot be used in a " + getParser().getThreadContext() + " context");
+									continue patternsLoop;
+								}
+							}
+							if (!t.getThreadSafety().isSafe(getParser().getThreadContext())) {
+								Skript.error("A " + t.getThreadSafety() + " element cannot be used in a " + getParser().getThreadContext() + " context");
+								continue;
+							}
 							if (t.init(res.exprs, i, getParser().getHasDelayBefore(), res)) {
 								log.printLog();
 								return t;

--- a/src/main/java/ch/njol/skript/lang/SyntaxElement.java
+++ b/src/main/java/ch/njol/skript/lang/SyntaxElement.java
@@ -47,4 +47,8 @@ public interface SyntaxElement {
 		return ParserInstance.get();
 	}
 
+	default ThreadSafety getThreadSafety() {
+		return ThreadSafety.MAIN_THREAD_ONLY;
+	}
+
 }

--- a/src/main/java/ch/njol/skript/lang/SyntaxElement.java
+++ b/src/main/java/ch/njol/skript/lang/SyntaxElement.java
@@ -47,8 +47,8 @@ public interface SyntaxElement {
 		return ParserInstance.get();
 	}
 
-	default ThreadSafety getThreadSafety() {
-		return ThreadSafety.MAIN_THREAD_ONLY;
+	default ThreadConstraint getThreadConstraint() {
+		return ThreadConstraint.MAIN_THREAD_ONLY;
 	}
 
 }

--- a/src/main/java/ch/njol/skript/lang/ThreadConstraint.java
+++ b/src/main/java/ch/njol/skript/lang/ThreadConstraint.java
@@ -18,7 +18,7 @@
  */
 package ch.njol.skript.lang;
 
-public enum ThreadSafety {
+public enum ThreadConstraint {
 	MAIN_THREAD_ONLY,
 	ASYNC_THREAD_ONLY,
 	EITHER_THREAD;

--- a/src/main/java/ch/njol/skript/lang/ThreadContext.java
+++ b/src/main/java/ch/njol/skript/lang/ThreadContext.java
@@ -1,0 +1,24 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.lang;
+
+public enum ThreadContext {
+	MAIN_THREAD,
+	ASYNC_THREAD
+}

--- a/src/main/java/ch/njol/skript/lang/ThreadSafety.java
+++ b/src/main/java/ch/njol/skript/lang/ThreadSafety.java
@@ -1,0 +1,38 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.lang;
+
+public enum ThreadSafety {
+	MAIN_THREAD_ONLY,
+	ASYNC_THREAD_ONLY,
+	EITHER_THREAD;
+
+	public boolean isSafe(ThreadContext threadContext) {
+		switch (this) {
+			case MAIN_THREAD_ONLY:
+				return threadContext == ThreadContext.MAIN_THREAD;
+			case ASYNC_THREAD_ONLY:
+				return threadContext == ThreadContext.ASYNC_THREAD;
+			case EITHER_THREAD:
+				return true;
+			default:
+				throw new IllegalStateException("Unexpected value: " + this);
+		}
+	}
+}

--- a/src/main/java/ch/njol/skript/lang/parser/ParserInstance.java
+++ b/src/main/java/ch/njol/skript/lang/parser/ParserInstance.java
@@ -25,6 +25,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptEvent;
 import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.ThreadContext;
 import ch.njol.skript.lang.TriggerSection;
 import ch.njol.skript.log.HandlerList;
 import ch.njol.skript.structures.StructOptions.OptionsData;
@@ -200,12 +201,14 @@ public final class ParserInstance {
 		currentEventName = name;
 		setCurrentEvents(events);
 		setHasDelayBefore(Kleenean.FALSE);
+		setThreadContext(ThreadContext.MAIN_THREAD);
 	}
 
 	public void deleteCurrentEvent() {
 		currentEventName = null;
 		setCurrentEvents(null);
 		setHasDelayBefore(Kleenean.FALSE);
+		setThreadContext(ThreadContext.MAIN_THREAD);
 	}
 
 	public Class<? extends Event> @Nullable [] getCurrentEvents() {
@@ -354,6 +357,25 @@ public final class ParserInstance {
 	 */
 	public Kleenean getHasDelayBefore() {
 		return hasDelayBefore;
+	}
+
+	// Thread Safety API
+
+	private ThreadContext threadContext = ThreadContext.MAIN_THREAD;
+
+	/**
+	 * @return The {@link ThreadContext} of this ParserInstance.
+	 */
+	public ThreadContext getThreadContext() {
+		return threadContext;
+	}
+
+	/**
+	 * Sets the {@link ThreadContext} of this ParserInstance.
+	 * @param threadContext The new {@link ThreadContext}.
+	 */
+	public void setThreadContext(ThreadContext threadContext) {
+		this.threadContext = threadContext;
 	}
 
 	// Miscellaneous

--- a/src/main/java/ch/njol/skript/sections/SecAsync.java
+++ b/src/main/java/ch/njol/skript/sections/SecAsync.java
@@ -1,0 +1,65 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.sections;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.config.SectionNode;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.Section;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.ThreadContext;
+import ch.njol.skript.lang.TriggerItem;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import java.util.List;
+
+public class SecAsync extends Section {
+
+	static {
+		Skript.registerSection(SecAsync.class, "do async");
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "async";
+	}
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
+		loadCode(sectionNode);
+		return true;
+	}
+
+	@Override
+	public boolean affectsThreadContext() {
+		return true;
+	}
+
+	@Override
+	public ThreadContext getThreadContext() {
+		return ThreadContext.ASYNC_THREAD;
+	}
+
+	@Override
+	protected @Nullable TriggerItem walk(Event e) {
+		return walk(e, true);
+	}
+}

--- a/src/main/java/org/skriptlang/skript/lang/entry/util/ExpressionEntryData.java
+++ b/src/main/java/org/skriptlang/skript/lang/entry/util/ExpressionEntryData.java
@@ -21,6 +21,7 @@ package org.skriptlang.skript.lang.entry.util;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ParseContext;
 import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.ThreadContext;
 import ch.njol.skript.lang.parser.ParserInstance;
 import org.skriptlang.skript.lang.entry.KeyValueEntryData;
 import ch.njol.util.Kleenean;
@@ -80,14 +81,17 @@ public class ExpressionEntryData<T> extends KeyValueEntryData<Expression<? exten
 
 		Class<? extends Event>[] oldEvents = parser.getCurrentEvents();
 		Kleenean oldHasDelayBefore = parser.getHasDelayBefore();
+		ThreadContext oldThreadContext = parser.getThreadContext();
 
 		parser.setCurrentEvents(events);
 		parser.setHasDelayBefore(Kleenean.FALSE);
+		parser.setThreadContext(ThreadContext.MAIN_THREAD);
 
 		Expression<? extends T> expression = new SkriptParser(value, flags, ParseContext.DEFAULT).parseExpression(returnType);
 
 		parser.setCurrentEvents(oldEvents);
 		parser.setHasDelayBefore(oldHasDelayBefore);
+		parser.setThreadContext(oldThreadContext);
 
 		return expression;
 	}

--- a/src/main/java/org/skriptlang/skript/lang/entry/util/TriggerEntryData.java
+++ b/src/main/java/org/skriptlang/skript/lang/entry/util/TriggerEntryData.java
@@ -21,6 +21,7 @@ package org.skriptlang.skript.lang.entry.util;
 import ch.njol.skript.ScriptLoader;
 import ch.njol.skript.config.Node;
 import ch.njol.skript.config.SectionNode;
+import ch.njol.skript.lang.ThreadContext;
 import ch.njol.skript.lang.Trigger;
 import ch.njol.skript.lang.parser.ParserInstance;
 import org.skriptlang.skript.lang.entry.EntryData;
@@ -63,9 +64,11 @@ public class TriggerEntryData extends EntryData<Trigger> {
 
 		Class<? extends Event>[] oldEvents = parser.getCurrentEvents();
 		Kleenean oldHasDelayBefore = parser.getHasDelayBefore();
+		ThreadContext oldContext = parser.getThreadContext();
 
 		parser.setCurrentEvents(events);
 		parser.setHasDelayBefore(Kleenean.FALSE);
+		parser.setThreadContext(ThreadContext.MAIN_THREAD);
 
 		Trigger trigger = new Trigger(
 			parser.getCurrentScript(), "entry with key: " + getKey(), new SimpleEvent(), ScriptLoader.loadItems((SectionNode) node)
@@ -73,6 +76,7 @@ public class TriggerEntryData extends EntryData<Trigger> {
 
 		parser.setCurrentEvents(oldEvents);
 		parser.setHasDelayBefore(oldHasDelayBefore);
+		parser.setThreadContext(oldContext);
 
 		return trigger;
 	}

--- a/src/main/java/org/skriptlang/skript/lang/entry/util/VariableStringEntryData.java
+++ b/src/main/java/org/skriptlang/skript/lang/entry/util/VariableStringEntryData.java
@@ -18,6 +18,7 @@
  */
 package org.skriptlang.skript.lang.entry.util;
 
+import ch.njol.skript.lang.ThreadContext;
 import ch.njol.skript.lang.VariableString;
 import ch.njol.skript.lang.parser.ParserInstance;
 import org.skriptlang.skript.lang.entry.KeyValueEntryData;
@@ -74,9 +75,11 @@ public class VariableStringEntryData extends KeyValueEntryData<VariableString> {
 
 		Class<? extends Event>[] oldEvents = parser.getCurrentEvents();
 		Kleenean oldHasDelayBefore = parser.getHasDelayBefore();
+		ThreadContext oldThreadContext = parser.getThreadContext();
 
 		parser.setCurrentEvents(events);
 		parser.setHasDelayBefore(Kleenean.FALSE);
+		parser.setThreadContext(ThreadContext.MAIN_THREAD);
 
 		// Double up quotations outside of expressions
 		if (stringMode != StringMode.VARIABLE_NAME)
@@ -86,6 +89,7 @@ public class VariableStringEntryData extends KeyValueEntryData<VariableString> {
 
 		parser.setCurrentEvents(oldEvents);
 		parser.setHasDelayBefore(oldHasDelayBefore);
+		parser.setThreadContext(oldThreadContext);
 
 		return variableString;
 	}


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

**This is currently a proof of concept. Comments should be limited to the concept for now, rather than the exact (sloppy) code.**
(but please, if you see something stupid, say something!)

Discussions around async capabilities in Skript always hit one major roadblock. Skript, at the moment, does not know what syntaxes are safe to run asynchronously and which must be run on the main thread. The goal of this PR is to establish a framework such that the parser can tell if a syntax element cannot be safely run and error out, rather than throwing exceptions in runtime,

This main goal, if nothing else, of this PR is to label all the elements in Skript according to their thread safety. There are changes to the parser in this concept, but those don't have to be made in this PR. Actual implementation of async features is completely out of scope.

The idea of the proof of concept shown here is to add a thread safety attribute to all SyntaxElements, marking what kinds of threads they can be safely run on. By default, all elements are main thread only and each syntax element can override `getThreadConstraint` to declare whether it is safe to run off the main thread, or even if it can't be run on the main thread at all.

To tell whether the element is in an unsafe environment, the current type of thread must also be tracked. I pulled inspiration from hasDelayBefore and added a ThreadContext field to ParserInstance, which tracks whether the current element will be running on the main thread or off of it. The changes I made extend only to Sections, which will tell the parser what ThreadContext to use via loadCode(). 

Here's an example of this in action:
```
on player teleporting:
    my async-only effect
    do async:
        my async-only effect using all players in radius 5 of player
    cancel event
```
![image](https://github.com/SkriptLang/Skript/assets/10354869/da6f11b7-cb6b-4b95-b236-46c25478aae6)


Skript errors at line 2, complaining that the async-only effect cannot be run in a synchronous context.
It also complains about line 4, as even though the effect is async-only, the expression it uses is main thread only.

---

The main feedback I'm looking for at the moment is around the API for telling what the thread type currently is. My changes only implement this for Sections, not Structures, which would also need API to handle things like the async chat event (as a hypothetical).

I'd also like any other feedback, suggestions, concerns, or alternative implementation ideas that anyone has. I'm still a bit confused by the parser and the overall structure of how the language is parsed, so I'm certain I have at least a few misconceptions.

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** #4005 #5563  <!-- Links to related issues -->
