### PR TITLE
Fix loading on Spigot versions older than 1.18

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/AliasesProvider.java
+++ b/src/main/java/ch/njol/skript/aliases/AliasesProvider.java
@@ -21,10 +21,12 @@ package ch.njol.skript.aliases;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.List;
 import java.util.Map;
 
+import ch.njol.skript.Skript;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
@@ -42,6 +44,9 @@ import ch.njol.skript.entity.EntityData;
  * Provides aliases on Bukkit/Spigot platform.
  */
 public class AliasesProvider {
+
+	// not supported on Spigot versions older than 1.18
+	private static final boolean FASTER_SET_SUPPORTED = Skript.classExists("it.unimi.dsi.fastutil.objects.ObjectOpenHashSet");
 	
 	/**
 	 * When an alias is not found, it will requested from this provider.
@@ -173,7 +178,12 @@ public class AliasesProvider {
 		this.aliases = new HashMap<>(expectedCount);
 		this.variations = new HashMap<>(expectedCount / 20);
 		this.aliasesMap = new AliasesMap();
-		this.materials = new ObjectOpenHashSet<>();
+
+		if (FASTER_SET_SUPPORTED) {
+			this.materials = new ObjectOpenHashSet<>();
+		} else {
+			this.materials = new HashSet<>();
+		}
 		
 		this.gson = new Gson();
 	}


### PR DESCRIPTION
### Description
The set implementation used by Aliases is not available on some older Spigot versions.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:**
- https://github.com/SkriptLang/Skript/issues/6398
