### PR TITLE
Improvements to EffAssert Logging

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondCompare.java
+++ b/src/main/java/ch/njol/skript/conditions/CondCompare.java
@@ -18,20 +18,17 @@
  */
 package ch.njol.skript.conditions;
 
+import ch.njol.skript.lang.VerboseAssert;
 import ch.njol.skript.log.ParseLogHandler;
-import ch.njol.skript.util.Time;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.ClassInfo;
 
-import org.jetbrains.annotations.ApiStatus;
 import org.skriptlang.skript.lang.comparator.Comparator;
 import org.skriptlang.skript.lang.comparator.ComparatorInfo;
 import org.skriptlang.skript.lang.comparator.Relation;
-import org.skriptlang.skript.lang.converter.ConverterInfo;
-import org.skriptlang.skript.lang.converter.Converters;
 
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -46,7 +43,6 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.UnparsedLiteral;
 import ch.njol.skript.lang.util.SimpleLiteral;
 import ch.njol.skript.log.ErrorQuality;
-import ch.njol.skript.log.RetainingLogHandler;
 import ch.njol.skript.log.SkriptLogger;
 import ch.njol.skript.registrations.Classes;
 
@@ -67,7 +63,7 @@ import org.skriptlang.skript.lang.util.Cyclical;
 		"time in the player's world is greater than 8:00",
 		"the creature is not an enderman or an ender dragon"})
 @Since("1.0")
-public class CondCompare extends Condition {
+public class CondCompare extends Condition implements VerboseAssert {
 	
 	private final static Patterns<Relation> patterns = new Patterns<>(new Object[][]{
 			{"(1¦neither|) %objects% ((is|are)(|2¦(n't| not|4¦ neither)) ((greater|more|higher|bigger|larger) than|above)|\\>) %objects%", Relation.GREATER},
@@ -383,41 +379,20 @@ public class CondCompare extends Condition {
 		), isNegated());
 	}
 
-	/**
-	 * For internal use. Callers should not modify the results.
-	 * @return the first expression in the comparison.
-	 */
-	@ApiStatus.Internal
-	public Expression<?> getFirst() {
-		return first;
+	public String getExpectedMessage(Event event) {
+		String message = "a value ";
+		if (third == null)
+			return message + (isNegated() ? "not " : "") + relation + " " + VerboseAssert.getExpressionValue(second, event);
+
+		// handle between
+		if (isNegated())
+			message += "not ";
+		message += "between " + VerboseAssert.getExpressionValue(second, event) + " and " + VerboseAssert.getExpressionValue(third, event);
+		return message;
 	}
 
-	/**
-	 * For internal use. Callers should not modify the results.
-	 * @return the second expression in the comparison.
-	 */
-	@ApiStatus.Internal
-	public Expression<?> getSecond() {
-		return second;
-	}
-	/**
-	 * For internal use. Callers should not modify the results.
-	 * @return the third expression in the comparison.
-	 */
-	@ApiStatus.Internal
-	@Nullable
-	public Expression<?> getThird() {
-		return third;
-	}
-
-
-	/**
-	 * For internal use.
-	 * @return the relation used to compare the expressions.
-	 */
-	@ApiStatus.Internal
-	public Relation getRelation() {
-		return relation;
+	public String getReceivedMessage(Event event) {
+		return VerboseAssert.getExpressionValue(first, event);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/conditions/CondCompare.java
+++ b/src/main/java/ch/njol/skript/conditions/CondCompare.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.ClassInfo;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.skriptlang.skript.lang.comparator.Comparator;
 import org.skriptlang.skript.lang.comparator.ComparatorInfo;
 import org.skriptlang.skript.lang.comparator.Relation;
@@ -381,7 +382,44 @@ public class CondCompare extends Condition {
 			}
 		), isNegated());
 	}
-	
+
+	/**
+	 * For internal use. Callers should not modify the results.
+	 * @return the first expression in the comparison.
+	 */
+	@ApiStatus.Internal
+	public Expression<?> getFirst() {
+		return first;
+	}
+
+	/**
+	 * For internal use. Callers should not modify the results.
+	 * @return the second expression in the comparison.
+	 */
+	@ApiStatus.Internal
+	public Expression<?> getSecond() {
+		return second;
+	}
+	/**
+	 * For internal use. Callers should not modify the results.
+	 * @return the third expression in the comparison.
+	 */
+	@ApiStatus.Internal
+	@Nullable
+	public Expression<?> getThird() {
+		return third;
+	}
+
+
+	/**
+	 * For internal use.
+	 * @return the relation used to compare the expressions.
+	 */
+	@ApiStatus.Internal
+	public Relation getRelation() {
+		return relation;
+	}
+
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
 		String s;

--- a/src/main/java/ch/njol/skript/conditions/CondIsSet.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsSet.java
@@ -18,6 +18,8 @@
  */
 package ch.njol.skript.conditions;
 
+import ch.njol.skript.lang.VerboseAssert;
+import ch.njol.skript.localization.Language;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -42,7 +44,7 @@ import ch.njol.util.Kleenean;
 		"	projectile exists",
 		"	broadcast \"%attacker% used a %projectile% to attack %victim%!\""})
 @Since("1.2")
-public class CondIsSet extends Condition {
+public class CondIsSet extends Condition implements VerboseAssert {
 	static {
 		Skript.registerCondition(CondIsSet.class,
 				"%~objects% (exist[s]|(is|are) set)",
@@ -79,7 +81,18 @@ public class CondIsSet extends Condition {
 	public boolean check(final Event e) {
 		return check(expr, e);
 	}
-	
+
+	@Override
+	public String getExpectedMessage(Event event) {
+		return isNegated() ? Language.get("none") : "a value";
+	}
+
+	@Override
+	public String getReceivedMessage(Event event) {
+		// TODO: may need to make this enumerate each value: "a, b, <none>, and d"
+		return VerboseAssert.getExpressionValue(expr,event);
+	}
+
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
 		return expr.toString(e, debug) + (isNegated() ? " isn't" : " is") + " set";

--- a/src/main/java/ch/njol/skript/lang/VerboseAssert.java
+++ b/src/main/java/ch/njol/skript/lang/VerboseAssert.java
@@ -1,0 +1,60 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.lang;
+
+import ch.njol.skript.registrations.Classes;
+import org.bukkit.event.Event;
+
+/**
+ * This interface provides methods for {@link Condition}s to provide expected and received values for {@link ch.njol.skript.test.runner.EffAssert}
+ * or others to use to in debugging or testing scenarios. <br>
+ * <br>
+ * Expected values should be the value being compared against, the source of truth. <br>
+ * Received values should be the value being tested, the value that may or may not be correct. 
+ */
+public interface VerboseAssert {
+	
+	/**
+	 * This method is intended to be used directly after {@code "Expected "} and the grammar of the returned string should match.
+	 * 
+	 * @param event The event used to evaluate this condition.
+	 * @return The expected value in this condition, formatted as a readable string.
+	 */
+	String getExpectedMessage(Event event);
+	
+	/**
+	 * This method is intended to be used directly after {@code "Expected x, but got "} and the grammar of the returned string should match.
+	 *
+	 * @param event The event used to evaluate this condition.
+	 * @return The received value in this condition, formatted as a readable string.
+	 */
+	String getReceivedMessage(Event event);
+	
+	/**
+	 * Helper method to simplify stringify-ing the values of expressions.
+	 * Evaluates the expression using {@link Expression#getAll(Event)} and stringifies using {@link Classes#toString(Object[], boolean)}.
+	 * @param expression The expression to evaluate
+	 * @param event The event used for evaluation
+	 * @return The string representation of the expression's value.
+	 */
+	static String getExpressionValue(Expression<?> expression, Event event) {
+		return Classes.toString(expression.getAll(event), expression.getAnd());
+	}
+	
+}

--- a/src/main/java/ch/njol/skript/test/runner/TestTracker.java
+++ b/src/main/java/ch/njol/skript/test/runner/TestTracker.java
@@ -61,9 +61,18 @@ public class TestTracker {
 	}
 
 	public static void testFailed(String msg, Script script) {
-		String file = script.getConfig().getFileName();
-		file = file.substring(file.lastIndexOf(File.separator) + 1);
+		String file = getFileName(script);
 		failedTests.put(currentTest, msg + " [" + file + "]");
+	}
+
+	public static void testFailed(String msg, Script script, int line) {
+		String file = getFileName(script);
+		failedTests.put(currentTest, msg + " [" + file + ", line " + line + "]");
+	}
+
+	private static String getFileName(Script script) {
+		String file = script.getConfig().getFileName();
+		return file.substring(file.lastIndexOf(File.separator) + 1);
 	}
 
 	public static void junitTestFailed(String junit, String msg) {


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Adds the ability to provide expected and received values for an assertion that will be provided in the error message.

```
assert <.+> [(1:to fail)] with [error] %string%, expected [value] %object%, [and] (received|got) [value] %object%
```

For assertions using conditions that implement VerboseAssert (and that don't provide custom expected/got values), EffAssert will automatically grab expected/got messages from the condition itself. This will not work reliably for expressions that change between calls, like random expressions or ExprNow, as the assert effect calls getSingle/getAll a second time. For those scenarios, using a variable or a custom expected/got message is recommended.

So far, only CondCompare and CondIsSet implement VerboseAssert, but any condition that has significant use in tests is a valid target for implementation.

Suggestions are extremely welcome for a better interface name. This is the best kenzie and I could come up with in 5 minutes.

Example:
```applescript
assert 1 is 2 with "failed number comparison" # sends "failed number comparison (Expected a value equal to 2, got 1)."
assert 1 is 2 or 3 with "failed number list comparison" # sends "failed number list comparison (Expected a value equal to 2 or 3, got 1)."

assert name of player is "tony" with "failed name check" # sends "failed name check (Expected a value equal to tony, got Sahvde)."

assert isNaN(difference between NaN value and NaN value) is true with "difference between NaN and NaN is not NaN", expected NaN value, got difference between NaN value and NaN value
# sends "difference between NaN and NaN is not NaN (Expected NaN value, got <number>)."
```

This PR also adds line numbers to the test error message:
```patch
- [ScriptName.sk]
+ [ScriptName.sk, line 24]
```

### Todo:

- [x] add expected/got value
- [x] add line numbers
- [x] clean up changes

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
