### PR TITLE
Add support for character codepoints

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprCharacterFromCodepoint.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCharacterFromCodepoint.java
@@ -1,0 +1,75 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.ExpressionType;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+@Name("Character From Codepoint")
+@Description("Returns the character at the specified codepoint")
+@Examples({
+	"function chars_between(lower: string, upper: string) :: strings:",
+	"\tset {_lower} to codepoint of {_lower}",
+	"\treturn {_none} if {_lower} is not set",
+	"",
+	"\tset {_upper} to codepoint of {_upper}",
+	"\treturn {_none} if {_upper} is not set",
+	"",
+	"\tloop integers between {_lower} and {_upper}:",
+	"\t\tadd character from codepoint loop-value to {_chars::*}",
+	"\treturn {_chars::*}",
+})
+@Since("INSERT VERSION")
+public class ExprCharacterFromCodepoint extends SimplePropertyExpression<Integer, String> {
+
+	static {
+		Skript.registerExpression(ExprCharacterFromCodepoint.class, String.class, ExpressionType.PROPERTY,
+				"character [from|at] code([ ]point|position) %integer%");
+	}
+	
+	@Override
+	@Nullable
+	public String convert(Integer integer) {
+		return String.valueOf((char) integer.intValue());
+	}
+
+	@Override
+	public Class<? extends String> getReturnType() {
+		return String.class;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "character at codepoint " + getExpr().toString(event, debug);
+	}
+
+	@Override
+	protected String getPropertyName() {
+		assert false;
+		return null;
+	}
+
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprCharacterFromCodepoint.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCharacterFromCodepoint.java
@@ -28,7 +28,7 @@ import ch.njol.skript.lang.ExpressionType;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
-@Name("Character From Codepoint")
+@Name("Character from Codepoint")
 @Description("Returns the character at the specified codepoint")
 @Examples({
 	"function chars_between(lower: string, upper: string) :: strings:",

--- a/src/main/java/ch/njol/skript/expressions/ExprCharacterFromCodepoint.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCharacterFromCodepoint.java
@@ -32,15 +32,15 @@ import org.eclipse.jdt.annotation.Nullable;
 @Description("Returns the character at the specified codepoint")
 @Examples({
 	"function chars_between(lower: string, upper: string) :: strings:",
-	"\tset {_lower} to codepoint of {_lower}",
-	"\treturn {_none} if {_lower} is not set",
-	"",
-	"\tset {_upper} to codepoint of {_upper}",
-	"\treturn {_none} if {_upper} is not set",
-	"",
-	"\tloop integers between {_lower} and {_upper}:",
-	"\t\tadd character from codepoint loop-value to {_chars::*}",
-	"\treturn {_chars::*}",
+		"\tset {_lower} to codepoint of {_lower}",
+		"\treturn {_none} if {_lower} is not set",
+		"",
+		"\tset {_upper} to codepoint of {_upper}",
+		"\treturn {_none} if {_upper} is not set",
+		"",
+		"\tloop integers between {_lower} and {_upper}:",
+			"\t\tadd character from codepoint loop-value to {_chars::*}",
+		"\treturn {_chars::*}",
 })
 @Since("INSERT VERSION")
 public class ExprCharacterFromCodepoint extends SimplePropertyExpression<Integer, String> {

--- a/src/main/java/ch/njol/skript/expressions/ExprCharacterFromCodepoint.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCharacterFromCodepoint.java
@@ -47,7 +47,7 @@ public class ExprCharacterFromCodepoint extends SimplePropertyExpression<Integer
 
 	static {
 		Skript.registerExpression(ExprCharacterFromCodepoint.class, String.class, ExpressionType.PROPERTY,
-				"character [from|at] code([ ]point|position) %integer%");
+				"character (from|at|with) code([ ]point| position) %integer%");
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprCodepoint.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCodepoint.java
@@ -56,7 +56,7 @@ public class ExprCodepoint extends SimplePropertyExpression<String, Integer> {
 	@Override
 	@Nullable
 	public Integer convert(String string) {
-		if (string.length() != 1)
+		if (string.isEmpty())
 			return null;
 		return string.codePointAt(0);
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprCodepoint.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCodepoint.java
@@ -1,0 +1,74 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import org.eclipse.jdt.annotation.Nullable;
+
+@Name("Character Codepoint")
+@Description("Returns the Unicode codepoint of a character")
+@Examples({
+	"function is_in_order(letters: strings) :: boolean:",
+	"\tloop {_letters::*}:",
+	"\t\tset {_codepoint} to codepoint of lowercase loop-value",
+	"",
+	"\t\treturn false if {_codepoint} is not set # 'loop-value is not a single character'",
+	"",
+	"\t\tif:",
+	"\t\t\t{_previous-codepoint} is set",
+	"\t\t\t# if the codepoint of the current character is not",
+	"\t\t\t#  1 more than the codepoint of the previous character",
+	"\t\t\t#  then the letters are not in order",
+	"\t\t\t{_codepoint} - {_previous-codepoint} is not 1",
+	"\t\tthen:",
+	"\t\t\treturn false",
+	"",
+	"\t\tset {_previous-codepoint} to {_codepoint}",
+	"\treturn true"
+})
+@Since("INSERT VERSION")
+public class ExprCodepoint extends SimplePropertyExpression<String, Integer> {
+
+	static {
+		register(ExprCodepoint.class, Integer.class, "[unicode|character] code([ ]point| position)", "strings");
+	}
+
+	@Override
+	@Nullable
+	public Integer convert(String string) {
+		if (string.length() != 1)
+			return null;
+		return string.codePointAt(0);
+	}
+
+	@Override
+	public Class<? extends Integer> getReturnType() {
+		return Integer.class;
+	}
+
+	@Override
+	protected String getPropertyName() {
+		return "codepoint";
+	}
+
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprCodepoint.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCodepoint.java
@@ -29,22 +29,22 @@ import org.eclipse.jdt.annotation.Nullable;
 @Description("Returns the Unicode codepoint of a character")
 @Examples({
 	"function is_in_order(letters: strings) :: boolean:",
-	"\tloop {_letters::*}:",
-	"\t\tset {_codepoint} to codepoint of lowercase loop-value",
-	"",
-	"\t\treturn false if {_codepoint} is not set # 'loop-value is not a single character'",
-	"",
-	"\t\tif:",
-	"\t\t\t{_previous-codepoint} is set",
-	"\t\t\t# if the codepoint of the current character is not",
-	"\t\t\t#  1 more than the codepoint of the previous character",
-	"\t\t\t#  then the letters are not in order",
-	"\t\t\t{_codepoint} - {_previous-codepoint} is not 1",
-	"\t\tthen:",
-	"\t\t\treturn false",
-	"",
-	"\t\tset {_previous-codepoint} to {_codepoint}",
-	"\treturn true"
+		"\tloop {_letters::*}:",
+			"\t\tset {_codepoint} to codepoint of lowercase loop-value",
+			"",
+			"\t\treturn false if {_codepoint} is not set # 'loop-value is not a single character'",
+			"",
+			"\t\tif:",
+				"\t\t\t{_previous-codepoint} is set",
+				"\t\t\t# if the codepoint of the current character is not",
+				"\t\t\t#  1 more than the codepoint of the previous character",
+				"\t\t\t#  then the letters are not in order",
+				"\t\t\t{_codepoint} - {_previous-codepoint} is not 1",
+			"\t\tthen:",
+				"\t\t\treturn false",
+			"",
+			"\t\tset {_previous-codepoint} to {_codepoint}",
+		"\treturn true"
 })
 @Since("INSERT VERSION")
 public class ExprCodepoint extends SimplePropertyExpression<String, Integer> {

--- a/src/test/skript/tests/syntaxes/expressions/ExprCodepoint.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprCodepoint.sk
@@ -1,0 +1,8 @@
+test "codepoint":
+	assert character from codepoint 65 is "A" with "character from codepoint 65 is not 'A'"
+	assert codepoint of "A" is 65 with "codepoint of 'A' is not 65"
+	assert codepoint of "ABC" is 65 with "codepoint of 'A' is not 65"
+	assert codepoint of "" is not set with "codepoint of an empty string is set"
+	assert codepoint of (character from codepoint -1) is 65535 with "character from codepoint does not wrap around"
+	assert codepoint of (character from codepoint infinity value) is 65535 with "codepoint of infinity value is not 65535"
+	assert codepoint of (character from codepoint NaN value) is 0 with "codepoint of NaN value is not 0"


### PR DESCRIPTION
### Description
This PR adds two expressions allowing you to get the codepoint of a character and get a character at a codepoint

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
