### PR TITLE
Improve UnparsedLiteral Handling

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.parallel=true
 
 groupid=ch.njol
 name=skript
-version=2.8.0-pre1
+version=2.8.0-pre2
 jarName=Skript.jar
 testEnv=java17/paper-1.20.4
 testEnvJavaVersion=17

--- a/src/main/java/ch/njol/skript/expressions/arithmetic/ExprArithmetic.java
+++ b/src/main/java/ch/njol/skript/expressions/arithmetic/ExprArithmetic.java
@@ -250,7 +250,8 @@ public class ExprArithmetic<L, R, T> extends SimpleExpression<T> {
 
 	private boolean error(Class<?> firstClass, Class<?> secondClass) {
 		ClassInfo<?> first = Classes.getSuperClassInfo(firstClass), second = Classes.getSuperClassInfo(secondClass);
-		Skript.error(operator.getName() + " can't be performed on " + first.getName().withIndefiniteArticle() + " and " + second.getName().withIndefiniteArticle());
+		if (first.getC() != Object.class && second.getC() != Object.class) // errors with "object" are not very useful and often misleading
+			Skript.error(operator.getName() + " can't be performed on " + first.getName().withIndefiniteArticle() + " and " + second.getName().withIndefiniteArticle());
 		return false;
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/arithmetic/ExprArithmetic.java
+++ b/src/main/java/ch/njol/skript/expressions/arithmetic/ExprArithmetic.java
@@ -221,7 +221,7 @@ public class ExprArithmetic<L, R, T> extends SimpleExpression<T> {
 		 * If the types of both are object (e.g. variables), the return type will be object (have to wait until runtime and hope it works).
 		 * Of course, if no operations are found, init will fail.
 		 *
-		 * After these checks, it is same to assume returnType has a value, as init should have failed by now if not.
+		 * After these checks, it is safe to assume returnType has a value, as init should have failed by now if not.
 		 * One final check is performed specifically for numerical types.
 		 * Any numerical operation involving division or exponents have a return type of Double.
 		 * Other operations will also return Double, UNLESS 'first' and 'second' are of integer types, in which case the return type will be Long.

--- a/src/main/java/ch/njol/skript/log/ParseLogHandler.java
+++ b/src/main/java/ch/njol/skript/log/ParseLogHandler.java
@@ -31,6 +31,19 @@ public class ParseLogHandler extends LogHandler {
 	private LogEntry error = null;
 	
 	private final List<LogEntry> log = new ArrayList<>();
+
+	public ParseLogHandler backup() {
+		ParseLogHandler copy = new ParseLogHandler();
+		copy.error = this.error;
+		copy.log.addAll(this.log);
+		return copy;
+	}
+
+	public void paste(ParseLogHandler parseLogHandler) {
+		this.error = parseLogHandler.error;
+		this.log.clear();
+		this.log.addAll(parseLogHandler.log);
+	}
 	
 	@Override
 	public LogResult log(LogEntry entry) {

--- a/src/main/java/ch/njol/skript/log/ParseLogHandler.java
+++ b/src/main/java/ch/njol/skript/log/ParseLogHandler.java
@@ -18,8 +18,9 @@
  */
 package ch.njol.skript.log;
 
-import ch.njol.skript.Skript;
 import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,6 +33,12 @@ public class ParseLogHandler extends LogHandler {
 	
 	private final List<LogEntry> log = new ArrayList<>();
 
+	/**
+	 * Internal method for creating a backup of this log.
+	 * @return A new ParseLogHandler containing the contents of this ParseLogHandler.
+	 */
+	@ApiStatus.Internal
+	@Contract("-> new")
 	public ParseLogHandler backup() {
 		ParseLogHandler copy = new ParseLogHandler();
 		copy.error = this.error;
@@ -39,7 +46,11 @@ public class ParseLogHandler extends LogHandler {
 		return copy;
 	}
 
-	public void paste(ParseLogHandler parseLogHandler) {
+	/**
+	 * Internal method for restoring a backup of this log.
+	 */
+	@ApiStatus.Internal
+	public void restore(ParseLogHandler parseLogHandler) {
 		this.error = parseLogHandler.error;
 		this.log.clear();
 		this.log.addAll(parseLogHandler.log);

--- a/src/test/skript/tests/misc/invalid unparsed literals.sk
+++ b/src/test/skript/tests/misc/invalid unparsed literals.sk
@@ -1,0 +1,6 @@
+test "invalid unparsed literals":
+
+	parse:
+		loop 9 times:
+			set {_i} to loop-value - 1
+	assert last parse logs is not set with "skript should be able to understand 'loop-value - 1' but did not"

--- a/src/test/skript/tests/syntaxes/expressions/ExprArithmetic.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprArithmetic.sk
@@ -255,3 +255,10 @@ local function component_equals(a: number, b: number) :: boolean:
 	then:
 		return true
 	return true if {_a} is {_b}, else false
+
+test "arithmetic return types":
+	# the issue below is that <none> is now returned for the function
+	# skript interprets this as "y-coordinate of ({_location} - 4)" which is valid due to Object.class return types
+	# however, we can get more specific return types by returning the superclass of the return types of all Object-Number operations
+	set {_location} to location(0,10,0,"world")
+	assert (y-coordinate of {_location} - 4) is 6 with "y-coordinate of {_location} - 4 is not 6 (got '%y-coordinate of {_location} - 4%')"


### PR DESCRIPTION
### Description
This is an experimental fix for some issues with UnparsedLiterals that have gotten more exposure due to the changes in Arithmetic parsing. One now problematic expression is the following:
`index of event-slot - 9`
This would typically be interpreted (and expected to be interpreted as) `(index of event-slot) - (9)`. Skript is correctly identifying this as ExprArithmetic, but the left and right expressions are wrong. Skript will move from left to right trying to determine what group of characters makes up the expression. When Skript gets to the following, things go wrong: `(index of event)-(slot - 9)` Skript gets to this point and TypePatternElement does not continue as `index of event` and `slot - 9` are both valid UnparsedLiterals. ExprArithmetic then fails due to encountering UnparsedLiterals it cannot convert.

This PR addresses this issue by having TypePatternElement continue matching in the event it gets a MatchResult containing UnparsedLiterals that cannot be converted by regular means (classinfo parsing). It saves a backup of the **first** valid MatchResult and falls back to that if further searching yields nothing valid.

This solution may need tweaking if further issues arise.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:**
- https://github.com/SkriptLang/Skript/issues/6326
