### PR TITLE
Fix event data pollution for event priority

### DIFF
--- a/src/main/java/ch/njol/skript/structures/StructEvent.java
+++ b/src/main/java/ch/njol/skript/structures/StructEvent.java
@@ -46,11 +46,18 @@ public class StructEvent extends Structure {
 	@SuppressWarnings("ConstantConditions")
 	public boolean init(Literal<?>[] args, int matchedPattern, ParseResult parseResult, EntryContainer entryContainer) {
 		String expr = parseResult.regexes.get(0).group();
+
 		EventData data = getParser().getData(EventData.class);
-		data.priority = null;
+		// ensure there's no leftover data from previous parses
+		data.clear();
+
 		if (!parseResult.tags.isEmpty())
 			data.priority = EventPriority.valueOf(parseResult.tags.get(0).toUpperCase(Locale.ENGLISH));
+
 		event = SkriptEvent.parse(expr, entryContainer.getSource(), null);
+
+		// cleanup after ourselves
+		data.clear();
 		return event != null;
 	}
 
@@ -112,6 +119,13 @@ public class StructEvent extends Structure {
 		@Nullable
 		public EventPriority getPriority() {
 			return priority;
+		}
+
+		/**
+		 * Clears all event-specific data from this instance.
+		 */
+		public void clear() {
+			priority = null;
 		}
 
 	}

--- a/src/main/java/ch/njol/skript/structures/StructEvent.java
+++ b/src/main/java/ch/njol/skript/structures/StructEvent.java
@@ -46,8 +46,10 @@ public class StructEvent extends Structure {
 	@SuppressWarnings("ConstantConditions")
 	public boolean init(Literal<?>[] args, int matchedPattern, ParseResult parseResult, EntryContainer entryContainer) {
 		String expr = parseResult.regexes.get(0).group();
+		EventData data = getParser().getData(EventData.class);
+		data.priority = null;
 		if (!parseResult.tags.isEmpty())
-			getParser().getData(EventData.class).priority = EventPriority.valueOf(parseResult.tags.get(0).toUpperCase(Locale.ENGLISH));
+			data.priority = EventPriority.valueOf(parseResult.tags.get(0).toUpperCase(Locale.ENGLISH));
 		event = SkriptEvent.parse(expr, entryContainer.getSource(), null);
 		return event != null;
 	}

--- a/src/test/skript/tests/regressions/6288-event data priority pollution.sk
+++ b/src/test/skript/tests/regressions/6288-event data priority pollution.sk
@@ -1,0 +1,5 @@
+on join with priority lowest:
+    stop
+
+every 10 seconds:
+    stop


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Sets priority to null if not specified. Fixes #6288 

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #6288 <!-- Links to related issues -->
