### PR TITLE
Add "for" to visual effect

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffVisualEffect.java
+++ b/src/main/java/ch/njol/skript/effects/EffVisualEffect.java
@@ -38,17 +38,21 @@ import ch.njol.skript.util.visual.VisualEffect;
 import ch.njol.util.Kleenean;
 
 @Name("Play Effect")
-@Description({"Plays a <a href='classes.html#visualeffect'>visual effect</a> at a given location or on a given entity.",
-		"Please note that some effects can only be played on entities, e.g. wolf hearts or the hurt effect, and that these are always visible to all players."})
-@Examples({"play wolf hearts on the clicked wolf",
-		"show mob spawner flames at the targeted block to the player"})
+@Description({
+	"Plays a <a href='classes.html#visualeffect'>visual effect/particle</a> at a given location or on a given entity.",
+	"Please note that some effects can only be played on entities, e.g. wolf hearts or the hurt effect, and that these are always visible to all players."
+})
+@Examples({
+	"play wolf hearts on the clicked wolf",
+	"show mob spawner flames at the targeted block to the player"
+})
 @Since("2.1")
 public class EffVisualEffect extends Effect {
 
 	static {
 		Skript.registerEffect(EffVisualEffect.class,
-			"(play|show) %visualeffects% (on|%directions%) %entities/locations% [(to %-players%|in (radius|range) of %-number%)]",
-			"(play|show) %number% %visualeffects% (on|%directions%) %locations% [(to %-players%|in (radius|range) of %-number%)]");
+				"(play|show) %visualeffects% (on|%directions%) %entities/locations% [((to|for) %-players%|in (radius|range) of %-number%)]",
+				"(play|show) %number% %visualeffects% (on|%directions%) %locations% [((to|for) %-players%|in (radius|range) of %-number%)]");
 	}
 
 	@SuppressWarnings("NotNullFieldNotInitialized")


### PR DESCRIPTION
### Description
The word "for" is not present on the visual effects similarity matched to the sound effect.
- The players is used for sending the element directly to the specified clients.
- Cleaned up the annotations and added `/particle` as the word "particle" needs to be in the description.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
