### PR TITLE
Added 'play time' and 'played time' to Time Played expression

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprTimePlayed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTimePlayed.java
@@ -53,7 +53,7 @@ public class ExprTimePlayed extends SimplePropertyExpression<OfflinePlayer, Time
 	private static final boolean IS_OFFLINE_SUPPORTED = Skript.methodExists(OfflinePlayer.class, "getStatistic", Statistic.class);
 
 	static {
-		register(ExprTimePlayed.class, Timespan.class, "time played", "offlineplayers");
+		register(ExprTimePlayed.class, Timespan.class, "(time played|play[ed] time)", "offlineplayers");
 	}
 	
 	@Nullable


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Changed the pattern of the Time Played Expression from 'time played' to '(time played|play[ed] time)'

---
**Target Minecraft Versions:** same as 2.8
**Requirements:** same as 2.8
**Related Issues:**  https://github.com/SkriptLang/Skript/issues/5914
