### PR TITLE
Fix inventory renaming error.

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprNamed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNamed.java
@@ -69,12 +69,10 @@ public class ExprNamed extends PropertyExpression<Object, Object> {
 			setExpr(exprs[0]);
 		}
 		name = (Expression<String>) exprs[1];
-		check_type_okay:
 		if (getExpr() instanceof Literal) {
 			Literal<?> literal = (Literal<?>) getExpr();
 			Object object = literal.getSingle();
-			if (!(object instanceof InventoryType)) break check_type_okay;
-			if (!isCreatable((InventoryType) object)) {
+			if (object instanceof InventoryType && !isCreatable((InventoryType) object)) {
 				Skript.error(Utils.A(literal) + " cannot be created.");
 				return false;
 			}

--- a/src/main/java/ch/njol/skript/expressions/ExprNamed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNamed.java
@@ -75,7 +75,7 @@ public class ExprNamed extends PropertyExpression<Object, Object> {
 			Object object = literal.getSingle();
 			if (!(object instanceof InventoryType)) break check_type_okay;
 			if (!isCreatable((InventoryType) object)) {
-				Skript.error("You can't create a '" + literal + "' inventory. It's not creatable!");
+				Skript.error(Utils.A(literal) + " cannot be created.");
 				return false;
 			}
 		}

--- a/src/main/java/ch/njol/skript/expressions/ExprNamed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNamed.java
@@ -19,6 +19,7 @@
 package ch.njol.skript.expressions;
 
 import ch.njol.skript.lang.Literal;
+import ch.njol.skript.util.Utils;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.inventory.InventoryType;
@@ -73,7 +74,7 @@ public class ExprNamed extends PropertyExpression<Object, Object> {
 			Literal<?> literal = (Literal<?>) getExpr();
 			Object object = literal.getSingle();
 			if (object instanceof InventoryType && !isCreatable((InventoryType) object)) {
-				Skript.error(Utils.A(literal) + " cannot be created.");
+				Skript.error(Utils.A(literal.toString()) + " cannot be created.");
 				return false;
 			}
 		}
@@ -86,40 +87,41 @@ public class ExprNamed extends PropertyExpression<Object, Object> {
 		if (name == null)
 			return get(source, object -> {
 				if (object instanceof InventoryType) {
-					if (!isCreatable(((InventoryType) object)))
+					InventoryType type = (InventoryType) object;
+					if (!isCreatable(type))
 						return null;
-					return Bukkit.createInventory(null, (InventoryType) object);
+					return Bukkit.createInventory(null, type);
 				}
 				return object; // Return the same ItemType they passed without applying a name.
 			});
 		return get(source, new Getter<Object, Object>() {
-            @Override
-            @Nullable
-            public Object get(Object object) {
-                if (object instanceof InventoryType) {
-                    InventoryType type = (InventoryType) object;
-                    if (!isCreatable(type))
-                        return null;
-                    return Bukkit.createInventory(null, type, name);
-                }
-                if (object instanceof ItemStack) {
-                    ItemStack stack = (ItemStack) object;
-                    stack = stack.clone();
-                    ItemMeta meta = stack.getItemMeta();
-                    if (meta != null) {
-                        meta.setDisplayName(name);
-                        stack.setItemMeta(meta);
-                    }
-                    return new ItemType(stack);
-                }
-                ItemType item = (ItemType) object;
-                item = item.clone();
-                ItemMeta meta = item.getItemMeta();
-                meta.setDisplayName(name);
-                item.setItemMeta(meta);
-                return item;
-            }
-        });
+			@Override
+			@Nullable
+			public Object get(Object object) {
+				if (object instanceof InventoryType) {
+					InventoryType type = (InventoryType) object;
+					if (!isCreatable(type))
+						return null;
+					return Bukkit.createInventory(null, type, name);
+				}
+				if (object instanceof ItemStack) {
+					ItemStack stack = (ItemStack) object;
+					stack = stack.clone();
+					ItemMeta meta = stack.getItemMeta();
+					if (meta != null) {
+						meta.setDisplayName(name);
+						stack.setItemMeta(meta);
+					}
+					return new ItemType(stack);
+				}
+				ItemType item = (ItemType) object;
+				item = item.clone();
+				ItemMeta meta = item.getItemMeta();
+				meta.setDisplayName(name);
+				item.setItemMeta(meta);
+				return item;
+			}
+		});
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprNamed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNamed.java
@@ -87,8 +87,11 @@ public class ExprNamed extends PropertyExpression<Object, Object> {
 		String name = this.name.getSingle(event);
 		if (name == null)
 			return get(source, object -> {
-				if (object instanceof InventoryType && !isCreatable(((InventoryType) object)))
-					return null;
+				if (object instanceof InventoryType) {
+					if (!isCreatable(((InventoryType) object)))
+						return null;
+					return Bukkit.createInventory(null, (InventoryType) object);
+				}
 				return object; // Return the same ItemType they passed without applying a name.
 			});
 		return get(source, new Getter<Object, Object>() {
@@ -123,13 +126,13 @@ public class ExprNamed extends PropertyExpression<Object, Object> {
 	}
 	
 	@Override
-	public Class<? extends Object> getReturnType() {
+	public Class<?> getReturnType() {
 		Class<?> returnType = getExpr().getReturnType();
 		if (returnType == InventoryType.class)
 			return Inventory.class;
-		else if (returnType == Object.class)
-			return Object.class;
-		return ItemType.class;
+		else if (returnType == ItemStack.class || returnType == ItemType.class)
+			return ItemType.class;
+		return Object.class;
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprNamed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNamed.java
@@ -102,8 +102,7 @@ public class ExprNamed extends PropertyExpression<Object, Object> {
                     InventoryType type = (InventoryType) object;
                     if (!isCreatable(type))
                         return null;
-                    else
-                        return Bukkit.createInventory(null, (InventoryType) object, name);
+                    return Bukkit.createInventory(null, type, name);
                 }
                 if (object instanceof ItemStack) {
                     ItemStack stack = (ItemStack) object;

--- a/src/main/java/ch/njol/skript/expressions/ExprNamed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNamed.java
@@ -19,7 +19,6 @@
 package ch.njol.skript.expressions;
 
 import ch.njol.skript.lang.Literal;
-import ch.njol.skript.registrations.Classes;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.inventory.InventoryType;
@@ -64,7 +63,11 @@ public class ExprNamed extends PropertyExpression<Object, Object> {
 	@Override
 	@SuppressWarnings("unchecked")
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		setExpr(exprs[0]);
+		if (exprs[0].getReturnType().equals(ItemStack.class)) {
+			setExpr(exprs[0].getConvertedExpression(ItemType.class));
+		} else {
+			setExpr(exprs[0]);
+		}
 		name = (Expression<String>) exprs[1];
 		check_type_okay:
 		if (getExpr() instanceof Literal) {
@@ -121,7 +124,12 @@ public class ExprNamed extends PropertyExpression<Object, Object> {
 	
 	@Override
 	public Class<? extends Object> getReturnType() {
-		return getExpr().getReturnType() == InventoryType.class ? Inventory.class : ItemType.class;
+		Class<?> returnType = getExpr().getReturnType();
+		if (returnType == InventoryType.class)
+			return Inventory.class;
+		else if (returnType == Object.class)
+			return Object.class;
+		return ItemType.class;
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprNamed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNamed.java
@@ -130,7 +130,7 @@ public class ExprNamed extends PropertyExpression<Object, Object> {
 		Class<?> returnType = getExpr().getReturnType();
 		if (returnType == InventoryType.class)
 			return Inventory.class;
-		else if (returnType == ItemStack.class || returnType == ItemType.class)
+		if (returnType == ItemStack.class || returnType == ItemType.class)
 			return ItemType.class;
 		return Object.class;
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprNamed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNamed.java
@@ -144,8 +144,10 @@ public class ExprNamed extends PropertyExpression<Object, Object> {
 		// Spigot forgot to label some InventoryTypes as non-creatable in some versions < 1.19.4
 		// So this throws NullPointerException as well as an IllegalArgumentException.
 		// See https://hub.spigotmc.org/jira/browse/SPIGOT-7301
-		if (Skript.isRunningMinecraft(1, 14) && type == InventoryType.COMPOSTER) return false;
-		if (Skript.isRunningMinecraft(1, 20) && type == InventoryType.CHISELED_BOOKSHELF) return false;
+		if (Skript.isRunningMinecraft(1, 14) && type == InventoryType.COMPOSTER)
+			return false;
+		if (Skript.isRunningMinecraft(1, 20) && type == InventoryType.CHISELED_BOOKSHELF)
+			return false;
 		return type.isCreatable();
 	}
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprNamed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNamed.java
@@ -133,8 +133,8 @@ public class ExprNamed extends PropertyExpression<Object, Object> {
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return getExpr().toString(e, debug) + " named " + name;
+	public String toString(@Nullable Event event, boolean debug) {
+		return getExpr().toString(event, debug) + " named " + name;
 	}
 	
 	private boolean isCreatable(InventoryType type) {

--- a/src/test/skript/tests/regressions/5923-exprnamed-inventorytype-name-null.sk
+++ b/src/test/skript/tests/regressions/5923-exprnamed-inventorytype-name-null.sk
@@ -1,0 +1,7 @@
+test "inventory type ExprNamed name null" when running minecraft "1.14.4": # 1.13 makes the inventory name return "Shulker Box"
+	set {_inventory} to shulker box inventory named name of tool of random player out of all players
+	assert {_inventory} is set with "Failed to set new inventory to local variable"
+	assert name of {_inventory} is not set with "The name of the inventory was set"
+	clear {_inventory}
+	set {_inventory} to shulker box inventory named {_null}
+	assert name of {_inventory} is not set with "The name of the inventory was set (2)"

--- a/src/test/skript/tests/syntaxes/expressions/ExprNamed.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprNamed.sk
@@ -3,7 +3,7 @@ test "named":
 	assert name of {_i} is not set with "default item name failed: %name of {_i}%"
 	set {_i} to {_i} named "blob"
 	assert name of {_i} is "blob" with "item name failed: %name of {_i}%"
-	set {_inventory} to a barrel inventory
+	set {_inventory} to a hopper inventory
 	assert name of {_inventory} is not set with "default inventory name failed: %name of {_inventory}%"
-	set {_inventory} to a barrel inventory named "test"
+	set {_inventory} to a hopper inventory named "test"
 	assert {_inventory} is set with "inventory set failed" # we can't check inventory names any more

--- a/src/test/skript/tests/syntaxes/expressions/ExprNamed.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprNamed.sk
@@ -1,0 +1,9 @@
+test "named":
+	set {_i} to an iron sword
+	assert name of {_i} is not set with "default item name failed: %name of {_i}%"
+	set {_i} to {_i} named "blob"
+	assert name of {_i} is "blob" with "item name failed: %name of {_i}%"
+	set {_inventory} to a barrel inventory
+	assert name of {_inventory} is not set with "default inventory name failed: %name of {_inventory}%"
+	set {_inventory} to a barrel inventory named "test"
+	assert {_inventory} is set with "inventory set failed" # we can't check inventory names any more


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Prevents attempts at creating a non-creatable inventory type.
Also (actually) fixes an error when trying to rename inventory types.

A cherry pick of #5943 for patch branch with extra bugs fixed.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #5495 and #5923 <!-- Links to related issues -->
