### PR TITLE
🚀 Add equip items

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffEquip.java
+++ b/src/main/java/ch/njol/skript/effects/EffEquip.java
@@ -171,7 +171,7 @@ public class EffEquip extends Effect {
 							equipment.setLeggings(equip ? item : null);
 						} else if (BOOTS.isOfType(item)) {
 							equipment.setBoots(equip ? item : null);
-						} else if (HELMET.isOfType(item) || isHat) {
+						} else if (isHat || HELMET.isOfType(item)) {
 							// Apply all other items to head (if isHat), as all items will appear on a player's head
 							equipment.setHelmet(equip ? item : null);
 						} else {

--- a/src/main/java/ch/njol/skript/effects/EffEquip.java
+++ b/src/main/java/ch/njol/skript/effects/EffEquip.java
@@ -175,10 +175,8 @@ public class EffEquip extends Effect {
 							// Apply all other items to head (if isHat), as all items will appear on a player's head
 							equipment.setHelmet(equip ? item : null);
 						} else {
-							if (entity instanceof Player) {
-								PlayerInventory inventory = ((Player) entity).getInventory();
-								inventory.addItem(item);
-							}
+							if (entity instanceof Player)
+								((Player) entity).getInventory().addItem(item);
 						}
 					}
 					if (unequipHelmet) { // Since players can wear any helmet, itemTypes won't have the item in the array every time


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Added equipping (aka giving) items not just armor. To be able to add this I had to add a new syntax to the first pattern `[hat:as [a] (hat|helmet|cap)]` in order to allow users to equip items as hats since that was the default behavior before this which means this PR has a **breaking change**, BUT syntax may not be the best so feel free to suggest improvements.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
- #6322
