### PR TITLE
Inventory Click event-value null check

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -1123,9 +1123,8 @@ public final class BukkitEventValues {
 			@Nullable
 			public Slot get(final InventoryClickEvent e) {
 				Inventory invi = e.getClickedInventory(); // getInventory is WRONG and dangerous
-				if (invi == null) {
+				if (invi == null)
 					return null;
-				}
 				int slotIndex = e.getSlot();
 
 				// Not all indices point to inventory slots. Equipment, for example

--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -1123,6 +1123,9 @@ public final class BukkitEventValues {
 			@Nullable
 			public Slot get(final InventoryClickEvent e) {
 				Inventory invi = e.getClickedInventory(); // getInventory is WRONG and dangerous
+				if (invi == null) {
+					return null;
+				}
 				int slotIndex = e.getSlot();
 
 				// Not all indices point to inventory slots. Equipment, for example


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

adds a null check to the event-slot of the inventory click event
I tested it, it just returns air when clicking outside the inventory, which should be fine (probably)

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** https://github.com/SkriptLang/Skript/issues/6458  <!-- Links to related issues -->
