### PR TITLE
Tests: Add Test Block Expression

### DIFF
--- a/src/main/java/ch/njol/skript/test/runner/ExprTestBlock.java
+++ b/src/main/java/ch/njol/skript/test/runner/ExprTestBlock.java
@@ -21,6 +21,7 @@ package ch.njol.skript.test.runner;
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.NoDoc;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/ch/njol/skript/test/runner/ExprTestBlock.java
+++ b/src/main/java/ch/njol/skript/test/runner/ExprTestBlock.java
@@ -31,8 +31,7 @@ import org.bukkit.block.Block;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
-@Name("Test Block")
-@Description("Returns the test block used by Skript's JUnit tests.")
+@NoDoc
 public class ExprTestBlock extends SimpleExpression<Block> {
 
 	static {

--- a/src/main/java/ch/njol/skript/test/runner/ExprTestBlock.java
+++ b/src/main/java/ch/njol/skript/test/runner/ExprTestBlock.java
@@ -30,9 +30,11 @@ import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.block.Block;
 import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 @NoDoc
+@Name("Test Block")
+@Description("Returns the test block used by Skript's JUnit tests.")
 public class ExprTestBlock extends SimpleExpression<Block> {
 
 	static {

--- a/src/main/java/ch/njol/skript/test/runner/ExprTestBlock.java
+++ b/src/main/java/ch/njol/skript/test/runner/ExprTestBlock.java
@@ -1,0 +1,68 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.test.runner;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.block.Block;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+@Name("Test Block")
+@Description("Returns the test block used by Skript's JUnit tests.")
+public class ExprTestBlock extends SimpleExpression<Block> {
+
+	static {
+		if (TestMode.ENABLED)
+			Skript.registerExpression(ExprTestBlock.class, Block.class, ExpressionType.SIMPLE, "[the] test block");
+	}
+
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		return true;
+	}
+
+	@Override
+	protected Block[] get(Event event) {
+		return CollectionUtils.array(SkriptJUnitTest.getBlock());
+	}
+
+	@Override
+	public boolean isSingle() {
+		return true;
+	}
+
+	@Override
+	public Class<? extends Block> getReturnType() {
+		return Block.class;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "test block";
+	}
+
+}


### PR DESCRIPTION
### Description
This PR adds the test block expression used by Skript's JUnit tests for ease of use in JUnit test scripts.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
