### PR TITLE
Simple Structures

### DIFF
--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -530,21 +530,22 @@ public class ScriptLoader {
 
 					// pre-loading
 					pairs.removeIf(pair -> {
+						LoadingScriptInfo loadingInfo = pair.getFirst();
 						Structure structure = pair.getSecond();
 
-						parser.setActive(pair.getFirst().script);
+						parser.setActive(loadingInfo.script);
 						parser.setCurrentStructure(structure);
-						parser.setNode(pair.getFirst().nodeMap.get(structure));
+						parser.setNode(loadingInfo.nodeMap.get(structure));
 
 						try {
 							if (!structure.preLoad()) {
-								pair.getFirst().structures.remove(structure);
+								loadingInfo.structures.remove(structure);
 								return true;
 							}
 						} catch (Exception e) {
 							//noinspection ThrowableNotThrown
 							Skript.exception(e, "An error occurred while trying to preLoad a Structure.");
-							pair.getFirst().structures.remove(structure);
+							loadingInfo.structures.remove(structure);
 							return true;
 						}
 						return false;
@@ -558,21 +559,22 @@ public class ScriptLoader {
 
 					// loading
 					pairs.removeIf(pair -> {
+						LoadingScriptInfo loadingInfo = pair.getFirst();
 						Structure structure = pair.getSecond();
 
-						parser.setActive(pair.getFirst().script);
+						parser.setActive(loadingInfo.script);
 						parser.setCurrentStructure(structure);
-						parser.setNode(pair.getFirst().nodeMap.get(structure));
+						parser.setNode(loadingInfo.nodeMap.get(structure));
 
 						try {
 							if (!structure.load()) {
-								pair.getFirst().structures.remove(structure);
+								loadingInfo.structures.remove(structure);
 								return true;
 							}
 						} catch (Exception e) {
 							//noinspection ThrowableNotThrown
 							Skript.exception(e, "An error occurred while trying to load a Structure.");
-							pair.getFirst().structures.remove(structure);
+							loadingInfo.structures.remove(structure);
 							return true;
 						}
 						return false;
@@ -581,21 +583,22 @@ public class ScriptLoader {
 
 					// post-loading
 					pairs.removeIf(pair -> {
+						LoadingScriptInfo loadingInfo = pair.getFirst();
 						Structure structure = pair.getSecond();
 
-						parser.setActive(pair.getFirst().script);
+						parser.setActive(loadingInfo.script);
 						parser.setCurrentStructure(structure);
-						parser.setNode(pair.getFirst().nodeMap.get(structure));
+						parser.setNode(loadingInfo.nodeMap.get(structure));
 
 						try {
 							if (!structure.postLoad()) {
-								pair.getFirst().structures.remove(structure);
+								loadingInfo.structures.remove(structure);
 								return true;
 							}
 						} catch (Exception e) {
 							//noinspection ThrowableNotThrown
 							Skript.exception(e, "An error occurred while trying to postLoad a Structure.");
-							pair.getFirst().structures.remove(structure);
+							loadingInfo.structures.remove(structure);
 							return true;
 						}
 						return false;

--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -60,8 +60,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.BlockingQueue;
@@ -490,7 +492,7 @@ public class ScriptLoader {
 		
 		ScriptInfo scriptInfo = new ScriptInfo();
 
-		List<NonNullPair<Script, List<Structure>>> scripts = new ArrayList<>();
+		List<LoadingScriptInfo> scripts = new ArrayList<>();
 
 		List<CompletableFuture<Void>> scriptInfoFutures = new ArrayList<>();
 		for (Config config : configs) {
@@ -498,9 +500,9 @@ public class ScriptLoader {
 				throw new NullPointerException();
 			
 			CompletableFuture<Void> future = makeFuture(() -> {
-				NonNullPair<Script, List<Structure>> pair = loadScript(config);
-				scripts.add(pair);
-				scriptInfo.add(new ScriptInfo(1, pair.getSecond().size()));
+				LoadingScriptInfo info = loadScript(config);
+				scripts.add(info);
+				scriptInfo.add(new ScriptInfo(1, info.structures.size()));
 				return null;
 			}, openCloseable);
 			
@@ -518,10 +520,10 @@ public class ScriptLoader {
 
 					// build sorted list
 					// this nest of pairs is terrible, but we need to keep the reference to the modifiable structures list
-					List<NonNullPair<NonNullPair<Script, List<Structure>>, Structure>> pairs = scripts.stream()
-							.flatMap(pair -> { // Flatten each entry down to a stream of Script-Structure pairs
-								return pair.getSecond().stream()
-										.map(structure -> new NonNullPair<>(pair, structure));
+					List<NonNullPair<LoadingScriptInfo, Structure>> pairs = scripts.stream()
+							.flatMap(info -> { // Flatten each entry down to a stream of Script-Structure pairs
+								return info.structures.stream()
+										.map(structure -> new NonNullPair<>(info, structure));
 							})
 							.sorted(Comparator.comparing(pair -> pair.getSecond().getPriority()))
 							.collect(Collectors.toCollection(ArrayList::new));
@@ -530,19 +532,19 @@ public class ScriptLoader {
 					pairs.removeIf(pair -> {
 						Structure structure = pair.getSecond();
 
-						parser.setActive(pair.getFirst().getFirst());
+						parser.setActive(pair.getFirst().script);
 						parser.setCurrentStructure(structure);
-						parser.setNode(structure.getEntryContainer().getSource());
+						parser.setNode(pair.getFirst().nodeMap.get(structure));
 
 						try {
 							if (!structure.preLoad()) {
-								pair.getFirst().getSecond().remove(structure);
+								pair.getFirst().structures.remove(structure);
 								return true;
 							}
 						} catch (Exception e) {
 							//noinspection ThrowableNotThrown
 							Skript.exception(e, "An error occurred while trying to preLoad a Structure.");
-							pair.getFirst().getSecond().remove(structure);
+							pair.getFirst().structures.remove(structure);
 							return true;
 						}
 						return false;
@@ -558,19 +560,19 @@ public class ScriptLoader {
 					pairs.removeIf(pair -> {
 						Structure structure = pair.getSecond();
 
-						parser.setActive(pair.getFirst().getFirst());
+						parser.setActive(pair.getFirst().script);
 						parser.setCurrentStructure(structure);
-						parser.setNode(structure.getEntryContainer().getSource());
+						parser.setNode(pair.getFirst().nodeMap.get(structure));
 
 						try {
 							if (!structure.load()) {
-								pair.getFirst().getSecond().remove(structure);
+								pair.getFirst().structures.remove(structure);
 								return true;
 							}
 						} catch (Exception e) {
 							//noinspection ThrowableNotThrown
 							Skript.exception(e, "An error occurred while trying to load a Structure.");
-							pair.getFirst().getSecond().remove(structure);
+							pair.getFirst().structures.remove(structure);
 							return true;
 						}
 						return false;
@@ -581,19 +583,19 @@ public class ScriptLoader {
 					pairs.removeIf(pair -> {
 						Structure structure = pair.getSecond();
 
-						parser.setActive(pair.getFirst().getFirst());
+						parser.setActive(pair.getFirst().script);
 						parser.setCurrentStructure(structure);
-						parser.setNode(structure.getEntryContainer().getSource());
+						parser.setNode(pair.getFirst().nodeMap.get(structure));
 
 						try {
 							if (!structure.postLoad()) {
-								pair.getFirst().getSecond().remove(structure);
+								pair.getFirst().structures.remove(structure);
 								return true;
 							}
 						} catch (Exception e) {
 							//noinspection ThrowableNotThrown
 							Skript.exception(e, "An error occurred while trying to postLoad a Structure.");
-							pair.getFirst().getSecond().remove(structure);
+							pair.getFirst().structures.remove(structure);
 							return true;
 						}
 						return false;
@@ -612,17 +614,34 @@ public class ScriptLoader {
 			});
 	}
 
+	private static class LoadingScriptInfo {
+
+		public final Script script;
+
+		public final List<Structure> structures;
+
+		public final Map<Structure, Node> nodeMap;
+
+		public LoadingScriptInfo(Script script, List<Structure> structures, Map<Structure, Node> nodeMap) {
+			this.script = script;
+			this.structures = structures;
+			this.nodeMap = nodeMap;
+		}
+
+	}
+
 	/**
 	 * Creates a script and loads the provided config into it.
 	 * @param config The config to load into a script.
 	 * @return A pair containing the script that was loaded and a modifiable version of the structures list.
 	 */
 	// Whenever you call this method, make sure to also call PreScriptLoadEvent
-	private static NonNullPair<Script, List<Structure>> loadScript(Config config) {
+	private static LoadingScriptInfo loadScript(Config config) {
 		if (config.getFile() == null)
 			throw new IllegalArgumentException("A config must have a file to be loaded.");
 
 		ParserInstance parser = getParser();
+		Map<Structure, Node> nodeMap = new HashMap<>();
 		List<Structure> structures = new ArrayList<>();
 		Script script = new Script(config, structures);
 		parser.setActive(script);
@@ -632,16 +651,17 @@ public class ScriptLoader {
 				SkriptConfig.configs.add(config);
 			
 			try (CountingLogHandler ignored = new CountingLogHandler(SkriptLogger.SEVERE).start()) {
-				for (Node cnode : config.getMainNode()) {
-					if (!(cnode instanceof SectionNode)) {
-						Skript.error("invalid line - all code has to be put into triggers");
+				for (Node node : config.getMainNode()) {
+					if (!(node instanceof SimpleNode) && !(node instanceof SectionNode)) {
+						// unlikely to occur, but just in case
+						Skript.error("could not interpret line as a structure");
 						continue;
 					}
 
-					SectionNode node = ((SectionNode) cnode);
 					String line = node.getKey();
 					if (line == null)
 						continue;
+					line = replaceOptions(line); // replace options here before validation
 
 					if (!SkriptParser.validateLine(line))
 						continue;
@@ -649,14 +669,13 @@ public class ScriptLoader {
 					if (Skript.logVeryHigh() && !Skript.debug())
 						Skript.info("loading trigger '" + line + "'");
 
-					line = replaceOptions(line);
-
 					Structure structure = Structure.parse(line, node, "Can't understand this structure: " + line);
 
 					if (structure == null)
 						continue;
 
 					structures.add(structure);
+					nodeMap.put(structure, node);
 				}
 				
 				if (Skript.logHigh()) {
@@ -694,8 +713,8 @@ public class ScriptLoader {
 				Skript.exception(e);
 			}
 		}
-		
-		return new NonNullPair<>(script, structures);
+
+		return new LoadingScriptInfo(script, structures, nodeMap);
 	}
 
 	/*

--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -1515,6 +1515,13 @@ public final class Skript extends JavaPlugin implements Listener {
 		structures.add(structureInfo);
 	}
 
+	public static <E extends Structure> void registerSimpleStructure(Class<E> c, String... patterns) {
+		checkAcceptRegistrations();
+		String originClassPath = Thread.currentThread().getStackTrace()[2].getClassName();
+		StructureInfo<E> structureInfo = new StructureInfo<>(patterns, c, originClassPath, true);
+		structures.add(structureInfo);
+	}
+
 	public static <E extends Structure> void registerStructure(Class<E> c, EntryValidator entryValidator, String... patterns) {
 		checkAcceptRegistrations();
 		String originClassPath = Thread.currentThread().getStackTrace()[2].getClassName();

--- a/src/main/java/ch/njol/skript/lang/SkriptEvent.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptEvent.java
@@ -54,6 +54,7 @@ public abstract class SkriptEvent extends Structure {
 	public static final Priority PRIORITY = new Priority(600);
 
 	private String expr;
+	private SectionNode source;
 	@Nullable
 	protected EventPriority eventPriority;
 	@Nullable
@@ -67,7 +68,7 @@ public abstract class SkriptEvent extends Structure {
 	protected Trigger trigger;
 
 	@Override
-	public final boolean init(Literal<?>[] args, int matchedPattern, ParseResult parseResult, EntryContainer entryContainer) {
+	public final boolean init(Literal<?>[] args, int matchedPattern, ParseResult parseResult, @Nullable EntryContainer entryContainer) {
 		this.expr = parseResult.expr;
 
 		EventData eventData = getParser().getData(EventData.class);
@@ -101,6 +102,9 @@ public abstract class SkriptEvent extends Structure {
 			return false;
 		}
 
+		assert entryContainer != null; // cannot be null for non-simple structures
+		this.source = entryContainer.getSource();
+
 		return init(args, matchedPattern, parseResult);
 	}
 
@@ -129,7 +133,6 @@ public abstract class SkriptEvent extends Structure {
 			return false;
 
 		// noinspection ConstantConditions - entry container cannot be null as this structure is not simple
-		SectionNode source = getEntryContainer().getSource();
 		if (Skript.debug() || source.debug())
 			Skript.debug(expr + " (" + this + "):");
 

--- a/src/main/java/ch/njol/skript/lang/SkriptEvent.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptEvent.java
@@ -128,6 +128,7 @@ public abstract class SkriptEvent extends Structure {
 		if (!shouldLoadEvent())
 			return false;
 
+		// noinspection ConstantConditions - entry container cannot be null as this structure is not simple
 		SectionNode source = getEntryContainer().getSource();
 		if (Skript.debug() || source.debug())
 			Skript.debug(expr + " (" + this + "):");
@@ -141,7 +142,7 @@ public abstract class SkriptEvent extends Structure {
 			Script script = getParser().getCurrentScript();
 
 			trigger = new Trigger(script, expr, this, items);
-			int lineNumber = getEntryContainer().getSource().getLine();
+			int lineNumber = source.getLine();
 			trigger.setLineNumber(lineNumber); // Set line number for debugging
 			trigger.setDebugLabel(script + ": line " + lineNumber);
 		} finally {

--- a/src/main/java/ch/njol/skript/structures/StructAliases.java
+++ b/src/main/java/ch/njol/skript/structures/StructAliases.java
@@ -51,7 +51,8 @@ public class StructAliases extends Structure {
 	}
 
 	@Override
-	public boolean init(Literal<?>[] args, int matchedPattern, ParseResult parseResult, EntryContainer entryContainer) {
+	public boolean init(Literal<?>[] args, int matchedPattern, ParseResult parseResult, @Nullable EntryContainer entryContainer) {
+		// noinspection ConstantConditions - entry container cannot be null as this structure is not simple
 		SectionNode node = entryContainer.getSource();
 		node.convertToEntries(0, "=");
 

--- a/src/main/java/ch/njol/skript/structures/StructCommand.java
+++ b/src/main/java/ch/njol/skript/structures/StructCommand.java
@@ -147,7 +147,7 @@ public class StructCommand extends Structure {
 	private ScriptCommand scriptCommand;
 
 	@Override
-	public boolean init(Literal<?>[] args, int matchedPattern, ParseResult parseResult, EntryContainer entryContainer) {
+	public boolean init(Literal<?>[] args, int matchedPattern, ParseResult parseResult, @Nullable EntryContainer entryContainer) {
 		return true;
 	}
 
@@ -156,6 +156,7 @@ public class StructCommand extends Structure {
 		getParser().setCurrentEvent("command", ScriptCommandEvent.class);
 
 		EntryContainer entryContainer = getEntryContainer();
+		assert entryContainer != null;
 
 		String fullCommand = entryContainer.getSource().getKey();
 		assert fullCommand != null;

--- a/src/main/java/ch/njol/skript/structures/StructCommand.java
+++ b/src/main/java/ch/njol/skript/structures/StructCommand.java
@@ -143,20 +143,22 @@ public class StructCommand extends Structure {
 		);
 	}
 
+	@SuppressWarnings("NotNullFieldNotInitialized")
+	private EntryContainer entryContainer;
+
 	@Nullable
 	private ScriptCommand scriptCommand;
 
 	@Override
 	public boolean init(Literal<?>[] args, int matchedPattern, ParseResult parseResult, @Nullable EntryContainer entryContainer) {
+		assert entryContainer != null; // cannot be null for non-simple structures
+		this.entryContainer = entryContainer;
 		return true;
 	}
 
 	@Override
 	public boolean load() {
 		getParser().setCurrentEvent("command", ScriptCommandEvent.class);
-
-		EntryContainer entryContainer = getEntryContainer();
-		assert entryContainer != null;
 
 		String fullCommand = entryContainer.getSource().getKey();
 		assert fullCommand != null;

--- a/src/main/java/ch/njol/skript/structures/StructEvent.java
+++ b/src/main/java/ch/njol/skript/structures/StructEvent.java
@@ -45,7 +45,7 @@ public class StructEvent extends Structure {
 
 	@Override
 	@SuppressWarnings("ConstantConditions")
-	public boolean init(Literal<?>[] args, int matchedPattern, ParseResult parseResult, EntryContainer entryContainer) {
+	public boolean init(Literal<?>[] args, int matchedPattern, ParseResult parseResult, @Nullable EntryContainer entryContainer) {
 		String expr = parseResult.regexes.get(0).group();
 
 		EventData data = getParser().getData(EventData.class);

--- a/src/main/java/ch/njol/skript/structures/StructEvent.java
+++ b/src/main/java/ch/njol/skript/structures/StructEvent.java
@@ -65,6 +65,7 @@ public class StructEvent extends Structure {
 			data.priority = EventPriority.valueOf(lastTag.toUpperCase(Locale.ENGLISH));
 		}
 
+		assert entryContainer != null;
 		event = SkriptEvent.parse(expr, entryContainer.getSource(), null);
 
 		// cleanup after ourselves

--- a/src/main/java/ch/njol/skript/structures/StructFunction.java
+++ b/src/main/java/ch/njol/skript/structures/StructFunction.java
@@ -75,7 +75,7 @@ public class StructFunction extends Structure {
 	private boolean local;
 
 	@Override
-	public boolean init(Literal<?>[] literals, int matchedPattern, ParseResult parseResult, EntryContainer entryContainer) {
+	public boolean init(Literal<?>[] literals, int matchedPattern, ParseResult parseResult, @Nullable EntryContainer entryContainer) {
 		local = parseResult.hasTag("local");
 		return true;
 	}
@@ -83,6 +83,7 @@ public class StructFunction extends Structure {
 	@Override
 	public boolean preLoad() {
 		// match signature against pattern
+		// noinspection ConstantConditions - entry container cannot be null as this structure is not simple
 		String rawSignature = getEntryContainer().getSource().getKey();
 		assert rawSignature != null;
 		rawSignature = ScriptLoader.replaceOptions(rawSignature);
@@ -110,6 +111,7 @@ public class StructFunction extends Structure {
 		parser.setCurrentEvent((local ? "local " : "") + "function", FunctionEvent.class);
 
 		assert signature != null;
+		// noinspection ConstantConditions - entry container cannot be null as this structure is not simple
 		Functions.loadFunction(parser.getCurrentScript(), getEntryContainer().getSource(), signature);
 
 		parser.deleteCurrentEvent();

--- a/src/main/java/ch/njol/skript/structures/StructFunction.java
+++ b/src/main/java/ch/njol/skript/structures/StructFunction.java
@@ -20,6 +20,7 @@ package ch.njol.skript.structures;
 
 import ch.njol.skript.ScriptLoader;
 import ch.njol.skript.Skript;
+import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -70,12 +71,16 @@ public class StructFunction extends Structure {
 		);
 	}
 
+	@SuppressWarnings("NotNullFieldNotInitialized")
+	private SectionNode source;
 	@Nullable
 	private Signature<?> signature;
 	private boolean local;
 
 	@Override
 	public boolean init(Literal<?>[] literals, int matchedPattern, ParseResult parseResult, @Nullable EntryContainer entryContainer) {
+		assert entryContainer != null; // cannot be null for non-simple structures
+		this.source = entryContainer.getSource();
 		local = parseResult.hasTag("local");
 		return true;
 	}
@@ -84,7 +89,7 @@ public class StructFunction extends Structure {
 	public boolean preLoad() {
 		// match signature against pattern
 		// noinspection ConstantConditions - entry container cannot be null as this structure is not simple
-		String rawSignature = getEntryContainer().getSource().getKey();
+		String rawSignature = source.getKey();
 		assert rawSignature != null;
 		rawSignature = ScriptLoader.replaceOptions(rawSignature);
 		Matcher matcher = SIGNATURE_PATTERN.matcher(rawSignature);
@@ -112,7 +117,7 @@ public class StructFunction extends Structure {
 
 		assert signature != null;
 		// noinspection ConstantConditions - entry container cannot be null as this structure is not simple
-		Functions.loadFunction(parser.getCurrentScript(), getEntryContainer().getSource(), signature);
+		Functions.loadFunction(parser.getCurrentScript(), source, signature);
 
 		parser.deleteCurrentEvent();
 

--- a/src/main/java/ch/njol/skript/structures/StructOptions.java
+++ b/src/main/java/ch/njol/skript/structures/StructOptions.java
@@ -73,7 +73,8 @@ public class StructOptions extends Structure {
 	}
 
 	@Override
-	public boolean init(Literal<?>[] args, int matchedPattern, ParseResult parseResult, EntryContainer entryContainer) {
+	public boolean init(Literal<?>[] args, int matchedPattern, ParseResult parseResult, @Nullable EntryContainer entryContainer) {
+		// noinspection ConstantConditions - entry container cannot be null as this structure is not simple
 		SectionNode node = entryContainer.getSource();
 		node.convertToEntries(-1);
 		loadOptions(node, "", getParser().getCurrentScript().getData(OptionsData.class, OptionsData::new).options);

--- a/src/main/java/ch/njol/skript/structures/StructVariables.java
+++ b/src/main/java/ch/njol/skript/structures/StructVariables.java
@@ -147,7 +147,8 @@ public class StructVariables extends Structure {
 	}
 
 	@Override
-	public boolean init(Literal<?>[] args, int matchedPattern, ParseResult parseResult, EntryContainer entryContainer) {
+	public boolean init(Literal<?>[] args, int matchedPattern, ParseResult parseResult, @Nullable EntryContainer entryContainer) {
+		// noinspection ConstantConditions - entry container cannot be null as this structure is not simple
 		SectionNode node = entryContainer.getSource();
 		node.convertToEntries(0, "=");
 		List<NonNullPair<String, Object>> variables;

--- a/src/main/java/org/skriptlang/skript/lang/structure/Structure.java
+++ b/src/main/java/org/skriptlang/skript/lang/structure/Structure.java
@@ -35,6 +35,7 @@ import ch.njol.skript.log.SkriptLogger;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.iterator.CheckedIterator;
 import ch.njol.util.coll.iterator.ConsumingIterator;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.entry.EntryContainer;
@@ -89,10 +90,17 @@ public abstract class Structure implements SyntaxElement, Debuggable {
 
 	/**
 	 * @return An EntryContainer containing this Structure's {@link EntryData} and {@link Node} parse results.
-	 * This method will return null if the Structure has not yet been initialized or if it is simple.
+	 * Please note that this Structure <b>MUST</b> have been initialized for this to work.
+	 * This method is not usable for simple structures.
+	 * @deprecated This method will be removed in a future version.
+	 * If the EntryContainer is needed outside of {@link #init(Literal[], int, ParseResult, EntryContainer)},
+	 * the Structure should keep a reference to it.
 	 */
-	@Nullable
+	@Deprecated
+	@ApiStatus.ScheduledForRemoval
 	public final EntryContainer getEntryContainer() {
+		if (entryContainer == null)
+			throw new IllegalStateException("This Structure hasn't been initialized!");
 		return entryContainer;
 	}
 

--- a/src/main/java/org/skriptlang/skript/lang/structure/StructureInfo.java
+++ b/src/main/java/org/skriptlang/skript/lang/structure/StructureInfo.java
@@ -30,14 +30,25 @@ public class StructureInfo<E extends Structure> extends SyntaxElementInfo<E> {
 	@Nullable
 	public final EntryValidator entryValidator;
 
+	/**
+	 * Whether the Structure is represented by a {@link ch.njol.skript.config.SimpleNode}.
+	 */
+	public final boolean simple;
+
 	public StructureInfo(String[] patterns, Class<E> c, String originClassPath) throws IllegalArgumentException {
+		this(patterns, c, originClassPath, false);
+	}
+
+	public StructureInfo(String[] patterns, Class<E> c, String originClassPath, boolean simple) throws IllegalArgumentException {
 		super(patterns, c, originClassPath);
-		entryValidator = null;
+		this.entryValidator = null;
+		this.simple = simple;
 	}
 
 	public StructureInfo(String[] patterns, Class<E> c, String originClassPath, EntryValidator entryValidator) throws IllegalArgumentException {
 		super(patterns, c, originClassPath);
 		this.entryValidator = entryValidator;
+		this.simple = false;
 	}
 
 }


### PR DESCRIPTION
### Description
This PR adds support for registering Structure that do not have sections. That is, they are based on SimpleNodes rather than SectionNodes. They simply look like:
```
# no end-of-line colon below means it is simple!
do something cool

# this is a regular structure
command /foo:
  trigger:
    ...
```

A Structure may be registered this way using `Skript#registerSimpleStructure`.

An API change was required that makes `EntryContainer` nullable in Structure's init. This will not break any existing code as for non-simple Structures, it is guaranteed that EntryContainer is NotNull.

`Structure#getEntryContainer` has also been deprecated. This method's existence was previously justified for internal reasons, but those reasons no longer exist (design has improved), so neither will this method in the future. Developers are encouraged to save a reference to the entry container during initialization if they need it during the loading period.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:**
- https://github.com/SkriptLang/Skript/issues/5318 (non-closing)
