### PR TITLE
🛠️ Fix ExprRandom missing canInitSafely

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprRandom.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprRandom.java
@@ -78,9 +78,7 @@ public class ExprRandom extends SimpleExpression<Object> {
 		} else {
 			expr = exprs[1].getConvertedExpression((((Literal<ClassInfo<?>>) exprs[0]).getSingle()).getC());
 		}
-		if (expr == null)
-			return false;
-		return true;
+		return expr != null && LiteralUtils.canInitSafely(expr);
 	}
 
 	@Override


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
This expression was missing `LiteralUtils#canInitSafely()` which caused it to throw an exception because it allowed parsing literally anything that is whether known or not and failing when an unknown expression is used such as `random color of somethingunkown`

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
- #6511 
