### PR TITLE
Fix stack overflow when stringifying block inventories.

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -876,6 +876,8 @@ public class BukkitClasses {
 							return Classes.toString(holder.getInventory().getLocation().getBlock());
 						} else if (holder instanceof BlockInventoryHolder) {
 							return Classes.toString(((BlockInventoryHolder) holder).getBlock());
+						} else if (Classes.getSuperClassInfo(holder.getClass()).getC() == InventoryHolder.class) {
+							return holder.getClass().getSimpleName(); // an inventory holder and only that
 						} else {
 							return Classes.toString(holder);
 						}

--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -64,6 +64,7 @@ import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerResourcePackStatusEvent.Status;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
+import org.bukkit.inventory.BlockInventoryHolder;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
@@ -873,6 +874,8 @@ public class BukkitClasses {
 							return Classes.toString(((BlockState) holder).getBlock());
 						} else if (holder instanceof DoubleChest) {
 							return Classes.toString(holder.getInventory().getLocation().getBlock());
+						} else if (holder instanceof BlockInventoryHolder) {
+							return Classes.toString(((BlockInventoryHolder) holder).getBlock());
 						} else {
 							return Classes.toString(holder);
 						}


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
A partial fix to inventory holder stringifying.

The previous implementation used a fall-back `Classes.toString` on the holder, in the hope that an inventory holder was also some other kind of type (a player, an entity, whatever) which would be checked first and printed as that thing. Unfortunately, 1.20.2 added block inventory holders for inventories without a tile state, which aren't any other kind of thing and so will just recurse infinitely.

I have added an explicit check for that type, to print the block (as is done with block entities).

However, this is not a complete fix: obviously any other kind of inventory holder that is not also a kind of thing with its own class info will run into this problem, so it's going to need fixing again in the future.

---
**Target Minecraft Versions:** 1.20.2 <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #6115 <!-- Links to related issues -->
