### PR TITLE
Fix multiple aliases sections not working

### DIFF
--- a/src/main/java/ch/njol/skript/structures/StructAliases.java
+++ b/src/main/java/ch/njol/skript/structures/StructAliases.java
@@ -20,6 +20,7 @@ package ch.njol.skript.structures;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.Aliases;
+import ch.njol.skript.aliases.ScriptAliases;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -30,6 +31,7 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.entry.EntryContainer;
+import org.skriptlang.skript.lang.script.Script;
 import org.skriptlang.skript.lang.structure.Structure;
 
 @Name("Aliases")
@@ -54,7 +56,11 @@ public class StructAliases extends Structure {
 		node.convertToEntries(0, "=");
 
 		// Initialize and load script aliases
-		Aliases.createScriptAliases(getParser().getCurrentScript()).parser.load(node);
+		Script script = getParser().getCurrentScript();
+		ScriptAliases scriptAliases = Aliases.getScriptAliases(script);
+		if (scriptAliases == null)
+			scriptAliases = Aliases.createScriptAliases(script);
+		scriptAliases.parser.load(node);
 
 		return true;
 	}

--- a/src/test/skript/tests/syntaxes/structures/StructAliases.sk
+++ b/src/test/skript/tests/syntaxes/structures/StructAliases.sk
@@ -1,0 +1,9 @@
+aliases:
+	cool_dirt = dirt
+
+aliases:
+	cool_stone = stone
+
+test "script aliases":
+	assert cool_dirt is dirt with "custom dirt alias failed"
+	assert cool_stone is stone with "custom stone alias failed"


### PR DESCRIPTION
### Description
This PR fixes an issue where using multiple aliases section in a single script did not work. The last one to load would overwrite the values of any others. The values are now merged together. I've also added a test for this.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none