### PR TITLE
Changes CondCompare to be able to directly compare two AND lists.

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondCompare.java
+++ b/src/main/java/ch/njol/skript/conditions/CondCompare.java
@@ -316,6 +316,8 @@ public class CondCompare extends Condition {
 	 * a # x and y === a # x && a # y
 	 * a # x or y === a # x || a # y
 	 * a and b # x and y === a # x and y && b # x and y === a # x && a # y && b # x && b # y
+	 * 	- Special case if # is =: (a and b = x and y) === (a = x && b = y)
+	 *  - This allows direct list comparisons for equality.
 	 * a and b # x or y === a # x or y && b # x or y
 	 * a or b # x and y === a # x and y || b # x and y
 	 * a or b # x or y === a # x or y || b # x or y
@@ -343,13 +345,20 @@ public class CondCompare extends Condition {
 	 */
 	@Override
 	@SuppressWarnings("unchecked")
-	public boolean check(final Event e) {
+	public boolean check(final Event event) {
 		final Expression<?> third = this.third;
-		return first.check(e, (Checker<Object>) o1 ->
-			second.check(e, (Checker<Object>) o2 -> {
+		// if we are directly comparing the equality of two AND lists, we should change behavior to
+		// compare element-wise, instead of comparing everything to everything.
+		if (relation == Relation.EQUAL && third == null &&
+				first.getAnd() && !first.isSingle() &&
+				second.getAnd() && !second.isSingle())
+			return compareLists(event);
+
+		return first.check(event, (Checker<Object>) o1 ->
+			second.check(event, (Checker<Object>) o2 -> {
 				if (third == null)
 					return relation.isImpliedBy(comparator != null ? comparator.compare(o1, o2) : Comparators.compare(o1, o2));
-				return third.check(e, (Checker<Object>) o3 -> {
+				return third.check(event, (Checker<Object>) o3 -> {
 					boolean isBetween;
 					if (comparator != null) {
 						if (o1 instanceof Cyclical<?> && o2 instanceof Cyclical<?> && o3 instanceof Cyclical<?>) {
@@ -381,15 +390,36 @@ public class CondCompare extends Condition {
 			}
 		), isNegated());
 	}
-	
+
+	/**
+	 * Used to directly compare two lists for equality.
+	 * This method assumes that {@link CondCompare#first} and {@link CondCompare#second} are both non-single.
+	 * @param event the event with which to evaluate {@link CondCompare#first} and {@link CondCompare#second}.
+	 * @return Whether every element in {@link CondCompare#first} is equal to its counterpart in {@link CondCompare#second}.
+	 * 		e.g. (1,2,3) = (1,2,3), but (1,2,3) != (3,2,1)
+	 */
+	private boolean compareLists(Event event) {
+		Object[] first = this.first.getArray(event);
+		Object[] second = this.second.getArray(event);
+		boolean notMatch = isNegated();
+		// read 'notMatch' as false and '!notMatch' as true
+		if (first.length != second.length)
+			return notMatch;
+		for (int i = 0; i < first.length; i++) {
+			if (!relation.isImpliedBy(comparator != null ? comparator.compare(first[i], second[i]) : Comparators.compare(first[i], second[i])))
+				return notMatch;
+		}
+		return !notMatch;
+	}
+
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
+	public String toString(final @Nullable Event event, final boolean debug) {
 		String s;
 		final Expression<?> third = this.third;
 		if (third == null)
-			s = first.toString(e, debug) + " is " + (isNegated() ? "not " : "") + relation + " " + second.toString(e, debug);
+			s = first.toString(event, debug) + " is " + (isNegated() ? "not " : "") + relation + " " + second.toString(event, debug);
 		else
-			s = first.toString(e, debug) + " is " + (isNegated() ? "not " : "") + "between " + second.toString(e, debug) + " and " + third.toString(e, debug);
+			s = first.toString(event, debug) + " is " + (isNegated() ? "not " : "") + "between " + second.toString(event, debug) + " and " + third.toString(event, debug);
 		if (debug)
 			s += " (comparator: " + comparator + ")";
 		return s;

--- a/src/main/java/ch/njol/skript/conditions/CondCompare.java
+++ b/src/main/java/ch/njol/skript/conditions/CondCompare.java
@@ -401,15 +401,14 @@ public class CondCompare extends Condition {
 	private boolean compareLists(Event event) {
 		Object[] first = this.first.getArray(event);
 		Object[] second = this.second.getArray(event);
-		boolean notMatch = isNegated();
-		// read 'notMatch' as false and '!notMatch' as true
+		boolean shouldMatch = !isNegated(); // for readability
 		if (first.length != second.length)
-			return notMatch;
+			return !shouldMatch;
 		for (int i = 0; i < first.length; i++) {
 			if (!relation.isImpliedBy(comparator != null ? comparator.compare(first[i], second[i]) : Comparators.compare(first[i], second[i])))
-				return notMatch;
+				return !shouldMatch;
 		}
-		return !notMatch;
+		return shouldMatch;
 	}
 
 	@Override

--- a/src/test/skript/tests/syntaxes/conditions/CondCompare.sk
+++ b/src/test/skript/tests/syntaxes/conditions/CondCompare.sk
@@ -1,4 +1,20 @@
 test "compare":
+	assert 1 is 1 with "Number isn't itself"
+	assert 1 is not 2 with "Number is equal to other number"
+	assert 1 is less than 2 with "Number is not less than a larger number"
+	assert 1 is greater than 0 with "Number is not greater than a smaller number"
+	assert 1 is greater than or equal to 0 and 1 with "Number is not greater than or equal to two smaller/equal numbers"
+	assert 1 is less than or equal to 1 and 2 with "Number is not smaller than or equal to two greater/equal numbers"
+
+	assert 1, 2 is 1, 2 with "direct list comparison of equal numbers failed"
+	assert 1, 2, 3 is not 1, 2 with "direct list comparison of non-equal numbers succeeded"
+	assert 1, 2 is 1, 2, or 3 with "comparison between AND list of numbers and OR list of superset of numbers failed"
+	assert 1, 2, 3 is 1 or 2 to fail with "comparison between AND list of numbers and OR list of subset of numbers succeeded"
+
+	assert 1, 2, 3 is greater than -1, -2, -3 with "Numbers are not larger than smaller numbers"
+	assert 1, 2, 3 is less than 5, 6, 7 with "Numbers are not smaller than larger numbers"
+	assert 1, 2, 3 is between -1, 1 and 3, 3.5 with "Numbers are not between smaller/equal numbers and larger/equal numbers"
+
 	assert 10 is between 5 and 15 with "Number isn't between smaller and larger"
 	assert 10 is between 9 and 11 with "Number isn't between smaller and larger"
 	assert 10 is between 11 and 9 with "Number isn't between larger and smaller"


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Currently, the only way to compare two lists for exact equality is to check each element individually within a loop. Attempting to do `1, 2, 3 is 1, 2, 3` will always fail, because Skript compares lists by comparing each element in A to every element in B. This is great for most comparisons, like >, is between, or when using OR lists like `1, 2 is 1, 2, or 3`. 

This PR adds a special case when comparing two AND lists for equality only which will compare each element to its corresponding position in the other list. This allows users to directly compare lists without having to manually loop.

Caveats: 
- If you have lists with different indices, `{indexed by name::*} = {indexed by number::*}` will return true if the values are the same (and the same order). I think this is fine, personally.
- 1, 2, 3 does not equal 3, 2, 1 with this PR. I also think this makes sense, but it may trip users up. Contains should be used to check that.

This is technically a breaking change, and I'm marking as such (and as enhancement), but I think it could be argued that there's no *useful* behavior this is breaking and it should be treated as a bug fix instead. We'd have to have a consensus on that, though.

Let me know opinions on or concerns about this change, or any suggestions!

This also adds more tests for CondCompare, but is by no means exhaustive.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #6293 <!-- Links to related issues -->
