### PR TITLE
Fixes EffSecSpawn not properly handling local variables created within the section

### DIFF
--- a/src/main/java/ch/njol/skript/sections/EffSecSpawn.java
+++ b/src/main/java/ch/njol/skript/sections/EffSecSpawn.java
@@ -137,16 +137,15 @@ public class EffSecSpawn extends EffectSection {
 	protected TriggerItem walk(Event event) {
 		lastSpawned = null;
 
-		Object localVars = Variables.copyLocalVariables(event);
-
 		Consumer<? extends Entity> consumer;
 		if (trigger != null) {
 			consumer = o -> {
 				lastSpawned = o;
 				SpawnEvent spawnEvent = new SpawnEvent(o);
 				// Copy the local variables from the calling code to this section
-				Variables.setLocalVariables(spawnEvent, localVars);
+				Variables.setLocalVariables(spawnEvent, Variables.copyLocalVariables(event));
 				TriggerItem.walk(trigger, spawnEvent);
+				// And copy our (possibly modified) local variables back to the calling code
 				Variables.setLocalVariables(event, Variables.copyLocalVariables(spawnEvent));
 				// Clear spawnEvent's local variables as it won't be done automatically
 				Variables.removeLocals(spawnEvent);

--- a/src/test/skript/tests/regressions/6032-local-vars-created-in-effsecspawn.sk
+++ b/src/test/skript/tests/regressions/6032-local-vars-created-in-effsecspawn.sk
@@ -1,0 +1,5 @@
+test "local vars created in EffSecSpawn":
+	set {_spawn} to spawn of world "world"
+	spawn 4 zombies at {_spawn}:
+		add 1 to {_test}
+	assert {_test} is 4 with "local var created in EffSecSpawn was not properly incremented"


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

EffSecSpawn now gets the current local variables at the start of each consumer run instead of using a cached version from before any consumer runs.

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** #6032 <!-- Links to related issues -->
