### PR TITLE
⚒ Fix stop all sounds NPE

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffStopSound.java
+++ b/src/main/java/ch/njol/skript/effects/EffStopSound.java
@@ -80,14 +80,9 @@ public class EffStopSound extends Effect {
 	@SuppressWarnings("unchecked")
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		allSounds = parseResult.hasTag("all");
-		if (allSounds) {
-			category = (Expression<SoundCategory>) exprs[0];
-			players = (Expression<Player>) exprs[1];
-		} else {
-			sounds = (Expression<String>) exprs[0];
-			category = (Expression<SoundCategory>) exprs[1];
-			players = (Expression<Player>) exprs[2];
-		}
+		sounds = (Expression<String>) exprs[0];
+		category = (Expression<SoundCategory>) exprs[1];
+		players = (Expression<Player>) exprs[2];
 		return true;
 	}
 


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Fix an NPE in EffStopSound due to exprs not actually changing positions but code tried to handle that.

---
**Target Minecraft Versions:** <!-- 'any' means all supported versions -->
**Requirements:** <!-- Required plugins, Minecraft versions, server software... -->
**Related Issues:** <!-- Links to related issues -->
- #6066 
