### PR TITLE
Add command argument tab complete

### DIFF
--- a/src/main/java/ch/njol/skript/command/Argument.java
+++ b/src/main/java/ch/njol/skript/command/Argument.java
@@ -41,6 +41,7 @@ import ch.njol.skript.log.RetainingLogHandler;
 import ch.njol.skript.log.SkriptLogger;
 import ch.njol.skript.util.Utils;
 import ch.njol.skript.variables.Variables;
+import ch.njol.util.coll.CollectionUtils;
 
 /**
  * Represents an argument of a command
@@ -118,8 +119,13 @@ public class Argument<T> {
 	}
 
 	public void setToDefault(ScriptCommandEvent event) {
-		if (defaultExpression != null)
-			set(event, defaultExpression.getArray(event));
+		if (defaultExpression != null) {
+			if (defaultExpression instanceof ExprTabCompletions) {
+				set(event, CollectionUtils.array(defaultExpression.getArray(event)[0]));
+			} else {
+				set(event, defaultExpression.getArray(event));
+			}
+		}
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/ch/njol/skript/command/ScriptCommand.java
+++ b/src/main/java/ch/njol/skript/command/ScriptCommand.java
@@ -576,17 +576,18 @@ public class ScriptCommand implements TabExecutor {
 
 	@Nullable
 	@Override
-	public List<String> onTabComplete(@Nullable CommandSender sender, @Nullable Command command, @Nullable String alias, @Nullable String[] args) {
+	public List<String> onTabComplete(@Nullable CommandSender sender, @Nullable Command command, @Nullable String commandLabel, @Nullable String[] args) {
 		assert args != null;
 		int argIndex = args.length - 1;
 		if (argIndex >= arguments.size())
 			return Collections.emptyList(); // Too many arguments, nothing to complete
-		Argument<?> arg = arguments.get(argIndex);
-		Class<?> argType = arg.getType();
-		if (argType.equals(Player.class) || argType.equals(OfflinePlayer.class))
+		Argument<?> argument = arguments.get(argIndex);
+		Class<?> argumentType = argument.getType();
+		if (argumentType.equals(Player.class) || argumentType.equals(OfflinePlayer.class))
 			return null; // Default completion
 
-		return Collections.emptyList(); // No tab completion here!
+		ScriptCommandEvent event = new ScriptCommandEvent(this, sender, commandLabel, StringUtils.join(args, " "));
+		return argument.getTabCompletions(event); // No tab completion here!
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprTabCompletions.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTabCompletions.java
@@ -1,0 +1,52 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.expressions;
+
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.command.ScriptCommandEvent;
+import ch.njol.skript.expressions.base.WrapperExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+
+public class ExprTabCompletions extends WrapperExpression<String> {
+
+	static {
+		Skript.registerExpression(ExprTabCompletions.class, String.class, ExpressionType.COMBINED, "tab complet(e|ion[s]) %strings%");
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		if (!getParser().isCurrentEvent(ScriptCommandEvent.class)) // No error to respect addons with similar pattern.
+			return false;
+		setExpr((Expression<? extends String>) expressions[0]);
+		return true;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "tab completions " + getExpr().toString(event, debug);
+	}
+
+}


### PR DESCRIPTION
### Description
Adds command parse context tab complete, and cleaned up Argument class.
Takes advantage of WrapperExpression to make this extremely easy and simple to implement.
```vb
command /example <string=%tab completions "example" and "another example"%>:
	trigger:
		message string argument # messages "example" and "another example" if just /example (existing behaviour)
		if the string argument is "example":
			message "1" to player
		else if the string argument is "another example":
			message "2" to player
```
![image](https://github.com/SkriptLang/Skript/assets/16087552/75914f11-4c4f-4101-83fc-53e203a88114)

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
