### PR TITLE
Updated Error messages in lang files to use light red and gold

### DIFF
--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -75,31 +75,31 @@ skript command:
 			enabling: Enabling all disabled scripts...
 			enabled: Successfully enabled & parsed all previously disabled scripts.
 			error: <light red>Encountered <gold>%s <light red>error¦¦s¦ while parsing disabled scripts!
-			io error: Could not load one or more scripts - some scripts might have been renamed already and will be enabled when the server restarts: %s
+			io error: <light red>Could not load one or more scripts - some scripts might have been renamed already and will be enabled when the server restarts: <gold>%s
 		single:
 			already enabled: <gold>%s<reset> is already enabled! Use <gray>/<gold>skript <cyan>reload <red>%s<reset> to reload it if it was changed.
 			enabling: Enabling <gold>%s<reset>...
 			enabled: Successfully enabled & parsed <gold>%s<reset>.
 			error: <light red>Encountered <gold>%2$s <light red>error¦¦s¦ while parsing <gold>%1$s<light red>!
-			io error: Could not enable <gold>%s<red>: %s
+			io error: <light red>Could not enable <gold>%s<light red>: <gold>%s
 		folder:
 			empty: <gold>%s<reset> does not contain any disabled scripts.
 			enabling: Enabling <gold>%2$s <reset>script¦¦s¦ in <gold>%1$s<reset>...
 			enabled: Successfully enabled & parsed <gold>%2$s<reset> previously disabled scripts in <gold>%1$s<reset>.
 			error: <light red>Encountered <gold>%2$s <light red>error¦¦s¦ while parsing scripts in <gold>%1$s<light red>!
-			io error: Error while enabling one or more scripts in <gold>%s<red> (some scripts might get enabled when the server restarts): %s
+			io error: <light red>Error while enabling one or more scripts in <gold>%s <light red>(some scripts might get enabled when the server restarts): <gold>%s
 	disable:
 		all:
 			disabled: Successfully disabled all scripts.
-			io error: Could not rename one or more scripts - some scripts might have been renamed already and will be disabled when the server restarts: %s
+			io error: <light red>Could not rename one or more scripts - some scripts might have been renamed already and will be disabled when the server restarts: <gold>%s
 		single:
 			already disabled: <gold>%s<reset> is already disabled!
 			disabled: Successfully disabled <gold>%s<reset>.
-			io error: Could not rename <gold>%s<red>, it will be enabled again when you restart the server: %s
+			io error: <light red>Could not rename <gold>%s<light red>, it will be enabled again when you restart the server: <gold>%s
 		folder:
 			empty: <gold>%s<reset> does not contain any enabled scripts.
 			disabled: Successfully disabled <gold>%2$s<reset> script(s) in <gold>%1$s<reset>.
-			io error: Could not disable one or more scripts in <gold>%s<red> (some scripts might get disabled when the server restarts): %s
+			io error: <light red>Could not disable one or more scripts in <gold>%s <light red>(some scripts might get disabled when the server restarts): <gold>%s
 	update:
 		# check/download: see Updater
 		changes:

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -74,19 +74,19 @@ skript command:
 		all:
 			enabling: Enabling all disabled scripts...
 			enabled: Successfully enabled & parsed all previously disabled scripts.
-			error: Encountered %s error¦¦s¦ while parsing disabled scripts!
+			error: <light red>Encountered <gold>%s <light red>error¦¦s¦ while parsing disabled scripts!
 			io error: Could not load one or more scripts - some scripts might have been renamed already and will be enabled when the server restarts: %s
 		single:
 			already enabled: <gold>%s<reset> is already enabled! Use <gray>/<gold>skript <cyan>reload <red>%s<reset> to reload it if it was changed.
 			enabling: Enabling <gold>%s<reset>...
 			enabled: Successfully enabled & parsed <gold>%s<reset>.
-			error: Encountered %2$s error¦¦s¦ while parsing <gold>%1$s<red>!
+			error: <light red>Encountered <gold>%2$s <light red>error¦¦s¦ while parsing <gold>%1$s<light red>!
 			io error: Could not enable <gold>%s<red>: %s
 		folder:
 			empty: <gold>%s<reset> does not contain any disabled scripts.
 			enabling: Enabling <gold>%2$s <reset>script¦¦s¦ in <gold>%1$s<reset>...
 			enabled: Successfully enabled & parsed <gold>%2$s<reset> previously disabled scripts in <gold>%1$s<reset>.
-			error: Encountered %2$s error¦¦s¦ while parsing scripts in <gold>%1$s<red>!
+			error: <light red>Encountered <gold>%2$s <light red>error¦¦s¦ while parsing scripts in <gold>%1$s<light red>!
 			io error: Error while enabling one or more scripts in <gold>%s<red> (some scripts might get enabled when the server restarts): %s
 	disable:
 		all:

--- a/src/main/resources/lang/french.lang
+++ b/src/main/resources/lang/french.lang
@@ -75,31 +75,31 @@ skript command:
 			enabling: Activation de tous les scripts désactivés...
 			enabled: Activation et analyse réussies de tous les scripts précédemment désactivés.
 			error: <gold>%s <light red>¦erreur rencontrée¦erreurs rencontrées¦ lors de l'analyse des scripts désactivés !
-			io error: Impossible de charger les scripts (certains scripts ont peut-être déjà été renommés et seront activés au redémarrage du serveur) : %s
+			io error: <light red>Impossible de charger les scripts (certains scripts ont peut-être déjà été renommés et seront activés au redémarrage du serveur) : <gold>%s
 		single:
 			already enabled: <gold>%s<reset> est déjà activé ! Utilisez <gray>/<gold>skript <cyan>reload <red>%s<reset> pour le recharger s'il a été modifié.
 			enabling: Activation de <gold>%s<reset>...
 			enabled: <gold>%s<reset> activé et analysé avec succès.
 			error: <gold>%2$s <light red>¦erreur rencontrée¦erreurs rencontrées¦ lors de l'analyse de <gold>%1$s<light red>!
-			io error: Impossible d'activer <gold>%s<red>: %s
+			io error: <light red>Impossible d'activer <gold>%s<light red>: <gold>%s
 		folder:
 			empty: <gold>%s<reset> ne contient aucun script désactivé.
 			enabling: Activation de <gold>%2$s <reset>script¦¦s¦ dans <gold>%1$s<reset>...
 			enabled: Activation et analyse réussies de <gold>%2$s<reset> script(s) précédemment désactivé(s) dans <gold>%1$s<reset>.
 			error: <gold>%2$s <light red>¦erreur rencontrée¦erreurs rencontrées¦ lors de l'analyse des scripts dans <gold>%1$s<light red>!
-			io error: Erreur lors de l'activation des scripts dans <gold>%s<red> (certains scripts pourraient être activés lors du redémarrage du serveur) : %s
+			io error: <light red>Erreur lors de l'activation des scripts dans <gold>%s <light red>(certains scripts pourraient être activés lors du redémarrage du serveur) : <gold>%s
 	disable:
 		all:
 			disabled: Désactivation de tous les scripts réussie.
-			io error: Impossible de renommer tous les scripts - certains scripts seront réactivés lorsque vous redémarrerez le serveur : %s
+			io error: <light red>Impossible de renommer tous les scripts - certains scripts seront réactivés lorsque vous redémarrerez le serveur : <gold>%s
 		single:
 			already disabled: <gold>%s<reset> est déjà désactivé !
 			disabled: <gold>%s<reset> désactivé avec succès.
-			io error: Impossible de renommer <gold>%s<red>, il sera à nouveau activé lorsque vous redémarrerez le serveur : %s
+			io error: <light red>Impossible de renommer <gold>%s<light red>, il sera à nouveau activé lorsque vous redémarrerez le serveur : <gold>%s
 		folder:
 			empty: <gold>%s<reset> ne contient aucun script activé.
 			disabled: Désactivation réussie de <gold>%2$s<reset> script(s) dans <gold>%1$s<reset>.
-			io error: Impossible de désactiver les scripts <gold>%s<red> (certains scripts pourraient être désactivés lors du redémarrage du serveur): %s
+			io error: <light red>Impossible de désactiver les scripts <gold>%s <light red>(certains scripts pourraient être désactivés lors du redémarrage du serveur): <gold>%s
 	update:
 		# check/download: see Updater
 		changes:

--- a/src/main/resources/lang/french.lang
+++ b/src/main/resources/lang/french.lang
@@ -74,19 +74,19 @@ skript command:
 		all:
 			enabling: Activation de tous les scripts désactivés...
 			enabled: Activation et analyse réussies de tous les scripts précédemment désactivés.
-			error: %s ¦erreur rencontrée¦erreurs rencontrées¦ lors de l'analyse des scripts désactivés !
+			error: <gold>%s <light red>¦erreur rencontrée¦erreurs rencontrées¦ lors de l'analyse des scripts désactivés !
 			io error: Impossible de charger les scripts (certains scripts ont peut-être déjà été renommés et seront activés au redémarrage du serveur) : %s
 		single:
 			already enabled: <gold>%s<reset> est déjà activé ! Utilisez <gray>/<gold>skript <cyan>reload <red>%s<reset> pour le recharger s'il a été modifié.
 			enabling: Activation de <gold>%s<reset>...
 			enabled: <gold>%s<reset> activé et analysé avec succès.
-			error: %2$s ¦erreur rencontrée¦erreurs rencontrées¦ lors de l'analyse de <gold>%1$s<red> !
+			error: <gold>%2$s <light red>¦erreur rencontrée¦erreurs rencontrées¦ lors de l'analyse de <gold>%1$s<light red>!
 			io error: Impossible d'activer <gold>%s<red>: %s
 		folder:
 			empty: <gold>%s<reset> ne contient aucun script désactivé.
 			enabling: Activation de <gold>%2$s <reset>script¦¦s¦ dans <gold>%1$s<reset>...
 			enabled: Activation et analyse réussies de <gold>%2$s<reset> script(s) précédemment désactivé(s) dans <gold>%1$s<reset>.
-			error: %2$s ¦erreur rencontrée¦erreurs rencontrées¦ lors de l'analyse des scripts dans <gold>%1$s<red> !
+			error: <gold>%2$s <light red>¦erreur rencontrée¦erreurs rencontrées¦ lors de l'analyse des scripts dans <gold>%1$s<light red>!
 			io error: Erreur lors de l'activation des scripts dans <gold>%s<red> (certains scripts pourraient être activés lors du redémarrage du serveur) : %s
 	disable:
 		all:

--- a/src/main/resources/lang/german.lang
+++ b/src/main/resources/lang/german.lang
@@ -75,31 +75,31 @@ skript command:
 			enabling: Aktiviere alle deaktivierten Skripte...
 			enabled: Alle Skripte wurden erfolgreich geladen & geparst.
 			error: <gold>%s <light red>Fehler ¦ist¦sind¦ aufgetreten beim Laden aller Skripte!
-			io error: Konnte keine Skripte laden (einige Skripte könnten bereits umbenannt worden sein und werden beim nächsten Serverneustart geladen): %s
+			io error: <light red>Konnte keine Skripte laden (einige Skripte könnten bereits umbenannt worden sein und werden beim nächsten Serverneustart geladen): <gold>%s
 		single:
 			already enabled: <gold>%s<reset> ist bereits aktiviert! Verwende <gray>/<gold>skript <cyan>reload <red>%s<reset> um es erneut zu laden.
 			enabling: Aktiviere <gold>%s<reset>...
 			enabled: <gold>%s<reset> wurde erfolgreich aktiviert & geparst.
 			error: <gold>%2$s <light red>Fehler ¦ist¦sind¦ aufgetreten beim Laden von <gold>%1$s<light red>!
-			io error: Konnte <gold>%s<red> nicht aktivieren: %s
+			io error: <light red>Konnte <gold>%s <light red>nicht aktivieren: <gold>%s
 		folder:
 			empty: <gold>%s<reset> enthält keine deaktivierten Skripte.
 			enabling: Aktiviere <gold>%2$s <reset>Skript¦¦e¦ in <gold>%1$s<reset>...
 			enabled: <gold>%2$s <reset>Skript¦¦e¦ aus <gold>%1$s<reset> wurden erfolgreich aktiviert.
 			error: <gold>%2$s <light red>Fehler ¦ist¦sind¦ aufgetreten beim Aktivieren der Skripte in <gold>%1$s<light red>!
-			io error: Fehler beim Aktivieren der Skripte in <gold>%s<red> (einige Skripte werden eventuell beim nächsten Serverneustart aktiviert): %s
+			io error: <light red>Fehler beim Aktivieren der Skripte in <gold>%s <light red>(einige Skripte werden eventuell beim nächsten Serverneustart aktiviert): <gold>%s
 	disable:
 		all:
 			disabled: Alle Skripte wurden erfolgreich deaktiviert.
-			io error: Konnte nicht alle Skripte umbennenen - einige Skripte werden beim nächsten Serverneustart wieder aktiviert: %s
+			io error: <light red>Konnte nicht alle Skripte umbennenen - einige Skripte werden beim nächsten Serverneustart wieder aktiviert: <gold>%s
 		single:
 			already disabled: <gold>%s<reset> ist bereits deaktiviert!
 			disabled: <gold>%s<reset> wurde erfolgreich deaktiviert.
-			io error: Konnte <gold>%s<red> nicht umbennenen, es wird beim nächsten Serverneustart wieder aktiviert sein: %s
+			io error: <light red>Konnte <gold>%s <light red>nicht umbennenen, es wird beim nächsten Serverneustart wieder aktiviert sein: <gold>%s
 		folder:
 			empty: <gold>%s<reset> enthält keine aktivierten Skripte.
 			disabled: <gold>%2$s <reset>Skript¦¦e¦ aus <gold>%1$s<reset> wurden erfolgreich deaktiviert.
-			io error: Konnte keine Skripte in <gold>%s<red> deaktivieren (einige Skripte werden beim nächten Neustart evtl. deaktiviert): %s
+			io error: <light red>Konnte keine Skripte in <gold>%s <light red>deaktivieren (einige Skripte werden beim nächten Neustart evtl. deaktiviert): <gold>%s
 	update:
 		# check/download: see Updater
 		changes:

--- a/src/main/resources/lang/german.lang
+++ b/src/main/resources/lang/german.lang
@@ -74,19 +74,19 @@ skript command:
 		all:
 			enabling: Aktiviere alle deaktivierten Skripte...
 			enabled: Alle Skripte wurden erfolgreich geladen & geparst.
-			error: %s Fehler ¦ist¦sind¦ aufgetreten beim Laden aller Skripte!
+			error: <gold>%s <light red>Fehler ¦ist¦sind¦ aufgetreten beim Laden aller Skripte!
 			io error: Konnte keine Skripte laden (einige Skripte könnten bereits umbenannt worden sein und werden beim nächsten Serverneustart geladen): %s
 		single:
 			already enabled: <gold>%s<reset> ist bereits aktiviert! Verwende <gray>/<gold>skript <cyan>reload <red>%s<reset> um es erneut zu laden.
 			enabling: Aktiviere <gold>%s<reset>...
 			enabled: <gold>%s<reset> wurde erfolgreich aktiviert & geparst.
-			error: %2$s Fehler ¦ist¦sind¦ aufgetreten beim Laden von <gold>%1$s<red>!
+			error: <gold>%2$s <light red>Fehler ¦ist¦sind¦ aufgetreten beim Laden von <gold>%1$s<light red>!
 			io error: Konnte <gold>%s<red> nicht aktivieren: %s
 		folder:
 			empty: <gold>%s<reset> enthält keine deaktivierten Skripte.
 			enabling: Aktiviere <gold>%2$s <reset>Skript¦¦e¦ in <gold>%1$s<reset>...
 			enabled: <gold>%2$s <reset>Skript¦¦e¦ aus <gold>%1$s<reset> wurden erfolgreich aktiviert.
-			error: %2$s Fehler ¦ist¦sind¦ aufgetreten beim Aktivieren der Skripte in <gold>%1$s<red>!
+			error: <gold>%2$s <light red>Fehler ¦ist¦sind¦ aufgetreten beim Aktivieren der Skripte in <gold>%1$s<light red>!
 			io error: Fehler beim Aktivieren der Skripte in <gold>%s<red> (einige Skripte werden eventuell beim nächsten Serverneustart aktiviert): %s
 	disable:
 		all:

--- a/src/main/resources/lang/japanese.lang
+++ b/src/main/resources/lang/japanese.lang
@@ -75,31 +75,31 @@ skript command:
 			enabling: 無効化された全てのスクリプトを有効化しています...
 			enabled: 全ての無効化されていたスクリプトの解析・有効化に成功しました。
 			error: <light red>解析中に%s個のエラーが見つかりました！
-			io error: 一つもしくは複数のスクリプトがロードできませんでした。 一部のスクリプトはファイル名が変更された可能性があります。 またサーバー再起動時に有効化されます: %s
+			io error: <light red>一つもしくは複数のスクリプトがロードできませんでした。 一部のスクリプトはファイル名が変更された可能性があります。 またサーバー再起動時に有効化されます: <gold>%s
 		single:
 			already enabled: <gold>%s<reset>はすでに有効化されています! もし変更を反映したい場合は<gray>/<gold>skript <cyan>reload <red>%s<reset>を使用して再読み込みします。
 			enabling: <gold>%s<reset>を有効化しています...
 			enabled: <gold>%s<reset>の解析・有効化に成功しました。
 			error: <gold>%1$s<light red>を解析中に<gold>%2$s<light red>個のエラーが見つかりました！
-			io error: <gold>%s<red>は有効化できませんでした。: %s
+			io error: <gold>%s<light red>は有効化できませんでした。: <gold>%s
 		folder:
 			empty: <gold>%s<reset>フォルダ内に無効化されたスクリプトが見つかりませんでした。
 			enabling: <gold>%1$s<reset>フォルダ内の<gold>%2$s<reset>個のスクリプトを有効化しています...
 			enabled: <gold>%1$s<reset>フォルダ内にある無効化されていた<gold>%2$s<reset>の解析・有効化に成功しました。
 			error: <gold>%1$s<light red>フォルダ内のスクリプトを解析中に<gold>%2$s<light red>個のエラーが見つかりました！
-			io error: <gold>%s<red>フォルダ内の一つもしくは複数のスクリプトのロード時にエラーが発生しました。 (一部のスクリプトはサーバー再起動時に有効になる場合があります): %s
+			io error: <gold>%s<light red>フォルダ内の一つもしくは複数のスクリプトのロード時にエラーが発生しました。 (一部のスクリプトはサーバー再起動時に有効になる場合があります): <gold>%s
 	disable:
 		all:
 			disabled: 全てのスクリプトの無効化に成功しました。
-			io error: 一つもしくは複数のスクリプトのファイル名を変更できませんでした。 一部のスクリプトはファイル名が変更された可能性があります。 またサーバー再起動時に無効化されます: %s
+			io error: <light red>一つもしくは複数のスクリプトのファイル名を変更できませんでした。 一部のスクリプトはファイル名が変更された可能性があります。 またサーバー再起動時に無効化されます: <gold>%s
 		single:
 			already disabled: <gold>%s<reset>はすでに無効化されています！
 			disabled: <gold>%s<reset>の無効化に成功しました。
-			io error: <gold>%s<red>のファイル名の変更ができませんでした。 サーバー再起動時に再度有効化されます: %s
+			io error: <gold>%s<light red>のファイル名の変更ができませんでした。 サーバー再起動時に再度有効化されます: <gold>%s
 		folder:
 			empty: <gold>%s<reset>フォルダ内に有効化されたスクリプトが見つかりませんでした。
 			disabled: <gold>%1$s<reset>フォルダ内の<gold>%2$s<reset>個のスクリプトが無効化されました。
-			io error: <gold>%s<red>フォルダ内の一つもしくは複数のスクリプトのファイル名を変更できませんでした。 (一部のスクリプトはサーバー再起動時に無効化される場合があります): %s
+			io error: <gold>%s<light red>フォルダ内の一つもしくは複数のスクリプトのファイル名を変更できませんでした。 (一部のスクリプトはサーバー再起動時に無効化される場合があります): <gold>%s
 	update:
 		# check/download: Upadater をご確認ください
 		changes:

--- a/src/main/resources/lang/japanese.lang
+++ b/src/main/resources/lang/japanese.lang
@@ -74,19 +74,19 @@ skript command:
 		all:
 			enabling: 無効化された全てのスクリプトを有効化しています...
 			enabled: 全ての無効化されていたスクリプトの解析・有効化に成功しました。
-			error: 解析中に%s個のエラーが見つかりました！
+			error: <light red>解析中に%s個のエラーが見つかりました！
 			io error: 一つもしくは複数のスクリプトがロードできませんでした。 一部のスクリプトはファイル名が変更された可能性があります。 またサーバー再起動時に有効化されます: %s
 		single:
 			already enabled: <gold>%s<reset>はすでに有効化されています! もし変更を反映したい場合は<gray>/<gold>skript <cyan>reload <red>%s<reset>を使用して再読み込みします。
 			enabling: <gold>%s<reset>を有効化しています...
 			enabled: <gold>%s<reset>の解析・有効化に成功しました。
-			error: <gold>%1$s<red>を解析中に%2$s個のエラーが見つかりました！
+			error: <gold>%1$s<light red>を解析中に<gold>%2$s<light red>個のエラーが見つかりました！
 			io error: <gold>%s<red>は有効化できませんでした。: %s
 		folder:
 			empty: <gold>%s<reset>フォルダ内に無効化されたスクリプトが見つかりませんでした。
 			enabling: <gold>%1$s<reset>フォルダ内の<gold>%2$s<reset>個のスクリプトを有効化しています...
 			enabled: <gold>%1$s<reset>フォルダ内にある無効化されていた<gold>%2$s<reset>の解析・有効化に成功しました。
-			error: <gold>%1$s<red>フォルダ内のスクリプトを解析中に%2$s個のエラーが見つかりました！
+			error: <gold>%1$s<light red>フォルダ内のスクリプトを解析中に<gold>%2$s<light red>個のエラーが見つかりました！
 			io error: <gold>%s<red>フォルダ内の一つもしくは複数のスクリプトのロード時にエラーが発生しました。 (一部のスクリプトはサーバー再起動時に有効になる場合があります): %s
 	disable:
 		all:

--- a/src/main/resources/lang/korean.lang
+++ b/src/main/resources/lang/korean.lang
@@ -74,19 +74,19 @@ skript command:
 		all:
 			enabling: 비활성화된 모든 스크립트를 활성화하는 중...
 			enabled: 비활성화된 모든 스크립트를 성공적으로 활성화하고 구문을 분석했습니다.
-			error: 비활성화된 스크립트의 구문을 분석하는 동안 %s개의 오류를 발견했습니다!
+			error: <light red>비활성화된 스크립트의 구문을 분석하는 동안 %s개의 오류를 발견했습니다!
 			io error: 스크립트를 로드할 수 없습니다 (일부 스크립트의 이름이 변경되어 서버가 다시 시작될 때 활성화됩니다): %s
 		single:
 			already enabled: <gold> %s<reset>이(가) 이미 활성화되었습니다! 파일이 변경된 경우 <gray>/<gold>skript<cyan> reload <red>%s<reset>을(를) 사용하여 다시 로드하십시오.
 			enabling: <gold>%s<reset>을(를) 활성화하는 중...
 			enabled: <gold>%s<reset>을(를) 활성화하고 구문을 분석했습니다.
-			error: <gold>%1$s<red>의 구문을 분석하는 동안 %2$s개의 오류를 발견했습니다!
+			error: <gold>%1$s<light red>의 구문을 분석하는 동안 <gold>%2$s<light red>개의 오류를 발견했습니다!
 			io error: <gold>%s<red>을(를) 활성화 할 수 없습니다: %s
 		folder:
 			empty: <gold>%s<reset>에 비활성화된 스크립트가 없습니다.
 			enabling: <gold>%1$s<reset>에서 <gold>%2$s<reset>개의 스크립트를 활성화하는 중...
 			enabled: <gold>%1$s<reset>에서 비활성화된 <gold>%2$s<reset>개의 스크립트를 성공적으로 활성화하고 구문을 분석했습니다.
-			error: <gold>%1$s<red>의 스크립트의 구문을 분석하는 동안 %2$s개의 오류를 발견했습니다!
+			error: <gold>%1$s<light red>의 스크립트의 구문을 분석하는 동안 <gold>%2$s<light red>개의 오류를 발견했습니다!
 			io error: <gold>%s<red>의 스크립트를 활성화하는 동안 오류가 발생했습니다 (서버가 다시 시작될 때 일부 스크립트가 활성화될 수 있습니다): %s
 	disable:
 		all:

--- a/src/main/resources/lang/korean.lang
+++ b/src/main/resources/lang/korean.lang
@@ -75,31 +75,31 @@ skript command:
 			enabling: 비활성화된 모든 스크립트를 활성화하는 중...
 			enabled: 비활성화된 모든 스크립트를 성공적으로 활성화하고 구문을 분석했습니다.
 			error: <light red>비활성화된 스크립트의 구문을 분석하는 동안 %s개의 오류를 발견했습니다!
-			io error: 스크립트를 로드할 수 없습니다 (일부 스크립트의 이름이 변경되어 서버가 다시 시작될 때 활성화됩니다): %s
+			io error: <light red>스크립트를 로드할 수 없습니다 (일부 스크립트의 이름이 변경되어 서버가 다시 시작될 때 활성화됩니다): <gold>%s
 		single:
 			already enabled: <gold> %s<reset>이(가) 이미 활성화되었습니다! 파일이 변경된 경우 <gray>/<gold>skript<cyan> reload <red>%s<reset>을(를) 사용하여 다시 로드하십시오.
 			enabling: <gold>%s<reset>을(를) 활성화하는 중...
 			enabled: <gold>%s<reset>을(를) 활성화하고 구문을 분석했습니다.
 			error: <gold>%1$s<light red>의 구문을 분석하는 동안 <gold>%2$s<light red>개의 오류를 발견했습니다!
-			io error: <gold>%s<red>을(를) 활성화 할 수 없습니다: %s
+			io error: <gold>%s<light red>을(를) 활성화 할 수 없습니다: <gold>%s
 		folder:
 			empty: <gold>%s<reset>에 비활성화된 스크립트가 없습니다.
 			enabling: <gold>%1$s<reset>에서 <gold>%2$s<reset>개의 스크립트를 활성화하는 중...
 			enabled: <gold>%1$s<reset>에서 비활성화된 <gold>%2$s<reset>개의 스크립트를 성공적으로 활성화하고 구문을 분석했습니다.
 			error: <gold>%1$s<light red>의 스크립트의 구문을 분석하는 동안 <gold>%2$s<light red>개의 오류를 발견했습니다!
-			io error: <gold>%s<red>의 스크립트를 활성화하는 동안 오류가 발생했습니다 (서버가 다시 시작될 때 일부 스크립트가 활성화될 수 있습니다): %s
+			io error: <gold>%s<light red>의 스크립트를 활성화하는 동안 오류가 발생했습니다 (서버가 다시 시작될 때 일부 스크립트가 활성화될 수 있습니다): <gold>%s
 	disable:
 		all:
 			disabled: 모든 스크립트를 성공적으로 비활성화했습니다.
-			io error: 모든 스크립트를 비활성화 할 수 없습니다 (서버를 다시 시작할 때 일부 스크립트가 다시 활성화될 수 있습니다): %s
+			io error: <light red>모든 스크립트를 비활성화 할 수 없습니다 (서버를 다시 시작할 때 일부 스크립트가 다시 활성화될 수 있습니다): <gold>%s
 		single:
 			already disabled: <gold>%s<reset>은(는) 이미 비활성화되었습니다!
 			disabled: <gold>%s<reset>을(를) 비활성화했습니다.
-			io error: <gold>%s<red>의 이름을 바꿀 수 없습니다 (서버를 다시 시작할 때 다시 활성화됩니다): %s
+			io error: <gold>%s<light red>의 이름을 바꿀 수 없습니다 (서버를 다시 시작할 때 다시 활성화됩니다): <gold>%s
 		folder:
 			empty: <gold>%s<reset>에 활성화된 스크립트가 없습니다.
 			disabled: <gold>%1$s<reset>에서 <gold>%2$s<reset>개의 스크립트를 성공적으로 비활성화했습니다.
-			io error: <gold>%s<red>의 스크립트를 비활성화 할 수 없습니다 (서버가 다시 시작될 때 일부 스크립트가 비활성화될 수 있음): %s
+			io error: <gold>%s<light red>의 스크립트를 비활성화 할 수 없습니다 (서버가 다시 시작될 때 일부 스크립트가 비활성화될 수 있음): <gold>%s
 	update:
 		# check/download: Updater 확인
 		changes:

--- a/src/main/resources/lang/polish.lang
+++ b/src/main/resources/lang/polish.lang
@@ -74,19 +74,19 @@ skript command:
 		all:
 			enabling: Włączanie wszystkich wyłączonych skryptów...
 			enabled: Pomyślnie włączono i zinterpretowano wszystkie wyłączone skrypty.
-			error: Znaleziono %s bł¦ąd¦ędów¦ podczas interpretacji wyłączonych skryptów!
+			error: <light red>Znaleziono <gold>%s <light red>bł¦ąd¦ędów¦ podczas interpretacji wyłączonych skryptów!
 			io error: Nie udało się włączyć jednego lub większej liczby skryptów (niektóre skrypty mogą pozostać wyłączone po restarcie serwera): %s
 		single:
 			already enabled: <gold>%s<reset> jest już włączony! Użyj <gray>/<gold>skript <cyan>reload <red>%s<reset> aby odświeżyć skrypt, jeśli został edytowany.
 			enabling: Włączanie <gold>%s<reset>...
 			enabled: Pomyślnie włączono i zinterpretowano <gold>%s<reset>.
-			error: Znaleziono %2$s bł¦ąd¦ędów¦ podczas interpretacji <gold>%1$s<red>!
+			error: <light red>Znaleziono <gold>%2$s <light red>bł¦ąd¦ędów¦ podczas interpretacji <gold>%1$s<light red>!
 			io error: Nie udało się włączyć <gold>%s<red>: %s
 		folder:
 			empty: <gold>%s<reset> nie zawiera w sobie żadnych wyłączonych skryptów.
 			enabling: Włączanie <gold>%2$s <reset>skrypt¦¦ów¦ in <gold>%1$s<reset>...
 			enabled: Pomyślnie włączono i zinterpretowano <gold>%2$s<reset> poprzednio wyłączonych skryptów <gold>%1$s<reset>.
-			error: Znaleziono %2$s bł¦ąd¦ędów¦ podczas interpretacji skryptów w folderze <gold>%1$s<red>!
+			error: <light red>Znaleziono <gold>%2$s <light red>bł¦ąd¦ędów¦ podczas interpretacji skryptów w folderze <gold>%1$s<light red>!
 			io error: Nie udało się włączyć jednego lub większej liczby skryptów w folderze <gold>%s<red> (niektóre skrypty mogą pozostać wyłączone po restarcie serwera): %s
 	disable:
 		all:

--- a/src/main/resources/lang/polish.lang
+++ b/src/main/resources/lang/polish.lang
@@ -75,31 +75,31 @@ skript command:
 			enabling: Włączanie wszystkich wyłączonych skryptów...
 			enabled: Pomyślnie włączono i zinterpretowano wszystkie wyłączone skrypty.
 			error: <light red>Znaleziono <gold>%s <light red>bł¦ąd¦ędów¦ podczas interpretacji wyłączonych skryptów!
-			io error: Nie udało się włączyć jednego lub większej liczby skryptów (niektóre skrypty mogą pozostać wyłączone po restarcie serwera): %s
+			io error: <light red>Nie udało się włączyć jednego lub większej liczby skryptów (niektóre skrypty mogą pozostać wyłączone po restarcie serwera): <gold>%s
 		single:
 			already enabled: <gold>%s<reset> jest już włączony! Użyj <gray>/<gold>skript <cyan>reload <red>%s<reset> aby odświeżyć skrypt, jeśli został edytowany.
 			enabling: Włączanie <gold>%s<reset>...
 			enabled: Pomyślnie włączono i zinterpretowano <gold>%s<reset>.
 			error: <light red>Znaleziono <gold>%2$s <light red>bł¦ąd¦ędów¦ podczas interpretacji <gold>%1$s<light red>!
-			io error: Nie udało się włączyć <gold>%s<red>: %s
+			io error: <light red>Nie udało się włączyć <gold>%s<light red>: <gold>%s
 		folder:
 			empty: <gold>%s<reset> nie zawiera w sobie żadnych wyłączonych skryptów.
 			enabling: Włączanie <gold>%2$s <reset>skrypt¦¦ów¦ in <gold>%1$s<reset>...
 			enabled: Pomyślnie włączono i zinterpretowano <gold>%2$s<reset> poprzednio wyłączonych skryptów <gold>%1$s<reset>.
 			error: <light red>Znaleziono <gold>%2$s <light red>bł¦ąd¦ędów¦ podczas interpretacji skryptów w folderze <gold>%1$s<light red>!
-			io error: Nie udało się włączyć jednego lub większej liczby skryptów w folderze <gold>%s<red> (niektóre skrypty mogą pozostać wyłączone po restarcie serwera): %s
+			io error: <light red>Nie udało się włączyć jednego lub większej liczby skryptów w folderze <gold>%s <light red>(niektóre skrypty mogą pozostać wyłączone po restarcie serwera): <gold>%s
 	disable:
 		all:
 			disabled: Pomyślnie wyłączono wszystkie skrypty.
-			io error: Nie udało się zmienić nazwy jednego lub większej liczby skryptów - niektóre skrypty mogą pozostać włączone po restarcie serwera: %s
+			io error: <light red>Nie udało się zmienić nazwy jednego lub większej liczby skryptów - niektóre skrypty mogą pozostać włączone po restarcie serwera: <gold>%s
 		single:
 			already disabled: <gold>%s<reset> jest już wyłączony!
 			disabled: Pomyślnie wyłączono <gold>%s<reset>.
-			io error: Nie udało się zmienić nazwy <gold>%s<red>, skrypt pozostanie włączony po restarcie serwera: %s
+			io error: <light red>Nie udało się zmienić nazwy <gold>%s<light red>, skrypt pozostanie włączony po restarcie serwera: <gold>%s
 		folder:
 			empty: <gold>%s<reset> nie zawiera żadnych włączonych skryptów.
 			disabled: Pomyślnie wyłączono <gold>%2$s<reset> skrypt¦¦ów¦ w <gold>%1$s<reset>.
-			io error: Nie udało się wyłączyć jednego lub większej liczby skryptów w folderze <gold>%s<red> (niektóre skrypty mogą pozostać włączone po restarcie serwera): %s
+			io error: <light red>Nie udało się wyłączyć jednego lub większej liczby skryptów w folderze <gold>%s <light red>(niektóre skrypty mogą pozostać włączone po restarcie serwera): <gold>%s
 	update:
 		# check/download: see Updater
 		changes:

--- a/src/main/resources/lang/simplifiedchinese.lang
+++ b/src/main/resources/lang/simplifiedchinese.lang
@@ -75,31 +75,31 @@ skript command:
 			enabling: 正在启用所有已禁用的脚本…
 			enabled: 已成功启用并解析了所有先前禁用的脚本。
 			error: <light red>在解析禁用的脚本时遇到了<gold>%s<light red>个错误！
-			io error: 无法加载一个或多个脚本 - 一些脚本可能已被重命名，并在服务器重新启动时启用：%s
+			io error: <light red>无法加载一个或多个脚本 - 一些脚本可能已被重命名，并在服务器重新启动时启用：<gold>%s
 		single:
 			already enabled: <gold>%s<reset>已经启用了！如果它已被更改，使用<gray>/<gold>skript <cyan>reload <red>%s<reset>来重新加载。
 			enabling: 正在启用<gold>%s<reset>…
 			enabled: 已成功启用并解析<gold>%s<reset>。
 			error: <light red>在解析<gold>%1$s<light red>时遇到了<gold>%2$s<light red>个错误！
-			io error: 无法启用<gold>%s<red>：%s
+			io error: <light red>无法启用<gold>%s<light red>：<gold>%s
 		folder:
 			empty: <gold>%s<reset>不包含任何已禁用的脚本。
 			enabling: 正在启用<gold>%1$s<reset>中的<gold>%2$s<reset>个脚本…
 			enabled: 已成功启用并解析<gold>%1$s<reset>中的<gold>%2$s<reset>个先前禁用的脚本。
 			error: <light red>在解析<gold>%1$s<light red>时遇到了<gold>%2$s<light red>个错误！
-			io error: 在启用<gold>%s<red>中的一个或多个脚本时出错（有些脚本可能会在服务器重新启动时启用）：%s
+			io error: <light red>在启用<gold>%s<light red>中的一个或多个脚本时出错（有些脚本可能会在服务器重新启动时启用）：<gold>%s
 	disable:
 		all:
 			disabled: 已成功禁用所有脚本。
-			io error: 无法重命名一个或多个脚本 - 一些脚本可能已被重命名，并在服务器重新启动时禁用：%s
+			io error: <light red>无法重命名一个或多个脚本 - 一些脚本可能已被重命名，并在服务器重新启动时禁用：<gold>%s
 		single:
 			already disabled: <gold>%s<reset>已经被禁用了！
 			disabled: 已成功禁用<gold>%s<reset>。
-			io error: 无法重命名<gold>%s<red>当你重新启动服务器时，它会再次启用：%s
+			io error: <light red>无法重命名<gold>%s<light red>当你重新启动服务器时，它会再次启用：<gold>%s
 		folder:
 			empty: <gold>%s<reset>不包含任何已启用的脚本。
 			disabled: 已成功禁用了<gold>%1$s<reset>中的<gold>%2$s<reset>的脚本。
-			io error: 在禁用<gold>%s<red>中的一个或多个脚本时出错（有些脚本可能会在服务器重新启动时禁用）：%s
+			io error: <light red>在禁用<gold>%s<light red>中的一个或多个脚本时出错（有些脚本可能会在服务器重新启动时禁用）：<gold>%s
 	update:
 		# check/download: see Updater
 		changes:

--- a/src/main/resources/lang/simplifiedchinese.lang
+++ b/src/main/resources/lang/simplifiedchinese.lang
@@ -74,19 +74,19 @@ skript command:
 		all:
 			enabling: 正在启用所有已禁用的脚本…
 			enabled: 已成功启用并解析了所有先前禁用的脚本。
-			error: 在解析禁用的脚本时遇到了%s个错误！
+			error: <light red>在解析禁用的脚本时遇到了<gold>%s<light red>个错误！
 			io error: 无法加载一个或多个脚本 - 一些脚本可能已被重命名，并在服务器重新启动时启用：%s
 		single:
 			already enabled: <gold>%s<reset>已经启用了！如果它已被更改，使用<gray>/<gold>skript <cyan>reload <red>%s<reset>来重新加载。
 			enabling: 正在启用<gold>%s<reset>…
 			enabled: 已成功启用并解析<gold>%s<reset>。
-			error: 在解析<gold>%1$s<red>时遇到了%2$s个错误！
+			error: <light red>在解析<gold>%1$s<light red>时遇到了<gold>%2$s<light red>个错误！
 			io error: 无法启用<gold>%s<red>：%s
 		folder:
 			empty: <gold>%s<reset>不包含任何已禁用的脚本。
 			enabling: 正在启用<gold>%1$s<reset>中的<gold>%2$s<reset>个脚本…
 			enabled: 已成功启用并解析<gold>%1$s<reset>中的<gold>%2$s<reset>个先前禁用的脚本。
-			error: 在解析<gold>%1$s<red>时遇到了%2$s个错误！
+			error: <light red>在解析<gold>%1$s<light red>时遇到了<gold>%2$s<light red>个错误！
 			io error: 在启用<gold>%s<red>中的一个或多个脚本时出错（有些脚本可能会在服务器重新启动时启用）：%s
 	disable:
 		all:

--- a/src/main/resources/lang/turkish.lang
+++ b/src/main/resources/lang/turkish.lang
@@ -73,31 +73,31 @@ skript command:
 			enabling: Tüm script'ler aktif ediliyor...
 			enabled: Önceden devre dışı olan tüm script'ler başarıyla aktif edildi ve yüklendi.
 			error: <light red>Devre dışı script'ler yüklenirken <gold>%s <light red>adet hata ile karşılaşıldı!
-			io error: Bir veya daha fazla script yüklenemedi - bazı scriptler zaten yeniden adlandırılmış olabilir ve sunucu tekrar başlatılınca aktif edilecektir: %s
+			io error: <light red>Bir veya daha fazla script yüklenemedi - bazı scriptler zaten yeniden adlandırılmış olabilir ve sunucu tekrar başlatılınca aktif edilecektir: <gold>%s
 		single:
 			already enabled: <gold>%s<reset> zaten aktif! Değişiklikleri uygulamak için <gray>/<gold>skript <cyan>reload <red>%s<reset> komutunu kullanın.
 			enabling: <gold>%s<reset> aktif ediliyor...
 			enabled: <gold>%s<reset> başarıyla aktif edildi ve yüklendi.
 			error: <gold>%1$s<light red> yüklenirken <gold>%2$s <light red>adet hata ile karşılaşıldı!
-			io error: <gold>%s<red> aktif edilemedi: %s
+			io error: <gold>%s <light red>aktif edilemedi: <gold>%s
 		folder:
 			empty: <gold>%s<reset> devre dışı script içermiyor.
 			enabling: <gold>%1$s<reset> klasöründeki <gold>%2$s <reset>script aktif ediliyor...
 			enabled: <gold>%1$s<reset> klasöründeki önceden devre dışı olan <gold>%2$s<reset> başarıyla yüklendi ve aktifleştirildi.
 			error: <gold>%1$s<light red> klasöründeki script'ler yüklenirken <gold>%2$s <light red>tane hatayla karşılaşıldı!
-			io error: <gold>%s<red> klasöründeki bir veya daha fazla script aktif edilirken hatayla karşılaşıldı. (bazı script'ler sunucu tekrar başlatılınca aktifleşebilir): %s
+			io error: <gold>%s <light red>klasöründeki bir veya daha fazla script aktif edilirken hatayla karşılaşıldı. (bazı script'ler sunucu tekrar başlatılınca aktifleşebilir): <gold>%s
 	disable:
 		all:
 			disabled: Tüm script'ler devre dışı bırakıldı.
-			io error: Bir veya daha fazla script yeniden adlandırılamadı - bazı scriptler zaten yeniden adlandırılmış olabilir ve sunucu tekrar başlatılınca devre dışı bırakılacaktır: %s
+			io error: <light red>Bir veya daha fazla script yeniden adlandırılamadı - bazı scriptler zaten yeniden adlandırılmış olabilir ve sunucu tekrar başlatılınca devre dışı bırakılacaktır: <gold>%s
 		single:
 			already disabled: <gold>%s<reset> zaten devre dışı!
 			disabled: <gold>%s<reset> başarıyla devre dışı bırakıldı.
-			io error: <gold>%s<red> yeniden adlandırılamadı, sunucuyu tekrar başlattığında tekrar aktifleşecek: %s
+			io error: <gold>%s <light red>yeniden adlandırılamadı, sunucuyu tekrar başlattığında tekrar aktifleşecek: <gold>%s
 		folder:
 			empty: <gold>%s<reset> aktif script içermiyor.
 			disabled: <gold>%1$s<reset> klasöründeki <gold>%2$s<reset> script başarıyla devre dışı bırakıldı.
-			io error: <gold>%s<red> klasöründeki bir veya daha fazla script devre dışı bırakılamadı. (bazı script'ler sunucu tekrar başladığında devre dışı olabilir): %s
+			io error: <gold>%s <light red>klasöründeki bir veya daha fazla script devre dışı bırakılamadı. (bazı script'ler sunucu tekrar başladığında devre dışı olabilir): <gold>%s
 	update:
 		# check/download: see Updater
 		changes:

--- a/src/main/resources/lang/turkish.lang
+++ b/src/main/resources/lang/turkish.lang
@@ -72,19 +72,19 @@ skript command:
 		all:
 			enabling: Tüm script'ler aktif ediliyor...
 			enabled: Önceden devre dışı olan tüm script'ler başarıyla aktif edildi ve yüklendi.
-			error: Devre dışı script'ler yüklenirken %s adet hata ile karşılaşıldı!
+			error: <light red>Devre dışı script'ler yüklenirken <gold>%s <light red>adet hata ile karşılaşıldı!
 			io error: Bir veya daha fazla script yüklenemedi - bazı scriptler zaten yeniden adlandırılmış olabilir ve sunucu tekrar başlatılınca aktif edilecektir: %s
 		single:
 			already enabled: <gold>%s<reset> zaten aktif! Değişiklikleri uygulamak için <gray>/<gold>skript <cyan>reload <red>%s<reset> komutunu kullanın.
 			enabling: <gold>%s<reset> aktif ediliyor...
 			enabled: <gold>%s<reset> başarıyla aktif edildi ve yüklendi.
-			error: <gold>%1$s<red> yüklenirken %2$s adet hata ile karşılaşıldı!
+			error: <gold>%1$s<light red> yüklenirken <gold>%2$s <light red>adet hata ile karşılaşıldı!
 			io error: <gold>%s<red> aktif edilemedi: %s
 		folder:
 			empty: <gold>%s<reset> devre dışı script içermiyor.
 			enabling: <gold>%1$s<reset> klasöründeki <gold>%2$s <reset>script aktif ediliyor...
 			enabled: <gold>%1$s<reset> klasöründeki önceden devre dışı olan <gold>%2$s<reset> başarıyla yüklendi ve aktifleştirildi.
-			error: <gold>%1$s<red> klasöründeki script'ler yüklenirken %2$s tane hatayla karşılaşıldı!
+			error: <gold>%1$s<light red> klasöründeki script'ler yüklenirken <gold>%2$s <light red>tane hatayla karşılaşıldı!
 			io error: <gold>%s<red> klasöründeki bir veya daha fazla script aktif edilirken hatayla karşılaşıldı. (bazı script'ler sunucu tekrar başlatılınca aktifleşebilir): %s
 	disable:
 		all:


### PR DESCRIPTION
### Description

Went through all the lang files and added `<light red>` color code in error messages for `/sk enable` so that it matches `/sk reload`.
Note: I do not speak any of the other languages so I relied on the structure of the reload message and the usage of placeholders so there is a chance I might have ruined the sentences.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #5728  <!-- Links to related issues -->
