### PR TITLE
Force UTF-8 encoding for Gradle daemon

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,6 @@
+# Ensure encoding is consistent across systems
+org.gradle.jvmargs=-Dfile.encoding=UTF-8
+
 groupid=ch.njol
 name=skript
 version=2.7.1


### PR DESCRIPTION
### Description
Adds an argument to force the Gradle daemon to use UTF-8 encoding regardless of the system setting. This fixes the issue where lang files built on some systems are not properly encoded.

See: https://docs.gradle.org/current/userguide/common_caching_problems.html#system_file_encoding

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
