### PR TITLE
Remove Player name/UUID in variables warning.

### DIFF
--- a/src/main/java/ch/njol/skript/lang/VariableString.java
+++ b/src/main/java/ch/njol/skript/lang/VariableString.java
@@ -224,16 +224,6 @@ public class VariableString implements Expression<String> {
 							log.printErrors("Can't understand this expression: " + original.substring(exprStart + 1, exprEnd));
 							return null;
 						} else {
-							if (
-								mode == StringMode.VARIABLE_NAME &&
-								!SkriptConfig.usePlayerUUIDsInVariableNames.value() &&
-								OfflinePlayer.class.isAssignableFrom(expr.getReturnType())
-							) {
-								Skript.warning(
-										"In the future, players in variable names will use the player's UUID instead of their name. " +
-										"For information on how to make sure your scripts won't be impacted by this change, see https://github.com/SkriptLang/Skript/discussions/6270."
-								);
-							}
 							strings.add(expr);
 						}
 						log.printLog();


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Since the default has been updated in config, this warning isn't needed anymore.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
