### PR TITLE
🚀 Making function param rules stricter for the better

### DIFF
--- a/src/main/java/ch/njol/skript/lang/function/Parameter.java
+++ b/src/main/java/ch/njol/skript/lang/function/Parameter.java
@@ -41,7 +41,7 @@ import java.util.regex.Pattern;
 
 public final class Parameter<T> {
 
-	public final static Pattern PARAM_PATTERN = Pattern.compile("\\s*([\\w .-]+?)\\s*:\\s*([a-zA-Z ]+?)\\s*(?:\\s*=\\s*(.+))?\\s*$");
+	public final static Pattern PARAM_PATTERN = Pattern.compile("^\\s*([\\w .-]+?)\\s*:\\s*([a-zA-Z ]+?)\\s*(?:\\s*=\\s*(.+))?\\s*$");
 
 	/**
 	 * Name of this parameter. Will be used as name for the local variable

--- a/src/main/java/ch/njol/skript/lang/function/Parameter.java
+++ b/src/main/java/ch/njol/skript/lang/function/Parameter.java
@@ -41,7 +41,7 @@ import java.util.regex.Pattern;
 
 public final class Parameter<T> {
 
-	public final static Pattern PARAM_PATTERN = Pattern.compile("\\s*(.+?)\\s*:(?=[^:]*$)\\s*(.+?)(?:\\s*=\\s*(.+))?\\s*");
+	public final static Pattern PARAM_PATTERN = Pattern.compile("\\s*([\\w .-]+?)\\s*:\\s*([a-zA-Z ]+?)\\s*(?:\\s*=\\s*(.+))?\\s*$");
 
 	/**
 	 * Name of this parameter. Will be used as name for the local variable

--- a/src/main/java/ch/njol/skript/lang/function/Parameter.java
+++ b/src/main/java/ch/njol/skript/lang/function/Parameter.java
@@ -41,7 +41,7 @@ import java.util.regex.Pattern;
 
 public final class Parameter<T> {
 
-	public final static Pattern PARAM_PATTERN = Pattern.compile("^\\s*([\\w .-]+?)\\s*:\\s*([a-zA-Z ]+?)\\s*(?:\\s*=\\s*(.+))?\\s*$");
+	public final static Pattern PARAM_PATTERN = Pattern.compile("^\\s*([^:(){}\",]+?)\\s*:\\s*([a-zA-Z ]+?)\\s*(?:\\s*=\\s*(.+))?\\s*$");
 
 	/**
 	 * Name of this parameter. Will be used as name for the local variable

--- a/src/test/skript/tests/regressions/pull-6361-function-param.sk
+++ b/src/test/skript/tests/regressions/pull-6361-function-param.sk
@@ -1,0 +1,46 @@
+# TODO add these to tests once structure test parsing is implemented (https://github.com/SkriptLang/Skript/pull/6291)
+# function testA(loc): location, previoustype(): text):
+# 	broadcast "a"
+
+# function testB(loc(: location, previoustype): text):
+#     broadcast "b"
+
+# function testE(loc: location, previoustyp): returns text: object = (")")):
+#     broadcast "%{_loc}% %{_previoustyp): returns text}%"
+
+# function this((function should(not: exist) returns text:) ? object : text) :: text:
+#     return {_(function should(not: exist) returns text:) ? object }
+
+
+# function never(gonna: give = (you - up)): and function never(gonna: let, you: down) :: text):
+#     broadcast {@magic}
+
+# function testA3(previoustyp): returns text: object = (")")):
+# 	broadcast 2
+
+
+function test_English(test: text) :: text:
+    return {_test}
+
+function test_Arabic(تجربة: text) :: text:
+	return {_تجربة}
+
+function test_Japanese(テスト: text) :: text:
+	return {_テスト}
+
+function test_Greek(δοκιμή: text) :: text:
+	return {_δοκιμή}
+
+function test_Thai(ทดสอบ: text) :: text:
+	return {_ทดสอบ}
+
+function test_German(prüfen: text) :: text:
+	return {_prüfen}
+
+test "function parameter names":
+    assert test_English("text") = "text" with "Function 'test_English' failed function parameter name test"
+    assert test_Arabic("text") = "text" with "Function 'test_Arabic' failed function parameter name test"
+    assert test_Japanese("text") = "text" with "Function 'test_Japanese' failed function parameter name test"
+    assert test_Greek("text") = "text" with "Function 'test_Greek' failed function parameter name test"
+    assert test_Thai("text") = "text" with "Function 'test_Thai' failed function parameter name test"
+    assert test_German("text") = "text" with "Function 'test_German' failed function parameter name test"


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Today is another day making Skript making more sense 🙃

# Old Behaviour

After playing around with #6358 we found out that function parameters actually have almost zero limitation and @sovdeeth was generous enough to provide the weirdest valid param examples, enjoy it:
```v
function testA(loc): location, previoustype(): text):
    broadcast "a"

function testB(loc(: location, previoustype): text):
    broadcast "b"

function testE(loc: location, previoustyp): returns text: object = (")")):
    broadcast "%{_loc}% %{_previoustyp): returns text}%"

function this((function should(not: exist) returns text:) ? object : text) :: text:
    return {_(function should(not: exist) returns text:) ? object }

function never(gonna: give = (you - up)): and function never(gonna: let, you: down) :: text):
    broadcast {@magic}

function testA3(previoustyp): returns text: object = (")")):
	broadcast 2
```

Actually, these all make no sense so we decided to rectify them :)

# New Behaviour
Welcome to the new function param rules

It is correct that variables do accept many forms of names but it's very odd to have those forms in function param and due to the parser limitation we are better off stricting this to make it easier for the parser.

Functions parameters will now only accept Alphanumeric, whitespace, period, underscore and a dash (regex: `[\w .-]`)

[Regex101 playground](https://regex101.com/r/gClXj9/2)

How they error now:
![image](https://github.com/SkriptLang/Skript/assets/20037329/b537e867-7c6a-4305-8da3-7bfa72c659d2)


---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
