### PR TITLE
Force "to location" in ExprLocationFromVector

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprLocationFromVector.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLocationFromVector.java
@@ -49,7 +49,7 @@ public class ExprLocationFromVector extends SimpleExpression<Location> {
 
 	static {
 		Skript.registerExpression(ExprLocationFromVector.class, Location.class, ExpressionType.SIMPLE,
-				"%vector% [to location] in %world%",
+				"%vector% to location in %world%",
 				"location (from|of) %vector% in %world%",
 				"%vector% [to location] in %world% with yaw %number% and pitch %number%",
 				"location (from|of) %vector% in %world% with yaw %number% and pitch %number%"


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Requires `to location` in `%vector% to location in %world%` as `%vector% in %world%` was conflicting with some addon syntaxes and in my opinion, matched much to broadly.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #6285 <!-- Links to related issues -->
