### PR TITLE
Fix AIOOB with ExprVectorXYZ when used with non-vectors

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprVectorXYZ.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorXYZ.java
@@ -52,7 +52,8 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprVectorXYZ extends SimplePropertyExpression<Vector, Number> {
 	
 	static {
-		register(ExprVectorXYZ.class, Number.class, "[vector] (0¦x|1¦y|2¦z) [component[s]]", "vectors");
+		// TODO: Combine with ExprCoordinates for 2.9
+		register(ExprVectorXYZ.class, Number.class, "[vector] (0:x|1:y|2:z) [component[s]]", "vectors");
 	}
 	
 	private final static Character[] axes = new Character[] {'x', 'y', 'z'};
@@ -84,6 +85,8 @@ public class ExprVectorXYZ extends SimplePropertyExpression<Vector, Number> {
 	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		assert delta != null;
 		Vector[] vectors = getExpr().getArray(event);
+		if (vectors.length == 0)
+			return;
 		double deltaValue = ((Number) delta[0]).doubleValue();
 		switch (mode) {
 			case REMOVE:

--- a/src/test/skript/tests/regressions/6385-x component of block.sk
+++ b/src/test/skript/tests/regressions/6385-x component of block.sk
@@ -1,0 +1,3 @@
+test "x component of block":
+	set {_a} to block at location(0, 0, 0)
+	add 1 to x of {_a} # should not throw exception


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Simple length check to prevent AIOOB when trying to mistakenly change the components of a non-vector.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #6385 <!-- Links to related issues -->
