### PR TITLE
Fix Erroneous Player UUID Warnings

### DIFF
--- a/src/main/java/ch/njol/skript/lang/VariableString.java
+++ b/src/main/java/ch/njol/skript/lang/VariableString.java
@@ -224,7 +224,11 @@ public class VariableString implements Expression<String> {
 							log.printErrors("Can't understand this expression: " + original.substring(exprStart + 1, exprEnd));
 							return null;
 						} else {
-							if (!SkriptConfig.usePlayerUUIDsInVariableNames.value() && OfflinePlayer.class.isAssignableFrom(expr.getReturnType())) {
+							if (
+								mode == StringMode.VARIABLE_NAME &&
+								!SkriptConfig.usePlayerUUIDsInVariableNames.value() &&
+								OfflinePlayer.class.isAssignableFrom(expr.getReturnType())
+							) {
 								Skript.warning(
 										"In the future, players in variable names will use the player's UUID instead of their name. " +
 										"For information on how to make sure your scripts won't be impacted by this change, see https://github.com/SkriptLang/Skript/discussions/6270."


### PR DESCRIPTION
### Description
This PR fixes an issue with the warning introduced in #6271 where it would print for all usages of a player-returning expression. I have updated the check to ensure it is actually a variable being parsed.

Below is an example of the issue:
![image](https://github.com/SkriptLang/Skript/assets/29044720/2f4b1f22-b2fa-409a-b31a-ddef1d71912d)
(photo credit @ShaneBeee)

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
