### PR TITLE
Ensure EvtGrow Junit test always grows the plants/trees

### DIFF
--- a/src/test/java/org/skriptlang/skript/test/tests/syntaxes/EvtGrowTest.java
+++ b/src/test/java/org/skriptlang/skript/test/tests/syntaxes/EvtGrowTest.java
@@ -23,6 +23,7 @@ import ch.njol.skript.test.runner.SkriptJUnitTest;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.Ageable;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -48,9 +49,18 @@ public class EvtGrowTest extends SkriptJUnitTest {
 	@Test
 	public void testGrow() {
 		if (canRun) {
-			for (int i = 0; i < 10; i++) {
+			int maxIterations = 100;
+			int iterations = 0;
+			while (((Ageable) plant.getBlockData()).getAge() != ((Ageable) plant.getBlockData()).getMaximumAge()) {
 				plant.applyBoneMeal(BlockFace.UP);
+				if (iterations++ > maxIterations)
+					return;
+			}
+			iterations = 0;
+			while (birch.getType() == Material.BIRCH_SAPLING) {
 				birch.applyBoneMeal(BlockFace.UP);
+				if (iterations++ > maxIterations)
+					return;
 			}
 		}
 	}


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

The JUnit test now bone meals the plants until they're grown, or it hits 100 attempts. This should help avoid test failures when the tree/wheat didn't grow (there was about a 0.5% chance the tree wouldn't grow with 10 bone meals).

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
