### PR TITLE
Add warnings for using %player% without using the UUID config setting.

### DIFF
--- a/src/main/java/ch/njol/skript/lang/VariableString.java
+++ b/src/main/java/ch/njol/skript/lang/VariableString.java
@@ -42,6 +42,7 @@ import ch.njol.util.StringUtils;
 import ch.njol.util.coll.CollectionUtils;
 import ch.njol.util.coll.iterator.SingleItemIterator;
 import com.google.common.collect.Lists;
+import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;

--- a/src/main/java/ch/njol/skript/lang/VariableString.java
+++ b/src/main/java/ch/njol/skript/lang/VariableString.java
@@ -43,7 +43,7 @@ import ch.njol.util.coll.CollectionUtils;
 import ch.njol.util.coll.iterator.SingleItemIterator;
 import com.google.common.collect.Lists;
 import org.bukkit.ChatColor;
-import org.bukkit.entity.Player;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 import org.jetbrains.annotations.NotNull;
@@ -229,7 +229,7 @@ public class VariableString implements Expression<String> {
 							log.printErrors("Can't understand this expression: " + s.substring(c + 1, c2));
 							return null;
 						} else {
-							if (!SkriptConfig.usePlayerUUIDsInVariableNames.value() && expr.getReturnType() == Player.class) {
+							if (!SkriptConfig.usePlayerUUIDsInVariableNames.value() && OfflinePlayer.class.isAssignableFrom(expr.getReturnType())) {
 								Skript.warning(
 										"In the future, players in variable names will use the player's UUID instead of their name. " +
 										"For information on how to make sure your scripts won't be impacted by this change, see https://github.com/SkriptLang/Skript/discussions/6270."

--- a/src/main/java/ch/njol/skript/lang/VariableString.java
+++ b/src/main/java/ch/njol/skript/lang/VariableString.java
@@ -18,21 +18,8 @@
  */
 package ch.njol.skript.lang;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.bukkit.ChatColor;
-import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
-import org.jetbrains.annotations.NotNull;
-import org.skriptlang.skript.lang.script.Script;
-
-import com.google.common.collect.Lists;
-
 import ch.njol.skript.Skript;
+import ch.njol.skript.SkriptConfig;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.expressions.ExprColoured;
@@ -54,6 +41,18 @@ import ch.njol.util.Kleenean;
 import ch.njol.util.StringUtils;
 import ch.njol.util.coll.CollectionUtils;
 import ch.njol.util.coll.iterator.SingleItemIterator;
+import com.google.common.collect.Lists;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.skriptlang.skript.lang.script.Script;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Represents a string that may contain expressions, and is thus "variable".
@@ -229,6 +228,12 @@ public class VariableString implements Expression<String> {
 							log.printErrors("Can't understand this expression: " + s.substring(c + 1, c2));
 							return null;
 						} else {
+							if (!SkriptConfig.usePlayerUUIDsInVariableNames.value() && expr.getReturnType() == Player.class) {
+								Skript.warning(
+										"In the future, players in variable names will use the player's UUID instead of their name. " +
+										"For information on how to make sure your scripts won't be impacted by this change, see https://github.com/SkriptLang/Skript/discussions/6270."
+								);
+							}
 							string.add(expr);
 						}
 						log.printLog();


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

As a precursor to #5676, we need to add warnings to users to warn them of the incoming changes. This PR adds a warning whenever an expression with a `Player` return type is used in a VariableString, if the `use UUIDs in variable names` config option is false.

It directs users to https://github.com/SkriptLang/Skript/discussions/6270 to learn more about how to address the warning.

Ideally, this prompts players to switch to UUIDs through the config, but forcing them to use `player's name` is also an acceptable outcome. 

Critique on the warning's content and the explanatory discussion post is welcome.

![image](https://github.com/SkriptLang/Skript/assets/10354869/5ebe5a32-fbde-4bf4-99d7-1cf85e020e58)


---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #5676 <!-- Links to related issues -->
