### PR TITLE
Fix options issue in functions

### DIFF
--- a/src/main/java/ch/njol/skript/structures/StructFunction.java
+++ b/src/main/java/ch/njol/skript/structures/StructFunction.java
@@ -18,6 +18,7 @@
  */
 package ch.njol.skript.structures;
 
+import ch.njol.skript.ScriptLoader;
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -35,7 +36,8 @@ import org.skriptlang.skript.lang.entry.EntryContainer;
 import org.skriptlang.skript.lang.structure.Structure;
 
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Name("Function")
 @Description({
@@ -55,38 +57,48 @@ public class StructFunction extends Structure {
 
 	public static final Priority PRIORITY = new Priority(400);
 
+	private static final Pattern SIGNATURE_PATTERN =
+			Pattern.compile("(?:local )?function (" + Functions.functionNamePattern + ")\\((.*)\\)(?:\\s*::\\s*(.+))?");
 	private static final AtomicBoolean VALIDATE_FUNCTIONS = new AtomicBoolean();
 
 	static {
 		Skript.registerStructure(StructFunction.class,
-			"[:local] function <(" + Functions.functionNamePattern + ")\\((.*)\\)(?:\\s*::\\s*(.+))?>"
+			"[:local] function <.+>"
 		);
 	}
 
-	@SuppressWarnings("NotNullFieldNotInitialized")
+	@Nullable
 	private Signature<?> signature;
 	private boolean local;
 
 	@Override
-	@SuppressWarnings("all")
 	public boolean init(Literal<?>[] literals, int matchedPattern, ParseResult parseResult, EntryContainer entryContainer) {
 		local = parseResult.hasTag("local");
-		MatchResult regex = parseResult.regexes.get(0);
-		String name = regex.group(1);
-		String args = regex.group(2);
-		String returnType = regex.group(3);
-
-		getParser().setCurrentEvent((local ? "local " : "") + "function", FunctionEvent.class);
-
-		signature = Functions.parseSignature(getParser().getCurrentScript().getConfig().getFileName(), name, args, returnType, local);
-
-		getParser().deleteCurrentEvent();
-		return signature != null;
+		return true;
 	}
 
 	@Override
 	public boolean preLoad() {
-		return Functions.registerSignature(signature) != null;
+		// match signature against pattern
+		String rawSignature = getEntryContainer().getSource().getKey();
+		assert rawSignature != null;
+		rawSignature = ScriptLoader.replaceOptions(rawSignature);
+		Matcher matcher = SIGNATURE_PATTERN.matcher(rawSignature);
+		if (!matcher.matches()) {
+			Skript.error("Invalid function signature: " + rawSignature);
+			return false;
+		}
+
+		// parse signature
+		getParser().setCurrentEvent((local ? "local " : "") + "function", FunctionEvent.class);
+		signature = Functions.parseSignature(
+			getParser().getCurrentScript().getConfig().getFileName(),
+			matcher.group(1), matcher.group(2), matcher.group(3), local
+		);
+		getParser().deleteCurrentEvent();
+
+		// attempt registration
+		return signature != null && Functions.registerSignature(signature) != null;
 	}
 
 	@Override
@@ -94,6 +106,7 @@ public class StructFunction extends Structure {
 		ParserInstance parser = getParser();
 		parser.setCurrentEvent((local ? "local " : "") + "function", FunctionEvent.class);
 
+		assert signature != null;
 		Functions.loadFunction(parser.getCurrentScript(), getEntryContainer().getSource(), signature);
 
 		parser.deleteCurrentEvent();
@@ -114,6 +127,7 @@ public class StructFunction extends Structure {
 
 	@Override
 	public void unload() {
+		assert signature != null;
 		Functions.unregisterFunction(signature);
 		VALIDATE_FUNCTIONS.set(true);
 	}
@@ -124,7 +138,7 @@ public class StructFunction extends Structure {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return (local ? "local " : "") + "function";
 	}
 

--- a/src/test/skript/tests/syntaxes/structures/StructCommand.sk
+++ b/src/test/skript/tests/syntaxes/structures/StructCommand.sk
@@ -2,7 +2,10 @@ test "commands":
 	execute command "skriptcommand taco"
 	execute command "//somecommand burrito is tasty"
 
-command skriptcommand <text> [<text>] [<itemtype = %dirt block named "steve"%>]:
+options:
+	command: skriptcommand
+
+command {@command} <text> [<text>] [<itemtype = %dirt block named "steve"%>]:
 	trigger:
 		set {_arg1} to arg-1
 		assert {_arg1} is "taco" with "arg-1 test failed (got '%{_arg1}%')"

--- a/src/test/skript/tests/syntaxes/structures/StructFunction.sk
+++ b/src/test/skript/tests/syntaxes/structures/StructFunction.sk
@@ -1,5 +1,8 @@
-function foo() :: boolean:
+function {@function}) :: boolean:
 	return true
+
+options:
+	function: foo(
 
 function local() :: number:
 	return 1


### PR DESCRIPTION
### Description
This PR fixes an issue where options would not work in functions in some cases. With the Structure API, we should avoid having declaration order matter in cases where possible, meaning the following should work:
```
function {@name}():
  ...blah blah blah

options:
  name: myFunction
```
This PR changes functions to load signatures in preLoad instead of init (in the same way that commands load). I have included tests for both.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
