### PR TITLE
Fix comparison of cyclical types (specifically comparing times)

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondCompare.java
+++ b/src/main/java/ch/njol/skript/conditions/CondCompare.java
@@ -18,6 +18,7 @@
  */
 package ch.njol.skript.conditions;
 
+import ch.njol.skript.util.Time;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -52,6 +53,7 @@ import ch.njol.skript.util.Patterns;
 import ch.njol.skript.util.Utils;
 import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
+import org.skriptlang.skript.lang.util.Cyclical;
 
 @Name("Comparison")
 @Description({"A very general condition, it simply compares two values. Usually you can only compare for equality (e.g. block is/isn't of &lt;type&gt;), " +
@@ -351,15 +353,29 @@ public class CondCompare extends Condition {
 				return third.check(e, (Checker<Object>) o3 -> {
 					boolean isBetween;
 					if (comparator != null) {
-						isBetween =
-							(Relation.GREATER_OR_EQUAL.isImpliedBy(comparator.compare(o1, o2)) && Relation.SMALLER_OR_EQUAL.isImpliedBy(comparator.compare(o1, o3)))
-							// Check OPPOSITE (switching o2 / o3)
-							|| (Relation.GREATER_OR_EQUAL.isImpliedBy(comparator.compare(o1, o3)) && Relation.SMALLER_OR_EQUAL.isImpliedBy(comparator.compare(o1, o2)));
+						if (o1 instanceof Cyclical<?> && o2 instanceof Cyclical<?> && o3 instanceof Cyclical<?>) {
+							if (Relation.GREATER_OR_EQUAL.isImpliedBy(comparator.compare(o2, o3)))
+								isBetween = Relation.GREATER_OR_EQUAL.isImpliedBy(comparator.compare(o1, o2)) || Relation.SMALLER_OR_EQUAL.isImpliedBy(comparator.compare(o1, o3));
+							else
+								isBetween = Relation.GREATER_OR_EQUAL.isImpliedBy(comparator.compare(o1, o2)) && Relation.SMALLER_OR_EQUAL.isImpliedBy(comparator.compare(o1, o3));
+						} else {
+							isBetween =
+								(Relation.GREATER_OR_EQUAL.isImpliedBy(comparator.compare(o1, o2)) && Relation.SMALLER_OR_EQUAL.isImpliedBy(comparator.compare(o1, o3)))
+								// Check OPPOSITE (switching o2 / o3)
+								|| (Relation.GREATER_OR_EQUAL.isImpliedBy(comparator.compare(o1, o3)) && Relation.SMALLER_OR_EQUAL.isImpliedBy(comparator.compare(o1, o2)));
+						}
 					} else {
-						isBetween =
-							(Relation.GREATER_OR_EQUAL.isImpliedBy(Comparators.compare(o1, o2)) && Relation.SMALLER_OR_EQUAL.isImpliedBy(Comparators.compare(o1, o3)))
-							// Check OPPOSITE (switching o2 / o3)
-							|| (Relation.GREATER_OR_EQUAL.isImpliedBy(Comparators.compare(o1, o3)) && Relation.SMALLER_OR_EQUAL.isImpliedBy(Comparators.compare(o1, o2)));
+						if (o1 instanceof Cyclical<?> && o2 instanceof Cyclical<?> && o3 instanceof Cyclical<?>) {
+							if (Relation.GREATER_OR_EQUAL.isImpliedBy(Comparators.compare(o2, o3)))
+								isBetween = Relation.GREATER_OR_EQUAL.isImpliedBy(Comparators.compare(o1, o2)) || Relation.SMALLER_OR_EQUAL.isImpliedBy(Comparators.compare(o1, o3));
+							else
+								isBetween = Relation.GREATER_OR_EQUAL.isImpliedBy(Comparators.compare(o1, o2)) && Relation.SMALLER_OR_EQUAL.isImpliedBy(Comparators.compare(o1, o3));
+						} else {
+							isBetween =
+									(Relation.GREATER_OR_EQUAL.isImpliedBy(Comparators.compare(o1, o2)) && Relation.SMALLER_OR_EQUAL.isImpliedBy(Comparators.compare(o1, o3)))
+									// Check OPPOSITE (switching o2 / o3)
+									|| (Relation.GREATER_OR_EQUAL.isImpliedBy(Comparators.compare(o1, o3)) && Relation.SMALLER_OR_EQUAL.isImpliedBy(Comparators.compare(o1, o2)));
+						}
 					}
 					return relation == Relation.NOT_EQUAL ^ isBetween;
 				});

--- a/src/main/java/ch/njol/skript/util/Time.java
+++ b/src/main/java/ch/njol/skript/util/Time.java
@@ -27,11 +27,12 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.localization.Message;
 import ch.njol.util.Math2;
 import ch.njol.yggdrasil.YggdrasilSerializable;
+import org.skriptlang.skript.lang.util.Cyclical;
 
 /**
  * @author Peter Güttinger
  */
-public class Time implements YggdrasilSerializable {
+public class Time implements YggdrasilSerializable, Cyclical<Integer> {
 	
 	private final static int TICKS_PER_HOUR = 1000, TICKS_PER_DAY = 24 * TICKS_PER_HOUR;
 	private final static double TICKS_PER_MINUTE = 1000. / 60;
@@ -152,6 +153,16 @@ public class Time implements YggdrasilSerializable {
 			return false;
 		final Time other = (Time) obj;
 		return time == other.time;
+	}
+	
+	@Override
+	public Integer getMaximum() {
+		return TICKS_PER_DAY;
+	}
+	
+	@Override
+	public Integer getMinimum() {
+		return 0;
 	}
 	
 }

--- a/src/main/java/org/skriptlang/skript/lang/util/Cyclical.java
+++ b/src/main/java/org/skriptlang/skript/lang/util/Cyclical.java
@@ -1,0 +1,52 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package org.skriptlang.skript.lang.util;
+
+/**
+ * This is for a special type of numerical value that is compared in a cyclical (rather than a linear) way.
+ * <p>
+ * The current example of this in Skript is Time,
+ * since 23:59 can be both before XOR after 00:01 depending on the context.
+ * <p>
+ * In practice, cyclical types have to be compared in a special way (particularly for "is between")
+ * when we can use the order of operations to determine the context.
+ * <p>
+ * The minimum/maximum values are intended to help with unusual equality checks, (e.g. 11pm = 1am - 2h).
+ *
+ * @param <Value> the type of number this uses, to help with type coercion
+ */
+public interface Cyclical<Value extends Number> {
+	
+	/**
+	 * The potential 'top' of the cycle, e.g. the highest value after which this should restart.
+	 * In practice, nothing forces this, so you can write 24:00 or 361° instead of 00:00 and 1° respectively.
+	 *
+	 * @return the highest legal value
+	 */
+	Value getMaximum();
+	
+	/**
+	 * The potential 'bottom' of the cycle, e.g. the lowest value.
+	 * In practice, nothing forces this, so 24:00 is synonymous with 00:00.
+	 *
+	 * @return the lowest legal value
+	 */
+	Value getMinimum();
+	
+}

--- a/src/main/java/org/skriptlang/skript/lang/util/package-info.java
+++ b/src/main/java/org/skriptlang/skript/lang/util/package-info.java
@@ -1,0 +1,23 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+@NonNullByDefault({DefaultLocation.PARAMETER, DefaultLocation.RETURN_TYPE, DefaultLocation.FIELD})
+package org.skriptlang.skript.lang.util;
+
+import org.eclipse.jdt.annotation.DefaultLocation;
+import org.eclipse.jdt.annotation.NonNullByDefault;

--- a/src/test/skript/tests/syntaxes/conditions/CondCompare.sk
+++ b/src/test/skript/tests/syntaxes/conditions/CondCompare.sk
@@ -1,0 +1,11 @@
+test "compare":
+	assert 10 is between 5 and 15 with "Number isn't between smaller and larger"
+	assert 10 is between 9 and 11 with "Number isn't between smaller and larger"
+	assert 10 is between 11 and 9 with "Number isn't between larger and smaller"
+	assert 10 is between 9 and 10 with "Number isn't between smaller and equal"
+	assert 10 is between 10 and 11 with "Number isn't between equal and larger"
+	assert 10 is between 10 and 10 with "Number isn't between equal and equal"
+	assert 19:00 is between 18:00 and 20:00 with "Time 19:00 isn't between 18:00 and 20:00"
+	assert 23:00 is between 20:00 and 24:00 with "Time 23:00 isn't between 20:00 and 24:00"
+	assert 23:00 is between 20:00 and 01:00 with "Time 23:00 isn't between 20:00 and 01:00 (cyclical)"
+	assert 23:00 is not between 01:00 and 20:00 with "Time 23:00 is between 01:00 and 20:00 (non-cyclical)"


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
This fixes one of the [oldest open issues](<https://github.com/SkriptLang/Skript/issues/1354>): times of day can't be compared correctly because a time can be both before or after another time depending on the context.

E.g. 06:00 is before 07:00, but it could also be after it (the following day).

This meant one of the examples `time in world of player is between 18:00 and 06:00` never worked as expected.

I added a special cyclical utility type for Time (and any future things we find/add that need to be compared in the same non-linear way). This might also be needed in future for things like angles (`360° == 0°`) or months of the year (January is between December and March, but not between March and December) or some other type.

Currently, this PR only fixes the `is between` check from `CondCompare` since it's a bug fix patch. In future, this could be used to add proper equality checking (e.g. `25:00 == 01:00`) using normalisation, but I didn't add that in this PR since it was out of scope of this patch.

Before: (linear number comparison)
```
19:00 is between 18:00 and 20:00 = true
19:00 is between 20:00 and 18:00 = true

19:00 is between 18:00 and 06:00 = false
19:00 is between 06:00 and 18:00 = false
```

After: (cyclical time comparison)
```
19:00 is between 18:00 and 20:00 = true
19:00 is between 20:00 and 18:00 = false

19:00 is between 18:00 and 06:00 = true
19:00 is between 06:00 and 18:00 = false
```

This patch doesn't touch relations like `greater than`, `less than` or `equals`.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #1354 <!-- Links to related issues -->
