### PR TITLE
Fixes IllegalArgumentException when trying to get shoes of entity

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprArmorSlot.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprArmorSlot.java
@@ -18,15 +18,6 @@
  */
 package ch.njol.skript.expressions;
 
-import java.util.Arrays;
-import java.util.Locale;
-import java.util.stream.Stream;
-
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.event.Event;
-import org.bukkit.inventory.EntityEquipment;
-import org.eclipse.jdt.annotation.Nullable;
-
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Keywords;
@@ -39,6 +30,14 @@ import ch.njol.skript.util.slot.EquipmentSlot;
 import ch.njol.skript.util.slot.EquipmentSlot.EquipSlot;
 import ch.njol.skript.util.slot.Slot;
 import ch.njol.util.Kleenean;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.Event;
+import org.bukkit.inventory.EntityEquipment;
+import org.eclipse.jdt.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.stream.Stream;
 
 @Name("Armour Slot")
 @Description("Equipment of living entities, i.e. the boots, leggings, chestplate or helmet.")
@@ -51,7 +50,7 @@ import ch.njol.util.Kleenean;
 public class ExprArmorSlot extends PropertyExpression<LivingEntity, Slot> {
 
 	static {
-		register(ExprArmorSlot.class, Slot.class, "((:boots|:shoes|leggings:leg[ging]s|chestplate:chestplate[s]|helmet:helmet[s]) [(item|:slot)]|armour:armo[u]r[s])", "livingentities");
+		register(ExprArmorSlot.class, Slot.class, "((boots:(boots|shoes)|leggings:leg[ging]s|chestplate:chestplate[s]|helmet:helmet[s]) [(item|:slot)]|armour:armo[u]r[s])", "livingentities");
 	}
 
 	@Nullable

--- a/src/test/skript/tests/regressions/6237-equip slot shoes exception.sk
+++ b/src/test/skript/tests/regressions/6237-equip slot shoes exception.sk
@@ -1,0 +1,10 @@
+test "equip slot shoes exception":
+	# this one threw an exception since EquipSlot.SHOES doesn't exist
+	set {_} to shoes of {_entity}
+	# just in case, test the rest
+	set {_} to boots of {_entity}
+	set {_} to leggings of {_entity}
+	set {_} to chestplate of {_entity}
+	set {_} to helmet of {_entity}
+	set {_armor::*} to armour of {_entity}
+


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Changes the parse tags of ExprArmor to avoid trying to get `EquipSlot.SHOES`, which doesn't exist and throws an exception. Instead uses `boots` as the parse tag for "shoes".

Adds a regression test to ensure it gets caught if something similar happens in the future.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** Fixes #6273 <!-- Links to related issues -->
