### PR TITLE
Fix parsing errors caused by special characters

### DIFF
--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -1201,7 +1201,7 @@ public class SkriptParser {
 		if (startIndex >= haystackLength)
 			return -1;
 
-		int needleLength = caseSensitive ? -1 : needle.length();
+		int needleLength = needle.length();
 
 		char firstChar = needle.charAt(0);
 		boolean startsWithSpecialChar = firstChar == '"' || firstChar == '{' || firstChar == '(';
@@ -1212,8 +1212,7 @@ public class SkriptParser {
 
 			if ( // Early check before special character handling
 				startsWithSpecialChar &&
-				caseSensitive ? haystack.startsWith(needle, startIndex)
-				: haystack.regionMatches(true, startIndex, needle, 0, needleLength)
+				haystack.regionMatches(!caseSensitive, startIndex, needle, 0, needleLength)
 			) {
 				return startIndex;
 			}
@@ -1236,12 +1235,8 @@ public class SkriptParser {
 					break;
 			}
 
-			if (
-				caseSensitive ? haystack.startsWith(needle, startIndex)
-				: haystack.regionMatches(true, startIndex, needle, 0, needleLength)
-			) {
+			if (haystack.regionMatches(!caseSensitive, startIndex, needle, 0, needleLength))
 				return startIndex;
-			}
 
 			startIndex++;
 		}

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -1075,10 +1075,11 @@ public class SkriptParser {
 	 */
 	private static int nextQuote(String string, int start) {
 		boolean inExpression = false;
-		for (int i = start; i < string.length(); i++) {
+		int length = string.length();
+		for (int i = start; i < length; i++) {
 			char character = string.charAt(i);
 			if (character == '"' && !inExpression) {
-				if (i == string.length() - 1 || string.charAt(i + 1) != '"')
+				if (i == length - 1 || string.charAt(i + 1) != '"')
 					return i;
 				i++;
 			} else if (character == '%') {
@@ -1200,10 +1201,7 @@ public class SkriptParser {
 		if (startIndex >= haystackLength)
 			return -1;
 
-		if (!caseSensitive) {
-			haystack = haystack.toLowerCase(Locale.ENGLISH);
-			needle = needle.toLowerCase(Locale.ENGLISH);
-		}
+		int needleLength = caseSensitive ? -1 : needle.length();
 
 		char firstChar = needle.charAt(0);
 		boolean startsWithSpecialChar = firstChar == '"' || firstChar == '{' || firstChar == '(';
@@ -1212,9 +1210,12 @@ public class SkriptParser {
 
 			char character = haystack.charAt(startIndex);
 
-			if (startsWithSpecialChar) { // Early check before special character handling
-				if (haystack.startsWith(needle, startIndex))
-					return startIndex;
+			if ( // Early check before special character handling
+				startsWithSpecialChar &&
+				caseSensitive ? haystack.startsWith(needle, startIndex)
+				: haystack.regionMatches(true, startIndex, needle, 0, needleLength)
+			) {
+				return startIndex;
 			}
 
 			switch (character) {
@@ -1235,8 +1236,12 @@ public class SkriptParser {
 					break;
 			}
 
-			if (haystack.startsWith(needle, startIndex))
+			if (
+				caseSensitive ? haystack.startsWith(needle, startIndex)
+				: haystack.regionMatches(true, startIndex, needle, 0, needleLength)
+			) {
 				return startIndex;
+			}
 
 			startIndex++;
 		}

--- a/src/test/skript/tests/regressions/6246-special character parsing issues.sk
+++ b/src/test/skript/tests/regressions/6246-special character parsing issues.sk
@@ -1,0 +1,4 @@
+test "special character parsing issues":
+	parse:
+		send "İİ" to {_}
+	assert last parse logs is not set with "parsing failed when the code is valid"


### PR DESCRIPTION
### Description
This PR fixes an issue that could occur with the keyword search (https://github.com/SkriptLang/Skript/pull/5103) system that caused valid code with special characters to fail to parse.

This issue is caused by the fact that the problematic code assumes `String#toLowerCase` will result in a String of the same length, which is not guaranteed. As a result, the used and returned indices do not align between the regular and converted strings.

To correct this issue, I have moved the code away from using lowercase conversion. Instead, it uses `String#regionMatches` (case-insensitive) instead of `String#startsWith` with `String#toLowerCase` to accomplish the same thing.

Test included! :)

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:**
- https://github.com/SkriptLang/Skript/issues/6426
