### PR TITLE
Add case-insensitive commands toggle in config.sk

### DIFF
--- a/src/main/java/ch/njol/skript/SkriptConfig.java
+++ b/src/main/java/ch/njol/skript/SkriptConfig.java
@@ -245,6 +245,9 @@ public class SkriptConfig {
 
 	public static final Option<Boolean> caseInsensitiveVariables = new Option<>("case-insensitive variables", true)
 			.setter(t -> Variables.caseInsensitiveVariables = t);
+
+	public static final Option<Boolean> caseInsensitiveCommands = new Option<>("case-insensitive commands", false)
+		.optional(true);
 	
 	public static final Option<Boolean> colorResetCodes = new Option<>("color codes reset formatting", true)
 			.setter(t -> {

--- a/src/main/java/ch/njol/skript/command/Commands.java
+++ b/src/main/java/ch/njol/skript/command/Commands.java
@@ -157,9 +157,18 @@ public abstract class Commands {
 			String arguments = cmd.length == 1 ? "" : "" + cmd[1];
 			ScriptCommand command = commands.get(label);
 
-			// if so, check permissions
-			if (command != null && !command.checkPermissions(event.getPlayer(), label, arguments))
-				event.setCancelled(true);
+			// is it a skript command?
+			if (command != null) {
+				// if so, check permissions to handle ourselves
+				if (!command.checkPermissions(event.getPlayer(), label, arguments))
+					event.setCancelled(true);
+
+				// we can also handle case sensitivity here:
+				if (SkriptConfig.caseInsensitiveCommands.value()) {
+					cmd[0] = event.getMessage().charAt(0) + label;
+					event.setMessage(String.join(" ", cmd));
+				}
+			}
 		}
 
 		@SuppressWarnings("null")

--- a/src/main/resources/config.sk
+++ b/src/main/resources/config.sk
@@ -144,6 +144,11 @@ case-insensitive variables: true
 # Whether Skript's variables should be case sensitive or not.
 # When set to true, all variable names and indices case will be ignored.
 
+case-insensitive commands: false
+# Whether Skript should accept custom commands regardless of case.
+# When set to true, /test, /Test, and /TEST will all be equivalent.
+# This does not affect non-Skript commands.
+
 disable variable will not be saved warnings: false
 # Disables the "... i.e contents cannot be saved ..." warning when reloading and something in your scripts sets a variable(non local) to a value that is not serializable.
 # By Mirre.


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

#5966 inadvertently caused Skript to stop parsing commands as case insensitive, since it now just defers to the Bukkit logic, which only accepts lowercase commands. This PR maintains this new behavior by default, but adds an optional config flag to pre-process incoming skript commands and force them to be lowercase. This allows users to use /test, /TEST, and /teST interchangeably, if they so wish.

Note that console commands are already case insensitive by default, so no logic was needed in that listener.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
