### PR TITLE
Fix Command Parsing

### DIFF
--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -115,7 +115,7 @@ public class SkriptParser {
 		this(expr, other.flags, other.context);
 	}
 
-	public static final String WILDCARD = "[^\"]*?(?:\"[^\"]*?\"[^\"])*?";
+	public static final String WILDCARD = "[^\"]*?(?:\"[^\"]*?\"[^\"]*?)*?";
 
 	public static class ParseResult {
 		public Expression<?>[] exprs;

--- a/src/test/skript/tests/syntaxes/structures/StructCommand.sk
+++ b/src/test/skript/tests/syntaxes/structures/StructCommand.sk
@@ -19,3 +19,8 @@ command //somecommand [<text>]:
 		set {_arg1} to arg-1
 		if {_arg1} is set:
 			assert {_arg1} is "burrito is tasty" with "arg-1 is 'burrito is tasty' test failed (got '%{_arg1}%')"
+
+# see https://github.com/SkriptLang/Skript/pull/6286
+command /commandtest <string="player">:
+	trigger:
+		stop


### PR DESCRIPTION
### Description
This PR fixes an issue that can occur with command parsing. #6000 made changes to the WILDCARD pattern. Reverting those changes resolved the issue.

Here is an example of the error:
![image](https://github.com/SkriptLang/Skript/assets/29044720/e428d72c-1336-41a2-ad75-e7d5c34461bb)
(thanks @ShaneBeee)

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
