### PR TITLE
fixed sql delete bug

### DIFF
--- a/src/main/java/ch/njol/skript/variables/SQLStorage.java
+++ b/src/main/java/ch/njol/skript/variables/SQLStorage.java
@@ -78,7 +78,7 @@ public abstract class SQLStorage extends VariablesStorage {
 
 	/**
 	 * Creates a SQLStorage with a create table query.
-	 * 
+	 *
 	 * @param name The name to be sent through this constructor when newInstance creates this class.
 	 * @param createTableQuery The create table query to send to the SQL engine.
 	 */
@@ -98,7 +98,7 @@ public abstract class SQLStorage extends VariablesStorage {
 
 	/**
 	 * Initializes an SQL database with the user provided configuration section for loading the database.
-	 * 
+	 *
 	 * @param config The configuration from the config.sk that defines this database.
 	 * @return A Database implementation from SQLibrary.
 	 */
@@ -175,7 +175,7 @@ public abstract class SQLStorage extends VariablesStorage {
 				if (!prepareQueries()) {
 					return false;
 				}
-				
+
 				// old
 				// Table name support was added after the verison that used the legacy database format
 				if (hasOldTable && !tableName.equals("variables")) {
@@ -387,7 +387,7 @@ public abstract class SQLStorage extends VariablesStorage {
 					if (deleteQuery != null)
 						deleteQuery.close();
 				} catch (final SQLException e) {}
-				deleteQuery = db.prepare("DELETE FROM " + getTableName() + " WHERE name = ?");
+				deleteQuery = db.prepare("DELETE FROM " + getTableName() + " WHERE name LIKE ?");
 
 				try {
 					if (monitorQuery != null)
@@ -460,7 +460,12 @@ public abstract class SQLStorage extends VariablesStorage {
 					assert value == null;
 					final PreparedStatement deleteQuery = this.deleteQuery;
 					assert deleteQuery != null;
-					deleteQuery.setString(1, name);
+					if (name.endsWith("::*")) {
+						deleteQuery.setString(1,name.substring(0,name.length()-1) + "%");
+					}else {
+						deleteQuery.setString(1, name);
+					}
+
 					deleteQuery.executeUpdate();
 				} else {
 					int i = 1;

--- a/src/main/java/ch/njol/skript/variables/SQLStorage.java
+++ b/src/main/java/ch/njol/skript/variables/SQLStorage.java
@@ -387,7 +387,7 @@ public abstract class SQLStorage extends VariablesStorage {
 					if (deleteQuery != null)
 						deleteQuery.close();
 				} catch (final SQLException e) {}
-				deleteQuery = db.prepare("DELETE FROM " + getTableName() + " WHERE name LIKE ?");
+				deleteQuery = db.prepare("DELETE FROM " + getTableName() + " WHERE name LIKE ? ESCAPE '\\'");
 
 				try {
 					if (monitorQuery != null)
@@ -461,16 +461,17 @@ public abstract class SQLStorage extends VariablesStorage {
 					final PreparedStatement deleteQuery = this.deleteQuery;
 					assert deleteQuery != null;
 
+					String backSlash = "\\\\";
 					String escapedName = name
-						.replaceAll("%", "\\\\%")
-						.replaceAll("_", "\\\\_");
+						.replaceAll(backSlash, backSlash.repeat(2))
+						.replaceAll("%", backSlash + "%")
+						.replaceAll("_", backSlash + "_");
 
 					if (name.endsWith("::*")) {
-						deleteQuery.setString(1, escapedName.substring(0, name.length() - 2) + "%");
+						deleteQuery.setString(1, escapedName.substring(0, name.length() - 1) + "%");
 					} else {
 						deleteQuery.setString(1, escapedName);
 					}
-
 					deleteQuery.executeUpdate();
 				} else {
 					int i = 1;

--- a/src/main/java/ch/njol/skript/variables/SQLStorage.java
+++ b/src/main/java/ch/njol/skript/variables/SQLStorage.java
@@ -460,10 +460,15 @@ public abstract class SQLStorage extends VariablesStorage {
 					assert value == null;
 					final PreparedStatement deleteQuery = this.deleteQuery;
 					assert deleteQuery != null;
+
+					String escapedName = name
+						.replaceAll("%", "\\\\%")
+						.replaceAll("_", "\\\\_");
+
 					if (name.endsWith("::*")) {
-						deleteQuery.setString(1,name.substring(0,name.length()-1) + "%");
-					}else {
-						deleteQuery.setString(1, name);
+						deleteQuery.setString(1, escapedName.substring(0, name.length() - 2) + "%");
+					} else {
+						deleteQuery.setString(1, escapedName);
 					}
 
 					deleteQuery.executeUpdate();


### PR DESCRIPTION
```
command /e:
    trigger:
        set {a::b::1} to true

command /g:
    trigger:
        delete {a::*}
```
That here also deletes `{a::b::1}` - thing is it doest from the database:

/e results in:
```
Saving... a::b::1 - [B@44beb5d3 (boolean)
```
/g in:
```
Saving... a::b - null (null)
Saving... a::* - null (null)
```

The problem is that Skript locally deletes the data but not in the db, so the deletion is only temporary.

This PR fixes that bug