### PR TITLE
Allow numbers in the changer for ExprHotbarSlot

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprHotbarSlot.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHotbarSlot.java
@@ -106,7 +106,7 @@ public class ExprHotbarSlot extends PropertyExpression<Player, Slot> {
 		Object object = delta[0];
 		Number number = null;
 		if (object instanceof InventorySlot) {
-			number = ((InventorySlot) slot).getIndex();
+			number = ((InventorySlot) object).getIndex();
 		} else if (object instanceof Number) {
 			number = (Number) object;
 		}

--- a/src/main/java/ch/njol/skript/expressions/ExprHotbarSlot.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHotbarSlot.java
@@ -105,11 +105,7 @@ public class ExprHotbarSlot extends PropertyExpression<Player, Slot> {
 		assert delta != null;
 		Object object = delta[0];
 		Number number = null;
-		if (object instanceof Slot) {
-			Slot slot = (Slot) delta[0];
-			if (!(slot instanceof InventorySlot))
-				return; // Only inventory slots can be hotbar slots
-	
+		if (object instanceof InventorySlot) {
 			number = ((InventorySlot) slot).getIndex();
 		} else if (object instanceof Number) {
 			number = (Number) object;

--- a/src/main/java/ch/njol/skript/expressions/ExprHotbarSlot.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHotbarSlot.java
@@ -96,19 +96,29 @@ public class ExprHotbarSlot extends PropertyExpression<Player, Slot> {
 	@Nullable
 	public Class<?>[] acceptChange(ChangeMode mode) {
 		if (mode == ChangeMode.SET)
-			return new Class[] {Slot.class};
+			return new Class[] {Slot.class, Number.class};
 		return null;
 	}
 
 	@Override
 	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		assert delta != null;
-		Slot slot = (Slot) delta[0];
-		if (!(slot instanceof InventorySlot))
-			return; // Only inventory slots can be hotbar slots
+		Object object = delta[0];
+		Number number = null;
+		if (object instanceof Slot) {
+			Slot slot = (Slot) delta[0];
+			if (!(slot instanceof InventorySlot))
+				return; // Only inventory slots can be hotbar slots
+	
+			number = ((InventorySlot) slot).getIndex();
+		} else if (object instanceof Number) {
+			number = (Number) object;
+		}
 
-		int index = ((InventorySlot) slot).getIndex();
-		if (index > 8) // Only slots in hotbar can be current hotbar slot
+		if (number == null)
+			return;
+		int index = number.intValue();
+		if (index > 8 || index < 0) // Only slots in hotbar can be current hotbar slot
 			return;
 
 		for (Player player : getExpr().getArray(event))


### PR DESCRIPTION
### Description
The ExprHotbarSlot currently requires a slot to be able to change the index of the slot.
This means that you have to type `set the currently selected hotbar slot of player to the slot 8 of player`

This pull request allows for that still, but also removes the redundancy of typing out the entire slot
`set hotbar slot of player to 8`

The `Player#setHeldItemSlot` method only takes in an integer, so it makes to sense to support a direct input of an integer.

Also fixes a bug where there was no integer check for the input value being under 0 which could lead to an IllegalArgumentException being thrown.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
