### PR TITLE
Adds the Entry Doc type

### DIFF
--- a/src/main/java/ch/njol/skript/doc/Entries.java
+++ b/src/main/java/ch/njol/skript/doc/Entries.java
@@ -1,0 +1,37 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.doc;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Allows the user to list all the entries used in a section.
+ */
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Entries {
+
+	String[] value();
+}

--- a/src/main/java/ch/njol/skript/doc/Entries.java
+++ b/src/main/java/ch/njol/skript/doc/Entries.java
@@ -33,5 +33,5 @@ import java.lang.annotation.Target;
 @Documented
 public @interface Entries {
 
-	String[] value();
+	public String[] value();
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

While looking through random sections on the docs, I noticed that not a lot of addon developers include much information (if any) about a section's entries, anywhere really.
However, it's not perfect and I don't really know how I would improve this, as it does have its flaws (e.g. you don't know if the entry is required or optional, etc).

Please let me know if you are welcome to this addition :)

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
