### PR TITLE
EffPotion - fix potion duration issue

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffPotion.java
+++ b/src/main/java/ch/njol/skript/effects/EffPotion.java
@@ -101,7 +101,7 @@ public class EffPotion extends Effect {
 			potions = (Expression<PotionEffectType>) exprs[0];
 			tier = (Expression<Number>) exprs[1];
 			entities = (Expression<LivingEntity>) exprs[2];
-			if (infinite)
+			if (!infinite)
 				duration = (Expression<Timespan>) exprs[3];
 		}
 		return true;
@@ -125,7 +125,7 @@ public class EffPotion extends Effect {
 				Timespan timespan = this.duration.getSingle(event);
 				if (timespan == null)
 					return;
-				duration = (int) Math.max(timespan.getTicks_i(), Integer.MAX_VALUE);
+				duration = (int) Math.min(timespan.getTicks_i(), Integer.MAX_VALUE);
 			}
 			for (LivingEntity entity : entities.getArray(event)) {
 				for (PotionEffectType potionEffectType : potionEffectTypes) {


### PR DESCRIPTION
### Description
This PR aims to fix the potion effects duration bug in 2.7

---
**Target Minecraft Versions:** none
**Requirements:** none
**Related Issues:** #5987 
