### PR TITLE
EntityData - check if entity can spawn

### DIFF
--- a/src/main/java/ch/njol/skript/entity/EntityData.java
+++ b/src/main/java/ch/njol/skript/entity/EntityData.java
@@ -95,7 +95,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		} catch (NoSuchMethodException | SecurityException ignored) { /* We already checked if the method exists */ }
 	}
 
-	private static final boolean HAS_ENABLED_BY_FEATURE = Skript.methodExists(org.bukkit.entity.EntityType.class, "isEnabledByFeature", World.class);
+	private static final boolean HAS_ENABLED_BY_FEATURE = Skript.methodExists(EntityType.class, "isEnabledByFeature", World.class);
 	public final static String LANGUAGE_NODE = "entities";
 
 	public final static Message m_age_pattern = new Message(LANGUAGE_NODE + ".age pattern");

--- a/src/main/java/ch/njol/skript/entity/EntityData.java
+++ b/src/main/java/ch/njol/skript/entity/EntityData.java
@@ -522,7 +522,8 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	@Nullable
 	public E spawn(Location location, @Nullable Consumer<E> consumer) {
 		assert location != null;
-		if (!canSpawn(location.getWorld())) return null;
+		if (!canSpawn(location.getWorld()))
+			return null;
 		if (consumer != null) {
 			return EntityData.spawn(location, getType(), e -> consumer.accept(this.apply(e)));
 		} else {

--- a/src/main/java/ch/njol/skript/entity/EntityData.java
+++ b/src/main/java/ch/njol/skript/entity/EntityData.java
@@ -472,7 +472,9 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	 * @param world World to check if entity can spawn in
 	 * @return True if entity can spawn else false
 	 */
-	public boolean canSpawn(World world) {
+	public boolean canSpawn(@Nullable World world) {
+		if (world == null)
+			return false;
 		if (HAS_ENABLED_BY_FEATURE) {
 			// Check if the entity can actually be spawned
 			// Some entity types may be restricted by experimental datapacks
@@ -523,7 +525,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	public E spawn(Location location, @Nullable Consumer<E> consumer) {
 		assert location != null;
 		World world = location.getWorld();
-		if (world == null || !canSpawn(world))
+		if (!canSpawn(world))
 			return null;
 		if (consumer != null) {
 			return EntityData.spawn(location, getType(), e -> consumer.accept(this.apply(e)));

--- a/src/main/java/ch/njol/skript/entity/EntityData.java
+++ b/src/main/java/ch/njol/skript/entity/EntityData.java
@@ -522,12 +522,13 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	@Nullable
 	public E spawn(Location location, @Nullable Consumer<E> consumer) {
 		assert location != null;
-		if (!canSpawn(location.getWorld()))
+		World world = location.getWorld();
+		if (world == null || !canSpawn(world))
 			return null;
 		if (consumer != null) {
 			return EntityData.spawn(location, getType(), e -> consumer.accept(this.apply(e)));
 		} else {
-			return apply(location.getWorld().spawn(location, getType()));
+			return apply(world.spawn(location, getType()));
 		}
 	}
 


### PR DESCRIPTION
### Description
This PR aims to add a check to see if a specific entity can spawn dependant on data packs.
Minecraft has started adding "Experimental Datapacks" which allow the server owner to use new things which are aimed for the next major update.

Currently in Skript, if a data pack is not enabled, and you attempt to spawn one of these entities an error is thrown.
This applies a check before spawning the entity.

I added a method rather than just directly applying this in the spawn method, this way classes which extend and override this method can also check using this method.

Also fixed a couple typos that were right there.

NOTE: Incase anyone wonders, we don't have to do this for items too. You can actually give an experimental item to a player and it will have in the lore "Disabled Item"
Same with setting a block, it works.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #6483 
