### PR TITLE
Add cherry picking action

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,0 +1,84 @@
+name: Cherry picks version targeted pull requests
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - closed
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+    check_label:
+        runs-on: ubuntu-latest
+        name: Configure workflow
+        if: github.event.pull_request.merged == true
+        outputs:
+          TARGET_VERSION: ${{ steps.set-outputs.outputs.TARGET_VERSION }}
+          TARGET_BRANCH: ${{ steps.set-outputs.outputs.TARGET_BRANCH }}
+        steps:
+          - name: Checkout Skript
+            uses: actions/checkout@v3
+            with:
+              fetch-depth: 0
+          - name: Set outputs
+            id: set-outputs
+            shell: bash
+            run: |
+              readarray -t labels < <(gh pr view --json labels --jq '.labels[].name | select(test("^[0-9].*"))' "${{ github.event.number }}")
+              if [ ${#labels[@]} -eq 0 ]
+              then
+                echo "No version labels found"
+                exit 0
+              fi
+              
+              for label in "${labels[@]}"
+              do
+                if git ls-remote --exit-code --heads origin "refs/heads/dev/$label"
+                then
+                  if [ -z "${target_branch}" ]
+                  then
+                    echo "Found target version label $label"
+                    target_version="$label"
+                    target_branch="dev/$label"
+                  else
+                    echo "Found multiple target version labels with branches (${labels[@]})"
+                    exit 0
+                  fi
+                else
+                  echo "Skipping $label as a dev/$label branch does not exist"
+                fi
+              done
+              
+              if [ -z "${target_branch}" ]
+              then
+                echo "No target version branch found (${labels[@]})"
+                exit 0
+              else
+                echo "TARGET_BRANCH=${target_branch}" >> $GITHUB_OUTPUT
+                echo "TARGET_VERSION=${target_version}" >> $GITHUB_OUTPUT
+              fi
+              
+    cherry_pick:
+        runs-on: ubuntu-latest
+        name: Cherry pick into version branch
+        needs: check_label
+        if: needs.check_label.outputs.TARGET_BRANCH != ''
+        steps:
+         - name: Checkout Skript
+           uses: actions/checkout@v3
+           with:
+             fetch-depth: 0
+         - name: Cherry pick into version branch
+           uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
+           with:
+            branch: ${{ needs.check_label.outputs.TARGET_BRANCH }} 
+            labels: ${{ needs.check_label.outputs.TARGET_VERSION }}
+            title: "[${{ needs.check_label.outputs.TARGET_VERSION }} target] {old_title}"
+            body: "Cherry picking #{old_pull_request_id} into ${{ needs.check_label.outputs.TARGET_VERSION }}"
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,6 +1,6 @@
 name: Cherry picks version targeted pull requests
 
-on: 
+on:
   pull_request:
     branches:
       - master


### PR DESCRIPTION
### Description
This PR adds an action that will automatically open a cherry pick pull request for merged PRs that have a version tag on them (e.g. `2.7`). It is functionally the same as #5906 but it works by dynamically identifying version labels rather than having one action for each label.

**Before merging someone with the permissions to do so will need to enable these options:**
1. Go to https://github.com/organizations/SkriptLang/settings/actions and enable "Allow GitHub Actions to create and approve pull requests"
2. Go to https://github.com/SkriptLang/Skript/settings/actions and enable "Allow GitHub Actions to create and approve pull requests"

Without these settings enabled, the action can't open a PR. See the GitHub blog [here](https://github.blog/changelog/2022-05-03-github-actions-prevent-github-actions-from-creating-and-approving-pull-requests/) for info on the setting. 

**Caveats:**
- This action will only work for PRs merged from SkriptLang/Skript branches and not from branches on forks. This might be possible to fix in the future but there are more security considerations there so I'm leaving it off for now.

**Test cases:**
- Merging a PR without labels: Job passes gracefully
- Merging a PR without a version target label (e.g. `2.7`): Job passes gracefully without opening PR
- Merging a PR with multiple version labels (e.g. it has both `2.7` and `2.8`): Job passes gracefully without opening PR
- Merging a PR with one version label: Job passes gracefully and opens PR


---
**Target Minecraft Versions:** N/A
**Requirements:** N/A
**Related Issues:** N/A
