### PR TITLE
Only determine cache if needed

### DIFF
--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -240,9 +240,11 @@ public class SkriptParser {
 						}
 						if (parseResult != null) {
 							assert parseResult.source != null; // parse results from parse_i have a source
-							List<TypePatternElement> types = parseResult.source.getElements(TypePatternElement.class);
+							List<TypePatternElement> types = null;
 							for (int i = 0; i < parseResult.exprs.length; i++) {
 								if (parseResult.exprs[i] == null) {
+									if (types == null)
+										types = parseResult.source.getElements(TypePatternElement.class);;
 									ExprInfo exprInfo = types.get(i).getExprInfo();
 									if (!exprInfo.isOptional) {
 										DefaultExpression<?> expr = getDefaultExpression(exprInfo, info.patterns[patternIndex]);


### PR DESCRIPTION
### Description
Related to #6594

This PR updates the code in SkriptParser to only obtain the TypePatternElements cache (or calculate it if it is the first time) if the exprs array has a null value (that is, potentially has a default expression). This should prevent any unnecessary calls from being made.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
