### PR TITLE
Fix ExprSets conflicting

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprSets.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSets.java
@@ -52,7 +52,7 @@ import ch.njol.util.Kleenean;
 public class ExprSets extends SimpleExpression<Object> {
 
 	static {
-		Skript.registerExpression(ExprSets.class, Object.class, ExpressionType.COMBINED,
+		Skript.registerExpression(ExprSets.class, Object.class, ExpressionType.PATTERN_MATCHES_EVERYTHING,
 				"[all [[of] the]|the|every] %*classinfo%");
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprSets.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSets.java
@@ -69,15 +69,16 @@ public class ExprSets extends SimpleExpression<Object> {
 			return false;
 
 		classInfo = ((Literal<ClassInfo<?>>) exprs[0]).getSingle();
-		// Silently ignores and moves on to next syntax if no supplier is provided.
-		// This is to avoid very similar matching syntax conflicts like 'all players'
-		// So do not include a Skript.error here.
-		return (supplier = classInfo.getSupplier()) != null;
+		supplier = classInfo.getSupplier();
+		if (supplier == null) {
+			Skript.error("You cannot get all values of type '" + classInfo.getName().getSingular() + "'");
+			return false;
+		}
+		return true;
 	}
 
 	@Override
 	protected Object[] get(Event event) {
-		assert supplier != null;
 		Iterator<?> iterator = supplier.get();
 		return Lists.newArrayList(iterator).toArray(new Object[0]);
 	}
@@ -85,7 +86,6 @@ public class ExprSets extends SimpleExpression<Object> {
 	@Override
 	@Nullable
 	public Iterator<?> iterator(Event event) {
-		assert supplier != null;
 		return supplier.get();
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprSets.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSets.java
@@ -18,6 +18,14 @@
  */
 package ch.njol.skript.expressions;
 
+import java.util.Iterator;
+import java.util.function.Supplier;
+
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.google.common.collect.Lists;
+
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.doc.Description;
@@ -31,33 +39,26 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.skript.util.Utils;
 import ch.njol.util.Kleenean;
-import com.google.common.collect.Lists;
-import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
-
-import java.util.Iterator;
-import java.util.List;
-import java.util.function.Supplier;
 
 @Name("Sets")
-@Description("Returns a list of all the values of a type; useful for looping.")
+@Description("Returns a list of all the values of a type. Useful for looping.")
 @Examples({
 	"loop all attribute types:",
-	"\tset loop-value attribute of player to 10",
-	"\tmessage \"Set attribute %loop-value% to 10!\""
+		"\tset loop-value attribute of player to 10",
+		"\tmessage \"Set attribute %loop-value% to 10!\""
 })
-@Since("<i>unknown</i> (before 1.4.2), 2.7 (colors)")
+// Class history rename order: LoopItems.class -> ExprItems.class (renamed in 2.3-alpha1) -> ExprSets.class (renamed in 2.7.0)
+@Since("1.0 pre-5, 2.7 (classinfo)")
 public class ExprSets extends SimpleExpression<Object> {
 
 	static {
 		Skript.registerExpression(ExprSets.class, Object.class, ExpressionType.COMBINED,
-			"[all [[of] the]|the|every] %*classinfo%"
-		);
+				"[all [[of] the]|the|every] %*classinfo%");
 	}
 
-	private ClassInfo<?> classInfo;
 	@Nullable
 	private Supplier<? extends Iterator<?>> supplier;
+	private ClassInfo<?> classInfo;
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -68,20 +69,17 @@ public class ExprSets extends SimpleExpression<Object> {
 			return false;
 
 		classInfo = ((Literal<ClassInfo<?>>) exprs[0]).getSingle();
-		supplier = classInfo.getSupplier();
-		if (supplier == null) {
-			Skript.error("You cannot get all values of type '" + classInfo.getName().getSingular() + "'");
-			return false;
-		}
-		return true;
+		// Silently ignores and moves on to next syntax if no supplier is provided.
+		// This is to avoid very similar matching syntax conflicts like 'all players'
+		// So do not include a Skript.error here.
+		return (supplier = classInfo.getSupplier()) != null;
 	}
 
 	@Override
 	protected Object[] get(Event event) {
 		assert supplier != null;
 		Iterator<?> iterator = supplier.get();
-		List<?> elements = Lists.newArrayList(iterator);
-		return elements.toArray(new Object[0]);
+		return Lists.newArrayList(iterator).toArray(new Object[0]);
 	}
 
 	@Override


### PR DESCRIPTION
### Description
Fixes ExprSets conflicting with `set {_players::*} to all players`
The error mainly is present when parsing syntaxes with `%players%` not the above example.
The expression ExprSets should be returning false silently without an error to allow Skript to continuously keep checking for other syntaxes. Essentially grabbing Player EntityData instead of ExprSets.
We don't want to error when Skript checks ExprSets as it should be returning all the players on the server, not using the classinfo to collect all the players (which has no supplier causing this error).

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
