### PR TITLE
Added "online" and the option to put "time" on either side of the Time Played Expression

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprTimePlayed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTimePlayed.java
@@ -53,7 +53,7 @@ public class ExprTimePlayed extends SimplePropertyExpression<OfflinePlayer, Time
 	private static final boolean IS_OFFLINE_SUPPORTED = Skript.methodExists(OfflinePlayer.class, "getStatistic", Statistic.class);
 
 	static {
-		register(ExprTimePlayed.class, Timespan.class, "time played", "offlineplayers");
+		register(ExprTimePlayed.class, Timespan.class, "(time (played|online)|(online|played) time)", "offlineplayers");
 	}
 	
 	@Nullable


### PR DESCRIPTION
Took 3 minutes

### Description
Added "online" and the option to put "time" on either side of the Time Played Expression

---
**Target Minecraft Versions:** same as 2.8.4
**Requirements:** same as 2.8.4
**Related Issues:** #5914 

coming from: https://github.com/SkriptLang/Skript/pull/6527
