### PR TITLE
Fixes entitydata consumer on versions 1.20.1 and below.

### DIFF
--- a/src/main/java/ch/njol/skript/entity/EntityData.java
+++ b/src/main/java/ch/njol/skript/entity/EntityData.java
@@ -646,15 +646,18 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	protected boolean deserialize(final String s) {
 		return false;
 	}
-	
+
 	@SuppressWarnings({"unchecked", "deprecation"})
 	protected static <E extends Entity> @Nullable E spawn(Location location, Class<E> type, Consumer<E> consumer) {
+		World world = location.getWorld();
+		if (world == null)
+			return null;
 		try {
 			if (WORLD_1_17_CONSUMER) {
-				return (@Nullable E) WORLD_1_17_CONSUMER_METHOD.invoke(location.getWorld(), location, type,
+				return (@Nullable E) WORLD_1_17_CONSUMER_METHOD.invoke(world, location, type,
 					(org.bukkit.util.Consumer<E>) consumer::accept);
 			} else if (WORLD_1_13_CONSUMER) {
-				return (@Nullable E) WORLD_1_13_CONSUMER_METHOD.invoke(location.getWorld(), location, type,
+				return (@Nullable E) WORLD_1_13_CONSUMER_METHOD.invoke(world, location, type,
 					(org.bukkit.util.Consumer<E>) consumer::accept);
 			}
 		} catch (InvocationTargetException | IllegalAccessException e) {
@@ -662,7 +665,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 				Skript.exception(e, "Can't spawn " + type.getName());
 			return null;
         }
-        return location.getWorld().spawn(location, type, consumer);
+        return world.spawn(location, type, consumer);
 	}
-	
+
 }


### PR DESCRIPTION
### Description
Fixes an exception from being thrown when attempting to spawn an EntityData when there is no World involved with the Location.
See header of EntityData for an explanation of this reflection https://github.com/SkriptLang/Skript/blob/11327579a9af912221ba6e0864d937935ead8799/src/main/java/ch/njol/skript/entity/EntityData.java#L73-L77
```
[09:48:07] [Server thread/ERROR]: #!#! 
[09:48:07] [Server thread/ERROR]: #!#! Stack trace:
[09:48:07] [Server thread/ERROR]: #!#! java.lang.NullPointerException: Cannot invoke "Object.getClass()" because "obj" is null
[09:48:07] [Server thread/ERROR]: #!#!     at java.base/java.lang.reflect.Method.invoke(Method.java:561)
[09:48:07] [Server thread/ERROR]: #!#!     at ch.njol.skript.entity.EntityData.spawn(EntityData.java:654)
[09:48:07] [Server thread/ERROR]: #!#!     at ch.njol.skript.entity.EntityData.spawn(EntityData.java:507)
[09:48:07] [Server thread/ERROR]: #!#!     at ch.njol.skript.sections.EffSecSpawn.walk(EffSecSpawn.java:172)
[09:48:07] [Server thread/ERROR]: #!#!     at ch.njol.skript.lang.TriggerItem.walk(TriggerItem.java:88)
[09:48:07] [Server thread/ERROR]: #!#!     at ch.njol.skript.lang.Trigger.execute(Trigger.java:52)
[09:48:07] [Server thread/ERROR]: #!#!     at ch.njol.skript.command.ScriptCommand.execute2(ScriptCommand.java:316)
[09:48:07] [Server thread/ERROR]: #!#!     at ch.njol.skript.command.ScriptCommand.lambda$execute$0(ScriptCommand.java:275)
[09:48:07] [Server thread/ERROR]: #!#!     at ch.njol.skript.command.ScriptCommand.execute(ScriptCommand.java:286)
[09:48:07] [Server thread/ERROR]: #!#!     at ch.njol.skript.command.ScriptCommand.onCommand(ScriptCommand.java:221)
[09:48:07] [Server thread/ERROR]: #!#!     at org.bukkit.command.PluginCommand.execute(PluginCommand.java:45)
[09:48:07] [Server thread/ERROR]: #!#!     at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:155)
[09:48:07] [Server thread/ERROR]: #!#!     at org.bukkit.craftbukkit.v1_20_R1.CraftServer.dispatchCommand(CraftServer.java:987)
[09:48:07] [Server thread/ERROR]: #!#!     at org.bukkit.craftbukkit.v1_20_R1.command.BukkitCommandWrapper.run(BukkitCommandWrapper.java:64)
[09:48:07] [Server thread/ERROR]: #!#!     at com.mojang.brigadier.CommandDispatcher.execute(CommandDispatcher.java:265)
[09:48:07] [Server thread/ERROR]: #!#!     at net.minecraft.commands.CommandDispatcher.performCommand(CommandDispatcher.java:324)
[09:48:07] [Server thread/ERROR]: #!#!     at net.minecraft.commands.CommandDispatcher.a(CommandDispatcher.java:308)
[09:48:07] [Server thread/ERROR]: #!#!     at net.minecraft.server.network.PlayerConnection.a(PlayerConnection.java:2354)
[09:48:07] [Server thread/ERROR]: #!#!     at net.minecraft.server.network.PlayerConnection.lambda$handleChatCommand$21(PlayerConnection.java:2314)
[09:48:07] [Server thread/ERROR]: #!#!     at net.minecraft.util.thread.IAsyncTaskHandler.b(IAsyncTaskHandler.java:59)
[09:48:07] [Server thread/ERROR]: #!#!     at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
[09:48:07] [Server thread/ERROR]: #!#!     at net.minecraft.server.TickTask.run(TickTask.java:18)
[09:48:07] [Server thread/ERROR]: #!#!     at net.minecraft.util.thread.IAsyncTaskHandler.d(IAsyncTaskHandler.java:153)
[09:48:07] [Server thread/ERROR]: #!#!     at net.minecraft.util.thread.IAsyncTaskHandlerReentrant.d(IAsyncTaskHandlerReentrant.java:24)
[09:48:07] [Server thread/ERROR]: #!#!     at net.minecraft.server.MinecraftServer.b(MinecraftServer.java:1338)
[09:48:07] [Server thread/ERROR]: #!#!     at net.minecraft.server.MinecraftServer.d(MinecraftServer.java:197)
[09:48:07] [Server thread/ERROR]: #!#!     at net.minecraft.util.thread.IAsyncTaskHandler.x(IAsyncTaskHandler.java:126)
[09:48:07] [Server thread/ERROR]: #!#!     at net.minecraft.server.MinecraftServer.bg(MinecraftServer.java:1315)
[09:48:07] [Server thread/ERROR]: #!#!     at net.minecraft.server.MinecraftServer.x(MinecraftServer.java:1308)
[09:48:07] [Server thread/ERROR]: #!#!     at net.minecraft.util.thread.IAsyncTaskHandler.c(IAsyncTaskHandler.java:136)
[09:48:07] [Server thread/ERROR]: #!#!     at net.minecraft.server.MinecraftServer.p_(MinecraftServer.java:1286)
[09:48:07] [Server thread/ERROR]: #!#!     at net.minecraft.server.MinecraftServer.w(MinecraftServer.java:1174)
[09:48:07] [Server thread/ERROR]: #!#!     at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:317)
[09:48:07] [Server thread/ERROR]: #!#!     at java.base/java.lang.Thread.run(Thread.java:833)
[09:48:07] [Server thread/ERROR]: #!#! 
[09:48:07] [Server thread/ERROR]: #!#! Version Information:
[09:48:07] [Server thread/ERROR]: #!#!     Flavor: selfbuilt-unknown
[09:48:07] [Server thread/ERROR]: #!#!     Date: unknown
[09:48:07] [Server thread/ERROR]: #!#!   Bukkit: 1.20.1-R0.1-SNAPSHOT
[09:48:07] [Server thread/ERROR]: #!#!   Minecraft: 1.20.1
[09:48:07] [Server thread/ERROR]: #!#!   Java: 17.0.8.1 (OpenJDK 64-Bit Server VM 17.0.8.1+8-LTS)
[09:48:07] [Server thread/ERROR]: #!#!   OS: Linux amd64 5.10.0-24-amd64
[09:48:07] [Server thread/ERROR]: #!#! 
[09:48:07] [Server thread/ERROR]: #!#! Server platform: Paper
[09:48:07] [Server thread/ERROR]: #!#! 
[09:48:07] [Server thread/ERROR]: #!#! Current node: null
[09:48:07] [Server thread/ERROR]: #!#! Current item: spawn [[entitytype:iron golem]] at {1::golemLocations::%loop-value%} (as org.bukkit.Location)
[09:48:07] [Server thread/ERROR]: #!#! Current trigger: command /1 (simple event) (1/1.sk, line 302)
[09:48:07] [Server thread/ERROR]: #!#! 
[09:48:07] [Server thread/ERROR]: #!#! Thread: Server thread
[09:48:07] [Server thread/ERROR]: #!#! 
[09:48:07] [Server thread/ERROR]: #!#! Language: english
[09:48:07] [Server thread/ERROR]: #!#! Link parse mode: DISABLED
[09:48:07] [Server thread/ERROR]: #!#! 
[09:48:07] [Server thread/ERROR]: #!#! End of Error.
[09:48:07] [Server thread/ERROR]: #!#! 
```

This is caused by the world not being loaded on server start or in my case, a server crash. I plan on addressing this better in the future to not outright delete the World. https://github.com/SkriptLang/Skript/blob/11327579a9af912221ba6e0864d937935ead8799/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java#L399-L403

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
