### PR TITLE
Fix Skript MinecraftServer.isRunning reflection on 1.20(.1)

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -1159,9 +1159,13 @@ public final class Skript extends JavaPlugin implements Listener {
 				// 1.19 mapping is u and 1.18 is v
 				String isRunningMethod = "isRunning";
 
-				if (Skript.isRunningMinecraft(1, 20)) isRunningMethod = "v";
-				else if (Skript.isRunningMinecraft(1, 19)) isRunningMethod = "u";
-				else if (Skript.isRunningMinecraft(1, 18)) isRunningMethod = "v";
+				if (Skript.isRunningMinecraft(1, 20)) {
+					isRunningMethod = "v";
+				} else if (Skript.isRunningMinecraft(1, 19)) {
+					isRunningMethod = "u";
+				} else if (Skript.isRunningMinecraft(1, 18)) {
+					isRunningMethod = "v";
+				}
 				IS_RUNNING = MC_SERVER.getClass().getMethod(isRunningMethod);
 			} catch (NoSuchMethodException e) {
 				throw new RuntimeException(e);

--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -1157,7 +1157,11 @@ public final class Skript extends JavaPlugin implements Listener {
 			try {
 				// Spigot removed the mapping for this method in 1.18, so its back to obfuscated method
 				// 1.19 mapping is u and 1.18 is v
-				String isRunningMethod = Skript.isRunningMinecraft(1, 19) ? "u" : Skript.isRunningMinecraft(1, 18) ? "v" :"isRunning";
+				String isRunningMethod = "isRunning";
+
+				if (Skript.isRunningMinecraft(1, 20)) isRunningMethod = "v";
+				else if (Skript.isRunningMinecraft(1, 19)) isRunningMethod = "u";
+				else if (Skript.isRunningMinecraft(1, 18)) isRunningMethod = "v";
 				IS_RUNNING = MC_SERVER.getClass().getMethod(isRunningMethod);
 			} catch (NoSuchMethodException e) {
 				throw new RuntimeException(e);


### PR DESCRIPTION
Related #6351 

Adds the obfuscated name for Server#isRunning for 1.20 versions.

Please note that whilst this change is untested, it should be correct.