### PR TITLE
Fix paths for enabled scripts in ExprScripts.

### DIFF
--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -1008,17 +1008,6 @@ public class ScriptLoader {
 	}
 
 	/**
-	 * @return An unmodifiable set containing a snapshot of the currently disabled scripts as Paths.
-	 */
-	public static Set<Path> getDisabledScriptPaths() {
-		return Collections.unmodifiableSet(
-				disabledScripts.stream()
-						.map(File::toPath)
-						.collect(Collectors.toSet())
-				);
-	}
-
-	/**
 	 * @return A FileFilter defining the naming conditions of a loaded script.
 	 */
 	public static FileFilter getLoadedScriptsFilter() {

--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -1008,6 +1008,17 @@ public class ScriptLoader {
 	}
 
 	/**
+	 * @return An unmodifiable set containing a snapshot of the currently disabled scripts as Paths.
+	 */
+	public static Set<Path> getDisabledScriptPaths() {
+		return Collections.unmodifiableSet(
+				disabledScripts.stream()
+						.map(File::toPath)
+						.collect(Collectors.toSet())
+				);
+	}
+
+	/**
 	 * @return A FileFilter defining the naming conditions of a loaded script.
 	 */
 	public static FileFilter getLoadedScriptsFilter() {

--- a/src/main/java/ch/njol/skript/expressions/ExprScripts.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprScripts.java
@@ -88,7 +88,12 @@ public class ExprScripts extends SimpleExpression<String> {
 	@SuppressWarnings("null")
 	private String[] formatFiles(List<File> files) {
 		return files.stream()
-			.map(f -> noPaths ? f.getName() : f.getPath().replaceFirst(Pattern.quote(SCRIPTS_PATH), ""))
+			.map(f -> {
+				if (noPaths)
+					return f.getName();
+				String[] split = f.getPath().split(Pattern.quote(SCRIPTS_PATH), 2);
+				return split[split.length - 1];
+			})
 			.toArray(String[]::new);
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprScripts.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprScripts.java
@@ -34,8 +34,10 @@ import ch.njol.util.Kleenean;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.bukkit.event.Event;
 
@@ -82,7 +84,10 @@ public class ExprScripts extends SimpleExpression<String> {
 				scripts.add(script.getConfig().getPath());
 		}
 		if (includeDisabled)
-			scripts.addAll(ScriptLoader.getDisabledScriptPaths());
+			scripts.addAll(ScriptLoader.getDisabledScripts()
+					.stream()
+					.map(File::toPath)
+					.collect(Collectors.toList()));
 		return formatPaths(scripts);
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprScripts.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprScripts.java
@@ -57,9 +57,9 @@ public class ExprScripts extends SimpleExpression<String> {
 
 	static {
 		Skript.registerExpression(ExprScripts.class, String.class, ExpressionType.SIMPLE,
-				"[all [of the]] scripts [1:without ([subdirectory] paths|parents)]",
-				"[all [of the]] (enabled|loaded) scripts [1:without ([subdirectory] paths|parents)]",
-				"[all [of the]] (disabled|unloaded) scripts [1:without ([subdirectory] paths|parents)]");
+				"[all [of the]|the] scripts [1:without ([subdirectory] paths|parents)]",
+				"[all [of the]|the] (enabled|loaded) scripts [1:without ([subdirectory] paths|parents)]",
+				"[all [of the]|the] (disabled|unloaded) scripts [1:without ([subdirectory] paths|parents)]");
 	}
 
 	private static final Path SCRIPTS_PATH = Skript.getInstance().getScriptsFolder().getAbsoluteFile().toPath();


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Disabled scripts are stored as files with relative paths, so the code works perfectly already.
Enabled scripts are Configs with Paths created by File#toPath(), so ExprScripts converts them back into Files with Path#toFile(). This creates a File with an absolute path, not relative. 
This fix relativizes the paths of all the scripts to the scripts folder.

There's an existing issue of accuracy in the disabled scripts that will be handled in another PR.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #6373 <!-- Links to related issues -->
