### PR TITLE
Fix ExprRandomNumber using a method from Java 17

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprRandomNumber.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprRandomNumber.java
@@ -88,7 +88,7 @@ public class ExprRandomNumber extends SimpleExpression<Number> {
 					return new Long[] {sup};
 				return new Long[0];
 			}
-			return new Long[] {random.nextLong(inf, sup + 1)};
+			return new Long[] {inf + Math2.mod(random.nextLong(), sup - inf + 1)};
 		}
 
 		return new Double[] {min + random.nextDouble() * (max - min)};


### PR DESCRIPTION
### Description
This PR fixes an issue where ExprRandomNumber used [RandomGenerator#nextLong(long,long)](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/random/RandomGenerator.html#nextLong(long,long)), which was added in Java 17.

closes https://github.com/SkriptLang/Skript/issues/5819

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** https://github.com/SkriptLang/Skript/issues/5819
