### PR TITLE
EffectCommandEvent: SkriptEvent support

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -27,6 +27,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.Aliases;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.command.CommandEvent;
+import ch.njol.skript.command.EffectCommandEvent;
 import ch.njol.skript.events.bukkit.ScriptEvent;
 import ch.njol.skript.events.bukkit.SkriptStartEvent;
 import ch.njol.skript.events.bukkit.SkriptStopEvent;
@@ -1828,6 +1829,14 @@ public final class BukkitEventValues {
 			@Override
 			public ItemStack get(InventoryMoveItemEvent event) {
 				return event.getItem();
+			}
+		}, EventValues.TIME_NOW);
+
+		// EffectCommandEvent
+		EventValues.registerEventValue(EffectCommandEvent.class, CommandSender.class, new Getter<CommandSender, EffectCommandEvent>() {
+			@Override
+			public CommandSender get(EffectCommandEvent event) {
+				return event.getSender();
 			}
 		}, EventValues.TIME_NOW);
 

--- a/src/main/java/ch/njol/skript/events/EvtEffectCommand.java
+++ b/src/main/java/ch/njol/skript/events/EvtEffectCommand.java
@@ -34,16 +34,18 @@ public class EvtEffectCommand extends SkriptEvent {
 	static {
 		Skript.registerEvent("Effect Command Event", EvtEffectCommand.class, EffectCommandEvent.class,
 				"[sender:(:player|console)] effect command")
-			.description("Called when a player or console executes a skript effect command.")
-			.examples("TODO")
-			.since("INSERT VERSION");
+				.description("Called when a player or console executes a skript effect command.")
+				.examples(
+						"on effect command:",
+								"\tlog \"%sender%: %command%\" to file \"effectcommand.log\"")
+				.since("INSERT VERSION");
 	}
 
 	private enum Executor {
 
 		ANY(""),
-		CONSOLE("console"),
-		PLAYER("player");
+		CONSOLE("console "),
+		PLAYER("player ");
 
 		final String toString;
 
@@ -88,7 +90,7 @@ public class EvtEffectCommand extends SkriptEvent {
 
 	@Override
 	public String toString(@Nullable Event event, boolean debug) {
-		return executor + " effect command";
+		return executor + "effect command";
 	}
 
 }

--- a/src/main/java/ch/njol/skript/events/EvtEffectCommand.java
+++ b/src/main/java/ch/njol/skript/events/EvtEffectCommand.java
@@ -1,0 +1,94 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.events;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.command.EffectCommandEvent;
+import ch.njol.skript.lang.Literal;
+import ch.njol.skript.lang.SkriptEvent;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+public class EvtEffectCommand extends SkriptEvent {
+
+	static {
+		Skript.registerEvent("Effect Command Event", EvtEffectCommand.class, EffectCommandEvent.class,
+				"[sender:(:player|console)] effect command")
+			.description("Called when a player or console executes a skript effect command.")
+			.examples("TODO")
+			.since("INSERT VERSION");
+	}
+
+	private enum Executor {
+
+		ANY(""),
+		CONSOLE("console"),
+		PLAYER("player");
+
+		final String toString;
+
+		Executor(String toString) {
+			this.toString = toString;
+		}
+
+		@Override
+		public String toString() {
+			return toString;
+		}
+
+	}
+
+	@SuppressWarnings("NotNullFieldNotInitialized")
+	private Executor executor;
+
+	@Override
+	public boolean init(Literal<?>[] args, int matchedPattern, ParseResult parseResult) {
+		executor = Executor.ANY;
+		if (parseResult.hasTag("sender")) {
+			executor = parseResult.hasTag("player") ? Executor.PLAYER : Executor.CONSOLE;
+		}
+		return true;
+	}
+
+	@Override
+	public boolean check(Event event) {
+		if (!(event instanceof EffectCommandEvent))
+			return false;
+		CommandSender sender = ((EffectCommandEvent) event).getSender();
+		switch (executor) {
+            case ANY:
+				return true;
+			case PLAYER:
+				return sender instanceof Player;
+			case CONSOLE:
+				return sender instanceof ConsoleCommandSender;
+        }
+		return false;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return executor + " effect command";
+	}
+
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprCommand.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCommand.java
@@ -18,6 +18,7 @@
  */
 package ch.njol.skript.expressions;
 
+import ch.njol.skript.command.EffectCommandEvent;
 import ch.njol.skript.command.ScriptCommandEvent;
 import org.bukkit.event.Event;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
@@ -62,8 +63,8 @@ public class ExprCommand extends SimpleExpression<String> {
 	
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		if (!getParser().isCurrentEvent(PlayerCommandPreprocessEvent.class, ServerCommandEvent.class, ScriptCommandEvent.class)) {
-			Skript.error("The 'command' expression can only be used in a script command or command event");
+		if (!getParser().isCurrentEvent(PlayerCommandPreprocessEvent.class, ServerCommandEvent.class, ScriptCommandEvent.class, EffectCommandEvent.class)) {
+			Skript.error("The 'command' expression can only be used in a command, script command or effect command event");
 			return false;
 		}
 		fullCommand = matchedPattern == 0;
@@ -79,12 +80,13 @@ public class ExprCommand extends SimpleExpression<String> {
 			s = ((PlayerCommandPreprocessEvent) e).getMessage().substring(1).trim();
 		} else if (e instanceof ServerCommandEvent) {
 			s = ((ServerCommandEvent) e).getCommand().trim();
-		} else { // It's a script command event
+		} else if (e instanceof ScriptCommandEvent) {
 			ScriptCommandEvent event = (ScriptCommandEvent) e;
 			s = event.getCommandLabel() + " " + event.getArgsString();
+		} else { // It's a EffectCommandEvent
+			s = ((EffectCommandEvent) e).getCommand();
 		}
-
-		if (fullCommand) {
+		if (e instanceof EffectCommandEvent || fullCommand) {
 			return new String[]{s};
 		} else {
 			int c = s.indexOf(' ');

--- a/src/main/java/ch/njol/skript/expressions/ExprCommand.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCommand.java
@@ -41,15 +41,19 @@ import ch.njol.util.Kleenean;
  * @author Peter Güttinger
  */
 @Name("Command")
-@Description("The command that caused an 'on command' event (excluding the leading slash and all arguments)")
-@Examples({"# prevent any commands except for the /exit command during some game",
-		"on command:",
+@Description("The command that caused an 'on command' event (excluding the leading slash and all arguments), or 'effect command' event.")
+@Examples({
+	"# prevent any commands except for the /exit command during some game",
+	"on command:",
 		"\tif {game::%player%::playing} is true:",
-		"\t\tif the command is not \"exit\":",
-		"\t\t\tmessage \"You're not allowed to use commands during the game\"",
-		"\t\t\tcancel the event"})
-@Since("2.0, 2.7 (support for script commands)")
-@Events("command")
+			"\t\tif the command is not \"exit\":",
+				"\t\t\tmessage \"You're not allowed to use commands during the game\"",
+				"\t\t\tcancel the event",
+	"on effect command:",
+		"\tlog \"%sender%: %command%\" to file \"effectcommand.log\""
+})
+@Since("2.0, 2.7 (support for script commands), INSERT VERSION (support for effect command)")
+@Events({"command", "effect command"})
 public class ExprCommand extends SimpleExpression<String> {
 
 	static {

--- a/src/main/java/ch/njol/skript/expressions/ExprCommand.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCommand.java
@@ -37,11 +37,8 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 
-/**
- * @author Peter Güttinger
- */
 @Name("Command")
-@Description("The command that caused an 'on command' event (excluding the leading slash and all arguments), or 'effect command' event.")
+@Description("The command that caused an 'on command' event (excluding the leading slash and all arguments), or an 'effect command' event.")
 @Examples({
 	"# prevent any commands except for the /exit command during some game",
 	"on command:",
@@ -77,24 +74,25 @@ public class ExprCommand extends SimpleExpression<String> {
 	
 	@Override
 	@Nullable
-	protected String[] get(final Event e) {
-		final String s;
+	protected String[] get(Event event) {
+		String command;
 
-		if (e instanceof PlayerCommandPreprocessEvent) {
-			s = ((PlayerCommandPreprocessEvent) e).getMessage().substring(1).trim();
-		} else if (e instanceof ServerCommandEvent) {
-			s = ((ServerCommandEvent) e).getCommand().trim();
-		} else if (e instanceof ScriptCommandEvent) {
-			ScriptCommandEvent event = (ScriptCommandEvent) e;
-			s = event.getCommandLabel() + " " + event.getArgsString();
-		} else { // It's a EffectCommandEvent
-			s = ((EffectCommandEvent) e).getCommand();
+		if (event instanceof PlayerCommandPreprocessEvent) {
+			command = ((PlayerCommandPreprocessEvent) event).getMessage().substring(1).trim();
+		} else if (event instanceof ServerCommandEvent) {
+			command = ((ServerCommandEvent) event).getCommand().trim();
+		} else if (event instanceof ScriptCommandEvent) {
+			ScriptCommandEvent e = (ScriptCommandEvent) event;
+			command = e.getCommandLabel() + " " + e.getArgsString();
+		} else { // It's an EffectCommandEvent
+			command = ((EffectCommandEvent) event).getCommand();
 		}
-		if (e instanceof EffectCommandEvent || fullCommand) {
-			return new String[]{s};
+
+		if (event instanceof EffectCommandEvent || fullCommand) {
+			return new String[]{command};
 		} else {
-			int c = s.indexOf(' ');
-			return new String[] {c == -1 ? s : s.substring(0, c)};
+			int c = command.indexOf(' ');
+			return new String[] {c == -1 ? command : command.substring(0, c)};
 		}
 	}
 	
@@ -109,7 +107,7 @@ public class ExprCommand extends SimpleExpression<String> {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return fullCommand ? "the full command" : "the command";
 	}
 	


### PR DESCRIPTION
### Description
This PR adds support for Skript users to listen to EffectCommandEvent, and cleans up the involved classes.

Event values are:
- `event-sender` returns the sender (i.e. Player, Console)
- `[the] command` (from ExprCommand) returns the involved command

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
