### PR TITLE
Fix Compilation Issues (Address DamageEvent Constructor Changes)

### DIFF
--- a/src/test/skript/tests/syntaxes/expressions/ExprLastDamageCause
+++ b/src/test/skript/tests/syntaxes/expressions/ExprLastDamageCause
@@ -1,0 +1,10 @@
+test "last damage cause":
+
+	spawn a pig at spawn of "world"
+	set {_pig} to last spawned pig
+
+	assert last damage cause of {_pig} is custom with "expected pig to have custom damage cause, but it didn't"
+	set last damage cause of {_pig} to drowning
+	assert last damage cause of {_pig} is drowning with "expected pig to have drowning damage cause, but it didn't"
+
+	delete the entity within {_pig}


### PR DESCRIPTION
### Description
This fixes the recent compilation issues by using the correct damage event constructor depending on which is available.

I've included a test to ensure functionality is kept.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
