### PR TITLE
Fix 'any sword' represents multiple types error

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -917,19 +917,16 @@ public class BukkitClasses {
 				.parser(new Parser<ItemStack>() {
 					@Override
 					@Nullable
-					public ItemStack parse(final String s, final ParseContext context) {
-						ItemType t = Aliases.parseItemType(s);
-						if (t == null)
+					public ItemStack parse(String string, ParseContext context) {
+						ItemType itemType = Aliases.parseItemType(string);
+						if (itemType == null)
 							return null;
-						t = t.getItem();
-						if (t.numTypes() != 1) {
-							Skript.error("'" + s + "' represents multiple materials");
+						itemType = itemType.getItem();
+						if (itemType.isAll() && itemType.numItems() > 1) {
+							Skript.error("'" + string + "' represents multiple materials");
 							return null;
 						}
-						
-						final ItemStack i = t.getRandom();
-						assert i != null;
-						return i;
+						return itemType.getRandom();
 					}
 					
 					@Override

--- a/src/test/skript/tests/regressions/6263-any aliases reference multiple itemtypes.sk
+++ b/src/test/skript/tests/regressions/6263-any aliases reference multiple itemtypes.sk
@@ -1,4 +1,4 @@
-test "itemstack aliases comparisons":
+test "any aliases reference multiple itemtypes":
 	assert stone sword is any sword with "stone sword is not any sword"
 	assert stone sword is every sword to fail with "stone sword is every sword"
 	assert any sword is any sword with "any sword is not any sword"

--- a/src/test/skript/tests/regressions/6263-any aliases reference multiple itemtypes.sk
+++ b/src/test/skript/tests/regressions/6263-any aliases reference multiple itemtypes.sk
@@ -1,0 +1,5 @@
+test "itemstack aliases comparisons":
+	assert stone sword is any sword with "stone sword is not any sword"
+	assert stone sword is every sword to fail with "stone sword is every sword"
+	assert any sword is any sword with "any sword is not any sword"
+	assert every sword is every sword to fail with "every sword is every sword"


### PR DESCRIPTION
### Description
This PR aims to fix the `if player's tool is any sword` comparison no longer working as intended due to a change somewhere in #5815. I am targeting dev/feature if this is incorrect please tell me I'll spend the 10 hours to fix it.

From what I've been able to tell this should of been caused by ItemStack parser not properly checking for `ItemType#isAll` I've now add a check for it as well removed some finals within the method.

While Pickle wasn't able to replicate it my guess is a change that was needed happened and brought to light this comparison issue.

Screenshot of it working in action, ignore the broadcast, this was a build with my debug messages
![image](https://github.com/SkriptLang/Skript/assets/81952476/01bbeb69-359c-464e-a120-b61f8bf3fe6f)


---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none
**Related Issues:** #6251
