### PR TITLE
Some armour stand syntax

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondArmorStandExtremities.java
+++ b/src/main/java/ch/njol/skript/conditions/CondArmorStandExtremities.java
@@ -1,0 +1,76 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.conditions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Condition;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Armor Stand - Has Extremities")
+@Description("Allows users to check the extremities of an armor stand (i.e. whether it has arms or a base plate).")
+@Examples({
+	"send true if {_armorstand} has arms",
+	"if {_armorstand} has no base plate"
+})
+@Since("INSERT VERSION")
+public class CondArmorStandExtremities extends Condition {
+
+	static {
+		Skript.registerCondition(CondArmorStandExtremities.class,
+			"%livingentities% (has|have) [:no] (:arms|[a] base[ ]plate)"
+		);
+	}
+
+	@SuppressWarnings("NotNullFieldNotInitialized")
+	private Expression<LivingEntity> entities;
+	private boolean arms;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		entities = (Expression<LivingEntity>) exprs[0];
+		arms = parseResult.hasTag("arms");
+		setNegated(parseResult.hasTag("no"));
+		return true;
+	}
+
+	@Override
+	public boolean check(Event event) {
+		if (arms)
+			return entities.check(event,
+				stand -> stand instanceof ArmorStand && ((ArmorStand) stand).hasArms(), isNegated());
+		return entities.check(event,
+			stand -> stand instanceof ArmorStand && ((ArmorStand) stand).hasBasePlate(), isNegated());
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return entities.toString(event, debug) + " has " + (isNegated() ? "no " : "") + (arms ? "arms" : "base plate");
+	}
+}

--- a/src/main/java/ch/njol/skript/conditions/CondArmorStandProperties.java
+++ b/src/main/java/ch/njol/skript/conditions/CondArmorStandProperties.java
@@ -1,0 +1,98 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.conditions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Condition;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Armor Stand - Has Properties")
+@Description("Allows users to check the properties of an armor stand (i.e. whether its small, a marker, ticking, or moving).")
+@Examples({
+	"send true if {_armorstand} is small else false",
+	"if {_armorstand} isn't a marker:",
+	"if {_armorstands::*} is not ticking:",
+	"if {_armorstand} is moving:"
+})
+@Since("INSERT VERSION")
+public class CondArmorStandProperties extends Condition {
+
+	static {
+		Skript.registerCondition(CondArmorStandProperties.class,
+			"%livingentities% is[not: not|'nt] (0:small|1:a marker|2:ticking|3:moving)"
+		);
+	}
+
+	private static final int SMALL = 0;
+	private static final int MARKER = 1;
+	private static final int TICKING = 2;
+	private static final int MOVING = 3;
+
+	@SuppressWarnings("NotNullFieldNotInitialized")
+	private Expression<LivingEntity> entities;
+	private int property;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		entities = (Expression<LivingEntity>) exprs[0];
+		property = parseResult.mark;
+		setNegated(parseResult.hasTag("not"));
+		return true;
+	}
+
+	@Override
+	public boolean check(Event event) {
+		if (property == SMALL) {
+			return entities.check(event, stand -> stand instanceof ArmorStand && ((ArmorStand) stand).isSmall(), isNegated());
+		} else if (property == MARKER) {
+			return entities.check(event, stand -> stand instanceof ArmorStand && ((ArmorStand) stand).isMarker(), isNegated());
+		} else if (property == TICKING) {
+			return entities.check(event, stand -> stand instanceof ArmorStand && ((ArmorStand) stand).canTick(), isNegated());
+		} else if (property == MOVING) {
+			return entities.check(event, stand -> stand instanceof ArmorStand && ((ArmorStand) stand).canMove(), isNegated());
+		}
+		return false;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		String prop = "unknown property";
+		if (property == SMALL) {
+			prop = "small";
+		} else if (property == MARKER) {
+			prop = "a marker";
+		} else if (property == TICKING) {
+			prop = "ticking";
+		} else if (property == MOVING) {
+			prop = "moving";
+		}
+		return entities.toString(event, debug) + " is " + (isNegated() ? "not " : "") + prop;
+	}
+}

--- a/src/main/java/ch/njol/skript/effects/EffArmorStandExtremities.java
+++ b/src/main/java/ch/njol/skript/effects/EffArmorStandExtremities.java
@@ -1,0 +1,82 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Armor Stand - Extremities")
+@Description("Allows users to modify the extremities of an armor stand (i.e. whether its has arms or a base plate).")
+@Examples({
+	"show {_armorstand}'s arms",
+	"hide the base plate of {_armorstands::*}"
+})
+@Since("INSERT VERSION")
+public class EffArmorStandExtremities extends Effect {
+
+	static {
+		Skript.registerEffect(EffArmorStandExtremities.class,
+			"(:show|hide) %livingentities%'[s] (base[ ]plate|:arms)",
+			"(:show|hide) [the] (base[ ]plate|:arms) of %livingentities%"
+		);
+	}
+
+	private boolean show;
+	private boolean arms;
+	@SuppressWarnings("NotNullFieldNotInitialized")
+	private Expression<LivingEntity> entities;
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		entities = (Expression<LivingEntity>) exprs[0];
+		show = parseResult.hasTag("show");
+		arms = parseResult.hasTag("arms");
+		return true;
+	}
+
+	@Override
+	protected void execute(Event event) {
+		for (LivingEntity entity : entities.getArray(event)) {
+			if (entity instanceof ArmorStand) {
+				if (arms) {
+					((ArmorStand) entity).setArms(show);
+				} else {
+					((ArmorStand) entity).setBasePlate(show);
+				}
+			}
+		}
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return (show ? "show " : "hide ") + "the " + (arms ? "arms " : "base plate ") + "of " + entities.toString(event, debug);
+	}
+}

--- a/src/main/java/ch/njol/skript/effects/EffArmorStandProperties.java
+++ b/src/main/java/ch/njol/skript/effects/EffArmorStandProperties.java
@@ -1,0 +1,99 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.*;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Armor Stand - Properties")
+@Description("Allows users to modify properties of an armor stand (i.e. whether its small, a marker, ticking, or moving).")
+@Examples({
+	"make {_armorstand} small",
+	"make {_armorstand} a marker",
+	"make {_armorstands::*} stop ticking",
+	"make {_armorstand} stop moving"
+})
+@Since("INSERT VERSION")
+public class EffArmorStandProperties extends Effect {
+
+	static {
+		Skript.registerEffect(EffArmorStandProperties.class,
+			"make %livingentities% [not:(not|stop)] (0:small|1:a marker|2:tick[ing]|3:mov[e|ing])"
+		);
+	}
+
+	private static final int SMALL = 0;
+	private static final int MARKER = 1;
+	private static final int TICKING = 2;
+	private static final int MOVING = 3;
+
+	private boolean not;
+	private int property;
+	@SuppressWarnings("NotNullFieldNotInitialized")
+	private Expression<LivingEntity> entities;
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		entities = (Expression<LivingEntity>) exprs[0];
+		not = parseResult.hasTag("not");
+		property = parseResult.mark;
+		return true;
+	}
+
+	@Override
+	protected void execute(Event event) {
+		for (LivingEntity entity : entities.getArray(event)) {
+			if (entity instanceof ArmorStand) {
+				if (property == SMALL) {
+					((ArmorStand) entity).setSmall(!not);
+				} else if (property == MARKER) {
+					((ArmorStand) entity).setMarker(!not);
+				} else if (property == TICKING) {
+					((ArmorStand) entity).setCanTick(!not);
+				} else if (property == MOVING) {
+					((ArmorStand) entity).setCanMove(!not);
+				}
+			}
+		}
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		String prop = "unknown property";
+		if (property == SMALL) {
+			prop = "small";
+		} else if (property == MARKER) {
+			prop = "a marker";
+		} else if (property == TICKING) {
+			prop = "tick";
+		} else if (property == MOVING) {
+			prop = "move";
+		}
+		return "make " + entities.toString(event, debug) + (not ? " not " : " ") + prop;
+	}
+}


### PR DESCRIPTION
### Description
Adds some armour stand syntax. So far, this PR includes a couple of effects and conditions for extremities and properties (arms, base plate, size, marker, ticking, moving). Not super set on the patterns and some of the implementations (mainly just some pattern stuff and check methods in the conditions), so would love any feedback.

Still to do:
- Disabled slots
- Locked slots

Probably won't do in this PR, because I'm unsure how they work:
- Poses
- Rotations

---
**Target Minecraft Versions:** any (so far) <!-- 'any' means all supported versions -->
**Requirements:** none (so far, maybe Paper-only for some of the slot stuff yet to be added) <!-- Required plugins, server software... -->
**Related Issues:** #6597 <!-- Links to related issues -->
