### PR TITLE
Remove final on 'cleanup' method and provide JUnit implementation warnings.

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -82,6 +82,7 @@ import ch.njol.util.Closeable;
 import ch.njol.util.Kleenean;
 import ch.njol.util.NullableChecker;
 import ch.njol.util.StringUtils;
+import ch.njol.util.coll.CollectionUtils;
 import ch.njol.util.coll.iterator.CheckedIterator;
 import ch.njol.util.coll.iterator.EnumerationIterable;
 import com.google.common.collect.Lists;
@@ -106,6 +107,7 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.eclipse.jdt.annotation.Nullable;
+import org.junit.After;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 import org.skriptlang.skript.lang.comparator.Comparator;
@@ -147,7 +149,6 @@ import java.util.logging.Filter;
 import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
@@ -702,6 +703,25 @@ public final class Skript extends JavaPlugin implements Listener {
 										info("Running JUnit test '" + test + "'");
 										Result junit = JUnitCore.runClasses(clazz);
 										TestTracker.testStarted("JUnit: '" + test + "'");
+
+										/**
+										 * Usage of @After is pointless if the JUnit class requires delay. As the @After will happen instantly.
+										 * The JUnit must override the 'cleanup' method to avoid Skript automatically cleaning up the test data.
+										 */
+										boolean overrides = false;
+										for (Method method : clazz.getDeclaredMethods()) {
+											if (!method.isAnnotationPresent(After.class))
+												continue;
+											SuppressWarnings suppressWarning = method.getAnnotation(SuppressWarnings.class);
+											if (suppressWarning != null && CollectionUtils.contains(suppressWarning.value(), "after"))
+												continue;
+											warning("Using @After in JUnit classes, happens instantaneously. Either add '@SuppressWarnings(\"after\")' to acknowledge this or do your test cleanup in the script junit file.");
+											if (method.getName().equals("cleanup"))
+												overrides = true;
+										}
+										if (SkriptJUnitTest.getShutdownDelay() > 1 && !overrides)
+											error("The JUnit class '" + test + "' does not override the method 'cleanup' thus the test data will instantly be cleaned up. " +
+													"This JUnit test requires longer shutdown time: " + SkriptJUnitTest.getShutdownDelay());
 
 										// Collect all data from the current JUnit test.
 										shutdownDelay = Math.max(shutdownDelay, SkriptJUnitTest.getShutdownDelay());

--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -712,10 +712,8 @@ public final class Skript extends JavaPlugin implements Listener {
 										for (Method method : clazz.getDeclaredMethods()) {
 											if (!method.isAnnotationPresent(After.class))
 												continue;
-											SuppressWarnings suppressWarning = method.getAnnotation(SuppressWarnings.class);
-											if (suppressWarning != null && CollectionUtils.contains(suppressWarning.value(), "after"))
-												continue;
-											warning("Using @After in JUnit classes, happens instantaneously. Either add '@SuppressWarnings(\"after\")' to acknowledge this or do your test cleanup in the script junit file.");
+											if (SkriptJUnitTest.getShutdownDelay() > 1)
+												warning("Using @After in JUnit classes, happens instantaneously, and JUnit class '" + test + "' requires a delay. Do your test cleanup in the script junit file or 'cleanup' method.");
 											if (method.getName().equals("cleanup"))
 												overrides = true;
 										}

--- a/src/main/java/ch/njol/skript/test/runner/SkriptJUnitTest.java
+++ b/src/main/java/ch/njol/skript/test/runner/SkriptJUnitTest.java
@@ -76,9 +76,12 @@ public abstract class SkriptJUnitTest {
 		SkriptJUnitTest.delay = delay;
 	}
 
+	/**
+	 * Override this method if your JUnit test requires block modification with delay over 1 tick.
+	 */
 	@Before
 	@After
-	public final void cleanup() {
+	public void cleanup() {
 		getTestWorld().getEntities().forEach(Entity::remove);
 		setBlock(Material.AIR);
 	}


### PR DESCRIPTION
### Description
Removes the final modifier on the 'cleanup' method, because this method will automatically cleanup all test data instantly, as JUnit runs instantly, and Skript itself will collect the results after the defined amount of shutdown time in ticks.

If a test is to be delayed, it needs to override the 'cleanup' method and do nothing in the method because the cleanup will happen at a later time in the junit script file code.

Added warnings to explain that if the test is delayed it needs to override the 'cleanup' method and do the cleanup itself.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
