### PR TITLE
add isNaN() function

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/DefaultFunctions.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultFunctions.java
@@ -541,6 +541,15 @@ public class DefaultFunctions {
 		}).description("Returns a offline player from their name or UUID. This function will still return the player if they're online.")
 			.examples("set {_p} to offlineplayer(\"Notch\")", "set {_p} to offlineplayer(\"069a79f4-44e9-4726-a5be-fca90e38aaf5\")")
 			.since("INSERT VERSION");
+
+		Functions.registerFunction(new SimpleJavaFunction<Boolean>("isNaN", numberParam, DefaultClasses.BOOLEAN, true) {
+			@Override
+			public Boolean[] executeSimple(Object[][] params) {
+				return new Boolean[] {Double.isNaN(((Number) params[0][0]).doubleValue())};
+			}
+		}).description("Returns true if the input is NaN (not a number).")
+			.examples("isNaN(0) # false", "isNaN(0/0) # true", "isNaN(sqrt(-1)) # true")
+			.since("INSERT VERSION");
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprSpecialNumber.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSpecialNumber.java
@@ -33,7 +33,7 @@ import org.eclipse.jdt.annotation.Nullable;
 
 @Name("Special Number")
 @Description("Special number values, namely NaN, Infinity and -Infinity")
-@Examples({"if {_number} is NaN value:"})
+@Examples({"if {_number} is infinity value:"})
 @Since("2.2-dev32d")
 public class ExprSpecialNumber extends SimpleExpression<Number> {
 	private int value;

--- a/src/test/skript/tests/syntaxes/functions/isNaN.sk
+++ b/src/test/skript/tests/syntaxes/functions/isNaN.sk
@@ -1,0 +1,7 @@
+test "is NaN function":
+	assert isNaN(0) is false with "0 should not be NaN"
+	assert isNaN(NaN value) is true with "NaN should be NaN"
+	assert isNaN(infinity value) is false with "Infinity should not be NaN"
+	assert isNaN(0/0) is true with "0/0 should be NaN"
+	assert isNaN(sqrt(2)) is false with "sqrt(2) should not be NaN"
+	assert isNaN(sqrt(-2)) is true with "sqrt(-2) should be NaN"


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Adds a function to check if a value is NaN, so you don't have to go through the hassle of checking if it's not equal to itself.
Also replaces a very misleading example in ExprSpecialNumber.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
