### PR TITLE
Fix command permission messages (2.7.1 issue)

### DIFF
--- a/src/main/java/ch/njol/skript/command/ScriptCommand.java
+++ b/src/main/java/ch/njol/skript/command/ScriptCommand.java
@@ -117,7 +117,7 @@ public class ScriptCommand implements TabExecutor {
 
 	/**
 	 * Creates a new SkriptCommand.
-	 * 
+	 *
 	 * @param name /name
 	 * @param pattern
 	 * @param arguments the list of Arguments this command takes
@@ -237,16 +237,8 @@ public class ScriptCommand implements TabExecutor {
 
 		final ScriptCommandEvent event = new ScriptCommandEvent(ScriptCommand.this, sender, commandLabel, rest);
 
-		if (!permission.isEmpty() && !sender.hasPermission(permission)) {
-			if (sender instanceof Player) {
-				List<MessageComponent> components =
-						permissionMessage.getMessageComponents(event);
-				((Player) sender).spigot().sendMessage(BungeeConverter.convert(components));
-			} else {
-				sender.sendMessage(permissionMessage.getSingle(event));
-			}
+		if (!checkPermissions(sender, event))
 			return false;
-		}
 
 		cooldownCheck : {
 			if (sender instanceof Player && cooldown != null) {
@@ -316,16 +308,34 @@ public class ScriptCommand implements TabExecutor {
 		} finally {
 			log.stop();
 		}
-		
+
 		if (Skript.log(Verbosity.VERY_HIGH))
 			Skript.info("# /" + name + " " + rest);
 		final long startTrigger = System.nanoTime();
-		
+
 		if (!trigger.execute(event))
 			sender.sendMessage(Commands.m_internal_error.toString());
-		
+
 		if (Skript.log(Verbosity.VERY_HIGH))
 			Skript.info("# " + name + " took " + 1. * (System.nanoTime() - startTrigger) / 1000000. + " milliseconds");
+		return true;
+	}
+
+	public boolean checkPermissions(CommandSender sender, String commandLabel, String arguments) {
+		return checkPermissions(sender, new ScriptCommandEvent(this, sender, commandLabel, arguments));
+	}
+
+	public boolean checkPermissions(CommandSender sender, Event event) {
+		if (!permission.isEmpty() && !sender.hasPermission(permission)) {
+			if (sender instanceof Player) {
+				List<MessageComponent> components =
+					permissionMessage.getMessageComponents(event);
+				((Player) sender).spigot().sendMessage(BungeeConverter.convert(components));
+			} else {
+				sender.sendMessage(permissionMessage.getSingle(event));
+			}
+			return false;
+		}
 		return true;
 	}
 
@@ -337,7 +347,7 @@ public class ScriptCommand implements TabExecutor {
 
 	/**
 	 * Gets the arguments this command takes.
-	 * 
+	 *
 	 * @return The internal list of arguments. Do not modify it!
 	 */
 	public List<Argument<?>> getArguments() {
@@ -575,7 +585,7 @@ public class ScriptCommand implements TabExecutor {
 		Class<?> argType = arg.getType();
 		if (argType.equals(Player.class) || argType.equals(OfflinePlayer.class))
 			return null; // Default completion
-		
+
 		return Collections.emptyList(); // No tab completion here!
 	}
 


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

#5966 pushed the handling of commands to the proper Bukkit method of onCommand, using command events instead of a PlayerPreprocessCommandEvent listener. This has the side effect of changing the behavior of the "no permission" messages.

Spigot and Paper (1.19+) seem to send "Unknown command" messages when a player tries to use a command they do not have permission for. This is good for security, as a player should not know what is available that they do not have permissions for, but it changes the behavior of Skript, which is unacceptable for a patch version.

This PR re-adds the PPCE listener to handle permissions. It will match the command given to a Skript command and check the permissions if found. If the player does not have the permissions, it will send the message and cancel the PPCE, preventing the "Unknown command" message from being sent. 

This fixes the issue, but has the side effect of re-introducing #5908 when using priority HIGHEST with the `on command` event. If the player doesn't have permission, `on command` won't be able to listen to it as Skript can't listen to cancelled events currently. I don't think there's a way to avoid this, but if anyone has ideas, please share.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #5908 #6125 <!-- Links to related issues -->
