### PR TITLE
ItemData/BlockCompat - strip out BlockState middleman

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/ItemData.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemData.java
@@ -30,6 +30,7 @@ import ch.njol.yggdrasil.YggdrasilSerializable.YggdrasilExtendedSerializable;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemFactory;
@@ -187,6 +188,14 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 	public ItemData(ItemStack stack) {
 		this(stack, BlockCompat.INSTANCE.getBlockValues(stack));
 		this.itemForm = true;
+	}
+
+	/**
+	 * @deprecated use {@link ItemData#ItemData(BlockData)} instead
+	 */
+	@Deprecated
+	public ItemData(BlockState blockState) {
+		this(blockState.getBlockData());
 	}
 
 	public ItemData(BlockData blockData) {

--- a/src/main/java/ch/njol/skript/aliases/ItemData.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemData.java
@@ -30,7 +30,7 @@ import ch.njol.yggdrasil.YggdrasilSerializable.YggdrasilExtendedSerializable;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockState;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemFactory;
 import org.bukkit.inventory.ItemFlag;
@@ -188,15 +188,15 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 		this(stack, BlockCompat.INSTANCE.getBlockValues(stack));
 		this.itemForm = true;
 	}
-	
-	public ItemData(BlockState block) {
-		this.type = ItemUtils.asItem(block.getType());
+
+	public ItemData(BlockData blockData) {
+		this.type = blockData.getMaterial();
 		this.stack = new ItemStack(type);
-		this.blockValues = BlockCompat.INSTANCE.getBlockValues(block);
+		this.blockValues = BlockCompat.INSTANCE.getBlockValues(blockData);
 	}
 	
 	public ItemData(Block block) {
-		this(block.getState());
+		this(block.getBlockData());
 	}
 	
 	/**

--- a/src/main/java/ch/njol/skript/aliases/ItemData.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemData.java
@@ -191,7 +191,7 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 	}
 
 	/**
-	 * @deprecated use {@link ItemData#ItemData(BlockData)} instead
+	 * @deprecated Use {@link ItemData#ItemData(BlockData)} instead
 	 */
 	@Deprecated
 	public ItemData(BlockState blockState) {

--- a/src/main/java/ch/njol/skript/aliases/ItemType.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemType.java
@@ -284,8 +284,7 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 	 */
 	@Deprecated
 	public boolean isOfType(@Nullable BlockState blockState) {
-		if (blockState == null) return false;
-		return isOfType(blockState.getBlockData());
+		return blockState != null && isOfType(blockState.getBlockData());
 	}
 
 	public boolean isOfType(@Nullable BlockData blockData) {

--- a/src/main/java/ch/njol/skript/aliases/ItemType.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemType.java
@@ -280,7 +280,7 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 	}
 
 	/**
-	 * @deprecated use {@link #isOfType(BlockData)} instead
+	 * @deprecated Use {@link #isOfType(BlockData)} instead
 	 */
 	@Deprecated
 	public boolean isOfType(@Nullable BlockState blockState) {

--- a/src/main/java/ch/njol/skript/aliases/ItemType.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemType.java
@@ -41,8 +41,8 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockState;
 import org.bukkit.block.Skull;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -184,10 +184,8 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 		add_(new ItemData(i));
 	}
 
-	public ItemType(BlockState b) {
-//		amount = 1;
-		add_(new ItemData(b));
-		// TODO metadata - spawners, skulls, etc.
+	public ItemType(BlockData blockData) {
+		add_(new ItemData(blockData));
 	}
 
 	/**
@@ -211,7 +209,7 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 	}
 
 	public ItemType(Block block) {
-		this(block.getState());
+		this(block.getBlockData());
 	}
 
 	/**
@@ -272,17 +270,17 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 		return isOfType(new ItemData(item));
 	}
 
-	public boolean isOfType(@Nullable BlockState block) {
-		if (block == null)
+	public boolean isOfType(@Nullable BlockData blockData) {
+		if (blockData == null)
 			return isOfType(Material.AIR, null);
 
-		return isOfType(new ItemData(block));
+		return isOfType(new ItemData(blockData));
 	}
 
 	public boolean isOfType(@Nullable Block block) {
 		if (block == null)
 			return isOfType(Material.AIR, null);
-		return isOfType(block.getState());
+		return isOfType(block.getBlockData());
 	}
 
 	public boolean isOfType(ItemData type) {

--- a/src/main/java/ch/njol/skript/aliases/ItemType.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemType.java
@@ -41,6 +41,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.Skull;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.enchantments.Enchantment;
@@ -184,6 +185,14 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 		add_(new ItemData(i));
 	}
 
+	/**
+	 * @deprecated Use {@link #ItemType(BlockData)} instead
+	 */
+	@Deprecated
+	public ItemType(BlockState blockState) {
+		this(blockState.getBlockData());
+	}
+
 	public ItemType(BlockData blockData) {
 		add_(new ItemData(blockData));
 	}
@@ -268,6 +277,15 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 		if (item == null)
 			return isOfType(Material.AIR, null);
 		return isOfType(new ItemData(item));
+	}
+
+	/**
+	 * @deprecated use {@link #isOfType(BlockData)} instead
+	 */
+	@Deprecated
+	public boolean isOfType(@Nullable BlockState blockState) {
+		if (blockState == null) return false;
+		return isOfType(blockState.getBlockData());
 	}
 
 	public boolean isOfType(@Nullable BlockData blockData) {

--- a/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
@@ -74,6 +74,19 @@ public class ItemUtils {
 			return null;
 		}
 	}
+
+	/**
+	 * Gets an item material corresponding to given block material, which might
+	 * be the given material.
+	 * @param type Material.
+	 * @return Item version of material or null.
+	 * @deprecated This just returns itself and has no use
+	 */
+	@Deprecated
+	public static Material asItem(Material type) {
+		// Assume (naively) that all types are valid items
+		return type;
+	}
 	
 	/**
 	 * Tests whether two item stacks are of the same type, i.e. it ignores the amounts.

--- a/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
@@ -76,17 +76,6 @@ public class ItemUtils {
 	}
 	
 	/**
-	 * Gets an item material corresponding to given block material, which might
-	 * be the given material.
-	 * @param type Material.
-	 * @return Item version of material or null.
-	 */
-	public static Material asItem(Material type) {
-		// Assume (naively) that all types are valid items
-		return type;
-	}
-	
-	/**
 	 * Tests whether two item stacks are of the same type, i.e. it ignores the amounts.
 	 *
 	 * @param is1

--- a/src/main/java/ch/njol/skript/bukkitutil/block/BlockCompat.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/block/BlockCompat.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.FallingBlock;
 import org.bukkit.inventory.ItemStack;
@@ -41,6 +42,17 @@ public interface BlockCompat {
 	BlockCompat INSTANCE = new NewBlockCompat();
 	
 	static final BlockSetter SETTER = INSTANCE.getSetter();
+
+	/**
+	 * Gets block values from a block state. They can be compared to other
+	 * values if needed, but cannot be used to retrieve any other data.
+	 * @param block Block state to retrieve value from.
+	 * @return Block values.
+	 * @deprecated Use {@link #getBlockValues(BlockData)} instead
+	 */
+	@Deprecated
+	@Nullable
+	BlockValues getBlockValues(BlockState block);
 	
 	/**
 	 * Gets block values from a block. They can be compared to other values
@@ -64,6 +76,15 @@ public interface BlockCompat {
 	 */
 	@Nullable
 	BlockValues getBlockValues(ItemStack stack);
+
+	/**
+	 * Creates a block state from a falling block.
+	 * @param entity Falling block entity
+	 * @return Block state.
+	 * @deprecated This shouldn't be used
+	 */
+	@Deprecated
+	BlockState fallingBlockToState(FallingBlock entity);
 
 	@Nullable
 	default BlockValues getBlockValues(FallingBlock entity) {

--- a/src/main/java/ch/njol/skript/bukkitutil/block/BlockCompat.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/block/BlockCompat.java
@@ -22,12 +22,11 @@ import java.util.Map;
 
 import org.bukkit.Material;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockState;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.FallingBlock;
 import org.bukkit.inventory.ItemStack;
 import org.eclipse.jdt.annotation.Nullable;
 
-import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemFlags;
 
 /**
@@ -44,15 +43,6 @@ public interface BlockCompat {
 	static final BlockSetter SETTER = INSTANCE.getSetter();
 	
 	/**
-	 * Gets block values from a block state. They can be compared to other
-	 * values if needed, but cannot be used to retrieve any other data.
-	 * @param block Block state to retrieve value from.
-	 * @return Block values.
-	 */
-	@Nullable
-	BlockValues getBlockValues(BlockState block);
-	
-	/**
 	 * Gets block values from a block. They can be compared to other values
 	 * if needed, but cannot be used to retrieve any other data.
 	 * @param block Block to retrieve value from.
@@ -60,8 +50,11 @@ public interface BlockCompat {
 	 */
 	@Nullable
 	default BlockValues getBlockValues(Block block) {
-		return getBlockValues(block.getState());
+		return getBlockValues(block.getBlockData());
 	}
+
+	@Nullable
+	BlockValues getBlockValues(BlockData blockData);
 	
 	/**
 	 * Gets block values from a item stack. They can be compared to other values
@@ -71,17 +64,10 @@ public interface BlockCompat {
 	 */
 	@Nullable
 	BlockValues getBlockValues(ItemStack stack);
-	
-	/**
-	 * Creates a block state from a falling block.
-	 * @param entity Falling block entity
-	 * @return Block state.
-	 */
-	BlockState fallingBlockToState(FallingBlock entity);
-	
+
 	@Nullable
 	default BlockValues getBlockValues(FallingBlock entity) {
-		return getBlockValues(fallingBlockToState(entity));
+		return getBlockValues(entity.getBlockData());
 	}
 
 	/**

--- a/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
@@ -326,7 +326,6 @@ public class NewBlockCompat implements BlockCompat {
 	
 	private NewBlockSetter setter = new NewBlockSetter();
 
-
 	/**
 	 * @deprecated Use {@link #getBlockValues(BlockData)} instead
 	 */
@@ -354,17 +353,17 @@ public class NewBlockCompat implements BlockCompat {
 		return null;
 	}
 
+	@Override
+	public BlockSetter getSetter() {
+		return setter;
+	}
+
 	@Deprecated
 	@Override
 	public BlockState fallingBlockToState(FallingBlock entity) {
 		BlockState state = entity.getWorld().getBlockAt(0, 0, 0).getState();
 		state.setBlockData(entity.getBlockData());
 		return state;
-	}
-	
-	@Override
-	public BlockSetter getSetter() {
-		return setter;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
@@ -30,10 +30,12 @@ import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.data.Bisected;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Directional;
 import org.bukkit.block.data.type.Bed;
+import org.bukkit.entity.FallingBlock;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.eclipse.jdt.annotation.NonNull;
@@ -324,6 +326,17 @@ public class NewBlockCompat implements BlockCompat {
 	
 	private NewBlockSetter setter = new NewBlockSetter();
 
+
+	/**
+	 * @deprecated Use {@link #getBlockValues(BlockData)} instead
+	 */
+	@Deprecated
+	@Nullable
+	@Override
+	public BlockValues getBlockValues(BlockState blockState) {
+		return getBlockValues(blockState.getBlockData());
+	}
+
 	@Nullable
 	@Override
 	public BlockValues getBlockValues(BlockData blockData) {
@@ -339,6 +352,14 @@ public class NewBlockCompat implements BlockCompat {
 			return new NewBlockValues(type, Bukkit.createBlockData(type), true);
 		}
 		return null;
+	}
+
+	@Deprecated
+	@Override
+	public BlockState fallingBlockToState(FallingBlock entity) {
+		BlockState state = entity.getWorld().getBlockAt(0, 0, 0).getState();
+		state.setBlockData(entity.getBlockData());
+		return state;
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
@@ -30,12 +30,10 @@ import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
-import org.bukkit.block.BlockState;
 import org.bukkit.block.data.Bisected;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Directional;
 import org.bukkit.block.data.type.Bed;
-import org.bukkit.entity.FallingBlock;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.eclipse.jdt.annotation.NonNull;
@@ -325,16 +323,13 @@ public class NewBlockCompat implements BlockCompat {
 	}
 	
 	private NewBlockSetter setter = new NewBlockSetter();
-	
+
 	@Nullable
 	@Override
-	public BlockValues getBlockValues(BlockState block) {
-		// If block doesn't have useful data, data field of type is MaterialData
-		if (block.getType().isBlock())
-			return new NewBlockValues(block.getType(), block.getBlockData(), false);
-		return null;
+	public BlockValues getBlockValues(BlockData blockData) {
+		return new NewBlockValues(blockData.getMaterial(), blockData, false);
 	}
-	
+
 	@Override
 	@Nullable
 	public BlockValues getBlockValues(ItemStack stack) {
@@ -349,13 +344,6 @@ public class NewBlockCompat implements BlockCompat {
 	@Override
 	public BlockSetter getSetter() {
 		return setter;
-	}
-
-	@Override
-	public BlockState fallingBlockToState(FallingBlock entity) {
-		BlockState state = entity.getWorld().getBlockAt(0, 0, 0).getState();
-		state.setBlockData(entity.getBlockData());
-		return state;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
@@ -361,7 +361,7 @@ public class NewBlockCompat implements BlockCompat {
 	@Deprecated
 	@Override
 	public BlockState fallingBlockToState(FallingBlock entity) {
-		BlockState state = entity.getWorld().getBlockAt(0, 0, 0).getState();
+		BlockState state = entity.getLocation().getBlock().getState();
 		state.setBlockData(entity.getBlockData());
 		return state;
 	}

--- a/src/main/java/ch/njol/skript/entity/FallingBlockData.java
+++ b/src/main/java/ch/njol/skript/entity/FallingBlockData.java
@@ -93,7 +93,7 @@ public class FallingBlockData extends EntityData<FallingBlock> {
 	@Override
 	protected boolean init(final @Nullable Class<? extends FallingBlock> c, final @Nullable FallingBlock e) {
 		if (e != null) // TODO material data support
-			types = new ItemType[] {new ItemType(BlockCompat.INSTANCE.fallingBlockToState(e))};
+			types = new ItemType[] {new ItemType(e.getBlockData())};
 		return true;
 	}
 	
@@ -101,7 +101,7 @@ public class FallingBlockData extends EntityData<FallingBlock> {
 	protected boolean match(final FallingBlock entity) {
 		if (types != null) {
 			for (final ItemType t : types) {
-				if (t.isOfType(BlockCompat.INSTANCE.fallingBlockToState(entity)))
+				if (t.isOfType(entity.getBlockData()))
 					return true;
 			}
 			return false;

--- a/src/main/java/ch/njol/skript/events/EvtBlock.java
+++ b/src/main/java/ch/njol/skript/events/EvtBlock.java
@@ -104,7 +104,7 @@ public class EvtBlock extends SkriptEvent {
 		if (event instanceof BlockFormEvent) {
 			BlockFormEvent blockFormEvent = (BlockFormEvent) event;
 			BlockState newState = blockFormEvent.getNewState();
-			item = new ItemType(newState);
+			item = new ItemType(newState.getBlockData());
 			blockData = newState.getBlockData();
 		} else if (event instanceof BlockEvent) {
 			BlockEvent blockEvent = (BlockEvent) event;

--- a/src/main/java/ch/njol/skript/events/EvtGrow.java
+++ b/src/main/java/ch/njol/skript/events/EvtGrow.java
@@ -174,7 +174,7 @@ public class EvtGrow extends SkriptEvent {
 			BlockState oldState = ((BlockGrowEvent) event).getBlock().getState();
 			return types.check(event, type -> {
 				if (type instanceof ItemType) {
-					return ((ItemType) type).isOfType(oldState);
+					return ((ItemType) type).isOfType(oldState.getBlockData());
 				} else if (type instanceof BlockData) {
 					return ((BlockData) type).matches(oldState.getBlockData());
 				}
@@ -201,7 +201,7 @@ public class EvtGrow extends SkriptEvent {
 			BlockState newState = ((BlockGrowEvent) event).getNewState();
 			return types.check(event, type -> {
 				if (type instanceof ItemType) {
-					return ((ItemType) type).isOfType(newState);
+					return ((ItemType) type).isOfType(newState.getBlockData());
 				} else if (type instanceof BlockData) {
 					return ((BlockData) type).matches(newState.getBlockData());
 				}


### PR DESCRIPTION
### Description
This PR was originally meant to fix an issue with FallingBlocks loading chunk(0,0).
~~It turned into stripping out all references of BlockState in ItemType/ItemData/BlockCompat.~~
It turned into deprecating all references of BlockState in ItemType/ItemData/BlockCompat and using BlockData instead.
These classes never cached nor actually ever used BlockState, it was merely a middle man to get to BlockData.
My guess is this was a pre-1.13 thing that just never properly got stripped out.

---
**Target Minecraft Versions:** any 
**Requirements:** none 
**Related Issues:** #6471 
