### PR TITLE
Fix colour codes being reset in reload message.

### DIFF
--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -68,7 +68,7 @@ skript command:
 		aliases: the aliases
 		script: <gold>%s<reset>
 		scripts in folder: all scripts in <gold>%s<reset>
-		x scripts in folder: <gold>%2$s <reset>script¦¦s¦ in <gold>%1$s<reset>
+		x scripts in folder: <gold>%2$s <lime>script¦¦s¦ in <gold>%1$s<reset>
 		empty folder: <gold>%s<reset> does not contain any enabled scripts.
 	enable:
 		all:

--- a/src/main/resources/lang/french.lang
+++ b/src/main/resources/lang/french.lang
@@ -68,7 +68,7 @@ skript command:
 		aliases: les alias
 		script: <gold>%s<reset>
 		scripts in folder: tous les scripts dans <gold>%s<reset>
-		x scripts in folder: <gold>%2$s <reset>script¦¦s¦ dans <gold>%1$s<reset>
+		x scripts in folder: <gold>%2$s <lime>script¦¦s¦ dans <gold>%1$s<reset>
 		empty folder: <gold>%s<reset> ne contient aucun script activé.
 	enable:
 		all:

--- a/src/main/resources/lang/german.lang
+++ b/src/main/resources/lang/german.lang
@@ -47,7 +47,7 @@ skript command:
 		info: Druckt eine Nachricht mit Links zu den Aliases und der Dokumentation von Skript.
 		gen-docs: Generiert Dokumentation mithilfe von docs/templates im Plugin-Ordner
 		test: Wird zum Ausführen von Skript-Tests verwendet
-	
+
 	invalid script: Das Skript <grey>'<gold>%s<grey>'<red> konnte nicht gefunden werden.
 	invalid folder: Der Ordner <grey>'<gold>%s<grey>'<red> konnte nicht gefunden werden.
 	reload:
@@ -61,14 +61,14 @@ skript command:
 		error details: <light red>    %s<reset>\n
 		other details: <white>    %s<reset>\n
 		line details: <gold>    Linie: <gray>%s<reset>\n <reset>
-		
+
 		config, aliases and scripts: die Konfiguration, alle Itemnamen und alle Skripte
 		scripts: alle Skripte
 		main config: Konfiguration
 		aliases: die Itemnamen
 		script: <gold>%s<reset>
 		scripts in folder: alle Skripte in <gold>%s<reset>
-		x scripts in folder: <gold>%2$s <reset>Skript¦¦e¦ in <gold>%1$s<reset>
+		x scripts in folder: <gold>%2$s <lime>Skript¦¦e¦ in <gold>%1$s<reset>
 		empty folder: <gold>%s<reset> enthält keine aktivierten Skripte.
 	enable:
 		all:

--- a/src/main/resources/lang/japanese.lang
+++ b/src/main/resources/lang/japanese.lang
@@ -68,7 +68,7 @@ skript command:
 		aliases: エイリアス
 		script: <gold>%s<reset>
 		scripts in folder: <gold>%s<reset>フォルダ内の全てのスクリプト
-		x scripts in folder: <gold>%1$s<reset>フォルダ内の<gold>%2$s<reset>個のスクリプト
+		x scripts in folder: <gold>%1$s<lime>フォルダ内の<gold>%2$s<reset>個のスクリプト
 		empty folder: 有効化されたスクリプトが<gold>%s<reset>フォルダ内にありませんでした。
 	enable:
 		all:

--- a/src/main/resources/lang/korean.lang
+++ b/src/main/resources/lang/korean.lang
@@ -47,7 +47,7 @@ skript command:
 		info: Skript의 별명 및 문서에 대한 링크가있는 메시지를 표시합니다
 		gen-docs: 플러그인 폴더의 문서 템플릿을 사용하여 문서를 생성합니다.
 		test: Skript 테스트를 실행할 때 사용됩니다.
-		
+
 	invalid script: 스크립트 폴더에서 <grey>'<gold>%s<grey>'<red> 스크립트를 찾을 수 없습니다!
 	invalid folder: 스크립트 폴더에서 <grey>'<gold>%s<grey>'<red> 폴더를 찾을 수 없습니다!
 	reload:
@@ -68,7 +68,7 @@ skript command:
 		aliases: 별칭(aliases)
 		script: <gold>%s<reset>
 		scripts in folder: <gold>%s<reset>폴더 속 모든 스크립트
-		x scripts in folder: <gold>%1$s<reset> 폴더 속 <gold>%2$s<reset>개의 스크립트
+		x scripts in folder: <gold>%1$s<lime> 폴더 속 <gold>%2$s<reset>개의 스크립트
 		empty folder: <gold>%s<reset>에 활성화된 스크립트가 없습니다.
 	enable:
 		all:

--- a/src/main/resources/lang/polish.lang
+++ b/src/main/resources/lang/polish.lang
@@ -68,7 +68,7 @@ skript command:
 		aliases: aliasy
 		script: <gold>%s<reset>
 		scripts in folder: wszystkie skrypty w <gold>%s<reset>
-		x scripts in folder: <gold>%2$s <reset>skrypt¦¦ów¦ w <gold>%1$s<reset>
+		x scripts in folder: <gold>%2$s <lime>skrypt¦¦ów¦ w <gold>%1$s<reset>
 		empty folder: <gold>%s<reset> nie ma w sobie żadnych włączonych skryptów.
 	enable:
 		all:


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Fixes the colour being reset to white when reloading a number of scripts in a directory.

This appears to be safe since it's the only place this language entry is used, _however_ there might be another that didn't come up in my search.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #6136 <!-- Links to related issues -->
