### PR TITLE
Fix NPE with invalid attributes and clean up ExprEntityAttribute

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprEntityAttribute.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntityAttribute.java
@@ -41,19 +41,23 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 @Name("Entity Attribute")
-@Description({"The numerical value of an entity's particular attribute.",
-			 "Note that the movement speed attribute cannot be reliably used for players. For that purpose, use the speed expression instead.",
-			 "Resetting an entity's attribute is only available in Minecraft 1.11 and above."})
-@Examples({"on damage of player:",
-		"	send \"You are wounded!\"",
-		"	set victim's attack speed attribute to 2"})
+@Description({
+	"The numerical value of an entity's particular attribute.",
+	"Note that the movement speed attribute cannot be reliably used for players. For that purpose, use the speed expression instead.",
+	"Resetting an entity's attribute is only available in Minecraft 1.11 and above."
+})
+@Examples({
+	"on damage of player:",
+		"\tsend \"You are wounded!\"",
+		"\tset victim's attack speed attribute to 2"
+})
 @Since("2.5, 2.6.1 (final attribute value)")
 public class ExprEntityAttribute extends PropertyExpression<Entity, Number> {
 	
 	static {
 		Skript.registerExpression(ExprEntityAttribute.class, Number.class, ExpressionType.COMBINED,
-				"[the] %attributetype% [(1¦(total|final|modified))] attribute [value] of %entities%",
-				"%entities%'[s] %attributetype% [(1¦(total|final|modified))] attribute [value]");
+				"[the] %attributetype% [(1:(total|final|modified))] attribute [value] of %entities%",
+				"%entities%'[s] %attributetype% [(1:(total|final|modified))] attribute [value]");
 	}
 
 	@Nullable

--- a/src/main/java/ch/njol/skript/expressions/ExprEntityAttribute.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntityAttribute.java
@@ -48,7 +48,7 @@ import java.util.stream.Stream;
 })
 @Examples({
 	"on damage of player:",
-		"\tsend \"You are wounded!\"",
+		"\tsend \"You are wounded!\" to victim",
 		"\tset victim's attack speed attribute to 2"
 })
 @Since("2.5, 2.6.1 (final attribute value)")

--- a/src/main/java/ch/njol/skript/expressions/ExprEntityAttribute.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntityAttribute.java
@@ -99,7 +99,7 @@ public class ExprEntityAttribute extends PropertyExpression<Entity, Number> {
 		double deltaValue = delta == null ? 0 : ((Number) delta[0]).doubleValue();
 		for (Entity entity : getExpr().getArray(event)) {
 			AttributeInstance instance = getAttribute(entity, attribute);
-			if(instance != null) {
+			if (instance != null) {
 				switch(mode) {
 					case ADD:
 						instance.setBaseValue(instance.getBaseValue() + deltaValue);


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Adds a filter to prevent .getValue or .getBaseValue from being called on null values.
Cleans up variable names/conventions in ExprEntityAttribute

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** #5640 <!-- Links to related issues -->
