### PR TITLE
Make bucket fill events provide the correct event-block.

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -712,14 +712,14 @@ public final class BukkitEventValues {
 			@Override
 			@Nullable
 			public Block get(final PlayerBucketFillEvent e) {
-				return e.getBlockClicked().getRelative(e.getBlockFace());
+				return e.getBlockClicked();
 			}
 		}, 0);
 		EventValues.registerEventValue(PlayerBucketFillEvent.class, Block.class, new Getter<Block, PlayerBucketFillEvent>() {
 			@Override
 			@Nullable
 			public Block get(final PlayerBucketFillEvent e) {
-				final BlockState s = e.getBlockClicked().getRelative(e.getBlockFace()).getState();
+				final BlockState s = e.getBlock().getState();
 				s.setType(Material.AIR);
 				s.setRawData((byte) 0);
 				return new BlockStateBlock(s, true);

--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -719,7 +719,7 @@ public final class BukkitEventValues {
 			@Override
 			@Nullable
 			public Block get(final PlayerBucketFillEvent e) {
-				final BlockState s = e.getBlock().getState();
+				final BlockState s = e.getBlockClicked().getState();
 				s.setType(Material.AIR);
 				s.setRawData((byte) 0);
 				return new BlockStateBlock(s, true);

--- a/src/main/java/ch/njol/skript/events/EvtBlock.java
+++ b/src/main/java/ch/njol/skript/events/EvtBlock.java
@@ -90,9 +90,9 @@ public class EvtBlock extends SkriptEvent {
 	
 	@SuppressWarnings("null")
 	@Override
-	public boolean check(final Event e) {
-		if (mine && e instanceof BlockBreakEvent) {
-			if (((BlockBreakEvent) e).getBlock().getDrops(((BlockBreakEvent) e).getPlayer().getItemInHand()).isEmpty())
+	public boolean check(final Event event) {
+		if (mine && event instanceof BlockBreakEvent) {
+			if (((BlockBreakEvent) event).getBlock().getDrops(((BlockBreakEvent) event).getPlayer().getItemInHand()).isEmpty())
 				return false;
 		}
 		if (types == null)
@@ -101,27 +101,27 @@ public class EvtBlock extends SkriptEvent {
 		ItemType item;
 		BlockData blockData = null;
 
-		if (e instanceof BlockFormEvent) {
-			BlockFormEvent blockFormEvent = (BlockFormEvent) e;
+		if (event instanceof BlockFormEvent) {
+			BlockFormEvent blockFormEvent = (BlockFormEvent) event;
 			BlockState newState = blockFormEvent.getNewState();
 			item = new ItemType(newState);
 			blockData = newState.getBlockData();
-		} else if (e instanceof BlockEvent) {
-			BlockEvent blockEvent = (BlockEvent) e;
+		} else if (event instanceof BlockEvent) {
+			BlockEvent blockEvent = (BlockEvent) event;
 			Block block = blockEvent.getBlock();
 			item = new ItemType(block);
 			blockData = block.getBlockData();
-		} else if (e instanceof PlayerBucketFillEvent) {
-			PlayerBucketFillEvent playerBucketFillEvent = ((PlayerBucketFillEvent) e);
-			Block relative = playerBucketFillEvent.getBlockClicked().getRelative(playerBucketFillEvent.getBlockFace());
-			item = new ItemType(relative);
-			blockData = relative.getBlockData();
-		} else if (e instanceof PlayerBucketEmptyEvent) {
-			PlayerBucketEmptyEvent playerBucketEmptyEvent = ((PlayerBucketEmptyEvent) e);
+		} else if (event instanceof PlayerBucketFillEvent) {
+			PlayerBucketFillEvent playerBucketFillEvent = ((PlayerBucketFillEvent) event);
+			Block block = playerBucketFillEvent.getBlockClicked();
+			item = new ItemType(block);
+			blockData = block.getBlockData();
+		} else if (event instanceof PlayerBucketEmptyEvent) {
+			PlayerBucketEmptyEvent playerBucketEmptyEvent = ((PlayerBucketEmptyEvent) event);
 			item = new ItemType(playerBucketEmptyEvent.getItemStack());
-		} else if (e instanceof HangingEvent) {
-			final EntityData<?> d = EntityData.fromEntity(((HangingEvent) e).getEntity());
-			return types.check(e, o -> {
+		} else if (event instanceof HangingEvent) {
+			final EntityData<?> d = EntityData.fromEntity(((HangingEvent) event).getEntity());
+			return types.check(event, o -> {
 				if (o instanceof ItemType)
 					return Relation.EQUAL.isImpliedBy(DefaultComparators.entityItemComparator.compare(d, ((ItemType) o)));
 				return false;
@@ -134,7 +134,7 @@ public class EvtBlock extends SkriptEvent {
 		final ItemType itemF = item;
 		BlockData finalBlockData = blockData;
 
-		return types.check(e, o -> {
+		return types.check(event, o -> {
 			if (o instanceof ItemType)
 				return ((ItemType) o).isSupertypeOf(itemF);
 			else if (o instanceof BlockData && finalBlockData != null)


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Guess there was some very outdated workaround code to get the water block. It's just `getClickedBlock` now.
Tested on paper + spigot 1.20.4 and paper 1.13.2

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #6268  <!-- Links to related issues -->
