### PR TITLE
Fix changing remaining time of command cooldown

### DIFF
--- a/src/main/java/ch/njol/skript/command/ScriptCommand.java
+++ b/src/main/java/ch/njol/skript/command/ScriptCommand.java
@@ -18,44 +18,11 @@
  */
 package ch.njol.skript.command;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.UUID;
-
 import ch.njol.skript.ScriptLoader;
-import ch.njol.skript.config.SectionNode;
-import org.skriptlang.skript.lang.script.Script;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.OfflinePlayer;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandSender;
-import org.bukkit.command.PluginCommand;
-import org.bukkit.command.SimpleCommandMap;
-import org.bukkit.command.TabExecutor;
-import org.bukkit.entity.Player;
-import org.bukkit.event.Event;
-import org.bukkit.help.GenericCommandHelpTopic;
-import org.bukkit.help.HelpMap;
-import org.bukkit.help.HelpTopic;
-import org.bukkit.help.HelpTopicComparator;
-import org.bukkit.help.IndexHelpTopic;
-import org.bukkit.plugin.Plugin;
-import org.eclipse.jdt.annotation.Nullable;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptConfig;
 import ch.njol.skript.command.Commands.CommandAliasHelpTopic;
+import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.Trigger;
@@ -77,6 +44,39 @@ import ch.njol.skript.util.chat.MessageComponent;
 import ch.njol.skript.variables.Variables;
 import ch.njol.util.StringUtils;
 import ch.njol.util.Validate;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.command.SimpleCommandMap;
+import org.bukkit.command.TabExecutor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.help.GenericCommandHelpTopic;
+import org.bukkit.help.HelpMap;
+import org.bukkit.help.HelpTopic;
+import org.bukkit.help.HelpTopicComparator;
+import org.bukkit.help.IndexHelpTopic;
+import org.bukkit.plugin.Plugin;
+import org.eclipse.jdt.annotation.Nullable;
+import org.skriptlang.skript.lang.script.Script;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
 
 /**
  * This class is used for user-defined commands.
@@ -274,9 +274,21 @@ public class ScriptCommand implements TabExecutor {
 		}
 
 		Runnable runnable = () -> {
+			// save previous last usage date to check if the execution has set the last usage date
+			Date previousLastUsage = null;
+			if (sender instanceof Player)
+				previousLastUsage = getLastUsage(((Player) sender).getUniqueId(), event);
+
+			// execute the command - may modify the last usage date
 			execute2(event, sender, commandLabel, rest);
-			if (sender instanceof Player && !event.isCooldownCancelled())
-				setLastUsage(((Player) sender).getUniqueId(), event, new Date());
+
+			if (sender instanceof Player && !event.isCooldownCancelled()) {
+				Date lastUsage = getLastUsage(((Player) sender).getUniqueId(), event);
+				// check if the execution has set the last usage date
+				// if not, set it to the current date. if it has, we leave it alone so as not to affect the remaining/elapsed time (#5862)
+				if (Objects.equals(lastUsage, previousLastUsage))
+					setLastUsage(((Player) sender).getUniqueId(), event, new Date());
+			}
 		};
 		if (Bukkit.isPrimaryThread()) {
 			runnable.run();
@@ -510,7 +522,7 @@ public class ScriptCommand implements TabExecutor {
 		assert cooldown != null;
 		long cooldownMs = cooldown.getMilliSeconds();
 		if (milliseconds > cooldownMs)
-			throw new IllegalArgumentException("Remaining time may not be longer than the cooldown");
+			milliseconds = cooldownMs;
 		setElapsedMilliSeconds(uuid, event, cooldownMs - milliseconds);
 	}
 


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Prevents setLastUsage from running if the execution of the command changed lastUsage already.
Also caps remaining time to the full length of the cooldown instead of throwing an exception.

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:**
closes #5861
closes #5862 <!-- Links to related issues -->
