### PR TITLE
Update Minecraft wiki links to new domain

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -1410,7 +1410,7 @@ public class BukkitClasses {
 					.user("(panda )?genes?")
 					.name("Gene")
 					.description("Represents a Panda's main or hidden gene. " +
-							"See <a href='https://minecraft.gamepedia.com/Panda#Genetics'>genetics</a> for more info.")
+							"See <a href='https://minecraft.wiki/w/Panda#Genetics'>genetics</a> for more info.")
 					.since("2.4")
 					.requiredPlugins("Minecraft 1.14 or newer"));
 		}
@@ -1486,7 +1486,7 @@ public class BukkitClasses {
 				.user("attribute ?types?")
 				.name("Attribute Type")
 				.description("Represents the type of an attribute. Note that this type does not contain any numerical values."
-						+ "See <a href='https://minecraft.gamepedia.com/Attribute#Attributes'>attribute types</a> for more info.")
+						+ "See <a href='https://minecraft.wiki/w/Attribute#Attributes'>attribute types</a> for more info.")
 				.since("2.5"));
 
 		Classes.registerClass(new EnumClassInfo<>(Environment.class, "environment", "environments")

--- a/src/main/java/ch/njol/skript/conditions/CondIsSlimeChunk.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsSlimeChunk.java
@@ -35,7 +35,7 @@ import ch.njol.skript.doc.Since;
 @Name("Is Slime Chunk")
 @Description({"Tests whether a chunk is a so-called slime chunk.",
 		"Slimes can generally spawn in the swamp biome and in slime chunks.",
-		"For more info, see <a href='https://minecraft.gamepedia.com/Slime#.22Slime_chunks.22'>the Minecraft wiki</a>."})
+		"For more info, see <a href='https://minecraft.wiki/w/Slime#.22Slime_chunks.22'>the Minecraft wiki</a>."})
 @Examples({"command /slimey:",
 		"\ttrigger:",
 		"\t\tif chunk at player is a slime chunk:",

--- a/src/main/java/ch/njol/skript/effects/EffExplosion.java
+++ b/src/main/java/ch/njol/skript/effects/EffExplosion.java
@@ -37,7 +37,7 @@ import ch.njol.util.Kleenean;
  * @author Peter Güttinger
  */
 @Name("Explosion")
-@Description({"Creates an explosion of a given force. The Minecraft Wiki has an <a href='https://www.minecraftwiki.net/wiki/Explosion'>article on explosions</a> " +
+@Description({"Creates an explosion of a given force. The Minecraft Wiki has an <a href='https://www.minecraft.wiki/w/Explosion'>article on explosions</a> " +
 		"which lists the explosion forces of TNT, creepers, etc.",
 		"Hint: use a force of 0 to create a fake explosion that does no damage whatsoever, or use the explosion effect introduced in Skript 2.0.",
 		"Starting with Bukkit 1.4.5 and Skript 2.0 you can use safe explosions which will damage entities but won't destroy any blocks."})

--- a/src/main/java/ch/njol/skript/expressions/ExprAge.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAge.java
@@ -119,7 +119,7 @@ public class ExprAge extends SimplePropertyExpression<Object, Integer> {
 					setAge(obj, newValue);
 					break;
 				case RESET:
-					// baby animals takes 20 minutes to grow up - ref: https://minecraft.fandom.com/wiki/Breeding
+					// baby animals takes 20 minutes to grow up - ref: https://minecraft.wiki/w/Breeding
 					if (obj instanceof org.bukkit.entity.Ageable)
 						// it might change later on so removing entity age reset would be better unless
 						// bukkit adds a method returning the default age

--- a/src/main/java/ch/njol/skript/expressions/ExprExplosionYield.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprExplosionYield.java
@@ -40,7 +40,7 @@ import ch.njol.util.coll.CollectionUtils;
 @Name("Explosion Yield")
 @Description({"The yield of the explosion in an explosion prime event. This is how big the explosion is.",
 				" When changing the yield, values less than 0 will be ignored.",
-				" Read <a href='https://minecraft.gamepedia.com/Explosion'>this wiki page</a> for more information"})
+				" Read <a href='https://minecraft.wiki/w/Explosion'>this wiki page</a> for more information"})
 @Examples({"on explosion prime:",
 		"\tset the yield of the explosion to 10"})
 @Events("explosion prime")

--- a/src/main/java/ch/njol/skript/expressions/ExprExplosiveYield.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprExplosiveYield.java
@@ -36,7 +36,7 @@ import ch.njol.util.coll.CollectionUtils;
 
 @Name("Explosive Yield")
 @Description({"The yield of an explosive (creeper, primed tnt, fireball, etc.). This is how big of an explosion is caused by the entity.",
-				"Read <a href='https://minecraft.gamepedia.com/Explosion'>this wiki page</a> for more information"})
+				"Read <a href='https://minecraft.wiki/w/Explosion'>this wiki page</a> for more information"})
 @Examples({"on spawn of a creeper:",
 			"\tset the explosive yield of the event-entity to 10"})
 @RequiredPlugins("Minecraft 1.12 or newer for creepers")

--- a/src/main/java/ch/njol/skript/expressions/ExprGlidingState.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprGlidingState.java
@@ -31,7 +31,7 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
 
 @Name("Gliding State")
-@Description("Sets of gets gliding state of player. It allows you to set gliding state of entity even if they do not have an <a href=\"https://minecraft.gamepedia.com/Elytra\">Elytra</a> equipped.")
+@Description("Sets of gets gliding state of player. It allows you to set gliding state of entity even if they do not have an <a href=\"https://minecraft.wiki/w/Elytra\">Elytra</a> equipped.")
 @Examples({"set gliding of player to off"})
 @Since("2.2-dev21")
 public class ExprGlidingState extends SimplePropertyExpression<LivingEntity, Boolean> {

--- a/src/main/java/ch/njol/skript/expressions/ExprScoreboardTags.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprScoreboardTags.java
@@ -41,7 +41,7 @@ import ch.njol.util.coll.CollectionUtils;
 @Name("Scoreboard Tags")
 @Description({"Scoreboard tags are simple list of texts stored directly in the data of an <a href='classes.html#entity'>entity</a>.",
 		"So this is a Minecraft related thing, not Bukkit, so the tags will not get removed when the server stops. " +
-		"You can visit <a href='https://minecraft.gamepedia.com/Scoreboard#Tags'>visit Minecraft Wiki</a> for more info.",
+		"You can visit <a href='https://minecraft.wiki/w/Scoreboard#Tags'>visit Minecraft Wiki</a> for more info.",
 		"This is changeable and valid for any type of entity. " +
 		"Also you can use use the <a href='conditions.html#CondHasScoreboardTag'>Has Scoreboard Tag</a> condition to check whether an entity has the given tags.",
 		"",


### PR DESCRIPTION
### Description

The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.

**Target Minecraft Versions:** any 
