### PR TITLE
Allow 'continue' the continue outer loops

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffContinue.java
+++ b/src/main/java/ch/njol/skript/effects/EffContinue.java
@@ -59,11 +59,15 @@ import java.util.List;
 public class EffContinue extends Effect {
 
 	static {
-		Skript.registerEffect(EffContinue.class, "continue [[this|[the] (%*integer%(st|nd|rd|th)|current)] loop]");
+		Skript.registerEffect(EffContinue.class,
+			"continue [this loop|[the] [current] loop]",
+			"continue [the] %*integer%(st|nd|rd|th) loop"
+		);
 	}
 
 	@SuppressWarnings("NotNullFieldNotInitialized")
 	private LoopSection loop;
+	@SuppressWarnings("NotNullFieldNotInitialized")
 	private List<LoopSection> innerLoops;
 
 	@Override
@@ -77,19 +81,19 @@ public class EffContinue extends Effect {
 			return false;
 		}
 
-		int levels = ((Literal<Integer>) exprs[0]).getSingle();
-		if (levels < 1) {
-			Skript.error("Can't continue the " + StringUtils.fancyOrderNumber(levels) + " loop");
+		int level = matchedPattern == 0 ? size : ((Literal<Integer>) exprs[0]).getSingle();
+		if (level < 1) {
+			Skript.error("Can't continue the " + StringUtils.fancyOrderNumber(level) + " loop");
 			return false;
 		}
-		if (levels > size) {
-			Skript.error("Can't continue the " + StringUtils.fancyOrderNumber(levels) + " loop as there " +
+		if (level > size) {
+			Skript.error("Can't continue the " + StringUtils.fancyOrderNumber(level) + " loop as there " +
 				(size == 1 ? "is only 1 loop" : "are only " + size + " loops") + " present");
 			return false;
 		}
 
-		loop = currentLoops.get(levels - 1);
-		innerLoops = currentLoops.subList(levels, size);
+		loop = currentLoops.get(level - 1);
+		innerLoops = currentLoops.subList(level, size);
 		return true;
 	}
 

--- a/src/test/skript/tests/syntaxes/effects/EffContinue.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffContinue.sk
@@ -9,3 +9,11 @@ test "continue effect":
 		if {_i} is equal to 5:
 			continue
 		assert {_i} is not 5 with "continue in while failed"
+	loop integers from 1 to 10:
+		continue this loop if loop-value is 5
+		assert loop-value is not 5 with "leveled continue failed ##1"
+		loop integers from 11 to 20:
+			continue 2nd loop if loop-value-2 is 15
+			assert loop-value-2 is not 15 with "leveled continue failed ##2"
+			continue 1st loop if loop-value-1 is 10
+		assert loop-value is not 10 with "leveled continue failed ##3"


### PR DESCRIPTION
### Description
This PR adds the ability to continue parent loops from within an inner loop. Loops are numbered from 1 to n and goes from outer to inner. For example:

```vb
loop all players: # Loop 1
    loop {values::%loop-value%::*}: # Loop 2
        set {_x} to foo(loop-value-2)
        if {_x} < 10:
            continue the 1st loop # Continues the 'loop all players' loop
    bar(loop-value)
    broadcast "Player has valid values!"
```

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #6012 
