### PR TITLE
Allow look-behind for headless effect sections during init.

### DIFF
--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -942,7 +942,7 @@ public class ScriptLoader {
 
 			if (subNode instanceof SimpleNode) {
 				long start = System.currentTimeMillis();
-				Statement stmt = Statement.parse(expr, "Can't understand this condition/effect: " + expr);
+				Statement stmt = Statement.parse(expr, items, "Can't understand this condition/effect: " + expr);
 				if (stmt == null)
 					continue;
 				long requiredTime = SkriptConfig.longParseTimeWarningThreshold.value().getMilliSeconds();

--- a/src/main/java/ch/njol/skript/lang/Statement.java
+++ b/src/main/java/ch/njol/skript/lang/Statement.java
@@ -22,9 +22,10 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.lang.function.EffFunctionCall;
 import ch.njol.skript.log.ParseLogHandler;
 import ch.njol.skript.log.SkriptLogger;
-import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * Supertype of conditions and effects
@@ -34,9 +35,14 @@ import java.util.Iterator;
  */
 public abstract class Statement extends TriggerItem implements SyntaxElement {
 
+
+	public static @Nullable Statement parse(String input, String defaultError) {
+		return parse(input, null, defaultError);
+	}
+
 	@Nullable
 	@SuppressWarnings({"rawtypes", "unchecked"})
-	public static Statement parse(String input, String defaultError) {
+	public static Statement parse(String input, @Nullable List<TriggerItem> items, String defaultError) {
 		ParseLogHandler log = SkriptLogger.startParseLogHandler();
 		try {
 			EffFunctionCall functionCall = EffFunctionCall.parse(input);
@@ -49,7 +55,7 @@ public abstract class Statement extends TriggerItem implements SyntaxElement {
 			}
 			log.clear();
 
-			EffectSection section = EffectSection.parse(input, null, null, null);
+			EffectSection section = EffectSection.parse(input, null, null, items);
 			if (section != null) {
 				log.printLog();
 				return new EffectSectionEffect(section);


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
When a Section `init`s, it is given a list of the preceding trigger items.
This is how an `else:` block searches for the `if..:` it belongs to.
<img width="449" alt="image" src="https://github.com/SkriptLang/Skript/assets/14147477/7cd8aa5d-0727-428d-ba41-bdbb1ff7ad90">

This list basically contains information about the lines before a syntax.

However, effect sections do not get given this information **unless** they are heading a section (i.e. if they're used as inline effects rather than sections with a `:`).
This means that
```cpp
spawn a zombie:
    # blah
```
gets the list of trigger items, whereas
```cpp
spawn a zombie
```
does not, despite both being the same syntax.

Presumably, this was historically done when EffectSections were made to avoid changing the signature of the `parse` method they use.

#### What I changed

This change gives the trigger items to effect sections _whether-or-not_ they are starting a section. The `SectionNode` will still be null, of course, since they don't have a section, but they are now able to look behind at the previous syntax elements.

This change is mainly targeted at providing API compatibility for future (or addon) effect sections and should have no effect on existing syntax.

#### Does this break anything?

It shouldn't do, since I duplicated the method with its original signature, in case something exists that uses it directly.

I don't expect this to be a breaking change for any addon, since it is inconceivable that syntax would be conditionally reliant on the `triggerItems` parameter being null without also being dependent on, for example, the `isSection` method or the `SectionNode` parameter.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
