### PR TITLE
Fix entity damage event 1.20.4 constructor changes

### DIFF
--- a/src/main/java/ch/njol/skript/bukkitutil/HealthUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/HealthUtils.java
@@ -132,7 +132,7 @@ public class HealthUtils {
 	public static boolean DAMAGE_SOURCE;
 
 	@Nullable
-	private static final Constructor<EntityDamageEvent> DAMAGE_EVENT_CONSTRUCTOR;
+	private static Constructor<EntityDamageEvent> DAMAGE_EVENT_CONSTRUCTOR;
 
 	static {
 		if (!DAMAGE_SOURCE) {
@@ -161,7 +161,7 @@ public class HealthUtils {
 			entity.setLastDamageCause(DAMAGE_EVENT_CONSTRUCTOR.newInstance(entity, cause, 0));
 		} catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
 			Skript.exception(e, "Failed to set last damage cause");
-    }
+		}
 	}
 
 }

--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -1585,12 +1585,12 @@ public class BukkitClasses {
 
 						@Override
 						public String toString(DamageType type, int flags) {
-							return type.getKey().getNamespace();
+							return type.getKey();
 						}
 
 						@Override
 						public String toVariableNameString(DamageType type) {
-							return "damage type:" + type.getKey().getNamespace();
+							return "damage type:" + type.getKey();
 						}
 					}));
 		}

--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -1585,12 +1585,12 @@ public class BukkitClasses {
 
 						@Override
 						public String toString(DamageType type, int flags) {
-							return type.getKey();
+							return type.getKey().toString();
 						}
 
 						@Override
 						public String toVariableNameString(DamageType type) {
-							return "damage type: " + type.getKey();
+							return "damage type: " + type.getKey().toString();
 						}
 					}));
 		}

--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.Map.Entry;
 import java.util.UUID;
 import java.util.regex.Matcher;
@@ -37,7 +38,9 @@ import org.bukkit.GameMode;
 import org.bukkit.GameRule;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.Registry;
 import org.bukkit.SoundCategory;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
@@ -48,6 +51,8 @@ import org.bukkit.block.BlockState;
 import org.bukkit.block.DoubleChest;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.command.CommandSender;
+import org.bukkit.damage.DamageSource;
+import org.bukkit.damage.DamageType;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.enchantments.EnchantmentOffer;
 import org.bukkit.entity.Cat;
@@ -1548,6 +1553,48 @@ public class BukkitClasses {
 				.name("Transform Reason")
 				.description("Represents a transform reason of an <a href='events.html#entity transform'>entity transform event</a>.")
 				.since("2.8.0"));
+
+		if (Skript.classExists("org.bukkit.damage.DamageType")) {
+			Classes.registerClass(new ClassInfo<>(DamageSource.class, "damagesource")
+					.user("damage ?sources?")
+					.name("Damage Source")
+					.description("The damage source in an entity damage event.")
+					.since("INSERT VERSION"));
+
+			Classes.registerClass(new ClassInfo<>(DamageType.class, "damagetype")
+					.user("damage ?types?")
+					.name("Damage Type")
+					.description("The damage type of a damage source.")
+					.since("INSERT VERSION")
+					.parser(new Parser<DamageType>() {
+						@Override
+						@Nullable
+						public DamageType parse(String input, ParseContext context) {
+							if (input.contains(":")) {
+								String[] split = input.split(Pattern.quote(":"));
+								try {
+									return Registry.DAMAGE_TYPE.get(new NamespacedKey(split[0], split[1]));
+								} catch (IllegalArgumentException e) {}
+							}
+							try {
+								return Registry.DAMAGE_TYPE.get(NamespacedKey.minecraft(input));
+							} catch (IllegalArgumentException e) {}
+
+							return null;
+						}
+
+						@Override
+						public String toString(DamageType type, int flags) {
+							return type.getKey().getNamespace();
+						}
+
+						@Override
+						public String toVariableNameString(DamageType type) {
+							return "damage type:" + type.getKey().getNamespace();
+						}
+					}));
+		}
+
 	}
 
 }

--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -1585,12 +1585,12 @@ public class BukkitClasses {
 
 						@Override
 						public String toString(DamageType type, int flags) {
-							return type.getKey();
+							return Classes.toString(type.getKey());
 						}
 
 						@Override
 						public String toVariableNameString(DamageType type) {
-							return "damage type:" + type.getKey();
+							return "damage type: " + Classes.toString(type.getKey());
 						}
 					}));
 		}

--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -1585,12 +1585,12 @@ public class BukkitClasses {
 
 						@Override
 						public String toString(DamageType type, int flags) {
-							return Classes.toString(type.getKey());
+							return type.getKey();
 						}
 
 						@Override
 						public String toVariableNameString(DamageType type) {
-							return "damage type: " + Classes.toString(type.getKey());
+							return "damage type: " + type.getKey();
 						}
 					}));
 		}

--- a/src/main/java/ch/njol/skript/expressions/ExprLastDamageCause.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLastDamageCause.java
@@ -18,14 +18,6 @@
  */
 package ch.njol.skript.expressions;
 
-import org.bukkit.damage.DamageSource;
-import org.bukkit.damage.DamageType;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.event.Event;
-import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
-import org.eclipse.jdt.annotation.Nullable;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.bukkitutil.HealthUtils;
 import ch.njol.skript.classes.Changer.ChangeMode;
@@ -41,17 +33,27 @@ import ch.njol.skript.util.Getter;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 
+import org.bukkit.damage.DamageType;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.Event;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+import org.eclipse.jdt.annotation.Nullable;
+
 @Name("Last Damage Cause/Type")
 @Description({
 	"Cause of last damage done to an entity.",
 	"Using 'damage type' is more accurate as it includes data pack types, but it is only available on versions 1.20.4 and newer."
 })
 @Examples({
-	"set last damage cause of event-entity to fire tick"
+	"set last damage cause of event-entity to fire tick",
+	"set last damage type of event-entity to wither"
 })
 @RequiredPlugins("Spigot 1.20.4+ for damage type")
 @Since("2.2-Fixes-V10")
 public class ExprLastDamageCause extends PropertyExpression<LivingEntity, Object> {
+
+	private static final boolean DAMAGE_TYPE = Skript.classExists("org.bukkit.damage.DamageType");
 
 	static {
 		register(ExprLastDamageCause.class, Object.class, "last damage (cause|reason|:type)", "livingentities");
@@ -74,11 +76,11 @@ public class ExprLastDamageCause extends PropertyExpression<LivingEntity, Object
 			public Object get(LivingEntity entity) {
 				EntityDamageEvent damageEvent = entity.getLastDamageCause();
 				if (damageEvent == null) {
-					if (type)
+					if (type && DAMAGE_TYPE)
 						return DamageType.GENERIC;
 					return DamageCause.CUSTOM;
 				}
-				if (type)
+				if (type && DAMAGE_TYPE)
 					return damageEvent.getDamageSource().getDamageType();
 				return damageEvent.getCause();
 			}
@@ -121,12 +123,12 @@ public class ExprLastDamageCause extends PropertyExpression<LivingEntity, Object
 
 	@Override
 	public Class<?> getReturnType() {
-		return type ? DamageType.class : DamageCause.class;
+		return type && DAMAGE_TYPE ? DamageType.class : DamageCause.class;
 	}
 
 	@Override
 	public String toString(@Nullable Event event, boolean debug) {
-		if (type)			
+		if (type && DAMAGE_TYPE)			
 			return "damage type " + getExpr().toString(event, debug);
 		return "damage cause " + getExpr().toString(event, debug);
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprLastDamageCause.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLastDamageCause.java
@@ -44,12 +44,12 @@ import ch.njol.util.coll.CollectionUtils;
 @Name("Last Damage Cause/Type")
 @Description({
 	"Cause of last damage done to an entity.",
-	"Damage type is more accurate including data pack types and only available in 1.20.4+"
+	"Using 'damage type' is more accurate as it includes data pack types, but it is only available on versions 1.20.4 and newer."
 })
 @Examples({
 	"set last damage cause of event-entity to fire tick"
 })
-@RequiredPlugins("Spigot 1.20.4+ damage type")
+@RequiredPlugins("Spigot 1.20.4+ for damage type")
 @Since("2.2-Fixes-V10")
 public class ExprLastDamageCause extends PropertyExpression<LivingEntity, Object> {
 

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -2059,6 +2059,8 @@ types:
 	quitreason: quit reason¦s @a
 	inventoryclosereason: inventory close reason¦s @an
 	transformreason: transform reason¦s @a
+	damagesource: damage source¦s @a
+	damagetype: damage type¦s @a
 
 	# Skript
 	weathertype: weather type¦s @a


### PR DESCRIPTION
### Description
- Fix entity damage event 1.20.4 constructor changes
- Opens up proper support for DamageSource

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
