### PR TITLE
Fix expression null pointer exception on expressions with null return type

### DIFF
--- a/src/main/java/ch/njol/skript/entity/EntityData.java
+++ b/src/main/java/ch/njol/skript/entity/EntityData.java
@@ -37,6 +37,7 @@ import org.bukkit.Location;
 import org.bukkit.RegionAccessor;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -94,6 +95,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		} catch (NoSuchMethodException | SecurityException ignored) { /* We already checked if the method exists */ }
 	}
 
+	private static final boolean HAS_ENABLED_BY_FEATURE = Skript.methodExists(EntityType.class, "isEnabledByFeature", World.class);
 	public final static String LANGUAGE_NODE = "entities";
 
 	public final static Message m_age_pattern = new Message(LANGUAGE_NODE + ".age pattern");
@@ -464,6 +466,25 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	}
 
 	/**
+	 * Check if this entity type can spawn.
+	 * <p>Some entity types may be restricted by experimental datapacks.</p>
+	 *
+	 * @param world World to check if entity can spawn in
+	 * @return True if entity can spawn else false
+	 */
+	public boolean canSpawn(@Nullable World world) {
+		if (world == null)
+			return false;
+		if (HAS_ENABLED_BY_FEATURE) {
+			// Check if the entity can actually be spawned
+			// Some entity types may be restricted by experimental datapacks
+			EntityType bukkitEntityType = EntityUtils.toBukkitEntityType(this);
+            return bukkitEntityType.isEnabledByFeature(world);
+		}
+		return true;
+	}
+
+	/**
 	 * Spawn this entity data at a location.
 	 *
 	 * @param location The {@link Location} to spawn the entity at.
@@ -476,7 +497,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 
 	/**
 	 * Spawn this entity data at a location.
-	 * The consumer allows for modiciation to the entity before it actually gets spawned.
+	 * The consumer allows for modification to the entity before it actually gets spawned.
 	 * <p>
 	 * Bukkit's own {@link org.bukkit.util.Consumer} is deprecated.
 	 * Use {@link #spawn(Location, Consumer)}
@@ -494,7 +515,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 
 	/**
 	 * Spawn this entity data at a location.
-	 * The consumer allows for modiciation to the entity before it actually gets spawned.
+	 * The consumer allows for modification to the entity before it actually gets spawned.
 	 *
 	 * @param location The {@link Location} to spawn the entity at.
 	 * @param consumer A {@link Consumer} to apply the entity changes to.
@@ -503,10 +524,13 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	@Nullable
 	public E spawn(Location location, @Nullable Consumer<E> consumer) {
 		assert location != null;
+		World world = location.getWorld();
+		if (!canSpawn(world))
+			return null;
 		if (consumer != null) {
 			return EntityData.spawn(location, getType(), e -> consumer.accept(this.apply(e)));
 		} else {
-			return apply(location.getWorld().spawn(location, getType()));
+			return apply(world.spawn(location, getType()));
 		}
 	}
 

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -531,6 +531,9 @@ public class SkriptParser {
 				Expression<?> parsedExpression = parseExpression(types, expr);
 				if (parsedExpression != null) { // Expression/VariableString parsing success
 					Class<?> returnType = parsedExpression.getReturnType(); // Sometimes getReturnType does non-trivial costly operations
+					if (returnType == null)
+						throw new SkriptAPIException("Expression '" + expr + "' returned null for method Expression#getReturnType. Consider using Object.class, as null is not a valid return.");
+
 					for (int i = 0; i < types.length; i++) {
 						Class<?> type = types[i];
 						if (type == null) // Ignore invalid (null) types

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -532,7 +532,7 @@ public class SkriptParser {
 				if (parsedExpression != null) { // Expression/VariableString parsing success
 					Class<?> returnType = parsedExpression.getReturnType(); // Sometimes getReturnType does non-trivial costly operations
 					if (returnType == null)
-						throw new SkriptAPIException("Expression '" + expr + "' returned null for method Expression#getReturnType. Consider using Object.class, as null is not a valid return.");
+						throw new SkriptAPIException("Expression '" + expr + "' returned null for method Expression#getReturnType. Null is not a valid return.");
 
 					for (int i = 0; i < types.length; i++) {
 						Class<?> type = types[i];


### PR DESCRIPTION
### Description
If an expression returns null as it's return type, it throws a NullPointerException at parse time. This pull request makes the error a safe SkriptAPIException.

Error this pull fixes:
```
[02:29:38] [Server thread/ERROR]: #!#! Stack trace:
[02:29:38] [Server thread/ERROR]: #!#! java.lang.NullPointerException
[02:29:38] [Server thread/ERROR]: #!#!     at java.base/java.lang.Class.isAssignableFrom(Native Method)
[02:29:38] [Server thread/ERROR]: #!#!     at Skript.jar//ch.njol.skript.lang.SkriptParser.parseSingleExpr(SkriptParser.java:540)
[02:29:38] [Server thread/ERROR]: #!#!     at Skript.jar//ch.njol.skript.lang.SkriptParser.parseExpression(SkriptParser.java:752)
[02:29:38] [Server thread/ERROR]: #!#!     at Skript.jar//ch.njol.skript.patterns.TypePatternElement.match(TypePatternElement.java:159)
[02:29:38] [Server thread/ERROR]: #!#!     at Skript.jar//ch.njol.skript.patterns.PatternElement.matchNext(PatternElement.java:54)
[02:29:38] [Server thread/ERROR]: #!#!     at Skript.jar//ch.njol.skript.patterns.LiteralPatternElement.match(LiteralPatternElement.java:65)
[02:29:38] [Server thread/ERROR]: #!#!     at Skript.jar//ch.njol.skript.patterns.SkriptPattern.match(SkriptPattern.java:58)
[02:29:38] [Server thread/ERROR]: #!#!     at Skript.jar//ch.njol.skript.lang.SkriptParser.parse_i(SkriptParser.java:1252)
[02:29:38] [Server thread/ERROR]: #!#!     at Skript.jar//ch.njol.skript.lang.SkriptParser.parse(SkriptParser.java:227)
[02:29:38] [Server thread/ERROR]: #!#!     at Skript.jar//ch.njol.skript.lang.SkriptParser.parse(SkriptParser.java:174)
[02:29:38] [Server thread/ERROR]: #!#!     at Skript.jar//ch.njol.skript.lang.Effect.parse(Effect.java:75)
[02:29:38] [Server thread/ERROR]: #!#!     at Skript.jar//ch.njol.skript.command.Commands.handleEffectCommand(Commands.java:190)
[02:29:38] [Server thread/ERROR]: #!#!     at Skript.jar//ch.njol.skript.command.Commands$2.lambda$onPlayerChat$0(Commands.java:300)
[02:29:38] [Server thread/ERROR]: #!#!     at org.bukkit.craftbukkit.v1_20_R1.scheduler.CraftFuture.run(CraftFuture.java:88)
[02:29:38] [Server thread/ERROR]: #!#!     at org.bukkit.craftbukkit.v1_20_R1.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:480)
[02:29:38] [Server thread/ERROR]: #!#!     at net.minecraft.server.MinecraftServer.b(MinecraftServer.java:1479)
[02:29:38] [Server thread/ERROR]: #!#!     at net.minecraft.server.dedicated.DedicatedServer.b(DedicatedServer.java:446)
[02:29:38] [Server thread/ERROR]: #!#!     at net.minecraft.server.MinecraftServer.a(MinecraftServer.java:1393)
[02:29:38] [Server thread/ERROR]: #!#!     at net.minecraft.server.MinecraftServer.w(MinecraftServer.java:1170)
[02:29:38] [Server thread/ERROR]: #!#!     at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:317)
[02:29:38] [Server thread/ERROR]: #!#!     at java.base/java.lang.Thread.run(Thread.java:833)
```

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
