### PR TITLE
Fix duplicate calls of certain click events

### DIFF
--- a/src/main/java/ch/njol/skript/events/EvtClick.java
+++ b/src/main/java/ch/njol/skript/events/EvtClick.java
@@ -57,11 +57,6 @@ public class EvtClick extends SkriptEvent {
 	 */
 	public static final ClickEventTracker interactTracker = new ClickEventTracker(Skript.getInstance());
 
-	/**
-	 * Tracks PlayerInteractEntityEvents to deduplicate them.
-	 */
-	private static final ClickEventTracker entityInteractTracker = new ClickEventTracker(Skript.getInstance());
-
 	static {
 		Class<? extends PlayerEvent>[] eventTypes = CollectionUtils.array(
 			PlayerInteractEvent.class, PlayerInteractEntityEvent.class, PlayerInteractAtEntityEvent.class
@@ -147,7 +142,7 @@ public class EvtClick extends SkriptEvent {
 			
 			// PlayerInteractAtEntityEvent called only once for armor stands
 			if (!(event instanceof PlayerInteractAtEntityEvent)) {
-				if (!entityInteractTracker.checkEvent(clickEvent.getPlayer(), clickEvent, clickEvent.getHand())) {
+				if (!interactTracker.checkEvent(clickEvent.getPlayer(), clickEvent, clickEvent.getHand())) {
 					return false; // Not first event this tick
 				}
 			}


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Fixes a bug where right clicking on an entity can fire a right click event twice.

When you right click on an entity with no block in reach, a PlayerInteractEntityEvent is called like normal
However, a PlayerInteractEvent is also called, with the type of RIGHT_CLICK_AIR.
(This is also the case if there's a block in reach, but the SkriptEventHandler filters out non-air clicks with a useItemInHand value of DENY. air clicks ALWAYS have useItemInHand value of DENY for, like, non-usable items. So those aren't an issue). This causes the following:
```applescript
on right click: # fires twice
on right click with <item>: # fires twice
on right click on player: # fires once
on right click on air: # fires once
```

The solution chosen is to combine the PIEE and PIE trackers, so we can only have one event of either type per tick from a player. This solves the issue, but is a breaking change (on right click on air no longer fires when clicking on an entity). Personally, I think this is acceptable, the behavior is technically a bug. The behavior now becomes the following:
```applescript
on right click: # fires once
on right click with <item>: # fires once
on right click on player: # fires once
on right click on air: # doesn't fire
```

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #6460 <!-- Links to related issues -->
