### PR TITLE
CommandReloader - fix reload issue on paper

### DIFF
--- a/src/main/java/ch/njol/skript/bukkitutil/CommandReloader.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/CommandReloader.java
@@ -36,14 +36,10 @@ public class CommandReloader {
 	
 	static {
 		try {
-			Class<?> craftServer;
-			String revision = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
-			craftServer = Class.forName("org.bukkit.craftbukkit." + revision + ".CraftServer");
-			
-			syncCommandsMethod = craftServer.getDeclaredMethod("syncCommands");
+			syncCommandsMethod = Bukkit.getServer().getClass().getDeclaredMethod("syncCommands");
 			if (syncCommandsMethod != null)
 				syncCommandsMethod.setAccessible(true);
-		} catch (ClassNotFoundException | NoSuchMethodException e) {
+		} catch (NoSuchMethodException e) {
 			// Ignore except for debugging. This is not necessary or in any way supported functionality
 			if (Skript.debug())
 				e.printStackTrace();


### PR DESCRIPTION
### Description
This PR aims to update the reloader code for modern PaperMC servers.
Paper has removed the CB Relocation revision number for the packages. 
As it stands right now Skript fails to load command and/or allow for reloading on Paper 1.20.5.

---
**Target Minecraft Versions:** 1.20.5+
**Requirements:** none
**Related Issues:** none
