### PR TITLE
Looking at locations permits (relative) locations without worlds.

### DIFF
--- a/src/main/java/ch/njol/skript/bukkitutil/PaperEntityUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/PaperEntityUtils.java
@@ -49,6 +49,10 @@ public class PaperEntityUtils {
 		Bukkit.getMobGoals().getRunningGoals(mob, GoalType.LOOK).forEach(goal -> Bukkit.getMobGoals().removeGoal(mob, goal));
 		float speed = headRotationSpeed != null ? headRotationSpeed : mob.getHeadRotationSpeed();
 		float maxPitch = maxHeadPitch != null ? maxHeadPitch : mob.getMaxHeadPitch();
+		if (target instanceof Location && !((Location) target).isWorldLoaded()) {
+			Location location = (Location) target;
+			target = new Location(mob.getWorld(), location.getX(), location.getY(), location.getZ());
+		}
 		Bukkit.getMobGoals().addGoal(mob, 0, new LookGoal(target, mob, speed, maxPitch));
 	}
 
@@ -102,6 +106,10 @@ public class PaperEntityUtils {
 		if (target == null || !LOOK_AT || !LOOK_ANCHORS)
 			return;
 		for (LivingEntity entity : entities) {
+			if (target instanceof Location && !((Location) target).isWorldLoaded()) {
+				Location location = (Location) target;
+				target = new Location(entity.getWorld(), location.getX(), location.getY(), location.getZ());
+			}
 			if (entity instanceof Player) {
 				Player player = (Player) entity;
 				if (target instanceof Vector) {

--- a/src/main/java/ch/njol/skript/effects/EffLook.java
+++ b/src/main/java/ch/njol/skript/effects/EffLook.java
@@ -110,9 +110,9 @@ public class EffLook extends Effect {
 		Float maxPitch = this.maxPitch == null ? null : this.maxPitch.getSingle(event).floatValue();
 		if (LOOK_ANCHORS) {
 			PaperEntityUtils.lookAt(anchor, object, speed, maxPitch, entities.getArray(event));
-			return;
+		} else {
+			PaperEntityUtils.lookAt(object, speed, maxPitch, entities.getArray(event));
 		}
-		PaperEntityUtils.lookAt(object, speed, maxPitch, entities.getArray(event));
 	}
 
 	@Override


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Previously, if you asked an entity to look at a location that had no attached world it would fail with an error.
Now, it will replace the location with the equivalent one in the entity's world.

Note that this won't fix entities being asked to look at locations in _different_ worlds (which I presume will probably error or do nothing, I don't know how Minecraft deals with that) but that seemed a little out of scope for this bug fix.

This should also fix the equivalent issue in legacy versions which use the old mob goal. I don't know if this issue occurred there, but in the case that it did I've done my best to support it.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** closes #6476 <!-- Links to related issues -->
