### PR TITLE
Fix AIIOB in Variable SET changer

### DIFF
--- a/src/main/java/ch/njol/skript/lang/Variable.java
+++ b/src/main/java/ch/njol/skript/lang/Variable.java
@@ -546,12 +546,11 @@ public class Variable<T> implements Expression<T> {
 						}
 						i++;
 					}
-				} else {
-					if (delta.length == 0) {
-						set(event, null);
-					} else {
-						set(event, delta[0]);
-					}
+				} else if (delta.length > 0) {
+					// if length = 0, likely a failure in casting
+					// (eg, set vector length of {_notvector} to 1, which casts delta to Vector[], resulting in an empty Vector array)
+					// so just do nothing.
+					set(event, delta[0]);
 				}
 				break;
 			case RESET:

--- a/src/main/java/ch/njol/skript/lang/Variable.java
+++ b/src/main/java/ch/njol/skript/lang/Variable.java
@@ -547,7 +547,11 @@ public class Variable<T> implements Expression<T> {
 						i++;
 					}
 				} else {
-					set(event, delta[0]);
+					if (delta.length == 0) {
+						set(event, null);
+					} else {
+						set(event, delta[0]);
+					}
 				}
 				break;
 			case RESET:

--- a/src/test/skript/tests/regressions/pull-6600-variable-set-changer-aiiob.sk
+++ b/src/test/skript/tests/regressions/pull-6600-variable-set-changer-aiiob.sk
@@ -1,0 +1,2 @@
+test "variable set aiiob":
+	set vector length of {_} to 1


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Variable's SET changer assumes that delta is either an array of length >=1 or null, and doesn't properly handle empty arrays in some cases. This adds a check for empty arrays, which then just ignores the set.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** https://github.com/SkriptLang/skript-reflect/issues/99 <!-- Links to related issues -->
