### PR TITLE
Support string concatenation.

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/DefaultFunctions.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultFunctions.java
@@ -570,9 +570,9 @@ public class DefaultFunctions {
 			.examples("isNaN(0) # false", "isNaN(0/0) # true", "isNaN(sqrt(-1)) # true")
 			.since("2.8.0");
 
-		Functions.registerFunction(new SimpleJavaFunction<String>("concat", new Parameter[]{
+		Functions.registerFunction(new SimpleJavaFunction<String>("concat", new Parameter[] {
 			 new Parameter<>("texts", DefaultClasses.OBJECT, false, null)
-		},DefaultClasses.STRING, true) {
+		}, DefaultClasses.STRING, true) {
 			@Override
 			public String[] executeSimple(Object[][] params) {
 				StringBuilder builder = new StringBuilder();
@@ -585,7 +585,7 @@ public class DefaultFunctions {
 			.examples(
 				"concat(\"hello \", \"there\") # hello there",
 				"concat(\"foo \", 100, \" bar\") # foo 100 bar"
-			).since("2.8.0");
+			).since("INSERT VERSION");
 
 	}
 	

--- a/src/main/java/ch/njol/skript/classes/data/DefaultFunctions.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultFunctions.java
@@ -568,6 +568,31 @@ public class DefaultFunctions {
 		}).description("Returns true if the input is NaN (not a number).")
 			.examples("isNaN(0) # false", "isNaN(0/0) # true", "isNaN(sqrt(-1)) # true")
 			.since("2.8.0");
+
+		Functions.registerFunction(new SimpleJavaFunction<String>("concat", new Parameter[]{
+			 new Parameter<>("texts", DefaultClasses.OBJECT, false, null)
+		},DefaultClasses.STRING, true) {
+			@Override
+			public String[] executeSimple(Object[][] params) {
+				StringBuilder builder = new StringBuilder();
+				for (Object[] param : params) {
+				if (param == null)
+					continue;
+				for (Object object : param) {
+					if (object == null)
+						builder.append("<none>");
+					else
+						builder.append(object);
+					}
+				}
+				return new String[] {builder.toString()};
+			}
+		}).description("Joins the provided texts (and other things) into a single text.")
+			.examples(
+				"concat(\"hello \", \"there\") # hello there",
+				"concat(\"foo \", 100, \" bar\") # foo 100 bar"
+			).since("2.8.0");
+
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/classes/data/DefaultFunctions.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultFunctions.java
@@ -25,6 +25,7 @@ import ch.njol.skript.lang.function.JavaFunction;
 import ch.njol.skript.lang.function.Parameter;
 import ch.njol.skript.lang.function.SimpleJavaFunction;
 import ch.njol.skript.lang.util.SimpleLiteral;
+import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.registrations.DefaultClasses;
 import ch.njol.skript.util.Color;
 import ch.njol.skript.util.ColorRGB;
@@ -575,15 +576,8 @@ public class DefaultFunctions {
 			@Override
 			public String[] executeSimple(Object[][] params) {
 				StringBuilder builder = new StringBuilder();
-				for (Object[] param : params) {
-				if (param == null)
-					continue;
-				for (Object object : param) {
-					if (object == null)
-						builder.append("<none>");
-					else
-						builder.append(object);
-					}
+				for (Object object : params[0]) {
+					builder.append(Classes.toString(object));
 				}
 				return new String[] {builder.toString()};
 			}

--- a/src/main/java/ch/njol/skript/classes/data/DefaultOperations.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultOperations.java
@@ -115,6 +115,9 @@ public class DefaultOperations {
 		Arithmetics.registerOperation(Operator.SUBTRACTION, Date.class, Timespan.class, Date::minus);
 		Arithmetics.registerDifference(Date.class, Timespan.class, Date::difference);
 
+		// String + String
+		Arithmetics.registerOperation(Operator.ADDITION, String.class, String.class, String::concat);
+
 	}
 
 }

--- a/src/main/java/ch/njol/skript/classes/data/DefaultOperations.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultOperations.java
@@ -115,7 +115,7 @@ public class DefaultOperations {
 		Arithmetics.registerOperation(Operator.SUBTRACTION, Date.class, Timespan.class, Date::minus);
 		Arithmetics.registerDifference(Date.class, Timespan.class, Date::difference);
 
-		// String + String
+		// String - String
 		Arithmetics.registerOperation(Operator.ADDITION, String.class, String.class, String::concat);
 
 	}

--- a/src/test/skript/tests/misc/string concatenation.sk
+++ b/src/test/skript/tests/misc/string concatenation.sk
@@ -1,0 +1,29 @@
+
+test "string concatenation":
+
+	# string + string
+	assert "hello " + "there" is "hello there" with "string + string concat failed"
+	assert "foo" + "bar" is "foobar" with "string + string concat failed"
+	assert "foo" + " " + "bar" is "foo bar" with "string + string + string concat failed"
+	assert "hello" + " " + "there" is "hello there" with "string + string + string concat failed"
+
+	# ? + string
+	set {_var} to "hello"
+	set {_var} to {_var} + " there"
+	assert {_var} is "hello there" with "var + string concat failed"
+
+	# ? + string
+	set {_var1} to "hello "
+	set {_var2} to "there"
+	assert {_var1} + {_var2} is "hello there" with "var + var concat failed"
+
+	# variable-string + string
+	set {_var} to "hello"
+	assert "%{_var}% " + "there" is "hello there" with "var-string + string concat failed"
+
+	# string + number = <none>
+	# parser prevents us adding "foo" + 1 or comparing "foo" + 1 with a string
+	# we test the edge case where somebody slips past us!
+	set {_var} to 1
+	set {_var} to "foo" + {_var}
+	assert {_var} doesn't exist with "string + number concat succeeded? %{_var}%"

--- a/src/test/skript/tests/misc/string concatenation.sk
+++ b/src/test/skript/tests/misc/string concatenation.sk
@@ -26,4 +26,4 @@ test "string concatenation":
 	# we test the edge case where somebody slips past us!
 	set {_var} to 1
 	set {_var} to "foo" + {_var}
-	assert {_var} doesn't exist with "string + number concat succeeded? %{_var}%"
+	assert {_var} doesn't exist with "string + number concat succeeded"

--- a/src/test/skript/tests/syntaxes/functions/concat.sk
+++ b/src/test/skript/tests/syntaxes/functions/concat.sk
@@ -1,0 +1,31 @@
+
+test "concat() function":
+
+	# string + string
+	assert concat("hello ", "there") is "hello there" with "string + string concat() failed"
+	assert concat("foo", "bar") is "foobar" with "string + string concat() failed"
+	assert concat("foo", " ", "bar") is "foo bar" with "string + string + string concat() failed"
+	assert concat("hello", " ", "there") is "hello there" with "string + string + string concat() failed"
+	assert concat("a", "b", "c", "d", "e") is "abcde" with "5 strings concat() failed"
+
+	# ? + string
+	set {_var} to "hello"
+	set {_var} to concat({_var}, " there")
+	assert {_var} is "hello there" with "var + string concat() failed"
+
+	# ? + string
+	set {_var1} to "hello "
+	set {_var2} to "there"
+	assert concat({_var1}, {_var2}) is "hello there" with "var + var concat() failed"
+
+	# variable-string + string
+	set {_var} to "hello"
+	assert concat("%{_var}% ", "there") is "hello there" with "var-string + string concat() failed"
+
+	# string + non-string
+	# unlike the maths expression we CAN concat objects here!
+	set {_var} to 1
+	set {_var} to concat("foo", {_var})
+	assert {_var} is "foo1" with "string + number concat() failed: %{_var}%"
+	assert concat("a", 1, "b", 2) is "a1b2" with "strings + numbers concat() failed"
+	assert concat("my nice new ", stone sword) is "my nice new stone sword" with "string + item concat() failed"

--- a/src/test/skript/tests/syntaxes/functions/concat.sk
+++ b/src/test/skript/tests/syntaxes/functions/concat.sk
@@ -26,6 +26,6 @@ test "concat() function":
 	# unlike the maths expression we CAN concat objects here!
 	set {_var} to 1
 	set {_var} to concat("foo", {_var})
-	assert {_var} is "foo1" with "string + number concat() failed: %{_var}%"
+	assert {_var} is "foo1" with "string + number concat() failed"
 	assert concat("a", 1, "b", 2) is "a1b2" with "strings + numbers concat() failed"
 	assert concat("my nice new ", stone sword) is "my nice new stone sword" with "string + item concat() failed"


### PR DESCRIPTION
## Summary
<!--- Describe your changes here. --->
1. Allows the joining of **strings** with `+`, e.g. `"foo" + "bar" = "foobar"`. \
Does **not** allow the joining of strings and numbers or other non-coercible objects.
2. Adds a var-args `concat(...)` function that permits joining anything into a single string (including non-texts).

### Description

I'm not a fan of strings as they are in Skript: I dislike that there's no true literal, I dislike how cumbersome and inefficient `"%...%"` interpolation is (both to write and to actually evaluate).
Aside from interpolation, our only other option for joining strings is the expression `(concat[enate]|join) %texts% [(with|using|by) [[the] delimiter] %text%]` which has a rather unpleasant pattern (it sounds more like an effect than an expression).
This is designed for joining texts, but _it can't coerce types properly_, so you still end up needing to use interpolation (or store things in middle man variables) to actually join things that aren't strings (e.g. `"your lucky number is "` and `66`).

### What This Doesn't Do

In 2.7 or 2.8 (I forget which) a deliberate change was made to make illegal expressions in maths completely fail (evaluate to `<none>`) rather than be permitted as `0`.
**This doesn't change that**. This doesn't permit you to add `"hello"` and `81`: it will fail at parsing time and, even if you try and get around that with variables, it will still evaluate to `<none>` as intended.

String addition ONLY supports adding strings together, whether they're from expressions, variables or `"..."`.

```applescript
broadcast "hello" + "world" # OK!

set {var} to "..."
broadcast "hello" + {var} # OK

broadcast "hello" + [some string expression] # OK
```

```applescript
broadcast "hello" + 1 # NOT OK! Fails at parse time

set {var} to 1
broadcast "hello" + {var} # NOT OK! Bad math to <none>

broadcast "hello" + [some non-string expression] # NOT OK! Probably fails at parse time
```

### String Addition

This pull request adds string addition arithmetic: `"A" + "B" = "AB"`.

Lots of languages allow you to concatenate (glue together) strings. Most languages use `+`, some like to do their own thing with `.` or `&` or some other joiner.
Just because other languages do something isn't a sufficient reason to add it to Skript, though.

I like it as a feature:
 - I think it's arguably cleaner and neater than `"%...%"` (especially if you have multiple interpolations in one text!)
 - It's especially cleaner than trying to use an expression (and heaven forbid a _text_) inside an interpolation, where you're having to double your quotes and whatever.
 - I think, realistically, it's more immediately understandable to a beginner that `"a" + "b" = "ab"` than whatever's going on with `"a%""b""%"`.
 - It _ought_ to be safer/easier for the machine to interpret, interpolation's usually pretty heavy (although this is Skript, who knows).

### String `concat(...)` Function

This pull request adds a `concat(...)` variable arguments function.
This is more advanced than the `concatenate|join` expression, since it properly supports non-text parameters even without coercion.

Concat takes in multiple objects and returns the result of all of them stringified and glued together.

```applescript
concat("hello") = "hello"
concat("hello", " world") # "hello world"
concat("hello", " ", "there") # "hello there"

set {_var} to "hello"
concat({_var}, " world") # "hello world"
```

Concat allows the joining of strings and objects, which are run through `Classes.toString`.

```applescript
concat("foo", 1) # "foo1"
concat("my nice new ", stone sword) # "my nice new stone sword"
```

Concat **ALWAYS** returns a text, even if none of the inputs are text. It doesn't do maths evaluation, it purely joins things into a text. 

```applescript
concat(1, 2) # "12"
concat(1, 2, 3) # "123"
concat(stone sword, stone sword) # "stone swordstone sword"
```

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
