### PR TITLE
Rename Slot classinfo name to Slot

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
@@ -479,7 +479,7 @@ public class SkriptClasses {
 
 		Classes.registerClass(new ClassInfo<>(Slot.class, "slot")
 				.user("(inventory )?slots?")
-				.name("Inventory Slot")
+				.name("Slot")
 				.description("Represents a single slot of an <a href='#inventory'>inventory</a>. " +
 						"Notable slots are the <a href='./expressions.html#ExprArmorSlot'>armour slots</a> and <a href='./expressions/#ExprFurnaceSlot'>furnace slots</a>. ",
 						"The most important property that distinguishes a slot from an <a href='#itemstack'>item</a> is its ability to be changed, e.g. it can be set, deleted, enchanted, etc. " +


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Renamed Slot classinfo name from Inventort Slot to Slot 
https://github.com/SkriptLang/Skript/issues/5931
---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** <!-- Links to related issues -->
