### PR TITLE
Add deprecated syntax warning type

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffSuppressWarnings.java
+++ b/src/main/java/ch/njol/skript/effects/EffSuppressWarnings.java
@@ -42,11 +42,11 @@ public class EffSuppressWarnings extends Effect {
 
 	static {
 		Skript.registerEffect(EffSuppressWarnings.class,
-			"[local[ly]] suppress [the] (1:conflict|2:variable save|3:[missing] conjunction[s]|4:starting [with] expression[s]) warning[s]"
+			"[local[ly]] suppress [the] (1:conflict|2:variable save|3:[missing] conjunction[s]|4:starting [with] expression[s]|5:deprecated syntax) warning[s]"
 		);
 	}
 
-	private static final int CONFLICT = 1, INSTANCE = 2, CONJUNCTION = 3, START_EXPR = 4;
+	private static final int CONFLICT = 1, INSTANCE = 2, CONJUNCTION = 3, START_EXPR = 4, DEPRECATED = 5;
 	private int mark = 0;
 
 	@Override
@@ -83,6 +83,9 @@ public class EffSuppressWarnings extends Effect {
 				break;
 			case START_EXPR:
 				word = "starting expression";
+				break;
+			case DEPRECATED:
+				word = "deprecated syntax";
 				break;
 			default:
 				throw new IllegalStateException();

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorArithmetic.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorArithmetic.java
@@ -37,6 +37,7 @@ import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.skript.util.Patterns;
 import ch.njol.util.Kleenean;
 import org.skriptlang.skript.lang.arithmetic.Arithmetics;
+import org.skriptlang.skript.lang.script.ScriptWarning;
 
 @Name("Vectors - Arithmetic")
 @Description("Arithmetic expressions for vectors.")
@@ -72,7 +73,7 @@ public class ExprVectorArithmetic extends SimpleExpression<Vector> {
 		first = (Expression<Vector>) exprs[0];
 		second = (Expression<Vector>) exprs[1];
 		operator = patterns.getInfo(matchedPattern);
-		Skript.warning("This expression was deprecated in favor of the arithmetic expression, and will be removed in the future." +
+		ScriptWarning.printDeprecationWarning("This expression was deprecated in favor of the arithmetic expression and will be removed in the future." +
 			" Please use that instead. E.g. 'vector(2, 4, 1) + vector(5, 2, 3)'");
 		return true;
 	}

--- a/src/main/java/org/skriptlang/skript/lang/script/ScriptWarning.java
+++ b/src/main/java/org/skriptlang/skript/lang/script/ScriptWarning.java
@@ -52,6 +52,7 @@ public enum ScriptWarning {
 	/**
 	 * Prints the given message using {@link Skript#warning(String)} iff the current script does not suppress deprecation warnings.
 	 * Intended for use in {@link ch.njol.skript.lang.SyntaxElement#init(Expression[], int, Kleenean, SkriptParser.ParseResult)}.
+	 * The given message is prefixed with {@code "[Deprecated] "} to provide a common link between deprecation warnings.
 	 *
 	 * @param message the warning message to print.
 	 */
@@ -60,7 +61,7 @@ public enum ScriptWarning {
 		Script currentScript = parser.isActive() ? parser.getCurrentScript() : null;
 		if (currentScript != null && currentScript.suppressesWarning(ScriptWarning.DEPRECATED_SYNTAX))
 			return;
-		Skript.warning(message);
+		Skript.warning("[Deprecated] " + message);
 	}
 
 }

--- a/src/main/java/org/skriptlang/skript/lang/script/ScriptWarning.java
+++ b/src/main/java/org/skriptlang/skript/lang/script/ScriptWarning.java
@@ -18,15 +18,49 @@
  */
 package org.skriptlang.skript.lang.script;
 
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.parser.ParserInstance;
+import ch.njol.util.Kleenean;
+
 /**
  * An enum containing {@link Script} warnings that can be suppressed.
  */
 public enum ScriptWarning {
 
-	VARIABLE_SAVE, // Variable cannot be saved (the ClassInfo is not serializable)
+	/**
+	 * Variable cannot be saved (the ClassInfo is not serializable)
+	 */
+	VARIABLE_SAVE,
 
-	MISSING_CONJUNCTION, // Missing "and" or "or"
+	/**
+	 * Missing "and" or "or"
+	 */
+	MISSING_CONJUNCTION,
 
-	VARIABLE_STARTS_WITH_EXPRESSION // Variable starts with an Expression
+	/**
+	 * Variable starts with an Expression
+	 */
+	VARIABLE_STARTS_WITH_EXPRESSION,
+
+	/**
+	 * This syntax is deprecated and scheduled for future removal
+	 */
+	DEPRECATED_SYNTAX;
+
+	/**
+	 * Prints the given message using {@link Skript#warning(String)} iff the current script does not suppress deprecation warnings.
+	 * Intended for use in {@link ch.njol.skript.lang.SyntaxElement#init(Expression[], int, Kleenean, SkriptParser.ParseResult)}.
+	 *
+	 * @param message the warning message to print.
+	 */
+	public static void printDeprecationWarning(String message) {
+		ParserInstance parser = ParserInstance.get();
+		Script currentScript = parser.isActive() ? parser.getCurrentScript() : null;
+		if (currentScript != null && currentScript.suppressesWarning(ScriptWarning.DEPRECATED_SYNTAX))
+			return;
+		Skript.warning(message);
+	}
 
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

For use when we intend to remove a syntax in a future version. The warning is locally, but not globally, suppressible for those who refuse to update. 

I chose to make it a static method, as opposed to an automatic warning in the parser, so that we can call it with whatever message is appropriate in a element's init method.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
