### PR TITLE
Change the effect command symbol

### DIFF
--- a/src/main/resources/config.sk
+++ b/src/main/resources/config.sk
@@ -57,7 +57,7 @@ release channel: @release-channel@
 # Initial value of this depends on the Skript version you first installed; it was '@release-channel@'.
 
 enable effect commands: false
-effect command token: !
+effect command token: \
 # If 'enable effect commands' is set to true, chat messages starting with the 'effect command token' will be interpreted as effects and executed.
 # The token can be longer than a single character, but it should not start with '/' as that starts a command.
 # A player needs the permission "skript.effectcommands" to use such commands,


### PR DESCRIPTION
Change the effect command symbol to be a back slash.

### Description
Change the effect command symbol to be a back slash.
This is one less key press, and I have converted many people to be using back slash and taught everyone with back slash as it's more convenient, and everyone agrees.
Should be the new standard.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
