### PR TITLE
Fix "vector from" syntax conflict by making ExprVectorFromDirection parse later.

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprLocationFromVector.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLocationFromVector.java
@@ -48,7 +48,7 @@ import org.jetbrains.annotations.Nullable;
 public class ExprLocationFromVector extends SimpleExpression<Location> {
 
 	static {
-		Skript.registerExpression(ExprLocationFromVector.class, Location.class, ExpressionType.SIMPLE,
+		Skript.registerExpression(ExprLocationFromVector.class, Location.class, ExpressionType.COMBINED,
 				"%vector% to location in %world%",
 				"location (from|of) %vector% in %world%",
 				"%vector% [to location] in %world% with yaw %number% and pitch %number%",

--- a/src/main/java/ch/njol/skript/expressions/ExprLocationVectorOffset.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLocationVectorOffset.java
@@ -46,7 +46,7 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprLocationVectorOffset extends SimpleExpression<Location> {
 
 	static {
-		Skript.registerExpression(ExprLocationVectorOffset.class, Location.class, ExpressionType.SIMPLE,
+		Skript.registerExpression(ExprLocationVectorOffset.class, Location.class, ExpressionType.COMBINED,
 				"%location% offset by [[the] vectors] %vectors%",
 				"%location%[ ]~[~][ ]%vectors%");
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorAngleBetween.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorAngleBetween.java
@@ -42,7 +42,7 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprVectorAngleBetween extends SimpleExpression<Number> {
 
 	static {
-		Skript.registerExpression(ExprVectorAngleBetween.class, Number.class, ExpressionType.SIMPLE,
+		Skript.registerExpression(ExprVectorAngleBetween.class, Number.class, ExpressionType.COMBINED,
 				"[the] angle between [[the] vectors] %vector% and %vector%");
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorBetweenLocations.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorBetweenLocations.java
@@ -42,7 +42,7 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprVectorBetweenLocations extends SimpleExpression<Vector> {
 
 	static {
-		Skript.registerExpression(ExprVectorBetweenLocations.class, Vector.class, ExpressionType.SIMPLE,
+		Skript.registerExpression(ExprVectorBetweenLocations.class, Vector.class, ExpressionType.COMBINED,
 				"[the] vector (from|between) %location% (to|and) %location%");
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorCrossProduct.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorCrossProduct.java
@@ -41,7 +41,7 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprVectorCrossProduct extends SimpleExpression<Vector> {
 
 	static {
-		Skript.registerExpression(ExprVectorCrossProduct.class, Vector.class, ExpressionType.SIMPLE, "%vector% cross %vector%");
+		Skript.registerExpression(ExprVectorCrossProduct.class, Vector.class, ExpressionType.COMBINED, "%vector% cross %vector%");
 	}
 
 	@SuppressWarnings("null")

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorCylindrical.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorCylindrical.java
@@ -46,7 +46,7 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprVectorCylindrical extends SimpleExpression<Vector> {
 
 	static {
-		Skript.registerExpression(ExprVectorCylindrical.class, Vector.class, ExpressionType.SIMPLE,
+		Skript.registerExpression(ExprVectorCylindrical.class, Vector.class, ExpressionType.COMBINED,
 				"[a] [new] cylindrical vector [(from|with)] [radius] %number%, [yaw] %number%(,| and) [height] %number%");
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorDotProduct.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorDotProduct.java
@@ -41,7 +41,7 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprVectorDotProduct extends SimpleExpression<Number> {
 
 	static {
-		Skript.registerExpression(ExprVectorDotProduct.class, Number.class, ExpressionType.SIMPLE, "%vector% dot %vector%");
+		Skript.registerExpression(ExprVectorDotProduct.class, Number.class, ExpressionType.COMBINED, "%vector% dot %vector%");
 	}
 
 	@SuppressWarnings("null")

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorFromDirection.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorFromDirection.java
@@ -49,7 +49,7 @@ import org.eclipse.jdt.annotation.Nullable;
 public class ExprVectorFromDirection extends SimpleExpression<Vector> {
 
 	static {
-		Skript.registerExpression(ExprVectorFromDirection.class, Vector.class, ExpressionType.SIMPLE,
+		Skript.registerExpression(ExprVectorFromDirection.class, Vector.class, ExpressionType.PROPERTY,
 				"vector[s] [from] %directions%",
 				"%directions% vector[s]");
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorFromXYZ.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorFromXYZ.java
@@ -41,7 +41,7 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprVectorFromXYZ extends SimpleExpression<Vector> {
 
 	static {
-		Skript.registerExpression(ExprVectorFromXYZ.class, Vector.class, ExpressionType.SIMPLE,
+		Skript.registerExpression(ExprVectorFromXYZ.class, Vector.class, ExpressionType.COMBINED,
 				"[a] [new] vector [(from|at|to)] %number%,[ ]%number%(,[ ]| and )%number%");
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorFromYawAndPitch.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorFromYawAndPitch.java
@@ -42,7 +42,7 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprVectorFromYawAndPitch extends SimpleExpression<Vector> {
 
 	static {
-		Skript.registerExpression(ExprVectorFromYawAndPitch.class, Vector.class, ExpressionType.SIMPLE,
+		Skript.registerExpression(ExprVectorFromYawAndPitch.class, Vector.class, ExpressionType.COMBINED,
 				"[a] [new] vector (from|with) yaw %number% and pitch %number%");
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorNormalize.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorNormalize.java
@@ -41,7 +41,7 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprVectorNormalize extends SimpleExpression<Vector> {
 
 	static {
-		Skript.registerExpression(ExprVectorNormalize.class, Vector.class, ExpressionType.SIMPLE,
+		Skript.registerExpression(ExprVectorNormalize.class, Vector.class, ExpressionType.COMBINED,
 				"normalize[d] %vector%",
 				"%vector% normalized");
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorOfLocation.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorOfLocation.java
@@ -42,7 +42,7 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprVectorOfLocation extends SimpleExpression<Vector> {
 
 	static {
-		Skript.registerExpression(ExprVectorOfLocation.class, Vector.class, ExpressionType.SIMPLE,
+		Skript.registerExpression(ExprVectorOfLocation.class, Vector.class, ExpressionType.PROPERTY,
 				"[the] vector (of|from|to) %location%",
 				"%location%'s vector");
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorSpherical.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorSpherical.java
@@ -46,7 +46,7 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprVectorSpherical extends SimpleExpression<Vector> {
 
 	static {
-		Skript.registerExpression(ExprVectorSpherical.class, Vector.class, ExpressionType.SIMPLE,
+		Skript.registerExpression(ExprVectorSpherical.class, Vector.class, ExpressionType.COMBINED,
 				"[new] spherical vector [(from|with)] [radius] %number%, [yaw] %number%(,| and) [pitch] %number%");
 	}
 

--- a/src/test/skript/tests/regressions/6348-vector from expressions conflict.sk
+++ b/src/test/skript/tests/regressions/6348-vector from expressions conflict.sk
@@ -1,0 +1,7 @@
+test "vector from expressions conflict":
+	set {_x} to 1
+	set {_y} to 2
+	set {_z} to -3
+	set {_v} to vector from {_x}, {_y}, {_z}
+	set {_v2} to vector({_x}, {_y}, {_z})
+	assert {_v} is {_v2} with "Vector from not generating correct vector. Expected %{_v2}%, got %{_v}%"


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Updates the ExpressionType for all vector expressions. Since FromDirection is now PROPERTY and fromXYZ is now COMBINED, from XYZ now takes priority. This does technically mean you cannot do ``vector[s] from {_dir1}, {_dir2}, {_dir3}``, but personally I think that's not something to worry about.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #6348 <!-- Links to related issues -->
