### PR TITLE
Add "invincible" as a synonym of "invulnerable" in related syntaxes.

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondIsInvulnerable.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsInvulnerable.java
@@ -33,7 +33,7 @@ import ch.njol.skript.doc.Since;
 public class CondIsInvulnerable extends PropertyCondition<Entity> {
 	
 	static {
-		register(CondIsInvulnerable.class, PropertyType.BE, "invulnerable", "entities");
+		register(CondIsInvulnerable.class, PropertyType.BE, "(invulnerable|invincible)", "entities");
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/effects/EffInvulnerability.java
+++ b/src/main/java/ch/njol/skript/effects/EffInvulnerability.java
@@ -40,8 +40,8 @@ public class EffInvulnerability extends Effect {
 	
 	static {
 		Skript.registerEffect(EffInvulnerability.class,
-			"make %entities% invulnerable",
-			"make %entities% (not invulnerable|vulnerable)");
+			"make %entities% (invulnerable|invincible)",
+			"make %entities% (not (invulnerable|invincible)|vulnerable)");
 	}
 	
 	@SuppressWarnings("null")
@@ -57,15 +57,15 @@ public class EffInvulnerability extends Effect {
 	}
 	
 	@Override
-	protected void execute(Event e) {
-		for (Entity entity : entities.getArray(e)) {
+	protected void execute(Event event) {
+		for (Entity entity : entities.getArray(event)) {
 			entity.setInvulnerable(invulnerable);
 		}
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "make " + entities.toString(e, debug) + (invulnerable ? " invulnerable" : " not invulnerable");
+	public String toString(@Nullable Event event, boolean debug) {
+		return "make " + entities.toString(event, debug) + (invulnerable ? " invulnerable" : " not invulnerable");
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffInvulnerability.java
+++ b/src/main/java/ch/njol/skript/effects/EffInvulnerability.java
@@ -41,7 +41,7 @@ public class EffInvulnerability extends Effect {
 	static {
 		Skript.registerEffect(EffInvulnerability.class,
 			"make %entities% (invulnerable|invincible)",
-			"make %entities% (not (invulnerable|invincible)|vulnerable)");
+			"make %entities% (not (invulnerable|invincible)|vulnerable|vincible)");
 	}
 	
 	@SuppressWarnings("null")

--- a/src/main/java/ch/njol/skript/expressions/ExprNoDamageTicks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNoDamageTicks.java
@@ -38,7 +38,7 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprNoDamageTicks extends SimplePropertyExpression<LivingEntity, Long> {
 	
 	static {
-		register(ExprNoDamageTicks.class, Long.class, "(invulnerability|no damage) tick[s]", "livingentities");
+		register(ExprNoDamageTicks.class, Long.class, "(invulnerability|invincibility|no damage) tick[s]", "livingentities");
 	}
 
 	@Override


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Syntaxes that use "invulnerable" will also allow "invincible" as well, to reduce confusion and make it slightly more likely someone can write the syntax from memory.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
