### PR TITLE
(Cherry Pick) Fix cast throwing if existing variable for command storage exists (#5942)

### DIFF
--- a/src/main/java/ch/njol/skript/command/ScriptCommand.java
+++ b/src/main/java/ch/njol/skript/command/ScriptCommand.java
@@ -486,7 +486,13 @@ public class ScriptCommand implements TabExecutor {
 		} else {
 			String name = getStorageVariableName(event);
 			assert name != null;
-			return (Date) Variables.getVariable(name, null, false);
+			Object variable = Variables.getVariable(name, null, false);
+			if (!(variable instanceof Date)) {
+				Skript.warning("Variable {" + name + "} was not a date! You may be using this variable elsewhere. " +
+						"This warning is letting you know that this variable is now overridden for the command storage.");
+				return null;
+			}
+			return (Date) variable;
 		}
 	}
 


### PR DESCRIPTION
Cherry pick of fix to patch branch.

* Fix cast throwing if existing variable for command storage exists

* Update src/main/java/ch/njol/skript/command/ScriptCommand.java