### PR TITLE
Add script reloading based on file difference.

### DIFF
--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -46,7 +46,7 @@ import ch.njol.util.OpenCloseable;
 import ch.njol.util.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.script.Script;
 import org.skriptlang.skript.lang.structure.Structure;
 
@@ -897,6 +897,22 @@ public class ScriptLoader {
 		}
 
 		return loadScripts(configs, openCloseable);
+	}
+
+	/**
+	 * Reloads all provided Scripts that could have potentially changed since their initial load.
+	 * This is tested by
+	 * @param scripts
+	 * @param openCloseable
+	 * @return
+	 */
+	public static CompletableFuture<ScriptInfo> reloadChangedScripts(Set<Script> scripts, OpenCloseable openCloseable) {
+		Set<Script> toReload = new HashSet<>(scripts.size());
+		for (Script script : scripts) {
+			if (script.getConfig().hasChanged())
+				toReload.add(script);
+		}
+		return reloadScripts(toReload, openCloseable);
 	}
 	
 	/*

--- a/src/main/java/ch/njol/skript/SkriptCommand.java
+++ b/src/main/java/ch/njol/skript/SkriptCommand.java
@@ -67,6 +67,7 @@ public class SkriptCommand implements CommandExecutor {
 			.add("config")
 			.add("aliases")
 			.add("scripts")
+			.add("changed")
 			.add("<script>")
 		).add(new CommandHelp("enable", SkriptColor.DARK_RED)
 			.add("all")
@@ -144,6 +145,17 @@ public class SkriptCommand implements CommandExecutor {
 								Skript.warning(Skript.m_no_scripts.toString());
 							reloaded(sender, logHandler, timingLogHandler, "config, aliases and scripts");
 						});
+				}
+
+				else if (args[1].equalsIgnoreCase("changed")) {
+					reloading(sender, "scripts that have changed since last load");
+
+					ScriptLoader.reloadChangedScripts(ScriptLoader.getLoadedScripts(), OpenCloseable.combine(logHandler, timingLogHandler))
+								.thenAccept(info -> {
+									if (info.files == 0)
+										Skript.warning(Skript.m_no_scripts.toString());
+									reloaded(sender, logHandler, timingLogHandler, "scripts that have changed since last load");
+								});
 				}
 
 				else if (args[1].equalsIgnoreCase("scripts")) {

--- a/src/main/java/ch/njol/skript/SkriptCommandTabCompleter.java
+++ b/src/main/java/ch/njol/skript/SkriptCommandTabCompleter.java
@@ -107,6 +107,7 @@ public class SkriptCommandTabCompleter implements TabCompleter {
 					options.add("config");
 					options.add("aliases");
 					options.add("scripts");
+					options.add("changed");
 				}
 			}
 


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
While script (and other Config) files are loaded, their SHA-256 checksum is calculated in the background and their file length is stored.
This information can then be compared against a file to see if it's (almost certainly) the same as the loaded script -- in other words, whether the file has changed since we loaded it.

This adds a `/skript reload changed` command that reloads only files that are potentially different from when they were *last* loaded. Files where the checksum/length couldn't be calculated, and scripts with no known source file, are assumed to have changed.

Todo:
- Also apply this to the `config.sk`, since that's something that can change too.


**Note of caution**: I don't have Minecraft and can't easily test this out reliably. It seemed fairly sound when I was writing it but I have to say I just guessed a lot of the messagedigest stuff from the docs. It may break everything in the universe and be completely different from what I expect. That's why this is in draft, so it's not my fault when everything breaks. I'd love it if somebody wanted to have a go at it.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #3003 <!-- Links to related issues -->
