### PR TITLE
Add real players to test suite

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -64,6 +64,8 @@ import ch.njol.skript.test.runner.SkriptJUnitTest;
 import ch.njol.skript.test.runner.SkriptTestEvent;
 import ch.njol.skript.test.runner.TestMode;
 import ch.njol.skript.test.runner.TestTracker;
+import ch.njol.skript.test.runner.clients.ClientLaunchException;
+import ch.njol.skript.test.runner.clients.MinosoftClientManager;
 import ch.njol.skript.timings.SkriptTimings;
 import ch.njol.skript.update.ReleaseManifest;
 import ch.njol.skript.update.ReleaseStatus;
@@ -107,6 +109,7 @@ import org.bukkit.event.server.ServerCommandEvent;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
 import org.eclipse.jdt.annotation.Nullable;
 import org.junit.After;
 import org.junit.runner.JUnitCore;
@@ -658,118 +661,146 @@ public final class Skript extends JavaPlugin implements Listener {
 					Bukkit.getScheduler().runTaskLater(Skript.this, () -> info("Skript testing environment enabled, starting soon..."), 1);
 					// Ignore late init (scripts, etc.) in test mode
 					Bukkit.getScheduler().runTaskLater(Skript.this, () -> {
-						// Delay is in Minecraft ticks.
-						long shutdownDelay = 0;
-						if (TestMode.GEN_DOCS) {
-							Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "skript gen-docs");
-						} else if (TestMode.DEV_MODE) { // Developer controlled environment.
-							info("Test development mode enabled. Test scripts are at " + TestMode.TEST_DIR);
-							return;
-						} else {
-							info("Loading all tests from " + TestMode.TEST_DIR);
-
-							// Treat parse errors as fatal testing failure
-							CountingLogHandler errorCounter = new CountingLogHandler(Level.SEVERE);
+						MinosoftClientManager minosoftClientManager = new MinosoftClientManager();
+						if (minosoftClientManager.isAvailable()) {
 							try {
-								errorCounter.start();
-								File testDir = TestMode.TEST_DIR.toFile();
-								assert testDir != null;
-								ScriptLoader.loadScripts(testDir, errorCounter);
-							} finally {
-								errorCounter.stop();
-							}
-
-							Bukkit.getPluginManager().callEvent(new SkriptTestEvent());
-							if (errorCounter.getCount() > 0) {
-								TestTracker.testStarted("parse scripts");
-								TestTracker.testFailed(errorCounter.getCount() + " error(s) found");
-							}
-							if (errored) { // Check for exceptions thrown while script was executing
-								TestTracker.testStarted("run scripts");
-								TestTracker.testFailed("exception was thrown during execution");
-							}
-							if (TestMode.JUNIT) {
-								info("Running all JUnit tests...");
-								long milliseconds = 0, tests = 0, fails = 0, ignored = 0, size = 0;
-								try {
-									List<Class<?>> classes = Lists.newArrayList(Utils.getClasses(Skript.getInstance(), "org.skriptlang.skript.test", "tests"));
-									// Don't attempt to run inner/anonymous classes as tests
-									classes.removeIf(Class::isAnonymousClass);
-									classes.removeIf(Class::isLocalClass);
-									// Test that requires package access. This is only present when compiling with src/test.
-									classes.add(Class.forName("ch.njol.skript.variables.FlatFileStorageTest"));
-									size = classes.size();
-									for (Class<?> clazz : classes) {
-										// Reset class SkriptJUnitTest which stores test requirements.
-										String test = clazz.getName();
-										SkriptJUnitTest.setCurrentJUnitTest(test);
-										SkriptJUnitTest.setShutdownDelay(0);
-
-										info("Running JUnit test '" + test + "'");
-										Result junit = JUnitCore.runClasses(clazz);
-										TestTracker.testStarted("JUnit: '" + test + "'");
-
-										/**
-										 * Usage of @After is pointless if the JUnit class requires delay. As the @After will happen instantly.
-										 * The JUnit must override the 'cleanup' method to avoid Skript automatically cleaning up the test data.
-										 */
-										boolean overrides = false;
-										for (Method method : clazz.getDeclaredMethods()) {
-											if (!method.isAnnotationPresent(After.class))
-												continue;
-											if (SkriptJUnitTest.getShutdownDelay() > 1)
-												warning("Using @After in JUnit classes, happens instantaneously, and JUnit class '" + test + "' requires a delay. Do your test cleanup in the script junit file or 'cleanup' method.");
-											if (method.getName().equals("cleanup"))
-												overrides = true;
-										}
-										if (SkriptJUnitTest.getShutdownDelay() > 1 && !overrides)
-											error("The JUnit class '" + test + "' does not override the method 'cleanup' thus the test data will instantly be cleaned up. " +
-													"This JUnit test requires longer shutdown time: " + SkriptJUnitTest.getShutdownDelay());
-
-										// Collect all data from the current JUnit test.
-										shutdownDelay = Math.max(shutdownDelay, SkriptJUnitTest.getShutdownDelay());
-										tests += junit.getRunCount();
-										milliseconds += junit.getRunTime();
-										ignored += junit.getIgnoreCount();
-										fails += junit.getFailureCount();
-
-										// If JUnit failures are present, add them to the TestTracker.
-										junit.getFailures().forEach(failure -> {
-											String message = failure.getMessage() == null ? "" : " " + failure.getMessage();
-											TestTracker.JUnitTestFailed(test, message);
-											Skript.exception(failure.getException(), "JUnit test '" + failure.getTestHeader() + " failed.");
-										});
-										SkriptJUnitTest.clearJUnitTest();
-									}
-								} catch (IOException e) {
-									Skript.exception(e, "Failed to execute JUnit runtime tests.");
-								} catch (ClassNotFoundException e) {
-									// Should be the Skript test jar gradle task.
-									assert false : "Class 'ch.njol.skript.variables.FlatFileStorageTest' was not found.";
-								}
-								if (ignored > 0)
-									Skript.warning("There were " + ignored + " ignored test cases! This can mean they are not properly setup in order in that class!");
-								
-								info("Completed " + tests + " JUnit tests in " + size + " classes with " + fails + " failures in " + milliseconds + " milliseconds.");
+								minosoftClientManager.launchClient("skripttester1", "127.0.0.1", "25565");
+								minosoftClientManager.launchClient("skripttester2", "127.0.0.1", "25565");
+							} catch (ClientLaunchException exception) {
+								Skript.error("Failed to launch test client");
+								exception.printStackTrace();
 							}
 						}
-						double display = shutdownDelay / 20;
-						info("Testing done, shutting down the server in " + display + " second" + (display <= 1D ? "" : "s") + "...");
-						// Delay server shutdown to stop the server from crashing because the current tick takes a long time due to all the tests
-						Bukkit.getScheduler().runTaskLater(Skript.this, () -> {
-							if (TestMode.JUNIT && !EffObjectives.isJUnitComplete())
-								EffObjectives.fail();
+						BukkitRunnable testRunnable = new BukkitRunnable() {
+								@Override
+								public void run() {
+									// wait for the test clients to join
+									int onlinePlayers = Bukkit.getOnlinePlayers().size();
+									int expectedOnlinePlayers = minosoftClientManager.getClientCount();
+									if (onlinePlayers != expectedOnlinePlayers) {
+										Skript.info("Waiting for test clients (expecting " + expectedOnlinePlayers + ", currently " + onlinePlayers + ")");
+										return;
+									}
 
-							info("Collecting results to " + TestMode.RESULTS_FILE);
-							String results = new Gson().toJson(TestTracker.collectResults());
-							try {
-								Files.write(TestMode.RESULTS_FILE, results.getBytes(StandardCharsets.UTF_8));
-							} catch (IOException e) {
-								Skript.exception(e, "Failed to write test results.");
-							}
+									// we only want to run once, so cancel future runs once we are running
+									cancel();
 
-							Bukkit.getServer().shutdown();
-						}, shutdownDelay);
+									// Delay is in Minecraft ticks.
+									long shutdownDelay = 0;
+									if (TestMode.GEN_DOCS) {
+										Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "skript gen-docs");
+									} else if (TestMode.DEV_MODE) { // Developer controlled environment.
+										info("Test development mode enabled. Test scripts are at " + TestMode.TEST_DIR);
+										return;
+									} else {
+										info("Loading all tests from " + TestMode.TEST_DIR);
+
+										// Treat parse errors as fatal testing failure
+										CountingLogHandler errorCounter = new CountingLogHandler(Level.SEVERE);
+										try {
+											errorCounter.start();
+											File testDir = TestMode.TEST_DIR.toFile();
+											assert testDir != null;
+											ScriptLoader.loadScripts(testDir, errorCounter);
+										} finally {
+											errorCounter.stop();
+										}
+
+										Bukkit.getPluginManager().callEvent(new SkriptTestEvent());
+										if (errorCounter.getCount() > 0) {
+											TestTracker.testStarted("parse scripts");
+											TestTracker.testFailed(errorCounter.getCount() + " error(s) found");
+										}
+										if (errored) { // Check for exceptions thrown while script was executing
+											TestTracker.testStarted("run scripts");
+											TestTracker.testFailed("exception was thrown during execution");
+										}
+										if (TestMode.JUNIT) {
+											info("Running all JUnit tests...");
+											long milliseconds = 0, tests = 0, fails = 0, ignored = 0, size = 0;
+											try {
+												List<Class<?>> classes = Lists.newArrayList(Utils.getClasses(Skript.getInstance(), "org.skriptlang.skript.test", "tests"));
+												// Don't attempt to run inner/anonymous classes as tests
+												classes.removeIf(Class::isAnonymousClass);
+												classes.removeIf(Class::isLocalClass);
+												// Test that requires package access. This is only present when compiling with src/test.
+												classes.add(Class.forName("ch.njol.skript.variables.FlatFileStorageTest"));
+												size = classes.size();
+												for (Class<?> clazz : classes) {
+													// Reset class SkriptJUnitTest which stores test requirements.
+													String test = clazz.getName();
+													SkriptJUnitTest.setCurrentJUnitTest(test);
+													SkriptJUnitTest.setShutdownDelay(0);
+
+													info("Running JUnit test '" + test + "'");
+													Result junit = JUnitCore.runClasses(clazz);
+													TestTracker.testStarted("JUnit: '" + test + "'");
+
+													/**
+													 * Usage of @After is pointless if the JUnit class requires delay. As the @After will happen instantly.
+													 * The JUnit must override the 'cleanup' method to avoid Skript automatically cleaning up the test data.
+													 */
+													boolean overrides = false;
+													for (Method method : clazz.getDeclaredMethods()) {
+														if (!method.isAnnotationPresent(After.class))
+															continue;
+														if (SkriptJUnitTest.getShutdownDelay() > 1)
+															warning("Using @After in JUnit classes, happens instantaneously, and JUnit class '" + test + "' requires a delay. Do your test cleanup in the script junit file or 'cleanup' method.");
+														if (method.getName().equals("cleanup"))
+															overrides = true;
+													}
+													if (SkriptJUnitTest.getShutdownDelay() > 1 && !overrides)
+														error("The JUnit class '" + test + "' does not override the method 'cleanup' thus the test data will instantly be cleaned up. " +
+															"This JUnit test requires longer shutdown time: " + SkriptJUnitTest.getShutdownDelay());
+
+													// Collect all data from the current JUnit test.
+													shutdownDelay = Math.max(shutdownDelay, SkriptJUnitTest.getShutdownDelay());
+													tests += junit.getRunCount();
+													milliseconds += junit.getRunTime();
+													ignored += junit.getIgnoreCount();
+													fails += junit.getFailureCount();
+
+													// If JUnit failures are present, add them to the TestTracker.
+													junit.getFailures().forEach(failure -> {
+														String message = failure.getMessage() == null ? "" : " " + failure.getMessage();
+														TestTracker.JUnitTestFailed(test, message);
+														Skript.exception(failure.getException(), "JUnit test '" + failure.getTestHeader() + " failed.");
+													});
+													SkriptJUnitTest.clearJUnitTest();
+												}
+											} catch (IOException e) {
+												Skript.exception(e, "Failed to execute JUnit runtime tests.");
+											} catch (ClassNotFoundException e) {
+												// Should be the Skript test jar gradle task.
+												assert false : "Class 'ch.njol.skript.variables.FlatFileStorageTest' was not found.";
+											}
+											if (ignored > 0)
+												Skript.warning("There were " + ignored + " ignored test cases! This can mean they are not properly setup in order in that class!");
+
+											info("Completed " + tests + " JUnit tests in " + size + " classes with " + fails + " failures in " + milliseconds + " milliseconds.");
+										}
+									}
+									double display = shutdownDelay / 20;
+									info("Testing done, shutting down the server in " + display + " second" + (display <= 1D ? "" : "s") + "...");
+									// Delay server shutdown to stop the server from crashing because the current tick takes a long time due to all the tests
+									Bukkit.getScheduler().runTaskLater(Skript.this, () -> {
+										if (TestMode.JUNIT && !EffObjectives.isJUnitComplete())
+											EffObjectives.fail();
+
+										info("Collecting results to " + TestMode.RESULTS_FILE);
+										String results = new Gson().toJson(TestTracker.collectResults());
+										try {
+											Files.write(TestMode.RESULTS_FILE, results.getBytes(StandardCharsets.UTF_8));
+										} catch (IOException e) {
+											Skript.exception(e, "Failed to write test results.");
+										}
+
+										minosoftClientManager.killClients();
+										Bukkit.getServer().shutdown();
+									}, shutdownDelay);
+								}
+							};
+							testRunnable.runTaskTimer(Skript.this, 0, 20);
 					}, 100);
 				}
 

--- a/src/main/java/ch/njol/skript/test/runner/SkriptJUnitTest.java
+++ b/src/main/java/ch/njol/skript/test/runner/SkriptJUnitTest.java
@@ -27,6 +27,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Pig;
+import org.bukkit.entity.Player;
 import org.junit.After;
 import org.junit.Before;
 
@@ -82,7 +83,9 @@ public abstract class SkriptJUnitTest {
 	@Before
 	@After
 	public void cleanup() {
-		getTestWorld().getEntities().forEach(Entity::remove);
+		getTestWorld().getEntities().stream()
+			.filter(entity -> !(entity instanceof Player))
+			.forEach(Entity::remove);
 		setBlock(Material.AIR);
 	}
 

--- a/src/main/java/ch/njol/skript/test/runner/clients/ClientLaunchException.java
+++ b/src/main/java/ch/njol/skript/test/runner/clients/ClientLaunchException.java
@@ -1,0 +1,25 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.test.runner.clients;
+
+public class ClientLaunchException extends Exception {
+	public ClientLaunchException(Exception exception) {
+		super(exception);
+	}
+}

--- a/src/main/java/ch/njol/skript/test/runner/clients/ClientManager.java
+++ b/src/main/java/ch/njol/skript/test/runner/clients/ClientManager.java
@@ -1,0 +1,31 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.test.runner.clients;
+
+public interface ClientManager {
+
+	boolean isAvailable();
+
+	void launchClient(String username, String server, String port) throws ClientLaunchException;
+
+	int getClientCount();
+
+	void killClients();
+
+}

--- a/src/main/java/ch/njol/skript/test/runner/clients/MinosoftClientManager.java
+++ b/src/main/java/ch/njol/skript/test/runner/clients/MinosoftClientManager.java
@@ -19,7 +19,6 @@
 package ch.njol.skript.test.runner.clients;
 
 import ch.njol.skript.Skript;
-import org.apache.commons.lang3.SystemUtils;
 import org.eclipse.jdt.annotation.Nullable;
 
 import java.io.BufferedWriter;
@@ -29,6 +28,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 public class MinosoftClientManager implements ClientManager {
@@ -43,9 +43,10 @@ public class MinosoftClientManager implements ClientManager {
 	@Nullable
 	private Path findMinosoftJar() {
 		Path skriptDataFolder = Skript.getInstance().getDataFolder().toPath();
-		if (SystemUtils.IS_OS_WINDOWS) {
+		String osName = System.getProperty("os.name", "unknown").toLowerCase(Locale.ENGLISH);
+		if (osName.contains("windows")) {
 			return skriptDataFolder.resolve("minosoft").resolve("minosoft-windows.jar").toAbsolutePath();
-		} else if (SystemUtils.IS_OS_LINUX) {
+		} else if (osName.contains("linux")) {
 			return skriptDataFolder.resolve("minosoft").resolve("minosoft-linux.jar").toAbsolutePath();
 		}
 		return null; // todo: support macs
@@ -60,7 +61,6 @@ public class MinosoftClientManager implements ClientManager {
 	public void launchClient(String username, String serverAddress, String serverPort) throws ClientLaunchException {
 		Path javaPath = Paths.get(System.getProperty("java.home"), "bin", "java").toAbsolutePath().normalize();
 		ProcessBuilder minosoftProcessBuilder = new ProcessBuilder(javaPath.toString(), "-jar", minosoftJarPath.toString(), "--headless");
-		minosoftProcessBuilder.inheritIO();
 		try {
 			Process minosoftProcess = minosoftProcessBuilder.start();
 			BufferedWriter minosoftCommandWriter = new BufferedWriter(new OutputStreamWriter(minosoftProcess.getOutputStream()));

--- a/src/main/java/ch/njol/skript/test/runner/clients/MinosoftClientManager.java
+++ b/src/main/java/ch/njol/skript/test/runner/clients/MinosoftClientManager.java
@@ -1,0 +1,86 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.test.runner.clients;
+
+import ch.njol.skript.Skript;
+import org.apache.commons.lang3.SystemUtils;
+import org.eclipse.jdt.annotation.Nullable;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Set;
+
+public class MinosoftClientManager implements ClientManager {
+
+	private Path minsoftJarPath;
+	private Set<Process> minsoftProcesses = new HashSet<>();
+
+	public MinosoftClientManager() {
+		this.minsoftJarPath = findMinsoftJar();
+	}
+
+	@Nullable
+	private Path findMinsoftJar() {
+		Path skriptDataFolder = Skript.getInstance().getDataFolder().toPath();
+		if (SystemUtils.IS_OS_WINDOWS) {
+			return skriptDataFolder.resolve("minosoft").resolve("minosoft-windows.jar").toAbsolutePath();
+		} else if (SystemUtils.IS_OS_LINUX) {
+			return skriptDataFolder.resolve("minosoft").resolve("minosoft-linux.jar").toAbsolutePath();
+		}
+		return null; // todo: support macs
+	}
+
+	@Override
+	public boolean isAvailable() {
+		return minsoftJarPath != null && Files.exists(minsoftJarPath);
+	}
+
+	@Override
+	public void launchClient(String username, String serverAddress, String serverPort) throws ClientLaunchException {
+		Path javaPath = Paths.get(System.getProperty("java.home"), "bin", "java").toAbsolutePath().normalize();
+		ProcessBuilder minosoftProcessBuilder = new ProcessBuilder(javaPath.toString(), "-jar", minsoftJarPath.toString(), "--headless");
+		try {
+			Process minsoftProcess = minosoftProcessBuilder.start();
+			BufferedWriter minsoftCommandWriter = new BufferedWriter(new OutputStreamWriter(minsoftProcess.getOutputStream()));
+			minsoftCommandWriter.write("account add offline " + username + '\n');
+			minsoftCommandWriter.write("account select " + username + '\n');
+			minsoftCommandWriter.write("connect " + serverAddress + ":" + serverPort + '\n');
+			minsoftCommandWriter.close();
+			minsoftProcesses.add(minsoftProcess);
+		} catch (IOException exception) {
+			throw new ClientLaunchException(exception);
+		}
+	}
+
+	@Override
+	public int getClientCount() {
+		return minsoftProcesses.size();
+	}
+
+	@Override
+	public void killClients() {
+		minsoftProcesses.forEach(Process::destroyForcibly);
+	}
+
+}

--- a/src/main/java/ch/njol/skript/test/runner/clients/MinosoftClientManager.java
+++ b/src/main/java/ch/njol/skript/test/runner/clients/MinosoftClientManager.java
@@ -33,15 +33,15 @@ import java.util.Set;
 
 public class MinosoftClientManager implements ClientManager {
 
-	private Path minsoftJarPath;
-	private Set<Process> minsoftProcesses = new HashSet<>();
+	private Path minosoftJarPath;
+	private Set<Process> minosoftProcesses = new HashSet<>();
 
 	public MinosoftClientManager() {
-		this.minsoftJarPath = findMinsoftJar();
+		this.minosoftJarPath = findMinosoftJar();
 	}
 
 	@Nullable
-	private Path findMinsoftJar() {
+	private Path findMinosoftJar() {
 		Path skriptDataFolder = Skript.getInstance().getDataFolder().toPath();
 		if (SystemUtils.IS_OS_WINDOWS) {
 			return skriptDataFolder.resolve("minosoft").resolve("minosoft-windows.jar").toAbsolutePath();
@@ -53,21 +53,22 @@ public class MinosoftClientManager implements ClientManager {
 
 	@Override
 	public boolean isAvailable() {
-		return minsoftJarPath != null && Files.exists(minsoftJarPath);
+		return minosoftJarPath != null && Files.exists(minosoftJarPath);
 	}
 
 	@Override
 	public void launchClient(String username, String serverAddress, String serverPort) throws ClientLaunchException {
 		Path javaPath = Paths.get(System.getProperty("java.home"), "bin", "java").toAbsolutePath().normalize();
-		ProcessBuilder minosoftProcessBuilder = new ProcessBuilder(javaPath.toString(), "-jar", minsoftJarPath.toString(), "--headless");
+		ProcessBuilder minosoftProcessBuilder = new ProcessBuilder(javaPath.toString(), "-jar", minosoftJarPath.toString(), "--headless");
+		minosoftProcessBuilder.inheritIO();
 		try {
-			Process minsoftProcess = minosoftProcessBuilder.start();
-			BufferedWriter minsoftCommandWriter = new BufferedWriter(new OutputStreamWriter(minsoftProcess.getOutputStream()));
-			minsoftCommandWriter.write("account add offline " + username + '\n');
-			minsoftCommandWriter.write("account select " + username + '\n');
-			minsoftCommandWriter.write("connect " + serverAddress + ":" + serverPort + '\n');
-			minsoftCommandWriter.close();
-			minsoftProcesses.add(minsoftProcess);
+			Process minosoftProcess = minosoftProcessBuilder.start();
+			BufferedWriter minosoftCommandWriter = new BufferedWriter(new OutputStreamWriter(minosoftProcess.getOutputStream()));
+			minosoftCommandWriter.write("account add offline " + username + '\n');
+			minosoftCommandWriter.write("account select " + username + '\n');
+			minosoftCommandWriter.write("connect " + serverAddress + ":" + serverPort + '\n');
+			minosoftCommandWriter.close();
+			minosoftProcesses.add(minosoftProcess);
 		} catch (IOException exception) {
 			throw new ClientLaunchException(exception);
 		}
@@ -75,12 +76,12 @@ public class MinosoftClientManager implements ClientManager {
 
 	@Override
 	public int getClientCount() {
-		return minsoftProcesses.size();
+		return minosoftProcesses.size();
 	}
 
 	@Override
 	public void killClients() {
-		minsoftProcesses.forEach(Process::destroyForcibly);
+		minosoftProcesses.forEach(Process::destroyForcibly);
 	}
 
 }

--- a/src/test/resources/runner_data/server.properties.generic
+++ b/src/test/resources/runner_data/server.properties.generic
@@ -40,6 +40,6 @@ use-native-transport=true
 max-players=20
 resource-pack-sha1=
 spawn-protection=0
-online-mode=true
+online-mode=false
 allow-flight=false
 max-world-size=29999984

--- a/src/test/skript/environments/java17/paper-1.17.1.json
+++ b/src/test/skript/environments/java17/paper-1.17.1.json
@@ -9,6 +9,16 @@
 			"target": "paperclip.jar"
 		}
 	],
+	"downloads": [
+		{
+			"source":  "https://github.com/Pikachu920/testing-room/raw/main/minosoft-fat-linux-amd64-ec602af.jar",
+			"target":  "plugins/Skript/minosoft/minosoft-linux.jar"
+		},
+		{
+			"source": "https://github.com/Pikachu920/testing-room/raw/main/minosoft-fat-windows-amd64-ec602af.jar",
+			"target": "plugins/Skript/minosoft/minosoft-windows.jar"
+		}
+	],
 	"skriptTarget": "plugins/Skript.jar",
 	"commandLine": [
 		"-Dcom.mojang.eula.agree=true",

--- a/src/test/skript/environments/java17/paper-1.18.2.json
+++ b/src/test/skript/environments/java17/paper-1.18.2.json
@@ -9,6 +9,16 @@
 			"target": "paperclip.jar"
 		}
 	],
+	"downloads": [
+		{
+			"source":  "https://github.com/Pikachu920/testing-room/raw/main/minosoft-fat-linux-amd64-ec602af.jar",
+			"target":  "plugins/Skript/minosoft/minosoft-linux.jar"
+		},
+		{
+			"source": "https://github.com/Pikachu920/testing-room/raw/main/minosoft-fat-windows-amd64-ec602af.jar",
+			"target": "plugins/Skript/minosoft/minosoft-windows.jar"
+		}
+	],
 	"skriptTarget": "plugins/Skript.jar",
 	"commandLine": [
 		"-Dcom.mojang.eula.agree=true",

--- a/src/test/skript/environments/java17/paper-1.19.4.json
+++ b/src/test/skript/environments/java17/paper-1.19.4.json
@@ -9,6 +9,16 @@
 			"target": "paperclip.jar"
 		}
 	],
+	"downloads": [
+		{
+			"source":  "https://github.com/Pikachu920/testing-room/raw/main/minosoft-fat-linux-amd64-ec602af.jar",
+			"target":  "plugins/Skript/minosoft/minosoft-linux.jar"
+		},
+		{
+			"source": "https://github.com/Pikachu920/testing-room/raw/main/minosoft-fat-windows-amd64-ec602af.jar",
+			"target": "plugins/Skript/minosoft/minosoft-windows.jar"
+		}
+	],
 	"skriptTarget": "plugins/Skript.jar",
 	"commandLine": [
 		"-Dcom.mojang.eula.agree=true",

--- a/src/test/skript/environments/java17/paper-1.20.4.json
+++ b/src/test/skript/environments/java17/paper-1.20.4.json
@@ -9,6 +9,16 @@
 			"target": "paperclip.jar"
 		}
 	],
+	"downloads": [
+		{
+			"source":  "https://github.com/Pikachu920/testing-room/raw/main/minosoft-fat-linux-amd64-ec602af.jar",
+			"target":  "plugins/Skript/minosoft/minosoft-linux.jar"
+		},
+		{
+			"source": "https://github.com/Pikachu920/testing-room/raw/main/minosoft-fat-windows-amd64-ec602af.jar",
+			"target": "plugins/Skript/minosoft/minosoft-windows.jar"
+		}
+	],
 	"skriptTarget": "plugins/Skript.jar",
 	"commandLine": [
 		"-Dcom.mojang.eula.agree=true",

--- a/src/test/skript/environments/java8/paper-1.13.2.json
+++ b/src/test/skript/environments/java8/paper-1.13.2.json
@@ -9,6 +9,16 @@
 			"target": "paperclip.jar"
 		}
 	],
+	"downloads": [
+		{
+			"source":  "https://github.com/Pikachu920/testing-room/raw/main/minosoft-fat-linux-amd64-ec602af.jar",
+			"target":  "plugins/Skript/minosoft/minosoft-linux.jar"
+		},
+		{
+			"source": "https://github.com/Pikachu920/testing-room/raw/main/minosoft-fat-windows-amd64-ec602af.jar",
+			"target": "plugins/Skript/minosoft/minosoft-windows.jar"
+		}
+	],
 	"skriptTarget": "plugins/Skript.jar",
 	"commandLine": [
 		"-Dcom.mojang.eula.agree=true",

--- a/src/test/skript/environments/java8/paper-1.14.4.json
+++ b/src/test/skript/environments/java8/paper-1.14.4.json
@@ -9,6 +9,16 @@
 			"target": "paperclip.jar"
 		}
 	],
+	"downloads": [
+		{
+			"source":  "https://github.com/Pikachu920/testing-room/raw/main/minosoft-fat-linux-amd64-ec602af.jar",
+			"target":  "plugins/Skript/minosoft/minosoft-linux.jar"
+		},
+		{
+			"source": "https://github.com/Pikachu920/testing-room/raw/main/minosoft-fat-windows-amd64-ec602af.jar",
+			"target": "plugins/Skript/minosoft/minosoft-windows.jar"
+		}
+	],
 	"skriptTarget": "plugins/Skript.jar",
 	"commandLine": [
 		"-Dcom.mojang.eula.agree=true",

--- a/src/test/skript/environments/java8/paper-1.15.2.json
+++ b/src/test/skript/environments/java8/paper-1.15.2.json
@@ -9,6 +9,16 @@
 			"target": "paperclip.jar"
 		}
 	],
+	"downloads": [
+		{
+			"source":  "https://github.com/Pikachu920/testing-room/raw/main/minosoft-fat-linux-amd64-ec602af.jar",
+			"target":  "plugins/Skript/minosoft/minosoft-linux.jar"
+		},
+		{
+			"source": "https://github.com/Pikachu920/testing-room/raw/main/minosoft-fat-windows-amd64-ec602af.jar",
+			"target": "plugins/Skript/minosoft/minosoft-windows.jar"
+		}
+	],
 	"skriptTarget": "plugins/Skript.jar",
 	"commandLine": [
 		"-Dcom.mojang.eula.agree=true",

--- a/src/test/skript/environments/java8/paper-1.16.5.json
+++ b/src/test/skript/environments/java8/paper-1.16.5.json
@@ -9,6 +9,16 @@
 			"target": "paperclip.jar"
 		}
 	],
+	"downloads": [
+		{
+			"source":  "https://github.com/Pikachu920/testing-room/raw/main/minosoft-fat-linux-amd64-ec602af.jar",
+			"target":  "plugins/Skript/minosoft/minosoft-linux.jar"
+		},
+		{
+			"source": "https://github.com/Pikachu920/testing-room/raw/main/minosoft-fat-windows-amd64-ec602af.jar",
+			"target": "plugins/Skript/minosoft/minosoft-windows.jar"
+		}
+	],
 	"skriptTarget": "plugins/Skript.jar",
 	"commandLine": [
 		"-Dcom.mojang.eula.agree=true",

--- a/src/test/skript/tests/misc/minosoft.sk
+++ b/src/test/skript/tests/misc/minosoft.sk
@@ -1,0 +1,2 @@
+test "minosoft":
+	assert size of all players is 2 with "minosoft worked :)"


### PR DESCRIPTION
### Description
this PR adds real players to the test suite. the aim it to allow us to test complex things that require players and may not be possible or feasible to mock (e.g parsing uuids 😆). it works by downloading an open-source minecraft implementation [Minosoft](https://github.com/Bixilon/Minosoft/tree/master). a few headless minosoft instances are started in the background and are instructed to join the test server. the test server waits for them to connect before running the tests.

this is currently passing with the `quickTest` task on my win10 machine but not much else.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
