### PR TITLE
Fix ReleaseChannel Logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -295,10 +295,8 @@ task githubResources(type: ProcessResources) {
 		include '**'
 		version = project.property('version')
 		def channel = 'stable'
-		if (version.contains('alpha'))
-			channel = 'alpha'
-		else if (version.contains('beta'))
-			channel = 'beta'
+		if (version.contains('pre'))
+			channel = 'prerelease'
 		filter ReplaceTokens, tokens: [
 			'version'         : version,
 			'today'           : '' + LocalTime.now(),
@@ -330,10 +328,8 @@ task spigotResources(type: ProcessResources) {
 		include '**'
 		version = project.property('version')
 		def channel = 'stable'
-		if (version.contains('alpha'))
-			channel = 'alpha'
-		else if (version.contains('beta'))
-			channel = 'beta'
+		if (version.contains('pre'))
+			channel = 'prerelease'
 		filter ReplaceTokens, tokens: [
 			'version'         : version,
 			'today'           : '' + LocalTime.now(),
@@ -369,7 +365,7 @@ task nightlyResources(type: ProcessResources) {
 			'version'         : version,
 			'today'           : '' + LocalTime.now(),
 			'release-flavor'  : 'skriptlang-nightly', // SkriptLang build, automatically done by CI
-			'release-channel' : 'alpha', // No update checking, but these are VERY unstable
+			'release-channel' : 'prerelease', // No update checking, but these are VERY unstable
 			'release-updater' : 'ch.njol.skript.update.NoUpdateChecker', // No autoupdates for now
 			'release-source'  : '',
 			'release-download': 'null'

--- a/src/main/java/ch/njol/skript/SkriptConfig.java
+++ b/src/main/java/ch/njol/skript/SkriptConfig.java
@@ -97,14 +97,15 @@ public class SkriptConfig {
 			.setter(t -> {
 				ReleaseChannel channel;
 				switch (t) {
-					case "alpha":  // Everything goes in alpha channel
+					case "alpha":
+					case "beta":
+						Skript.warning("'alpha' and 'beta' are no longer valid release channels. Use 'prerelease' instead.");
+					case "prerelease": // All development builds are valid
 						channel = new ReleaseChannel((name) -> true, t);
 						break;
-					case "beta":
-						channel = new ReleaseChannel((name) -> !name.contains("alpha"), t);
-						break;
 					case "stable":
-						channel = new ReleaseChannel((name) -> !name.contains("alpha") && !name.contains("beta"), t);
+						// TODO a better option would be to check that it is not a pre-release through GH API
+						channel = new ReleaseChannel((name) -> !name.contains("pre"), t);
 						break;
 					case "none":
 						channel = new ReleaseChannel((name) -> false, t);
@@ -116,9 +117,6 @@ public class SkriptConfig {
 				}
 				SkriptUpdater updater = Skript.getInstance().getUpdater();
 				if (updater != null) {
-					if (updater.getCurrentRelease().flavor.contains("spigot") && !t.equals("stable")) {
-						Skript.error("Only stable Skript versions are uploaded to Spigot resources.");
-					}
 					updater.setReleaseChannel(channel);
 				}
 			});

--- a/src/main/resources/config.sk
+++ b/src/main/resources/config.sk
@@ -53,7 +53,7 @@ update check interval: 12 hours
 release channel: @release-channel@
 # If 'check for new version' is enabled, this determines how stable the updates must be.
 # 'stable' means that only stable releases of Skript will be considered updates.
-# 'beta' and 'alpha' mean that also development releases will be checked for.
+# 'prerelease' means that development releases will also be checked for.
 # Initial value of this depends on the Skript version you first installed; it was '@release-channel@'.
 
 enable effect commands: false


### PR DESCRIPTION
### Description
This PR updates the ReleaseChannel/UpdateChecker logic to account for our change in release naming. Right now it is set to have 2 channels, "stable" and "prerelease"

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** <!-- Links to related issues -->
- https://github.com/SkriptLang/Skript/issues/6304
