### PR TITLE
Change the target branch of dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,14 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
+    target-branch: "dev/patch"
     directory: "/"
     schedule:
         interval: "weekly"
     labels:
       - "dependencies"
   - package-ecosystem: "gradle"
+    target-branch: "dev/patch"
     directory: "/"
     schedule:
         interval: "weekly"


### PR DESCRIPTION
### Description
Changes the target branch of dependabot to always be `dev/patch`
This is the lowest point of coverage with the newest branch structure. Any and all dependency updates will flood down into dev/feature and also master from dev/patch, so it's best to set dependabot to target `dev/patch`
