### PR TITLE
Fix error when unloading a script with multiple variables sections

### DIFF
--- a/src/main/java/ch/njol/skript/structures/StructVariables.java
+++ b/src/main/java/ch/njol/skript/structures/StructVariables.java
@@ -148,10 +148,21 @@ public class StructVariables extends Structure {
 		List<NonNullPair<String, Object>> variables;
 		Script script = getParser().getCurrentScript();
 		DefaultVariables existing = script.getData(DefaultVariables.class); // if the user has TWO variables: sections
-		if (existing != null && existing.hasDefaultVariables())
-			variables = new ArrayList<>(existing.variables);
-		else
-			variables = new ArrayList<>();
+		if (existing != null && existing.hasDefaultVariables()) {
+			{
+				{
+					{
+						{
+							variables = new ArrayList<>(existing.variables);
+						}}}}}else {
+			{
+				{ {}{}{}
+					{
+						variables = new ArrayList<>();
+					}
+				}
+			}
+		}
 		for (Node n : node) {
 			if (!(n instanceof EntryNode)) {
 				Skript.error("Invalid line in variables structure");

--- a/src/main/java/ch/njol/skript/structures/StructVariables.java
+++ b/src/main/java/ch/njol/skript/structures/StructVariables.java
@@ -18,7 +18,14 @@
  */
 package ch.njol.skript.structures;
 
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;

--- a/src/main/java/ch/njol/skript/structures/StructVariables.java
+++ b/src/main/java/ch/njol/skript/structures/StructVariables.java
@@ -18,14 +18,7 @@
  */
 package ch.njol.skript.structures;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
@@ -141,7 +134,7 @@ public class StructVariables extends Structure {
 			return variables;
 		}
 		
-		public boolean isLoaded() {
+		private boolean isLoaded() {
 			return loaded;
 		}
 	}
@@ -266,8 +259,11 @@ public class StructVariables extends Structure {
 		DefaultVariables data = script.getData(DefaultVariables.class);
 		if (data == null) // band-aid fix for this section's behaviour being handled by a previous section
 			return; // see https://github.com/SkriptLang/Skript/issues/6013
-		for (NonNullPair<String, Object> pair : data.getVariables())
-			Variables.setVariable(pair.getKey(), null, null, false);
+		for (NonNullPair<String, Object> pair : data.getVariables()) {
+			String name = pair.getKey();
+			if (name.contains("<") && name.contains(">")) // probably a template made by us
+				Variables.setVariable(pair.getKey(), null, null, false);
+		}
 		script.removeData(DefaultVariables.class);
 	}
 

--- a/src/main/java/ch/njol/skript/structures/StructVariables.java
+++ b/src/main/java/ch/njol/skript/structures/StructVariables.java
@@ -238,13 +238,14 @@ public class StructVariables extends Structure {
 	@Override
 	public boolean load() {
 		DefaultVariables data = getParser().getCurrentScript().getData(DefaultVariables.class);
-		if (data == null) // band-aid fix for this section's behaviour being handled by a previous section
-			return true; // see https://github.com/SkriptLang/Skript/issues/6013
+		if (data == null) { // this shouldn't happen
+			Skript.error("Default variables data missing");
+			return false;
+		}
 		for (NonNullPair<String, Object> pair : data.getVariables()) {
 			String name = pair.getKey();
 			if (Variables.getVariable(name, null, false) != null)
 				continue;
-
 			Variables.setVariable(name, pair.getValue(), null, false);
 		}
 		return true;

--- a/src/main/java/ch/njol/skript/structures/StructVariables.java
+++ b/src/main/java/ch/njol/skript/structures/StructVariables.java
@@ -87,6 +87,7 @@ public class StructVariables extends Structure {
 
 		private final Deque<Map<String, Class<?>[]>> hints = new ArrayDeque<>();
 		private final List<NonNullPair<String, Object>> variables;
+		private boolean loaded;
 
 		public DefaultVariables(Collection<NonNullPair<String, Object>> variables) {
 			this.variables = ImmutableList.copyOf(variables);
@@ -139,6 +140,10 @@ public class StructVariables extends Structure {
 		public List<NonNullPair<String, Object>> getVariables() {
 			return variables;
 		}
+		
+		public boolean isLoaded() {
+			return loaded;
+		}
 	}
 
 	@Override
@@ -149,19 +154,9 @@ public class StructVariables extends Structure {
 		Script script = getParser().getCurrentScript();
 		DefaultVariables existing = script.getData(DefaultVariables.class); // if the user has TWO variables: sections
 		if (existing != null && existing.hasDefaultVariables()) {
-			{
-				{
-					{
-						{
-							variables = new ArrayList<>(existing.variables);
-						}}}}}else {
-			{
-				{ {}{}{}
-					{
-						variables = new ArrayList<>();
-					}
-				}
-			}
+			variables = new ArrayList<>(existing.variables);
+		} else {
+			variables = new ArrayList<>();
 		}
 		for (Node n : node) {
 			if (!(n instanceof EntryNode)) {
@@ -252,6 +247,8 @@ public class StructVariables extends Structure {
 		if (data == null) { // this shouldn't happen
 			Skript.error("Default variables data missing");
 			return false;
+		} else if (data.isLoaded()) {
+			return true;
 		}
 		for (NonNullPair<String, Object> pair : data.getVariables()) {
 			String name = pair.getKey();
@@ -259,6 +256,7 @@ public class StructVariables extends Structure {
 				continue;
 			Variables.setVariable(name, pair.getValue(), null, false);
 		}
+		data.loaded = true;
 		return true;
 	}
 

--- a/src/main/java/ch/njol/skript/structures/StructVariables.java
+++ b/src/main/java/ch/njol/skript/structures/StructVariables.java
@@ -92,9 +92,8 @@ public class StructVariables extends Structure {
 			this.variables = ImmutableList.copyOf(variables);
 		}
 
-		@SuppressWarnings("unchecked")
 		public void add(String variable, Class<?>... hints) {
-			if (hints == null || hints.length <= 0)
+			if (hints == null || hints.length == 0)
 				return;
 			if (CollectionUtils.containsAll(hints, Object.class)) // Ignore useless type hint.
 				return;
@@ -115,7 +114,7 @@ public class StructVariables extends Structure {
 		/**
 		 * Returns the type hints of a variable.
 		 * Can be null if no type hint was saved.
-		 * 
+		 *
 		 * @param variable The variable string of a variable.
 		 * @return type hints of a variable if found otherwise null.
 		 */
@@ -146,8 +145,13 @@ public class StructVariables extends Structure {
 	public boolean init(Literal<?>[] args, int matchedPattern, ParseResult parseResult, EntryContainer entryContainer) {
 		SectionNode node = entryContainer.getSource();
 		node.convertToEntries(0, "=");
-
-		List<NonNullPair<String, Object>> variables = new ArrayList<>();
+		List<NonNullPair<String, Object>> variables;
+		Script script = getParser().getCurrentScript();
+		DefaultVariables existing = script.getData(DefaultVariables.class); // if the user has TWO variables: sections
+		if (existing != null && existing.hasDefaultVariables())
+			variables = new ArrayList<>(existing.variables);
+		else
+			variables = new ArrayList<>();
 		for (Node n : node) {
 			if (!(n instanceof EntryNode)) {
 				Skript.error("Invalid line in variables structure");
@@ -227,13 +231,15 @@ public class StructVariables extends Structure {
 			}
 			variables.add(new NonNullPair<>(name, o));
 		}
-		getParser().getCurrentScript().addData(new DefaultVariables(variables));
+		script.addData(new DefaultVariables(variables)); // we replace the previous entry
 		return true;
 	}
 
 	@Override
 	public boolean load() {
 		DefaultVariables data = getParser().getCurrentScript().getData(DefaultVariables.class);
+		if (data == null) // band-aid fix for this section's behaviour being handled by a previous section
+			return true; // see https://github.com/SkriptLang/Skript/issues/6013
 		for (NonNullPair<String, Object> pair : data.getVariables()) {
 			String name = pair.getKey();
 			if (Variables.getVariable(name, null, false) != null)
@@ -248,6 +254,8 @@ public class StructVariables extends Structure {
 	public void postUnload() {
 		Script script = getParser().getCurrentScript();
 		DefaultVariables data = script.getData(DefaultVariables.class);
+		if (data == null) // band-aid fix for this section's behaviour being handled by a previous section
+			return; // see https://github.com/SkriptLang/Skript/issues/6013
 		for (NonNullPair<String, Object> pair : data.getVariables())
 			Variables.setVariable(pair.getKey(), null, null, false);
 		script.removeData(DefaultVariables.class);

--- a/src/test/skript/tests/syntaxes/structures/StructVariables.sk
+++ b/src/test/skript/tests/syntaxes/structures/StructVariables.sk
@@ -1,0 +1,10 @@
+variables:
+	{variables_test1} = true
+
+variables:
+	{variables_test1} = false # we hope it doesn't overwrite!
+	{variables_test2} = true
+
+test "default variables":
+	assert {variables_test1} is true with "{variables_test1} was not true"
+	assert {variables_test2} is true with "{variables_test2} was not true"


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
In `2.7.0` and potentially the latest 2.7 beta, having multiple `variables:` sections in a script would produce a severe error when trying to unload or reload.

This is described in issue #6013.

The cause of this error was both variables sections using the same `DefaultVariables.class` key in the data map, so the first one to unload would remove the data, leaving it `null` for the second unload.

As version `2.6.4` supported multiple `variables:` sections (although potentially unintentionally) I have re-created the original behaviour with a bandage bug fix.

**Note:** I make no comment about whether this behaviour is correct or incorrect, intended or unintended. This is simply a fix to restore the old, expected behaviour _for the time being_.

I used the following code to test:
<img width="360" alt="image" src="https://github.com/SkriptLang/Skript/assets/14147477/aa15e835-ceab-4079-9357-bb566bceb803">

Version `2.6.4` produces the following output, which is what I am aiming for:
<img width="73" alt="image" src="https://github.com/SkriptLang/Skript/assets/14147477/c779dc53-f8ab-4513-878f-001813c9e619">

Version `2.7.0` produces the following output, and errors when unloading:
<img width="73" alt="image" src="https://github.com/SkriptLang/Skript/assets/14147477/712b51ed-c5b8-482b-915a-85d5d186b6f0">

This is because the first variables section is discarded when the second one is parsed, and so the first one will never be loaded.

My fix produces the following output:
<img width="73" alt="image" src="https://github.com/SkriptLang/Skript/assets/14147477/4798cf11-896f-4ead-b5e6-9c5086ec137f">

My approach was to look for an existing variables section when parsing and insert its contents first (therefore giving it precedence) and replace it with the new, combined version.
This appears to produce the closest match to the `2.6.4` behaviour.


---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** #6013 
