### PR TITLE
Fix unloading/reloading a directory in the scripts effect

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffScriptFile.java
+++ b/src/main/java/ch/njol/skript/effects/EffScriptFile.java
@@ -37,6 +37,7 @@ import org.eclipse.jdt.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Set;
 
 @Name("Enable/Disable/Reload Script File")
 @Description("Enables, disables, or reloads a script file.")
@@ -102,10 +103,8 @@ public class EffScriptFile extends Effect {
 			case RELOAD: {
 				if (ScriptLoader.getDisabledScriptsFilter().accept(scriptFile))
 					return;
-
-				Script script = ScriptLoader.getScript(scriptFile);
-				if (script != null)
-					ScriptLoader.unloadScript(script);
+				
+				this.unloadScripts(scriptFile);
 				
 				ScriptLoader.loadScripts(scriptFile, OpenCloseable.EMPTY);
 				break;
@@ -114,9 +113,7 @@ public class EffScriptFile extends Effect {
 				if (ScriptLoader.getDisabledScriptsFilter().accept(scriptFile))
 					return;
 
-				Script script = ScriptLoader.getScript(scriptFile);
-				if (script != null)
-					ScriptLoader.unloadScript(script);
+				this.unloadScripts(scriptFile);
 
 				try {
 					FileUtils.move(
@@ -133,6 +130,19 @@ public class EffScriptFile extends Effect {
 			}
 			default:
 				assert false;
+		}
+	}
+	
+	private void unloadScripts(File file) {
+		if (file.isDirectory()) {
+			Set<Script> scripts = ScriptLoader.getScripts(file);
+			if (scripts.isEmpty())
+				return;
+			ScriptLoader.unloadScripts(scripts);
+		} else  {
+			Script script = ScriptLoader.getScript(file);
+			if (script != null)
+				ScriptLoader.unloadScript(script);
 		}
 	}
 

--- a/src/main/java/ch/njol/skript/effects/EffScriptFile.java
+++ b/src/main/java/ch/njol/skript/effects/EffScriptFile.java
@@ -139,7 +139,7 @@ public class EffScriptFile extends Effect {
 			if (scripts.isEmpty())
 				return;
 			ScriptLoader.unloadScripts(scripts);
-		} else  {
+		} else {
 			Script script = ScriptLoader.getScript(file);
 			if (script != null)
 				ScriptLoader.unloadScript(script);


### PR DESCRIPTION
### Description
Fixes the reloading/disabling script effect when used with a directory (e.g. `reload script "foo/"`) instead of a single file.

This moves both unloading actions to a common method that will check if the provided thing was a directory and, if so, unload everything in it.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #6096 <!-- Links to related issues -->
