### PR TITLE
Handle invalid amounts in ExprRandomCharacter

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprRandomCharacter.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprRandomCharacter.java
@@ -50,17 +50,17 @@ public class ExprRandomCharacter extends SimpleExpression<String> {
 
 	static {
 		Skript.registerExpression(ExprRandomCharacter.class, String.class, ExpressionType.COMBINED,
-				"[a|%-number%] random [:alphanumeric] character[s] (from|between) %string% (to|and) %string%");
+				"[a|%-integer%] random [:alphanumeric] character[s] (from|between) %string% (to|and) %string%");
 	}
 
 	@Nullable
-	private Expression<Number> amount;
+	private Expression<Integer> amount;
 	private Expression<String> from, to;
 	private boolean isAlphanumeric;
 
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		amount = (Expression<Number>) exprs[0];
+		amount = (Expression<Integer>) exprs[0];
 		from = (Expression<String>) exprs[1];
 		to = (Expression<String>) exprs[2];
 		isAlphanumeric = parseResult.hasTag("alphanumeric");
@@ -70,10 +70,9 @@ public class ExprRandomCharacter extends SimpleExpression<String> {
 	@Override
 	@Nullable
 	protected String[] get(Event event) {
-		Number amountNumber = this.amount == null ? 1 : this.amount.getSingle(event);
-		if (amountNumber == null || amountNumber.intValue() <= 0 || !Double.isFinite(amountNumber.doubleValue()))
+		Integer amount = this.amount == null ? Integer.valueOf(1) : this.amount.getSingle(event);
+		if (amount == null || amount <= 0)
 			return new String[0];
-		int amount = amountNumber.intValue();
 
 		String from = this.from.getSingle(event);
 		String to = this.to.getSingle(event);
@@ -121,7 +120,7 @@ public class ExprRandomCharacter extends SimpleExpression<String> {
 	@Override
 	public boolean isSingle() {
 		if (amount instanceof Literal)
-			return ((Literal<Number>) amount).getSingle().intValue() == 1;
+			return ((Literal<Integer>) amount).getSingle() == 1;
 		return amount == null;
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprRandomCharacter.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprRandomCharacter.java
@@ -70,7 +70,11 @@ public class ExprRandomCharacter extends SimpleExpression<String> {
 	@Override
 	@Nullable
 	protected String[] get(Event event) {
-		int amount = this.amount == null ? 1 : this.amount.getOptionalSingle(event).orElse(1).intValue();
+		Number amountNumber = this.amount == null ? 1 : this.amount.getSingle(event);
+		if (amountNumber == null || amountNumber.intValue() <= 0 || !Double.isFinite(amountNumber.doubleValue()))
+			return new String[0];
+		int amount = amountNumber.intValue();
+
 		String from = this.from.getSingle(event);
 		String to = this.to.getSingle(event);
 		if (from == null || to == null)

--- a/src/test/skript/tests/syntaxes/expressions/ExprCharacters.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprCharacters.sk
@@ -1,5 +1,16 @@
 test "characters between":
 	set {_a} to 1 random character between "a" and "z"
+	assert {_a} is set with "failed to generate random character"
+
+	set {_a::*} to infinity value random character between "a" and "z"
+	assert {_a::*} is not set with "infinite random characters returned non-null value: {_a::*}"
+
+	set {_a::*} to -10 random character between "a" and "z"
+	assert {_a::*} is not set with "-10 random characters returned non-null value: {_a::*}"
+
+	set {_a::*} to {_null} random character between "a" and "z"
+	assert {_a::*} is not set with "null random characters returned non-null value: {_a::*}"
+
 	assert join characters between "a" and "d" is "abcd" with "Invalid characters between a and d"
 	assert join characters between "d" and "a" is "dcba" with "Invalid characters between d and a"
 	assert join characters between "Z" and "a" is "Z[\]^_`a" with "Invalid characters between Z and a"

--- a/src/test/skript/tests/syntaxes/expressions/ExprCharacters.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprCharacters.sk
@@ -2,9 +2,6 @@ test "characters between":
 	set {_a} to 1 random character between "a" and "z"
 	assert {_a} is set with "failed to generate random character"
 
-	set {_a::*} to infinity value random character between "a" and "z"
-	assert {_a::*} is not set with "infinite random characters returned non-null value: %{_a::*}%"
-
 	set {_a::*} to -10 random character between "a" and "z"
 	assert {_a::*} is not set with "-10 random characters returned non-null value: %{_a::*}%"
 

--- a/src/test/skript/tests/syntaxes/expressions/ExprCharacters.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprCharacters.sk
@@ -3,13 +3,13 @@ test "characters between":
 	assert {_a} is set with "failed to generate random character"
 
 	set {_a::*} to infinity value random character between "a" and "z"
-	assert {_a::*} is not set with "infinite random characters returned non-null value: {_a::*}"
+	assert {_a::*} is not set with "infinite random characters returned non-null value: %{_a::*}%"
 
 	set {_a::*} to -10 random character between "a" and "z"
-	assert {_a::*} is not set with "-10 random characters returned non-null value: {_a::*}"
+	assert {_a::*} is not set with "-10 random characters returned non-null value: %{_a::*}%"
 
 	set {_a::*} to {_null} random character between "a" and "z"
-	assert {_a::*} is not set with "null random characters returned non-null value: {_a::*}"
+	assert {_a::*} is not set with "null random characters returned non-null value: %{_a::*}%"
 
 	assert join characters between "a" and "d" is "abcd" with "Invalid characters between a and d"
 	assert join characters between "d" and "a" is "dcba" with "Invalid characters between d and a"


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Previously, there were no guards against `infinite value random characters between "a" and "b"`, or `-10 random characters`. 
This also fixes an issue where a null value for the amount would default to 1 character instead of 0. Needs a warning on release, but arguably a bug so not a breaking change imo.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
