### PR TITLE
Fix ExprPlain always getting the base material from ItemTypes

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprPlain.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPlain.java
@@ -61,7 +61,7 @@ public class ExprPlain extends SimpleExpression<ItemType> {
 		ItemType itemType = item.getSingle(e);
 		if (itemType == null)
 			return new ItemType[0];
-		ItemData data = new ItemData(itemType.getMaterial());
+		ItemData data = new ItemData(itemType.getRandom().getType());
 		data.setPlain(true);
 		ItemType plain = new ItemType(data);
 		return new ItemType[]{plain};

--- a/src/test/java/org/skriptlang/skript/test/tests/regression/ExprPlainAliasTest.java
+++ b/src/test/java/org/skriptlang/skript/test/tests/regression/ExprPlainAliasTest.java
@@ -32,6 +32,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+// https://github.com/SkriptLang/Skript/issues/5994
 public class ExprPlainAliasTest extends SkriptJUnitTest {
 	private ItemType itemType;
 	@Nullable

--- a/src/test/java/org/skriptlang/skript/test/tests/regression/ExprPlainAliasTest.java
+++ b/src/test/java/org/skriptlang/skript/test/tests/regression/ExprPlainAliasTest.java
@@ -1,0 +1,61 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package org.skriptlang.skript.test.tests.regression;
+
+import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.TriggerItem;
+import ch.njol.skript.lang.util.ContextlessEvent;
+import ch.njol.skript.test.runner.SkriptJUnitTest;
+import ch.njol.skript.variables.Variables;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.easymock.EasyMock;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ExprPlainAliasTest extends SkriptJUnitTest {
+	private ItemType itemType;
+	@Nullable
+	private Effect getPlainRandomItemEffect;
+
+	@Before
+	public void setup() {
+		itemType = EasyMock.niceMock(ItemType.class);
+		getPlainRandomItemEffect = Effect.parse("set {_a} to plain {_item}", null);
+	}
+
+	@Test
+	public void test() {
+		if (getPlainRandomItemEffect == null)
+			Assert.fail("Plain item effect is null");
+
+		ContextlessEvent event = ContextlessEvent.get();
+		Variables.setVariable("item", itemType, event, true);
+
+		EasyMock.expect(itemType.getRandom()).andReturn(new ItemStack(Material.STONE)).atLeastOnce();
+		EasyMock.replay(itemType);
+		TriggerItem.walk(getPlainRandomItemEffect, event);
+		EasyMock.verify(itemType);
+
+	}
+
+}


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Calls ItemType#getRandom() to ensure the item is a accurate representation of the alias (e.g. any sword) before getting the material.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #5994 <!-- Links to related issues -->
