### PR TITLE
Dynamic Functions

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.Locale;
 import java.util.regex.Pattern;
 
+import ch.njol.skript.lang.function.Function;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
@@ -753,6 +754,39 @@ public class SkriptClasses {
 				.since("2.5")
 				.serializer(new YggdrasilSerializer<GameruleValue>())
 		);
+		
+		Classes.registerClass(new ClassInfo<>(Function.class, "function")
+			.user("functions?")
+			.name("Function")
+			.description("Represents a Skript function")
+			.examples(
+				"set {_func} to function named \"sum\"",
+				"set {_func} to function named \"foo\" in script \"bar\""
+			)
+			.since("INSERT VERSION")
+			.parser(new Parser<Function>() {
+				@Override
+				@Nullable
+				public Function parse(String s, ParseContext context) {
+					return null;
+				}
+
+				@Override
+				public boolean canParse(ParseContext context) {
+					return false;
+				}
+
+				@Override
+                public String toString(Function function, int flags) {
+                    return function.toString();
+                }
+
+                @Override
+                public String toVariableNameString(Function function) {
+                    return "function:" + function.getName() + "," + function.getSignature().isLocal();
+                }
+            })
+		);
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/effects/EffExecuteFunction.java
+++ b/src/main/java/ch/njol/skript/effects/EffExecuteFunction.java
@@ -1,0 +1,72 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.function.Function;
+import ch.njol.skript.util.LiteralUtils;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+@Name("Execute Function")
+@Description("Executes a function with the given parameters.")
+@Examples("run function \"rotate_%{_direction}%\" with {_structure-name}")
+@Since("INSERT VERSION")
+public class EffExecuteFunction extends Effect {
+
+	static {
+		Skript.registerEffect(EffExecuteFunction.class,
+				"(call|execute|run) %functions% [(using|with) [[the] (argument|parameter)[s]] %-objects%]");
+	}
+
+	private Expression<Function<?>> functions;
+	@Nullable
+	private Expression<?> arguments;
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		functions = (Expression<Function<?>>) exprs[0];
+		if (exprs[1] == null)
+			return true;
+		arguments = LiteralUtils.defendExpression(exprs[1]);
+		return true;
+	}
+
+	@Override
+	protected void execute(Event event) {
+		for (Function<?> function : functions.getArray(event))
+			function.execute(event, arguments);
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "execute " + functions.toString(event, debug) +
+				(arguments == null ? "" : " with the arguments " + arguments.toString(event, debug));
+	}
+
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprFunction.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFunction.java
@@ -1,0 +1,96 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.function.Function;
+import ch.njol.skript.lang.function.Functions;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+@Name("Function")
+@Description("Returns a the function with the provided name")
+@Examples("run (function \"foo\" from \"bar.sk\")")
+@Since("INSERT VERSION")
+public class ExprFunction extends SimpleExpression<Function> {
+
+	static {
+		Skript.registerExpression(ExprFunction.class, Function.class, ExpressionType.COMBINED,
+				"[the] [:global] function[s] [named] %strings% [(in|from) [script] [file] %-string%]");
+	}
+
+	private Expression<String> names;
+	@Nullable
+	private Expression<String> script;
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		names = (Expression<String>) exprs[0];
+        script = (Expression<String>) exprs[1];
+		if (script != null && parseResult.hasTag("global")) {
+			Skript.error("A global function cannot be referenced from a specific script");
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	@Nullable
+	protected Function<?>[] get(Event event) {
+		String script = this.script == null ? null : this.script.getOptionalSingle(event)
+			.map(ExprFunction::formatScript)
+			.orElse(null);
+		return names.stream(event)
+			.map(name -> Functions.getFunction(name, script))
+			.toArray(Function[]::new);
+	}
+
+	@Override
+	public boolean isSingle() {
+		return names.isSingle();
+	}
+
+	@Override
+	public Class<? extends Function> getReturnType() {
+		return Function.class;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "the function" + (isSingle() ? " " : "s ") + names.toString(event, debug) +
+				(script != null ? " from script " + script.toString(event, debug) : "");
+	}
+
+	private static String formatScript(String script) {
+		if (!script.endsWith(".sk")) script += ".sk";
+		script = script.replace('/', '\\');
+		return script.charAt(0) == '\\' ? script.substring(1) : script;
+	}
+	
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprFunctionResult.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFunctionResult.java
@@ -1,0 +1,90 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.function.Function;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.skript.util.LiteralUtils;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+@Name("Function Result")
+@Description("Returns the result of executing a function with the given arguments.")
+@Examples("broadcast result of function {_function} with {_foo} and {_bar}")
+@Since("INSERT VERSION")
+public class ExprFunctionResult extends SimpleExpression<Object> {
+
+	static {
+		Skript.registerExpression(ExprFunctionResult.class, Object.class, ExpressionType.PATTERN_MATCHES_EVERYTHING,
+				"[the] [call|execution] result of %functions% [(using|with) [[the] (argument|parameter)[s]] %-objects%]");
+	}
+
+	private Expression<Function<?>> functions;
+	@Nullable
+	private Expression<?> arguments;
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		functions = (Expression<Function<?>>) exprs[0];
+		if (exprs[1] == null)
+			return true;
+		arguments = LiteralUtils.defendExpression(exprs[1]);
+		return true;
+	}
+
+	@Override
+	@Nullable
+	protected Object[] get(Event event) {
+		return functions.stream(event)
+			.map(function -> function.execute(event, arguments))
+			.filter(Objects::nonNull)
+			.flatMap(Arrays::stream)
+			.toArray();
+	}
+
+	@Override
+	public boolean isSingle() {
+		return false;
+	}
+
+	@Override
+	public Class<?> getReturnType() {
+		return Object.class;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "the result of " + functions.toString(event, debug) +
+				(arguments == null ? "" : " with the arguments " + arguments.toString(event, debug));
+	}
+
+}

--- a/src/main/java/ch/njol/skript/lang/function/FunctionReference.java
+++ b/src/main/java/ch/njol/skript/lang/function/FunctionReference.java
@@ -27,16 +27,11 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.log.RetainingLogHandler;
 import ch.njol.skript.log.SkriptLogger;
-import ch.njol.skript.registrations.Classes;
 import org.skriptlang.skript.lang.converter.Converters;
 import ch.njol.skript.util.LiteralUtils;
 import ch.njol.util.StringUtils;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * Reference to a Skript function.
@@ -263,8 +258,7 @@ public class FunctionReference<T> {
 	}
 
 	@SuppressWarnings("unchecked")
-	@Nullable
-	protected T[] execute(Event e) {
+	protected T @Nullable [] execute(Event e) {
 		// If needed, acquire the function reference
 		if (function == null)
 			function = (Function<? extends T>) Functions.getFunction(functionName, script);
@@ -273,32 +267,9 @@ public class FunctionReference<T> {
 			Skript.error("Couldn't resolve call for '" + functionName + "'.");
 			return null; // Return nothing and hope it works
 		}
-		
-		// Prepare parameter values for calling
-		Object[][] params = new Object[singleListParam ? 1 : parameters.length][];
-		if (singleListParam && parameters.length > 1) { // All parameters to one list
-			List<Object> l = new ArrayList<>();
-			for (Expression<?> parameter : parameters)
-				l.addAll(Arrays.asList(parameter.getArray(e)));
-			params[0] = l.toArray();
-			
-			// Don't allow mutating across function boundary; same hack is applied to variables
-			for (int i = 0; i < params[0].length; i++) {
-				params[0][i] = Classes.clone(params[0][i]);
-			}
-		} else { // Use parameters in normal way
-			for (int i = 0; i < parameters.length; i++) {
-				Object[] array = parameters[i].getArray(e);
-				params[i] = Arrays.copyOf(array, array.length);
-				// Don't allow mutating across function boundary; same hack is applied to variables
-				for (int j = 0; j < params[i].length; j++) {
-					params[i][j] = Classes.clone(params[i][j]);
-				}
-			}
-		}
-		
+
 		// Execute the function
-		return function.execute(params);
+		return function.execute(e, parameters);
 	}
 	
 	public boolean isSingle() {


### PR DESCRIPTION
### Description
This PR adds the long-awaited feature to Skript, dynamic functions! Functions are now objects that can be dealt with inside scripts with the new `function` type. To get a function object, you use the `ExprFunction` expression.
Example:
```vb
set {_func} to function "sum"
```
You can even get local functions from other scripts, like so:
```vb
set {_func} to function "foo" in script "hello"
```

Using these objects you can execute or get the result of a function's execution dynamically, like so:
```vb
set {_func} to function "product"
set {_result} to execution result of {_func} with arguments 3, 4 and 5
broadcast {_result} # 60
```

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #1265
