### PR TITLE
Remove redundant [the] in hotbar expression

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprHotbarSlot.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHotbarSlot.java
@@ -58,7 +58,7 @@ import ch.njol.util.Kleenean;
 public class ExprHotbarSlot extends PropertyExpression<Player, Slot> {
 
 	static {
-		registerDefault(ExprHotbarSlot.class, Slot.class, "[the] [([current:currently] selected|current:current)] hotbar slot[s]", "players");
+		registerDefault(ExprHotbarSlot.class, Slot.class, "[([current:currently] selected|current:current)] hotbar slot[s]", "players");
 	}
 
 	// This exists because time states should not register when the 'currently' tag of the syntax is present.


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Removed an extra [the] in the syntax to stop weird grammar such as `send the player's the hotbar slot`
It's a big change, I know

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #6563 <!-- Links to related issues -->
