### PR TITLE
ExprIndices - fix strings not sorting alphabetically

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprIndices.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprIndices.java
@@ -33,6 +33,7 @@ import ch.njol.skript.util.LiteralUtils;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
+import org.skriptlang.skript.lang.comparator.Relation;
 
 import java.util.Map;
 import java.util.Map.Entry;
@@ -132,6 +133,12 @@ public class ExprIndices extends SimpleExpression<String> {
 
 	// Extracted method for better readability
 	private int compare(Entry<String, Object> a, Entry<String, Object> b, int direction) {
-		return Comparators.compare(a.getValue(), b.getValue()).getRelation() * direction;
+		Object first = a.getValue();
+		Object second = b.getValue();
+		if (first instanceof String && second instanceof String) {
+			return Relation.get(((String) first).compareToIgnoreCase((String) second)).getRelation() * direction;
+		}
+		return Comparators.compare(first, second).getRelation() * direction;
 	}
+
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprIndices.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprIndices.java
@@ -101,7 +101,7 @@ public class ExprIndices extends SimpleExpression<String> {
 		if (sort) {
 			int direction = descending ? -1 : 1;
 			return variable.entrySet().stream()
-				.sorted((a, b) -> ExprSortedList.compare(a, b) * direction)
+				.sorted((a, b) -> ExprSortedList.compare(a.getValue(), b.getValue()) * direction)
 				.map(Entry::getKey)
 				.toArray(String[]::new);
 		}

--- a/src/main/java/ch/njol/skript/expressions/ExprIndices.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprIndices.java
@@ -28,12 +28,10 @@ import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.Variable;
 import ch.njol.skript.lang.util.SimpleExpression;
-import org.skriptlang.skript.lang.comparator.Comparators;
 import ch.njol.skript.util.LiteralUtils;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
-import org.skriptlang.skript.lang.comparator.Relation;
 
 import java.util.Map;
 import java.util.Map.Entry;
@@ -103,7 +101,7 @@ public class ExprIndices extends SimpleExpression<String> {
 		if (sort) {
 			int direction = descending ? -1 : 1;
 			return variable.entrySet().stream()
-				.sorted((a, b) -> compare(a, b, direction))
+				.sorted((a, b) -> ExprSortedList.compare(a, b) * direction)
 				.map(Entry::getKey)
 				.toArray(String[]::new);
 		}
@@ -129,16 +127,6 @@ public class ExprIndices extends SimpleExpression<String> {
 			text = "sorted " + text + " in " + (descending ? "descending" : "ascending") + " order";
 
 		return text;
-	}
-
-	// Extracted method for better readability
-	private int compare(Entry<String, Object> a, Entry<String, Object> b, int direction) {
-		Object first = a.getValue();
-		Object second = b.getValue();
-		if (first instanceof String && second instanceof String) {
-			return Relation.get(((String) first).compareToIgnoreCase((String) second)).getRelation() * direction;
-		}
-		return Comparators.compare(first, second).getRelation() * direction;
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprSortedList.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSortedList.java
@@ -85,7 +85,7 @@ public class ExprSortedList extends SimpleExpression<Object> {
         if (comparator != null && comparator.supportsOrdering())
 			return comparator.compare(a, b).getRelation();
 		if (!(a instanceof Comparable))
-			throw new IllegalArgumentException();
+			throw new IllegalArgumentException("Cannot compare " + a.getClass());
 		return ((Comparable<B>) a).compareTo(b);
     }
 

--- a/src/main/java/ch/njol/skript/expressions/ExprSortedList.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSortedList.java
@@ -34,6 +34,7 @@ import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 import org.skriptlang.skript.lang.comparator.Comparator;
 import org.skriptlang.skript.lang.comparator.Comparators;
+import org.skriptlang.skript.lang.comparator.Relation;
 
 import java.lang.reflect.Array;
 
@@ -77,7 +78,9 @@ public class ExprSortedList extends SimpleExpression<Object> {
 	}
 
 	@SuppressWarnings("unchecked")
-	private static <A, B> int compare(A a, B b) throws IllegalArgumentException, ClassCastException {
+	public static <A, B> int compare(A a, B b) throws IllegalArgumentException, ClassCastException {
+		if (a instanceof String && b instanceof String)
+			return Relation.get(((String) a).compareToIgnoreCase((String) b)).getRelation();
 		Comparator<A, B> comparator = Comparators.getComparator((Class<A>) a.getClass(), (Class<B>) b.getClass());
         if (comparator != null && comparator.supportsOrdering())
 			return comparator.compare(a, b).getRelation();

--- a/src/test/skript/tests/syntaxes/expressions/ExprIndices.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprIndices.sk
@@ -23,3 +23,17 @@ test "sorted indices":
 		set {_a} to {_leader-board::%loop-value%}
 		set {_b} to {_descending-values::%loop-index%}
 		assert {_a} is equal to {_b} with "Sorting indices in descending order is incorrect"
+
+test "alphabetically sorted indices":
+	set {_test::a} to "Bob"
+	set {_test::b} to "Donald"
+	set {_test::c} to "Zeffer"
+	set {_test::d} to "Angus"
+	set {_test::e} to "Kevin"
+	set {_test::f} to "anderson"
+	set {_test::g} to "robertson"
+
+	set {_indexes::*} to sorted indices of {_test::*} in ascending order
+
+	assert {_test::%{_indexes::1}%} = "anderson" with "First element of sorted strings should be 'anderson'"
+	assert {_test::%{_indexes::7}%} = "Zeffer" with "Last element of sorted strings should be 'Zeffer'"


### PR DESCRIPTION
### Description
This PR aims to fix the alphabetically sorted issue with the sorted indices expression.

NOTE:
This changes the behaviour of ExprSortedList by sorting alphabetically ignoring case.
Previous:
```
A
B
C
a
b
c
```
NEW:
```
A
a
B
b
C
c
```

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none #6492 
