### PR TITLE
Allow nullable patterns with different modifier orders.

### DIFF
--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -50,6 +50,7 @@ import ch.njol.util.coll.CollectionUtils;
 import com.google.common.primitives.Booleans;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
 import org.skriptlang.skript.lang.script.Script;
 import org.skriptlang.skript.lang.script.ScriptWarning;
 
@@ -240,19 +241,9 @@ public class SkriptParser {
 								int endIndex = nextUnescaped(pattern, '%', startIndex + 1);
 								if (parseResult.exprs[i] == null) {
 									String name = pattern.substring(startIndex + 1, endIndex);
-									if (!this.isInputDefault(name)) {
-										ExprInfo exprInfo = getExprInfo(name);
-										DefaultExpression<?> expr = exprInfo.classes[0].getDefaultExpression();
-										if (expr == null)
-											throw new SkriptAPIException("The class '" + exprInfo.classes[0].getCodeName() + "' does not provide a default expression. Either allow null (with %-" + exprInfo.classes[0].getCodeName() + "%) or make it mandatory [pattern: " + info.patterns[patternIndex] + "]");
-										if (!(expr instanceof Literal) && (exprInfo.flagMask & PARSE_EXPRESSIONS) == 0)
-											throw new SkriptAPIException("The default expression of '" + exprInfo.classes[0].getCodeName() + "' is not a literal. Either allow null (with %-*" + exprInfo.classes[0].getCodeName() + "%) or make it mandatory [pattern: " + info.patterns[patternIndex] + "]");
-										if (expr instanceof Literal && (exprInfo.flagMask & PARSE_LITERALS) == 0)
-											throw new SkriptAPIException("The default expression of '" + exprInfo.classes[0].getCodeName() + "' is a literal. Either allow null (with %-~" + exprInfo.classes[0].getCodeName() + "%) or make it mandatory [pattern: " + info.patterns[patternIndex] + "]");
-										if (!exprInfo.isPlural[0] && !expr.isSingle())
-											throw new SkriptAPIException("The default expression of '" + exprInfo.classes[0].getCodeName() + "' is not a single-element expression. Change your pattern to allow multiple elements or make the expression mandatory [pattern: " + info.patterns[patternIndex] + "]");
-										if (exprInfo.time != 0 && !expr.setTime(exprInfo.time))
-											throw new SkriptAPIException("The default expression of '" + exprInfo.classes[0].getCodeName() + "' does not have distinct time states. [pattern: " + info.patterns[patternIndex] + "]");
+									ExprInfo exprInfo = getExprInfo(name);
+									if (!exprInfo.isOptional) {
+										DefaultExpression<?> expr = getDefaultExpression(exprInfo, info, patternIndex);
 										if (!expr.init())
 											continue patternsLoop;
 										parseResult.exprs[i] = expr;
@@ -278,20 +269,19 @@ public class SkriptParser {
 		}
 	}
 
-	/**
-	 * Whether an %input% declares itself as default (with a preceding '-').
-	 */
-	private boolean isInputDefault(String name) {
-		if (name.isEmpty())
-			return false;
-		for (int i = 0; i < Math.min(5, name.length()); i++) { // we only care about the start of the string
-			char c = name.charAt(i);
-			if (c == '-')
-				return true;
-			else if (c == 0 || Character.isAlphabetic(c) || Character.isDigit(c))
-				return false; // if the pattern's started we don't want `foo-bar` to be optional
-		}
-		return false;
+	private static <T extends SyntaxElement> @NotNull DefaultExpression<?> getDefaultExpression(ExprInfo exprInfo, SyntaxElementInfo<? extends T> info, int patternIndex) {
+		DefaultExpression<?> expr = exprInfo.classes[0].getDefaultExpression();
+		if (expr == null)
+			throw new SkriptAPIException("The class '" + exprInfo.classes[0].getCodeName() + "' does not provide a default expression. Either allow null (with %-" + exprInfo.classes[0].getCodeName() + "%) or make it mandatory [pattern: " + info.patterns[patternIndex] + "]");
+		if (!(expr instanceof Literal) && (exprInfo.flagMask & PARSE_EXPRESSIONS) == 0)
+			throw new SkriptAPIException("The default expression of '" + exprInfo.classes[0].getCodeName() + "' is not a literal. Either allow null (with %-*" + exprInfo.classes[0].getCodeName() + "%) or make it mandatory [pattern: " + info.patterns[patternIndex] + "]");
+		if (expr instanceof Literal && (exprInfo.flagMask & PARSE_LITERALS) == 0)
+			throw new SkriptAPIException("The default expression of '" + exprInfo.classes[0].getCodeName() + "' is a literal. Either allow null (with %-~" + exprInfo.classes[0].getCodeName() + "%) or make it mandatory [pattern: " + info.patterns[patternIndex] + "]");
+		if (!exprInfo.isPlural[0] && !expr.isSingle())
+			throw new SkriptAPIException("The default expression of '" + exprInfo.classes[0].getCodeName() + "' is not a single-element expression. Change your pattern to allow multiple elements or make the expression mandatory [pattern: " + info.patterns[patternIndex] + "]");
+		if (exprInfo.time != 0 && !expr.setTime(exprInfo.time))
+			throw new SkriptAPIException("The default expression of '" + exprInfo.classes[0].getCodeName() + "' does not have distinct time states. [pattern: " + info.patterns[patternIndex] + "]");
+		return expr;
 	}
 
 	private static final Pattern VARIABLE_PATTERN = Pattern.compile("((the )?var(iable)? )?\\{.+\\}", Pattern.CASE_INSENSITIVE);
@@ -1398,25 +1388,30 @@ public class SkriptParser {
 
 	private static ExprInfo createExprInfo(String string) throws IllegalArgumentException, SkriptAPIException {
 		ExprInfo exprInfo = new ExprInfo(StringUtils.count(string, '/') + 1);
-		exprInfo.isOptional = string.startsWith("-");
-		if (exprInfo.isOptional)
-			string = string.substring(1);
-		if (string.startsWith("*")) {
-			string = string.substring(1);
-			exprInfo.flagMask &= ~PARSE_EXPRESSIONS;
-		} else if (string.startsWith("~")) {
-			string = string.substring(1);
-			exprInfo.flagMask &= ~PARSE_LITERALS;
-		}
-		if (!exprInfo.isOptional) {
-			exprInfo.isOptional = string.startsWith("-");
-			if (exprInfo.isOptional)
-				string = "" + string.substring(1);
-		}
-		int atSign = string.indexOf("@");
+		int caret = 0;
+		flags:
+		do {
+			switch (string.charAt(caret)) {
+				case '-':
+					exprInfo.isOptional = true;
+					break;
+				case '*':
+					exprInfo.flagMask &= ~PARSE_EXPRESSIONS;
+					break;
+				case '~':
+					exprInfo.flagMask &= ~PARSE_LITERALS;
+					break;
+				default:
+					break flags;
+			}
+			++caret;
+		} while (true);
+		int atSign = string.indexOf('@', caret);
 		if (atSign != -1) {
 			exprInfo.time = Integer.parseInt(string.substring(atSign + 1));
-			string = "" + string.substring(0, atSign);
+			string = string.substring(caret, atSign);
+		} else {
+			string = string.substring(caret);
 		}
 		String[] classes = string.split("/");
 		assert classes.length == exprInfo.classes.length;

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -243,7 +243,7 @@ public class SkriptParser {
 									String name = pattern.substring(startIndex + 1, endIndex);
 									ExprInfo exprInfo = getExprInfo(name);
 									if (!exprInfo.isOptional) {
-										DefaultExpression<?> expr = getDefaultExpression(exprInfo, info, patternIndex);
+										DefaultExpression<?> expr = getDefaultExpression(exprInfo, info.patterns[patternIndex]);
 										if (!expr.init())
 											continue patternsLoop;
 										parseResult.exprs[i] = expr;
@@ -269,18 +269,18 @@ public class SkriptParser {
 		}
 	}
 
-	private static <T extends SyntaxElement> @NotNull DefaultExpression<?> getDefaultExpression(ExprInfo exprInfo, SyntaxElementInfo<? extends T> info, int patternIndex) {
+	private static <T extends SyntaxElement> @NotNull DefaultExpression<?> getDefaultExpression(ExprInfo exprInfo, String pattern) {
 		DefaultExpression<?> expr = exprInfo.classes[0].getDefaultExpression();
 		if (expr == null)
-			throw new SkriptAPIException("The class '" + exprInfo.classes[0].getCodeName() + "' does not provide a default expression. Either allow null (with %-" + exprInfo.classes[0].getCodeName() + "%) or make it mandatory [pattern: " + info.patterns[patternIndex] + "]");
+			throw new SkriptAPIException("The class '" + exprInfo.classes[0].getCodeName() + "' does not provide a default expression. Either allow null (with %-" + exprInfo.classes[0].getCodeName() + "%) or make it mandatory [pattern: " + pattern + "]");
 		if (!(expr instanceof Literal) && (exprInfo.flagMask & PARSE_EXPRESSIONS) == 0)
-			throw new SkriptAPIException("The default expression of '" + exprInfo.classes[0].getCodeName() + "' is not a literal. Either allow null (with %-*" + exprInfo.classes[0].getCodeName() + "%) or make it mandatory [pattern: " + info.patterns[patternIndex] + "]");
+			throw new SkriptAPIException("The default expression of '" + exprInfo.classes[0].getCodeName() + "' is not a literal. Either allow null (with %-*" + exprInfo.classes[0].getCodeName() + "%) or make it mandatory [pattern: " + pattern + "]");
 		if (expr instanceof Literal && (exprInfo.flagMask & PARSE_LITERALS) == 0)
-			throw new SkriptAPIException("The default expression of '" + exprInfo.classes[0].getCodeName() + "' is a literal. Either allow null (with %-~" + exprInfo.classes[0].getCodeName() + "%) or make it mandatory [pattern: " + info.patterns[patternIndex] + "]");
+			throw new SkriptAPIException("The default expression of '" + exprInfo.classes[0].getCodeName() + "' is a literal. Either allow null (with %-~" + exprInfo.classes[0].getCodeName() + "%) or make it mandatory [pattern: " + pattern + "]");
 		if (!exprInfo.isPlural[0] && !expr.isSingle())
-			throw new SkriptAPIException("The default expression of '" + exprInfo.classes[0].getCodeName() + "' is not a single-element expression. Change your pattern to allow multiple elements or make the expression mandatory [pattern: " + info.patterns[patternIndex] + "]");
+			throw new SkriptAPIException("The default expression of '" + exprInfo.classes[0].getCodeName() + "' is not a single-element expression. Change your pattern to allow multiple elements or make the expression mandatory [pattern: " + pattern + "]");
 		if (exprInfo.time != 0 && !expr.setTime(exprInfo.time))
-			throw new SkriptAPIException("The default expression of '" + exprInfo.classes[0].getCodeName() + "' does not have distinct time states. [pattern: " + info.patterns[patternIndex] + "]");
+			throw new SkriptAPIException("The default expression of '" + exprInfo.classes[0].getCodeName() + "' does not have distinct time states. [pattern: " + pattern + "]");
 		return expr;
 	}
 

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -240,7 +240,7 @@ public class SkriptParser {
 								int endIndex = nextUnescaped(pattern, '%', startIndex + 1);
 								if (parseResult.exprs[i] == null) {
 									String name = pattern.substring(startIndex + 1, endIndex);
-									if (!name.startsWith("-")) {
+									if (!this.isInputOptional(name)) {
 										ExprInfo exprInfo = getExprInfo(name);
 										DefaultExpression<?> expr = exprInfo.classes[0].getDefaultExpression();
 										if (expr == null)
@@ -276,6 +276,22 @@ public class SkriptParser {
 		} finally {
 			log.stop();
 		}
+	}
+
+	/**
+	 * Whether an %input% declares itself as optional (with a preceding '-').
+	 */
+	private boolean isInputOptional(String name) {
+		if (name.isEmpty())
+			return false;
+		for (int i = 0; i < Math.min(5, name.length()); i++) { // we only care about the start of the string
+			char c = name.charAt(i);
+			if (c == '-')
+				return true;
+			else if (c == 0 || Character.isAlphabetic(c) || Character.isDigit(c))
+				return false; // if the pattern's started we don't want `foo-bar` to be optional
+		}
+		return false;
 	}
 
 	private static final Pattern VARIABLE_PATTERN = Pattern.compile("((the )?var(iable)? )?\\{.+\\}", Pattern.CASE_INSENSITIVE);

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -240,7 +240,7 @@ public class SkriptParser {
 								int endIndex = nextUnescaped(pattern, '%', startIndex + 1);
 								if (parseResult.exprs[i] == null) {
 									String name = pattern.substring(startIndex + 1, endIndex);
-									if (!this.isInputOptional(name)) {
+									if (!this.isInputDefault(name)) {
 										ExprInfo exprInfo = getExprInfo(name);
 										DefaultExpression<?> expr = exprInfo.classes[0].getDefaultExpression();
 										if (expr == null)
@@ -279,9 +279,9 @@ public class SkriptParser {
 	}
 
 	/**
-	 * Whether an %input% declares itself as optional (with a preceding '-').
+	 * Whether an %input% declares itself as default (with a preceding '-').
 	 */
-	private boolean isInputOptional(String name) {
+	private boolean isInputDefault(String name) {
 		if (name.isEmpty())
 			return false;
 		for (int i = 0; i < Math.min(5, name.length()); i++) { // we only care about the start of the string

--- a/src/main/java/ch/njol/skript/patterns/TypePatternElement.java
+++ b/src/main/java/ch/njol/skript/patterns/TypePatternElement.java
@@ -57,34 +57,37 @@ public class TypePatternElement extends PatternElement {
 		this.expressionIndex = expressionIndex;
 	}
 
-	public static TypePatternElement fromString(String s, int expressionIndex) {
-		boolean isNullable = s.startsWith("-");
-		if (isNullable)
-			s = s.substring(1);
-
-		int flagMask = ~0;
-		if (s.startsWith("*")) {
-			s = s.substring(1);
-			flagMask &= ~SkriptParser.PARSE_EXPRESSIONS;
-		} else if (s.startsWith("~")) {
-			s = s.substring(1);
-			flagMask &= ~SkriptParser.PARSE_LITERALS;
-		}
-
-		if (!isNullable) {
-			isNullable = s.startsWith("-");
-			if (isNullable)
-				s = s.substring(1);
-		}
+	public static TypePatternElement fromString(String string, int expressionIndex) {
+		int caret = 0, flagMask = ~0;
+		boolean isNullable = false;
+		flags:
+		do {
+			switch (string.charAt(caret)) {
+				case '-':
+					isNullable = true;
+					break;
+				case '*':
+					flagMask &= ~SkriptParser.PARSE_EXPRESSIONS;
+					break;
+				case '~':
+					flagMask &= ~SkriptParser.PARSE_LITERALS;
+					break;
+				default:
+					break flags;
+			}
+			++caret;
+		} while (true);
 
 		int time = 0;
-		int timeStart = s.indexOf("@");
+		int timeStart = string.indexOf('@', caret);
 		if (timeStart != -1) {
-			time = Integer.parseInt(s.substring(timeStart + 1));
-			s = s.substring(0, timeStart);
+			time = Integer.parseInt(string.substring(timeStart + 1));
+			string = string.substring(0, timeStart);
+		} else {
+			string = string.substring(caret);
 		}
 
-		String[] classes = s.split("/");
+		String[] classes = string.split("/");
 		ClassInfo<?>[] classInfos = new ClassInfo[classes.length];
 		boolean[] isPlural = new boolean[classes.length];
 

--- a/src/main/java/ch/njol/skript/patterns/TypePatternElement.java
+++ b/src/main/java/ch/njol/skript/patterns/TypePatternElement.java
@@ -267,7 +267,7 @@ public class TypePatternElement extends PatternElement {
 		return stringBuilder.append("%").toString();
 	}
 
-	private ExprInfo getExprInfo() {
+	public ExprInfo getExprInfo() {
 		ExprInfo exprInfo = new ExprInfo(classes.length);
 		for (int i = 0; i < classes.length; i++) {
 			exprInfo.classes[i] = classes[i];


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

SkriptParser checked for nullable/default inputs to start with `-`, which would fail if the input was something like `%~-objects%` (since it starts with `~`, not `-`).

I delegated it to a method that checks the first `n = min(length, 5)` characters of the string for the `-` and fails if one isn't present, or the text of the input (like `objects`) starts before the `-` is found.

Obviously, if we add a hundred new `%!?^&*$-~+objects` modifiers in future this limit will need to be increased, but I kept it low for safety in case of some unusual (addon) pattern.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** closes #6202 <!-- Links to related issues -->
