### PR TITLE
Fix "parsed as a player" Not Working 

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -681,7 +681,7 @@ public class BukkitClasses {
 					@Override
 					@Nullable
 					public Player parse(String string, ParseContext context) {
-						if (context == ParseContext.COMMAND) {
+						if (context == ParseContext.COMMAND || context == ParseContext.PARSE) {
 							if (string.isEmpty())
 								return null;
 							if (UUID_PATTERN.matcher(string).matches())


### PR DESCRIPTION
### Description
Fixes "parsed as a player" not working. The issue was caused by the new PARSE ParseContext not being considered in the Player ClassInfo's parse method. I have confirmed that it works as expected now.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:**
- https://github.com/SkriptLang/Skript/issues/6316
