### PR TITLE
Fix exception when the location has no world in ExprBlocks.

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprBlocks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBlocks.java
@@ -116,6 +116,7 @@ public class ExprBlocks extends SimpleExpression<Block> {
 			return from.stream(event)
 					.filter(Location.class::isInstance)
 					.map(Location.class::cast)
+				    .filter(Location::isWorldLoaded)
 					.map(direction::getRelative)
 					.map(Location::getBlock)
 					.toArray(Block[]::new);

--- a/src/main/java/ch/njol/skript/expressions/ExprBlocks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBlocks.java
@@ -142,7 +142,7 @@ public class ExprBlocks extends SimpleExpression<Block> {
 					return null;
 				Location location = object instanceof Location ? (Location) object : ((Block) object).getLocation().add(0.5, 0.5, 0.5);
 				Direction direction = this.direction.getSingle(event);
-				if (direction == null)
+				if (direction == null || location.getWorld() == null)
 					return null;
 				Vector vector = object != location ? direction.getDirection((Block) object) : direction.getDirection(location);
 				// Cannot be zero.


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
The other cases all check if the world exists and return null if not, but the direction case checks only the *direction* and not the world, so this fails later on in the iterator if there isn't a world.

I followed what the other cases do and return null if the world is null.

I also added an `isWorldLoaded` filter to the getter, which *should* be okay since it checks if the world is null and if Bukkit has actually initialised the world.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** closes #6480, closes #6479 <!-- Links to related issues -->
