### PR TITLE
⚒️ Fix function signature parentheses

### DIFF
--- a/src/main/java/ch/njol/skript/structures/StructFunction.java
+++ b/src/main/java/ch/njol/skript/structures/StructFunction.java
@@ -61,7 +61,7 @@ public class StructFunction extends Structure {
 	public static final Priority PRIORITY = new Priority(400);
 
 	private static final Pattern SIGNATURE_PATTERN =
-			Pattern.compile("(?:local )?function (" + Functions.functionNamePattern + ")\\((.*)\\)(?:\\s*(?:::| returns )\\s*(.+))?");
+			Pattern.compile("^(?:local )?function (" + Functions.functionNamePattern + ")\\((.*?)\\)(?:\\s*(?:::| returns )\\s*(.+))?$");
 	private static final AtomicBoolean VALIDATE_FUNCTIONS = new AtomicBoolean();
 
 	static {


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Fix a greedy regex group to not allow `function test3(uhhhhh: string) :: string)` (adding ending parentheses at the end) which now gives the error `Cannot recognise the type 'string)'` which is the best I could get.

I tried making return type group `[a-zA-Z0-9 ]+` but that broke it again and returned it to the first error because it still matches the regex thinking it's part of params.

![image](https://github.com/SkriptLang/Skript/assets/20037329/9ff1e984-1fee-4ffe-8b35-87e12d61838a)


---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
