### PR TITLE
Fix exception when no world available to explode effect.

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffExplosion.java
+++ b/src/main/java/ch/njol/skript/effects/EffExplosion.java
@@ -78,11 +78,13 @@ public class EffExplosion extends Effect {
 		final Number power = force != null ? force.getSingle(e) : 0;
 		if (power == null)
 			return;
-		for (final Location l : locations.getArray(e)) {
+		for (Location location : locations.getArray(e)) {
+			if (location.getWorld() == null)
+				continue;
 			if (!blockDamage)
-				l.getWorld().createExplosion(l.getX(), l.getY(), l.getZ(), power.floatValue(), false, false);
+				location.getWorld().createExplosion(location.getX(), location.getY(), location.getZ(), power.floatValue(), false, false);
 			else
-				l.getWorld().createExplosion(l, power.floatValue(), setFire);
+				location.getWorld().createExplosion(location, power.floatValue(), setFire);
 		}
 	}
 


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Adds a check for the location having a world in the create explosion effect.
If there is no world present then the effect will not occur (since we do not know where it should take place!)

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** closes #6481 <!-- Links to related issues -->
