### PR TITLE
Disable watchdog in tests

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -668,15 +668,16 @@ public final class Skript extends JavaPlugin implements Listener {
 							return;
 						} else {
 							info("Loading all tests from " + TestMode.TEST_DIR);
-							try {
-								/* not a great thing to do, but it's ok because this will never run on a "real" server
-								   we just want to avoid watchdog killing the test runner if the tests take too long
-								   to run */
-								WatchdogUtils.stopWatchdog();
-							} catch (IllegalAccessException | ClassNotFoundException | NoSuchMethodException |
-                                     InvocationTargetException exception) {
-								Skript.exception(exception, "Unable to stop watchdog");
-							}
+
+//							try {
+//								/* not a great thing to do, but it's ok because this will never run on a "real" server
+//								   we just want to avoid watchdog killing the test runner if the tests take too long
+//								   to run */
+//								WatchdogUtils.stopWatchdog();
+//							} catch (IllegalAccessException | ClassNotFoundException | NoSuchMethodException |
+//                                     InvocationTargetException exception) {
+//								Skript.exception(exception, "Unable to stop watchdog");
+//							}
 
 							// Treat parse errors as fatal testing failure
 							CountingLogHandler errorCounter = new CountingLogHandler(Level.SEVERE);

--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -76,6 +76,7 @@ import ch.njol.skript.util.Getter;
 import ch.njol.skript.util.Task;
 import ch.njol.skript.util.Utils;
 import ch.njol.skript.util.Version;
+import ch.njol.skript.util.WatchdogUtils;
 import ch.njol.skript.util.chat.BungeeConverter;
 import ch.njol.skript.util.chat.ChatMessages;
 import ch.njol.skript.variables.Variables;
@@ -667,6 +668,15 @@ public final class Skript extends JavaPlugin implements Listener {
 							return;
 						} else {
 							info("Loading all tests from " + TestMode.TEST_DIR);
+							try {
+								/* not a great thing to do, but it's ok because this will never run on a "real" server
+								   we just want to avoid watchdog killing the test runner if the tests take too long
+								   to run */
+								WatchdogUtils.stopWatchdog();
+							} catch (IllegalAccessException | ClassNotFoundException | NoSuchMethodException |
+                                     InvocationTargetException exception) {
+								Skript.exception(exception, "Unable to stop watchdog");
+							}
 
 							// Treat parse errors as fatal testing failure
 							CountingLogHandler errorCounter = new CountingLogHandler(Level.SEVERE);

--- a/src/main/java/ch/njol/skript/util/WatchdogUtils.java
+++ b/src/main/java/ch/njol/skript/util/WatchdogUtils.java
@@ -1,0 +1,32 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.util;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class WatchdogUtils {
+
+	public static void stopWatchdog() throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+		Class<?> watchdogThreadClass = Class.forName("org.spigotmc.WatchdogThread");
+		Method stopWatchdogMethod = watchdogThreadClass.getMethod("doStop");
+		stopWatchdogMethod.invoke(null);
+    }
+
+}

--- a/src/test/skript/tests/misc/watchdog.sk
+++ b/src/test/skript/tests/misc/watchdog.sk
@@ -1,0 +1,5 @@
+test "watchdog stopped":
+  set {_start} to now
+  while difference between {_start} and now is less than 5 minutes:
+    continue loop
+  assert true is false with "watchdog was stopped!"

--- a/src/test/skript/tests/misc/watchdog.sk
+++ b/src/test/skript/tests/misc/watchdog.sk
@@ -2,7 +2,7 @@
 # in order to test certain things like whether or not Watchdog has been
 # successfully disabled in the test environment
 #
-#test "timeout test system":
-#  while true is true:
-#    continue loop
-#  assert true is false with "reached end of an infinite loop"
+test "timeout test system":
+  while true is true:
+    continue loop
+  assert true is false with "reached end of an infinite loop"

--- a/src/test/skript/tests/misc/watchdog.sk
+++ b/src/test/skript/tests/misc/watchdog.sk
@@ -1,5 +1,8 @@
-test "watchdog stopped":
-  set {_start} to now
-  while difference between {_start} and now is less than 5 minutes:
-    continue loop
-  assert true is false with "watchdog was stopped!"
+# This test can be used to purposefully cause the test system to timeout
+# in order to test certain things like whether or not Watchdog has been
+# successfully disabled in the test environment
+#
+#test "timeout test system":
+#  while true is true:
+#    continue loop
+#  assert true is false with "reached end of an infinite loop"


### PR DESCRIPTION
### Description
This PR disables watchdog in the test runner so that watchdog doesn't cause a failure if the tests take too long to run.

---
**Target Minecraft Versions:** any
**Requirements:** a spigot derivative?
**Related Issues:** none