### PR TITLE
Add GitHub's gradle wrapper checker for security

### DIFF
--- a/.github/workflows/java-17-builds.yml
+++ b/.github/workflows/java-17-builds.yml
@@ -15,6 +15,8 @@ jobs:
             - uses: actions/checkout@v4
               with:
                   submodules: recursive
+            - name: validate gradle wrapper
+              uses: gradle/wrapper-validation-action@v1
             - name: Set up JDK 17
               uses: actions/setup-java@v3
               with:

--- a/.github/workflows/java-8-builds.yml
+++ b/.github/workflows/java-8-builds.yml
@@ -15,6 +15,8 @@ jobs:
             - uses: actions/checkout@v4
               with:
                   submodules: recursive
+            - name: validate gradle wrapper
+              uses: gradle/wrapper-validation-action@v1
             - name: Set up JDK 17
               uses: actions/setup-java@v3
               with:

--- a/.github/workflows/junit-17-builds.yml
+++ b/.github/workflows/junit-17-builds.yml
@@ -15,6 +15,8 @@ jobs:
             - uses: actions/checkout@v4
               with:
                   submodules: recursive
+            - name: validate gradle wrapper
+              uses: gradle/wrapper-validation-action@v1
             - name: Set up JDK 17
               uses: actions/setup-java@v3
               with:

--- a/.github/workflows/junit-8-builds.yml
+++ b/.github/workflows/junit-8-builds.yml
@@ -15,6 +15,8 @@ jobs:
             - uses: actions/checkout@v4
               with:
                   submodules: recursive
+            - name: validate gradle wrapper
+              uses: gradle/wrapper-validation-action@v1
             - name: Set up JDK 17
               uses: actions/setup-java@v3
               with:

--- a/.github/workflows/repo.yml
+++ b/.github/workflows/repo.yml
@@ -11,6 +11,8 @@ jobs:
             - uses: actions/checkout@v4
               with:
                   submodules: recursive
+            - name: validate gradle wrapper
+              uses: gradle/wrapper-validation-action@v1
             - name: Set up JDK 17
               uses: actions/setup-java@v3
               with:


### PR DESCRIPTION
### Description
Adds GitHub's gradle wrapper checker for security.
See https://github.com/gradle/wrapper-validation-action for more information.

Notes:
- GitHub recently added this gradle wrapper validation action to the default gradle build script template.
- Dependabot will keep this version updated.
