### PR TITLE
⚒️ Fix isSingle of ExprArmorSlot

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprArmorSlot.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprArmorSlot.java
@@ -56,11 +56,13 @@ public class ExprArmorSlot extends PropertyExpression<LivingEntity, Slot> {
 	@Nullable
 	private EquipSlot slot;
 	private boolean explicitSlot;
+	private boolean isArmor;
 
 	@Override
 	@SuppressWarnings("unchecked")
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		slot = parseResult.hasTag("armour") ? null : EquipSlot.valueOf(parseResult.tags.get(0).toUpperCase(Locale.ENGLISH));
+		isArmor = parseResult.hasTag("armour");
+		slot = isArmor ? null : EquipSlot.valueOf(parseResult.tags.get(0).toUpperCase(Locale.ENGLISH));
 		explicitSlot = parseResult.hasTag("slot"); // User explicitly asked for SLOT, not item
 		setExpr((Expression<? extends LivingEntity>) exprs[0]);
 		return true;
@@ -90,6 +92,11 @@ public class ExprArmorSlot extends PropertyExpression<LivingEntity, Slot> {
 				return null;
 			return new EquipmentSlot(equipment, slot, explicitSlot);
 		});
+	}
+
+	@Override
+	public boolean isSingle() {
+		return !isArmor && super.isSingle();
 	}
 
 	@Override


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Fixes a simple bug in ExprArmorSlot class where it only returns not single if expr is not single, while this property expression may return non single while expr is single if user asked for armor of expr

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
- #6354 
