### PR TITLE
Replace SkriptParser ExprInfo Cache

### DIFF
--- a/src/main/java/ch/njol/skript/patterns/MatchResult.java
+++ b/src/main/java/ch/njol/skript/patterns/MatchResult.java
@@ -21,6 +21,7 @@ package ch.njol.skript.patterns;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ParseContext;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
+import com.google.common.base.MoreObjects;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,6 +31,8 @@ import java.util.List;
  * A result from pattern matching.
  */
 public class MatchResult {
+
+	SkriptPattern source;
 
 	int exprOffset;
 
@@ -45,6 +48,7 @@ public class MatchResult {
 
 	public MatchResult copy() {
 		MatchResult matchResult = new MatchResult();
+		matchResult.source = this.source;
 		matchResult.exprOffset = this.exprOffset;
 		matchResult.expressions = this.expressions.clone();
 		matchResult.expr = this.expr;
@@ -58,6 +62,7 @@ public class MatchResult {
 
 	public ParseResult toParseResult() {
 		ParseResult parseResult = new ParseResult(expr, expressions);
+		parseResult.source = source;
 		parseResult.regexes.addAll(regexResults);
 		parseResult.mark = mark;
 		parseResult.tags.addAll(tags);
@@ -86,16 +91,17 @@ public class MatchResult {
 
 	@Override
 	public String toString() {
-		return "MatchResult{" +
-			"exprOffset=" + exprOffset +
-			", expressions=" + Arrays.toString(expressions) +
-			", expr='" + expr + '\'' +
-			", mark=" + mark +
-			", tags=" + tags +
-			", regexResults=" + regexResults +
-			", parseContext=" + parseContext +
-			", flags=" + flags +
-			'}';
+		return MoreObjects.toStringHelper(this)
+			.add("source", source)
+			.add("exprOffset", exprOffset)
+			.add("expressions", Arrays.toString(expressions))
+			.add("expr", expr)
+			.add("mark", mark)
+			.add("tags", tags)
+			.add("regexResults", regexResults)
+			.add("parseContext", parseContext)
+			.add("flags", flags)
+			.toString();
 	}
 
 }

--- a/src/main/java/ch/njol/skript/patterns/SkriptPattern.java
+++ b/src/main/java/ch/njol/skript/patterns/SkriptPattern.java
@@ -21,6 +21,7 @@ package ch.njol.skript.patterns;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ParseContext;
 import ch.njol.skript.lang.SkriptParser;
+import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -33,6 +34,8 @@ public class SkriptPattern {
 	private final int expressionAmount;
 
 	private final String[] keywords;
+	@Nullable
+	private List<TypePatternElement> types;
 
 	public SkriptPattern(PatternElement first, int expressionAmount) {
 		this.first = first;
@@ -155,6 +158,13 @@ public class SkriptPattern {
 	 * @param <T> The type of pattern element.
 	 */
 	public <T extends PatternElement> List<T> getElements(Class<T> type) {
+		if (type == TypePatternElement.class) {
+			if (types == null) {
+				types = ImmutableList.copyOf(getElements(TypePatternElement.class, first, new ArrayList<>()));
+			}
+			//noinspection unchecked - checked with type == TypePatternElement
+			return (List<T>) types;
+		}
 		return getElements(type, first, new ArrayList<>());
 	}
 

--- a/src/main/java/ch/njol/skript/patterns/SkriptPattern.java
+++ b/src/main/java/ch/njol/skript/patterns/SkriptPattern.java
@@ -51,6 +51,7 @@ public class SkriptPattern {
 		expr = expr.trim();
 
 		MatchResult matchResult = new MatchResult();
+		matchResult.source = this;
 		matchResult.expr = expr;
 		matchResult.expressions = new Expression[expressionAmount];
 		matchResult.parseContext = parseContext;
@@ -145,6 +146,41 @@ public class SkriptPattern {
 		}
 
 		return count;
+	}
+
+	/**
+	 * A method to obtain a list of all pattern elements of a specified type that are represented by this SkriptPattern.
+	 * @param type The type of pattern elements to obtain.
+	 * @return A list of all pattern elements of the specified type represented by this SkriptPattern.
+	 * @param <T> The type of pattern element.
+	 */
+	public <T extends PatternElement> List<T> getElements(Class<T> type) {
+		return getElements(type, first, new ArrayList<>());
+	}
+
+	/**
+	 * A method to obtain a list of all pattern elements of a specified type (from a starting element).
+	 * @param type The type of pattern elements to obtain.
+	 * @param element The element to start searching for other elements from (this will unwrap certain elements).
+	 * @param elements A list to add matching elements to.
+	 * @return A list of all pattern elements of a specified type (from a starting element).
+	 * @param <T> The type of pattern element.
+	 */
+	private static <T extends PatternElement> List<T> getElements(Class<T> type, PatternElement element, List<T> elements) {
+		while (element != null) {
+			if (element instanceof ChoicePatternElement) {
+				((ChoicePatternElement) element).getPatternElements().forEach(e -> getElements(type, e, elements));
+			} else if (element instanceof GroupPatternElement) {
+				getElements(type, ((GroupPatternElement) element).getPatternElement(), elements);
+			} else if (element instanceof OptionalPatternElement) {
+				getElements(type, ((OptionalPatternElement) element).getPatternElement(), elements);
+			} else if (type.isInstance(element)) {
+				//noinspection unchecked - it is checked with isInstance
+				elements.add((T) element);
+			}
+			element = element.originalNext;
+		}
+		return elements;
 	}
 
 }

--- a/src/main/java/ch/njol/skript/patterns/SkriptPattern.java
+++ b/src/main/java/ch/njol/skript/patterns/SkriptPattern.java
@@ -159,9 +159,8 @@ public class SkriptPattern {
 	 */
 	public <T extends PatternElement> List<T> getElements(Class<T> type) {
 		if (type == TypePatternElement.class) {
-			if (types == null) {
+			if (types == null)
 				types = ImmutableList.copyOf(getElements(TypePatternElement.class, first, new ArrayList<>()));
-			}
 			//noinspection unchecked - checked with type == TypePatternElement
 			return (List<T>) types;
 		}


### PR DESCRIPTION
### Description
This PR is a follow up to #6591. It aims to replace the ExprInfo cache with the usage of the existing, compiled SkriptPatterns (rather than creating csubstrings). This should help to reduce any performance impact.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
