### PR TITLE
Fix floating point rounding error in loop N times

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprTimes.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTimes.java
@@ -107,8 +107,8 @@ public class ExprTimes extends SimpleExpression<Long> {
 		Number end = this.end.getSingle(e);
 		if (end == null)
 			return null;
-
-		return LongStream.range(1, end.longValue() + 1).iterator();
+		long fixed = (long) (end.doubleValue() + Skript.EPSILON);
+		return LongStream.range(1, fixed + 1).iterator();
 	}
 
 	@Override

--- a/src/test/skript/tests/syntaxes/expressions/ExprTimes.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprTimes.sk
@@ -1,0 +1,8 @@
+test "times":
+	set {_seven} to 1.05 / 0.15 # = 7
+	set {_three} to 10 - {_seven} # = 3
+	set {_count} to 0
+	loop {_three} times:
+		add 1 to {_count}
+	assert {_count} is 3 with "count was %{_count}% instead of 3"
+	assert {_three} is 3 with "original number wasn't 3"


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Adjusts numbers by a tiny bit when used in `X times` to account for floating point errors.
The case seen in [this issue](https://github.com/SkriptLang/Skript/issues/5488) is fixed.

This shouldn't affect anything except for floating point errors since it shifts the number up by a tiny bit before it is rounded down when converted to a long.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #5488 <!-- Links to related issues -->
