### PR TITLE
⚒ Disable Javadocs generation for nightly docs & improvements

### DIFF
--- a/.github/workflows/docs/generate-docs/action.yml
+++ b/.github/workflows/docs/generate-docs/action.yml
@@ -53,7 +53,7 @@ runs:
         }
 
         # pull before checking for docs templates
-        cd DOCS_REPO_DIR
+        cd $DOCS_REPO_DIR
         git pull origin main
 
         if [ -d "${DOCS_REPO_DIR}/docs/templates" ]

--- a/.github/workflows/docs/generate-docs/action.yml
+++ b/.github/workflows/docs/generate-docs/action.yml
@@ -81,7 +81,9 @@ runs:
         fi
 
         if [ -d "${DOCS_OUTPUT_DIR}" ]; then
-          mkdir -p "${SKRIPT_DOCS_OUTPUT_DIR}/javadocs" && cp -a "./build/docs/javadoc/." "$_"
+          if [[ "${GENERATE_JAVADOCS}" == "true" ]]; then
+              mkdir -p "${SKRIPT_DOCS_OUTPUT_DIR}/javadocs" && cp -a "./build/docs/javadoc/." "$_"
+          fi
   
           mkdir -p "/tmp/normalized-output-docs" && cp -a "${DOCS_OUTPUT_DIR}/." "$_"
           mkdir -p "/tmp/normalized-generated-docs" && cp -a "${SKRIPT_DOCS_OUTPUT_DIR}/." "$_"

--- a/.github/workflows/docs/generate-docs/action.yml
+++ b/.github/workflows/docs/generate-docs/action.yml
@@ -58,10 +58,6 @@ runs:
           grep skriptVersion "$1/docs.json" | cut -d\" -f 4
         }
 
-        # pull before checking for docs templates
-        cd $DOCS_REPO_DIR
-        git pull origin main
-
         if [ -d "${DOCS_REPO_DIR}/docs/templates" ]
         then
           export SKRIPT_DOCS_TEMPLATE_DIR=${DOCS_REPO_DIR}/docs/templates

--- a/.github/workflows/docs/generate-docs/action.yml
+++ b/.github/workflows/docs/generate-docs/action.yml
@@ -23,6 +23,11 @@ inputs:
     required: false
     default: "*"
     type: string
+  generate_javadocs:
+    description: "Designates whether to generate javadocs for this nightly documentation"
+    required: false
+    default: false
+    type: boolean
 
 outputs:
   DOCS_CHANGED:
@@ -41,6 +46,7 @@ runs:
         SKRIPT_REPO_DIR: ${{ inputs.skript_repo_dir }}
         IS_RELEASE: ${{ inputs.is_release }}
         CLEANUP_PATTERN: ${{ inputs.cleanup_pattern }}
+        GENERATE_JAVADOCS: ${{ inputs.generate_javadocs }}
       run: |
         replace_in_directory() {
           find $1 -type f -exec sed -i -e "s/$2/$3/g" {} \;
@@ -68,8 +74,10 @@ runs:
         cd $SKRIPT_REPO_DIR
         if [[ "${IS_RELEASE}" == "true" ]]; then
           ./gradlew genReleaseDocs releaseJavadoc
-        else
+        elif [[ "${GENERATE_JAVADOCS}" == "true" ]]; then
           ./gradlew genNightlyDocs javadoc
+        else
+          ./gradlew genNightlyDocs
         fi
 
         if [ -d "${DOCS_OUTPUT_DIR}" ]; then

--- a/.github/workflows/docs/generate-docs/action.yml
+++ b/.github/workflows/docs/generate-docs/action.yml
@@ -52,10 +52,14 @@ runs:
           grep skriptVersion "$1/docs.json" | cut -d\" -f 4
         }
 
+        # pull before checking for docs templates
+        cd DOCS_REPO_DIR
+        git pull origin main
+
         if [ -d "${DOCS_REPO_DIR}/docs/templates" ]
         then
           export SKRIPT_DOCS_TEMPLATE_DIR=${DOCS_REPO_DIR}/docs/templates
-        else
+        else # compatibility for older versions
           export SKRIPT_DOCS_TEMPLATE_DIR=${DOCS_REPO_DIR}/doc-templates
         fi
 

--- a/.github/workflows/nightly-docs.yml
+++ b/.github/workflows/nightly-docs.yml
@@ -3,7 +3,11 @@ name: Nightly documentation
 on:
   push:
     branches:
-      - '**'
+      - 'dev/feature'
+      - 'dev/patch'
+      - 'enhancement/**'
+      - 'feature/**'
+      - 'fix/**'
     tags-ignore:
       - '**'
 

--- a/build.gradle
+++ b/build.gradle
@@ -189,7 +189,7 @@ enum Modifiers {
 void createTestTask(String name, String desc, String environments, int javaVersion, Modifiers... modifiers) {
 	boolean junit = modifiers.contains(Modifiers.JUNIT)
 	boolean releaseDocs = modifiers.contains(Modifiers.GEN_RELEASE_DOCS)
-	boolean docs = modifiers.contains(Modifiers.GEN_NIGHTLY_DOCS)
+	boolean docs = modifiers.contains(Modifiers.GEN_NIGHTLY_DOCS) || releaseDocs
 	def artifact = 'build' + File.separator + 'libs' + File.separator
 	if (junit) {
 		artifact += 'Skript-JUnit.jar'

--- a/build.gradle
+++ b/build.gradle
@@ -189,7 +189,7 @@ enum Modifiers {
 void createTestTask(String name, String desc, String environments, int javaVersion, Modifiers... modifiers) {
 	boolean junit = modifiers.contains(Modifiers.JUNIT)
 	boolean releaseDocs = modifiers.contains(Modifiers.GEN_RELEASE_DOCS)
-	boolean docs = modifiers.contains(Modifiers.GEN_NIGHTLY_DOCS) || releaseDocs
+	boolean docs = modifiers.contains(Modifiers.GEN_NIGHTLY_DOCS)
 	def artifact = 'build' + File.separator + 'libs' + File.separator
 	if (junit) {
 		artifact += 'Skript-JUnit.jar'

--- a/src/main/java/ch/njol/skript/SkriptCommand.java
+++ b/src/main/java/ch/njol/skript/SkriptCommand.java
@@ -398,7 +398,7 @@ public class SkriptCommand implements CommandExecutor {
 			else if (args[0].equalsIgnoreCase("gen-docs")) {
 				File templateDir = Documentation.getDocsTemplateDirectory();
 				if (!templateDir.exists()) {
-					Skript.error(sender, "Cannot generate docs! Documentation templates not found at 'plugins/Skript/docs/templates/'");
+					Skript.error(sender, "Cannot generate docs! Documentation templates not found at '" + Documentation.getDocsTemplateDirectory().getPath() + "'");
 					TestMode.docsFailed = true;
 					return true;
 				}

--- a/src/main/java/ch/njol/skript/SkriptCommand.java
+++ b/src/main/java/ch/njol/skript/SkriptCommand.java
@@ -398,7 +398,7 @@ public class SkriptCommand implements CommandExecutor {
 			else if (args[0].equalsIgnoreCase("gen-docs")) {
 				File templateDir = Documentation.getDocsTemplateDirectory();
 				if (!templateDir.exists()) {
-					Skript.error(sender, "Cannot generate docs! Documentation templates not found at 'plugins/Skript/doc-templates/'");
+					Skript.error(sender, "Cannot generate docs! Documentation templates not found at 'plugins/Skript/docs/templates/'");
 					TestMode.docsFailed = true;
 					return true;
 				}

--- a/src/main/java/ch/njol/skript/SkriptCommandTabCompleter.java
+++ b/src/main/java/ch/njol/skript/SkriptCommandTabCompleter.java
@@ -18,6 +18,7 @@
  */
 package ch.njol.skript;
 
+import ch.njol.skript.doc.Documentation;
 import ch.njol.skript.test.runner.TestMode;
 import ch.njol.util.StringUtils;
 import org.bukkit.command.Command;
@@ -116,7 +117,7 @@ public class SkriptCommandTabCompleter implements TabCompleter {
 			options.add("disable");
 			options.add("update");
 			options.add("info");
-			if (new File(Skript.getInstance().getDataFolder() + "/doc-templates").exists())
+			if (Documentation.getDocsTemplateDirectory().exists())
 				options.add("gen-docs");
 			if (TestMode.DEV_MODE)
 				options.add("test");

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -45,7 +45,7 @@ skript command:
 			changes: Lists all changes since the current version
 			download: Download the newest version
 		info: Prints a message with links to Skript's aliases and documentation
-		gen-docs: Generates documentation using doc-templates in plugin folder
+		gen-docs: Generates documentation using docs/templates in plugin folder
 		test: Used for running internal Skript tests
 
 	invalid script: Can't find the script <grey>'<gold>%s<grey>'<red> in the scripts folder!

--- a/src/main/resources/lang/french.lang
+++ b/src/main/resources/lang/french.lang
@@ -45,7 +45,7 @@ skript command:
 			changes: Liste toutes les modifications apportées depuis la version actuelle
 			download: Télécharge la dernière version
 		info: Affiche un message contenant les liens vers les alias et la documentation de Skript
-		gen-docs: Génère la documentation en utilisant doc-templates dans le dossier du plugin
+		gen-docs: Génère la documentation en utilisant docs/templates dans le dossier du plugin
 		test: Utilisé pour exécuter les tests Skript
 
 	invalid script: Impossible de trouver le script <grey>'<gold>%s<grey>'<red> dans le dossier des scripts !

--- a/src/main/resources/lang/german.lang
+++ b/src/main/resources/lang/german.lang
@@ -45,7 +45,7 @@ skript command:
 			changes: Listet alle Änderungen seit der aktuellen Version auf (auf englisch)
 			download: Lädt die neueste Version herunter
 		info: Druckt eine Nachricht mit Links zu den Aliases und der Dokumentation von Skript.
-		gen-docs: Generiert Dokumentation mithilfe von doc-templates im Plugin-Ordner
+		gen-docs: Generiert Dokumentation mithilfe von docs/templates im Plugin-Ordner
 		test: Wird zum Ausführen von Skript-Tests verwendet
 	
 	invalid script: Das Skript <grey>'<gold>%s<grey>'<red> konnte nicht gefunden werden.

--- a/src/main/resources/lang/simplifiedchinese.lang
+++ b/src/main/resources/lang/simplifiedchinese.lang
@@ -45,7 +45,7 @@ skript command:
 			changes: 列出自当前版本以来的所有变化
 			download: 下载最新的版本
 		info: 打印一个带有Skript的别名和文档链接的信息
-		gen-docs: 使用插件文件夹中的doc-templates生成文档
+		gen-docs: 使用插件文件夹中的docs/templates生成文档
 		test: 用于运行内部的Skript测试
 
 	invalid script: 无法在scripts文件夹中找到脚本<grey>“<gold>%s<grey>”<red>！


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
In this PR:
- Disable Javadocs generation for nightly docs (see note IMPORTANT)
- Fix various placing still using old docs templates path
- Reduced Docs Nightly Push branches to limit size (might need to limit more as we're at 3GB size atm 😬)

## 🛑 IMPORTANT
Nightly docs javadocs was causing the issue, each javadoc is ~50mb! right now javadocs generate is disabled for nightly docs with an option for flexibility. Each of our docs files is ~2mb so we're all good without nightly javadocs.

Reopened after old PR: https://github.com/SkriptLang/Skript/pull/6044

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** <!-- Links to related issues -->

