### PR TITLE
Prevent InventoryHolder -> X chaining

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/DefaultConverters.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultConverters.java
@@ -158,14 +158,14 @@ public class DefaultConverters {
 			if (holder instanceof DoubleChest)
 				return holder.getInventory().getLocation().getBlock();
 			return null;
-		}, Converter.NO_LEFT_CHAINING | Converter.NO_RIGHT_CHAINING);
+		}, Converter.NO_CHAINING);
 
 		// InventoryHolder - Entity
 		Converters.registerConverter(InventoryHolder.class, Entity.class, holder -> {
 			if (holder instanceof Entity)
 				return (Entity) holder;
 			return null;
-		}, Converter.NO_LEFT_CHAINING | Converter.NO_RIGHT_CHAINING);
+		}, Converter.NO_CHAINING);
 		
 		// Enchantment - EnchantmentType
 		Converters.registerConverter(Enchantment.class, EnchantmentType.class, e -> new EnchantmentType(e, -1));

--- a/src/main/java/ch/njol/skript/classes/data/DefaultConverters.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultConverters.java
@@ -158,14 +158,14 @@ public class DefaultConverters {
 			if (holder instanceof DoubleChest)
 				return holder.getInventory().getLocation().getBlock();
 			return null;
-		});
+		}, Converter.NO_LEFT_CHAINING | Converter.NO_RIGHT_CHAINING);
 
 		// InventoryHolder - Entity
 		Converters.registerConverter(InventoryHolder.class, Entity.class, holder -> {
 			if (holder instanceof Entity)
 				return (Entity) holder;
 			return null;
-		});
+		}, Converter.NO_LEFT_CHAINING | Converter.NO_RIGHT_CHAINING);
 		
 		// Enchantment - EnchantmentType
 		Converters.registerConverter(Enchantment.class, EnchantmentType.class, e -> new EnchantmentType(e, -1));


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Prevents both left and right chaining on the InventoryHolder -> X converters.
Left because it could lead to converters like `(Entity -> Player, InventoryHolder -> Block)` which is fundamentally flawed. This issue caused #5755 and #5830.
Right because converters like `(InventoryHolder -> Entity -> Location)` are unreliable as Inventory holder could be a Block, resulting in a null value halfway through the converter.

I believe this to be a non-breaking change based on a pretty significant amount of testing, but I would appreciate second checks.

Considering making all default nullable converters unable to right chain, as the following converters rely on the first converter to have an accurate conversion, which it may not. However, this is a breaking change in at least one aspect, as it would break ambiguous syntaxes like `open sender to player`, which currently work if the sender is a player. Something to consider for the future.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** fixes #5755 and fixes #5830<!-- Links to related issues -->
