### PR TITLE
Make the "inventory" word optional in ExprChestInventory

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprChestInventory.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprChestInventory.java
@@ -66,8 +66,8 @@ public class ExprChestInventory extends SimpleExpression<Inventory> {
 				Skript.methodExists(Bukkit.class, "createInventory", InventoryHolder.class, int.class, Component.class))
 			serializer = BungeeComponentSerializer.get();
 		Skript.registerExpression(ExprChestInventory.class, Inventory.class, ExpressionType.COMBINED,
-				"[a] [new] chest inventory (named|with name) %string% [with %-number% row[s]]",
-				"[a] [new] chest inventory with %number% row[s] [(named|with name) %-string%]");
+				"[a] [new] chest [inventory] (named|with name) %string% [with %-number% row[s]]",
+				"[a] [new] chest [inventory] with %number% row[s] [(named|with name) %-string%]");
 	}
 
 	private static final String DEFAULT_CHEST_TITLE = InventoryType.CHEST.getDefaultTitle();


### PR DESCRIPTION
### Description
Make inventory word optional in ExprChestInventory.
When Snow and I discussed and added the inventory creation syntaxes a long time ago. We made the `inventory` part of the syntax mandatory to avoid conflicts with addons such as Umbaska, WildSkript, SkQuery and Skellett.

Of those addons that are active, being SkQuery and Skellett, have had their inventory syntaxes removed for creating inventories. Skript is the new standard for making inventories, and is currently the most common way to make inventories.

Users in Discord skript-help today as of posting this, were wondering why the word `inventory` was mandatory. I answered them and we were waiting until a decent amount of time had passed to apply this change. That time is now.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->