### PR TITLE
Allow multiple potential return types & defer expression type checking.

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/arithmetic/ExprArithmetic.java
+++ b/src/main/java/ch/njol/skript/expressions/arithmetic/ExprArithmetic.java
@@ -343,15 +343,8 @@ public class ExprArithmetic<L, R, T> extends SimpleExpression<T> {
 
 	@Override
 	public boolean canReturn(Class<?> returnType) {
-		if (this.returnType == Object.class) {
-			if (knownReturnTypes.contains(returnType))
-				return true;
-			for (Class<?> type : knownReturnTypes) {
-				if (returnType.isAssignableFrom(type))
-					return true;
-			}
-			return false;
-		}
+		if (this.returnType == Object.class && knownReturnTypes.contains(returnType))
+			return true;
 		return super.canReturn(returnType);
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/arithmetic/ExprArithmetic.java
+++ b/src/main/java/ch/njol/skript/expressions/arithmetic/ExprArithmetic.java
@@ -342,7 +342,7 @@ public class ExprArithmetic<L, R, T> extends SimpleExpression<T> {
 	}
 
 	@Override
-	public boolean mayReturn(Class<?> returnType) {
+	public boolean canReturn(Class<?> returnType) {
 		if (this.returnType == Object.class) {
 			if (knownReturnTypes.contains(returnType))
 				return true;
@@ -352,7 +352,7 @@ public class ExprArithmetic<L, R, T> extends SimpleExpression<T> {
 			}
 			return false;
 		}
-		return super.mayReturn(returnType);
+		return super.canReturn(returnType);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/arithmetic/ExprArithmetic.java
+++ b/src/main/java/ch/njol/skript/expressions/arithmetic/ExprArithmetic.java
@@ -43,7 +43,7 @@ import org.skriptlang.skript.lang.arithmetic.Operator;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Set;
 import java.util.List;
 import java.util.Collection;
 
@@ -253,10 +253,12 @@ public class ExprArithmetic<L, R, T> extends SimpleExpression<T> {
 			}
 			if (returnTypes == null) { // both are object; can't determine anything
 				returnType = (Class<? extends T>) Object.class;
+				knownReturnTypes = Arithmetics.getAllReturnTypes(operator);
 			} else if (returnTypes.length == 0) { // one of the classes is known but doesn't have any operations
 				return error(firstClass, secondClass);
 			} else {
 				returnType = (Class<? extends T>) Classes.getSuperClassInfo(returnTypes).getC();
+				knownReturnTypes = Set.of(returnTypes);
 			}
 		} else if (returnType == null) { // lookup
 			OperationInfo<L, R, T> operationInfo = (OperationInfo<L, R, T>) Arithmetics.lookupOperationInfo(operator, firstClass, secondClass);
@@ -307,10 +309,6 @@ public class ExprArithmetic<L, R, T> extends SimpleExpression<T> {
 		}
 
 		arithmeticGettable = ArithmeticChain.parse(chain);
-		if (returnType == Object.class) // get everything it might be
-			knownReturnTypes = Arithmetics.getAllReturnTypes(operator);
-		else
-			knownReturnTypes = Collections.emptySet();
 		return arithmeticGettable != null || error(firstClass, secondClass);
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/base/WrapperExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/WrapperExpression.java
@@ -153,8 +153,8 @@ public abstract class WrapperExpression<T> extends SimpleExpression<T> {
 	}
 
 	@Override
-	public boolean mayReturn(Class<?> returnType) {
-		return expr.mayReturn(returnType);
+	public boolean canReturn(Class<?> returnType) {
+		return expr.canReturn(returnType);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/base/WrapperExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/WrapperExpression.java
@@ -146,5 +146,15 @@ public abstract class WrapperExpression<T> extends SimpleExpression<T> {
 	public Object[] beforeChange(Expression<?> changed, @Nullable Object[] delta) {
 		return expr.beforeChange(changed, delta); // Forward to what we're wrapping
 	}
-	
+
+	@Override
+	public Class<? extends T>[] possibleReturnTypes() {
+		return expr.possibleReturnTypes();
+	}
+
+	@Override
+	public boolean mayReturn(Class<?> returnType) {
+		return expr.mayReturn(returnType);
+	}
+
 }

--- a/src/main/java/ch/njol/skript/lang/Expression.java
+++ b/src/main/java/ch/njol/skript/lang/Expression.java
@@ -192,7 +192,7 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	 * @param returnType The type to test
 	 * @return true if the argument is within the bounds of the return types
 	 */
-	default boolean mayReturn(Class<?> returnType) {
+	default boolean canReturn(Class<?> returnType) {
 		for (Class<?> type : this.possibleReturnTypes()) {
 			if (returnType.isAssignableFrom(type))
 				return true;

--- a/src/main/java/ch/njol/skript/lang/Expression.java
+++ b/src/main/java/ch/njol/skript/lang/Expression.java
@@ -184,11 +184,11 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	 */
 	default Class<? extends T>[] possibleReturnTypes() {
 		//noinspection unchecked
-		return new Class[]{this.getReturnType()};
+		return new Class[] {this.getReturnType()};
 	}
 
 	/**
-	 * Whether this expression *might* return the following type.
+	 * Whether this expression <b>might</b> return the following type.
 	 * @param returnType The type to test
 	 * @return true if the argument is within the bounds of the return types
 	 */

--- a/src/main/java/ch/njol/skript/lang/Expression.java
+++ b/src/main/java/ch/njol/skript/lang/Expression.java
@@ -176,6 +176,31 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	Class<? extends T> getReturnType();
 
 	/**
+	 * For expressions that might return multiple (incalculable at parse time) types,
+	 * this provides a list of all possible types.
+	 * Use cases include: expressions that depend on the return type of their input.
+	 *
+	 * @return A list of all possible types this might return
+	 */
+	default Class<? extends T>[] possibleReturnTypes() {
+		//noinspection unchecked
+		return new Class[]{this.getReturnType()};
+	}
+
+	/**
+	 * Whether this expression *might* return the following type.
+	 * @param returnType The type to test
+	 * @return true if the argument is within the bounds of the return types
+	 */
+	default boolean mayReturn(Class<?> returnType) {
+		for (Class<?> type : this.possibleReturnTypes()) {
+			if (returnType.isAssignableFrom(type))
+				return true;
+		}
+		return false;
+	}
+
+	/**
 	 * Returns true if this expression returns all possible values, false if it only returns some of them.
 	 * <p>
 	 * This method significantly influences {@link #check(Event, Checker)}, {@link #check(Event, Checker, boolean)} and {@link CondIsSet} and thus breaks conditions that use this

--- a/src/main/java/ch/njol/skript/lang/ExpressionList.java
+++ b/src/main/java/ch/njol/skript/lang/ExpressionList.java
@@ -43,6 +43,7 @@ public class ExpressionList<T> implements Expression<T> {
 
 	protected final Expression<? extends T>[] expressions;
 	private final Class<T> returnType;
+	private final Class<?>[] possibleReturnTypes;
 	protected boolean and;
 	private final boolean single;
 
@@ -53,10 +54,19 @@ public class ExpressionList<T> implements Expression<T> {
 		this(expressions, returnType, and, null);
 	}
 
+	public ExpressionList(Expression<? extends T>[] expressions, Class<T> returnType, Class<?>[] possibleReturnTypes, boolean and) {
+		this(expressions, returnType, possibleReturnTypes, and, null);
+	}
+
 	protected ExpressionList(Expression<? extends T>[] expressions, Class<T> returnType, boolean and, @Nullable ExpressionList<?> source) {
+		this(expressions, returnType, new Class[]{returnType}, and, source);
+	}
+
+	protected ExpressionList(Expression<? extends T>[] expressions, Class<T> returnType, Class<?>[] possibleReturnTypes, boolean and, @Nullable ExpressionList<?> source) {
 		assert expressions != null;
 		this.expressions = expressions;
 		this.returnType = returnType;
+		this.possibleReturnTypes = possibleReturnTypes;
 		this.and = and;
 		if (and) {
 			single = false;
@@ -178,12 +188,18 @@ public class ExpressionList<T> implements Expression<T> {
 				return null;
 			returnTypes[i] = exprs[i].getReturnType();
 		}
-		return new ExpressionList<>(exprs, (Class<R>) Classes.getSuperClassInfo(returnTypes).getC(), and, this);
+		return new ExpressionList<>(exprs, (Class<R>) Classes.getSuperClassInfo(returnTypes).getC(), returnTypes, and, this);
 	}
 
 	@Override
 	public Class<T> getReturnType() {
 		return returnType;
+	}
+
+	@Override
+	public Class<? extends T>[] possibleReturnTypes() {
+		//noinspection unchecked
+		return (Class<? extends T>[]) possibleReturnTypes;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/lang/LiteralList.java
+++ b/src/main/java/ch/njol/skript/lang/LiteralList.java
@@ -26,7 +26,7 @@ import java.lang.reflect.Array;
 
 /**
  * A list of literals. Can contain {@link UnparsedLiteral}s.
- * 
+ *
  * @author Peter Güttinger
  */
 public class LiteralList<T> extends ExpressionList<T> implements Literal<T> {
@@ -35,8 +35,16 @@ public class LiteralList<T> extends ExpressionList<T> implements Literal<T> {
 		super(literals, returnType, and);
 	}
 
+	public LiteralList(Literal<? extends T>[] literals, Class<T> returnType, Class<?>[] possibleReturnTypes, boolean and) {
+		super(literals, returnType, possibleReturnTypes, and);
+	}
+
 	public LiteralList(Literal<? extends T>[] literals, Class<T> returnType, boolean and, LiteralList<?> source) {
 		super(literals, returnType, and, source);
+	}
+
+	public LiteralList(Literal<? extends T>[] literals, Class<T> returnType, Class<?>[] possibleReturnTypes, boolean and, LiteralList<?> source) {
+		super(literals, returnType, possibleReturnTypes, and, source);
 	}
 
 	@Override
@@ -64,7 +72,7 @@ public class LiteralList<T> extends ExpressionList<T> implements Literal<T> {
 				return null;
 			returnTypes[i] = exprs[i].getReturnType();
 		}
-		return new LiteralList<>(exprs, (Class<R>) Classes.getSuperClassInfo(returnTypes).getC(), and, this);
+		return new LiteralList<>(exprs, (Class<R>) Classes.getSuperClassInfo(returnTypes).getC(), returnTypes, and, this);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -371,7 +371,7 @@ public class SkriptParser {
 				if (parsedExpression != null) { // Expression/VariableString parsing success
 					for (Class<? extends T> type : types) {
 						// Check return type against everything that expression accepts
-						if (type.isAssignableFrom(parsedExpression.getReturnType())) {
+						if (parsedExpression.mayReturn(type)) {
 							log.printLog();
 							return (Expression<? extends T>) parsedExpression;
 						}
@@ -541,17 +541,13 @@ public class SkriptParser {
 			if ((flags & PARSE_EXPRESSIONS) != 0) {
 				Expression<?> parsedExpression = parseExpression(types, expr);
 				if (parsedExpression != null) { // Expression/VariableString parsing success
-					Class<?> returnType = parsedExpression.getReturnType(); // Sometimes getReturnType does non-trivial costly operations
-					if (returnType == null)
-						throw new SkriptAPIException("Expression '" + expr + "' returned null for method Expression#getReturnType. Null is not a valid return.");
-
 					for (int i = 0; i < types.length; i++) {
 						Class<?> type = types[i];
 						if (type == null) // Ignore invalid (null) types
 							continue;
 
 						// Check return type against everything that expression accepts
-						if (type.isAssignableFrom(returnType)) {
+						if (parsedExpression.mayReturn(type)) {
 							if (!exprInfo.isPlural[i] && !parsedExpression.isSingle()) { // Wrong number of arguments
 								if (context == ParseContext.COMMAND) {
 									Skript.error(Commands.m_too_many_arguments.toString(exprInfo.classes[i].getName().getIndefiniteArticle(), exprInfo.classes[i].getName().toString()), ErrorQuality.SEMANTIC_ERROR);

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -57,7 +57,6 @@ import org.skriptlang.skript.lang.script.ScriptWarning;
 
 import java.util.ArrayList;
 import java.util.Deque;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -371,7 +370,7 @@ public class SkriptParser {
 				if (parsedExpression != null) { // Expression/VariableString parsing success
 					for (Class<? extends T> type : types) {
 						// Check return type against everything that expression accepts
-						if (parsedExpression.mayReturn(type)) {
+						if (parsedExpression.canReturn(type)) {
 							log.printLog();
 							return (Expression<? extends T>) parsedExpression;
 						}
@@ -547,7 +546,7 @@ public class SkriptParser {
 							continue;
 
 						// Check return type against everything that expression accepts
-						if (parsedExpression.mayReturn(type)) {
+						if (parsedExpression.canReturn(type)) {
 							if (!exprInfo.isPlural[i] && !parsedExpression.isSingle()) { // Wrong number of arguments
 								if (context == ParseContext.COMMAND) {
 									Skript.error(Commands.m_too_many_arguments.toString(exprInfo.classes[i].getName().getIndefiniteArticle(), exprInfo.classes[i].getName().toString()), ErrorQuality.SEMANTIC_ERROR);

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -75,7 +75,7 @@ import java.util.stream.Stream;
  * Used for parsing my custom patterns.<br>
  * <br>
  * Note: All parse methods print one error at most xor any amount of warnings and lower level log messages. If the given string doesn't match any pattern then nothing is printed.
- * 
+ *
  * @author Peter Güttinger
  */
 public class SkriptParser {
@@ -101,7 +101,7 @@ public class SkriptParser {
 	 * Constructs a new SkriptParser object that can be used to parse the given expression.
 	 * <p>
 	 * A SkriptParser can be re-used indefinitely for the given expression, but to parse a new expression a new SkriptParser has to be created.
-	 * 
+	 *
 	 * @param expr The expression to parse
 	 * @param flags Some parse flags ({@link #PARSE_EXPRESSIONS}, {@link #PARSE_LITERALS})
 	 * @param context The parse context
@@ -747,11 +747,15 @@ public class SkriptParser {
 			exprReturnTypes[i] = parsedExpressions.get(i).getReturnType();
 
 		if (isLiteralList) {
-			Literal<T>[] literals = parsedExpressions.toArray(new Literal[parsedExpressions.size()]);
-			return new LiteralList<>(literals, (Class<T>) Classes.getSuperClassInfo(exprReturnTypes).getC(), !and.isFalse());
+			//noinspection unchecked,SuspiciousToArrayCall
+			Literal<T>[] literals = parsedExpressions.toArray(new Literal[0]);
+			//noinspection unchecked
+			return new LiteralList<>(literals, (Class<T>) Classes.getSuperClassInfo(exprReturnTypes).getC(), exprReturnTypes, !and.isFalse());
 		} else {
-			Expression<T>[] expressions = parsedExpressions.toArray(new Expression[parsedExpressions.size()]);
-			return new ExpressionList<>(expressions, (Class<T>) Classes.getSuperClassInfo(exprReturnTypes).getC(), !and.isFalse());
+			//noinspection unchecked
+			Expression<T>[] expressions = parsedExpressions.toArray(new Expression[0]);
+			//noinspection unchecked
+			return new ExpressionList<>(expressions, (Class<T>) Classes.getSuperClassInfo(exprReturnTypes).getC(), exprReturnTypes, !and.isFalse());
 		}
 	}
 
@@ -880,10 +884,10 @@ public class SkriptParser {
 
 			if (isLiteralList) {
 				Literal<?>[] literals = parsedExpressions.toArray(new Literal[parsedExpressions.size()]);
-				return new LiteralList(literals, Classes.getSuperClassInfo(exprReturnTypes).getC(), !and.isFalse());
+				return new LiteralList(literals, Classes.getSuperClassInfo(exprReturnTypes).getC(), exprReturnTypes, !and.isFalse());
 			} else {
 				Expression<?>[] expressions = parsedExpressions.toArray(new Expression[parsedExpressions.size()]);
-				return new ExpressionList(expressions, Classes.getSuperClassInfo(exprReturnTypes).getC(), !and.isFalse());
+				return new ExpressionList(expressions, Classes.getSuperClassInfo(exprReturnTypes).getC(), exprReturnTypes, !and.isFalse());
 
 			}
 		} finally {
@@ -1019,7 +1023,7 @@ public class SkriptParser {
 
 	/**
 	 * Finds the closing bracket of the group at <tt>start</tt> (i.e. <tt>start</tt> has to be <i>in</i> a group).
-	 * 
+	 *
 	 * @param pattern The string to search in
 	 * @param closingBracket The bracket to look for, e.g. ')'
 	 * @param openingBracket A bracket that opens another group, e.g. '('
@@ -1070,7 +1074,7 @@ public class SkriptParser {
 
 	/**
 	 * Counts how often the given character occurs in the given string, ignoring any escaped occurrences of the character.
-	 * 
+	 *
 	 * @param haystack The string to search in
 	 * @param needle The character to search for
 	 * @return The number of unescaped occurrences of the given character
@@ -1105,7 +1109,7 @@ public class SkriptParser {
 
 	/**
 	 * Find the next unescaped (i.e. single) double quote in the string.
-	 * 
+	 *
 	 * @param string The string to search in
 	 * @param start Index after the starting quote
 	 * @return Index of the end quote
@@ -1176,7 +1180,7 @@ public class SkriptParser {
 	 * Returns the next character in the expression, skipping strings,
 	 * variables and parentheses
 	 * (unless {@code context} is {@link ParseContext#COMMAND} or {@link ParseContext#PARSE}).
-	 * 
+	 *
 	 * @param expr The expression to traverse.
 	 * @param startIndex The index to start at.
 	 * @return The next index (can be expr.length()), or -1 if
@@ -1294,7 +1298,7 @@ public class SkriptParser {
 
 	/**
 	 * Validates a user-defined pattern (used in {@link ExprParse}).
-	 * 
+	 *
 	 * @param pattern The pattern string to validate
 	 * @return The pattern with %codenames% and a boolean array that contains whether the expressions are plural or not
 	 */

--- a/src/main/java/ch/njol/skript/lang/util/ConvertedExpression.java
+++ b/src/main/java/ch/njol/skript/lang/util/ConvertedExpression.java
@@ -43,7 +43,7 @@ import java.util.NoSuchElementException;
  * <li>automatically lets the source expression handle everything apart from the get() methods</li>
  * <li>will never convert itself to another type, but rather request a new converted expression from the source expression.</li>
  * </ol>
- * 
+ *
  * @author Peter Güttinger
  */
 public class ConvertedExpression<F, T> implements Expression<T> {
@@ -73,7 +73,7 @@ public class ConvertedExpression<F, T> implements Expression<T> {
 			// casting <? super ? extends F> to <? super F> is wrong, but since the converter is only used for values returned by the expression
 			// (which are instances of "<? extends F>") this won't result in any ClassCastExceptions.
 			for (Class<? extends F> checking : from.possibleReturnTypes()) {
-				@SuppressWarnings("unchecked")
+				//noinspection unchecked
 				ConverterInfo<? super F, ? extends T> conv = (ConverterInfo<? super F, ? extends T>) Converters.getConverterInfo(checking, type);
 				if (conv == null)
 					continue;

--- a/src/main/java/ch/njol/skript/lang/util/ConvertedExpression.java
+++ b/src/main/java/ch/njol/skript/lang/util/ConvertedExpression.java
@@ -33,8 +33,13 @@ import org.skriptlang.skript.lang.converter.Converter;
 import org.skriptlang.skript.lang.converter.ConverterInfo;
 import org.skriptlang.skript.lang.converter.Converters;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
 
 /**
  * Represents a expression converted to another type. This, and not Expression, is the required return type of {@link SimpleExpression#getConvertedExpr(Class...)} because this
@@ -55,30 +60,59 @@ public class ConvertedExpression<F, T> implements Expression<T> {
 	/**
 	 * Converter information.
 	 */
-	private final ConverterInfo<? super F, ? extends T> converterInfo;
+	private final Collection<ConverterInfo<? super F, ? extends T>> converterInfos;
 
 	public ConvertedExpression(Expression<? extends F> source, Class<T> to, ConverterInfo<? super F, ? extends T> info) {
 		this.source = source;
 		this.to = to;
 		this.converter = info.getConverter();
-		this.converterInfo = info;
+		this.converterInfos = Collections.singleton(info);
+	}
+
+	/**
+	 * @param source The expression to use for obtaining values
+	 * @param to The type we are converting to
+	 * @param infos A collection of converters to attempt
+	 * @param performFromCheck Whether a safety check should be performed to ensure that objects being converted
+	 *  are valid for the converter being attempted
+	 */
+	public ConvertedExpression(Expression<? extends F> source, Class<T> to, Collection<ConverterInfo<? super F, ? extends T>> infos, boolean performFromCheck) {
+		this.source = source;
+		this.to = to;
+		this.converterInfos = infos;
+		this.converter = fromObject -> {
+			for (ConverterInfo<? super F, ? extends T> info : converterInfos) {
+				if (!performFromCheck || info.getFrom().isInstance(fromObject)) { // the converter is safe to attempt
+					T converted = info.getConverter().convert(fromObject);
+					if (converted != null)
+						return converted;
+				}
+			}
+			return null;
+		};
 	}
 
 	@SafeVarargs
 	@Nullable
 	public static <F, T> ConvertedExpression<F, T> newInstance(Expression<F> from, Class<T>... to) {
 		assert !CollectionUtils.containsSuperclass(to, from.getReturnType());
+		// we track a list of converters that may work
+		List<ConverterInfo<? super F, ? extends T>> converters = new ArrayList<>();
 		for (Class<T> type : to) { // REMIND try more converters? -> also change WrapperExpression (and maybe ExprLoopValue)
 			assert type != null;
 			// casting <? super ? extends F> to <? super F> is wrong, but since the converter is only used for values returned by the expression
 			// (which are instances of "<? extends F>") this won't result in any ClassCastExceptions.
 			for (Class<? extends F> checking : from.possibleReturnTypes()) {
 				//noinspection unchecked
-				ConverterInfo<? super F, ? extends T> conv = (ConverterInfo<? super F, ? extends T>) Converters.getConverterInfo(checking, type);
-				if (conv == null)
-					continue;
-				return new ConvertedExpression<>(from, type, conv);
+				ConverterInfo<? super F, ? extends T> converter = (ConverterInfo<? super F, ? extends T>) Converters.getConverterInfo(checking, type);
+				if (converter != null)
+					converters.add(converter);
 			}
+			int size = converters.size();
+			if (size == 1) // if there is only one info, there is no need to wrap it in a list
+				return new ConvertedExpression<>(from, type, converters.get(0));
+			if (size > 1)
+				return new ConvertedExpression<>(from, type, converters, true);
 		}
 		return null;
 	}
@@ -92,7 +126,7 @@ public class ConvertedExpression<F, T> implements Expression<T> {
 	public String toString(@Nullable Event event, boolean debug) {
 		if (debug && event == null)
 			return "(" + source.toString(event, debug) + " >> " + converter + ": "
-				+ converterInfo + ")";
+				+ converterInfos.stream().map(Object::toString).collect(Collectors.joining(", ")) + ")";
 		return source.toString(event, debug);
 	}
 

--- a/src/main/java/ch/njol/skript/lang/util/ConvertedExpression.java
+++ b/src/main/java/ch/njol/skript/lang/util/ConvertedExpression.java
@@ -72,11 +72,13 @@ public class ConvertedExpression<F, T> implements Expression<T> {
 			assert type != null;
 			// casting <? super ? extends F> to <? super F> is wrong, but since the converter is only used for values returned by the expression
 			// (which are instances of "<? extends F>") this won't result in any ClassCastExceptions.
-			@SuppressWarnings("unchecked")
-			ConverterInfo<? super F, ? extends T> conv = (ConverterInfo<? super F, ? extends T>) Converters.getConverterInfo(from.getReturnType(), type);
-			if (conv == null)
-				continue;
-			return new ConvertedExpression<>(from, type, conv);
+			for (Class<? extends F> checking : from.possibleReturnTypes()) {
+				@SuppressWarnings("unchecked")
+				ConverterInfo<? super F, ? extends T> conv = (ConverterInfo<? super F, ? extends T>) Converters.getConverterInfo(checking, type);
+				if (conv == null)
+					continue;
+				return new ConvertedExpression<>(from, type, conv);
+			}
 		}
 		return null;
 	}

--- a/src/main/java/ch/njol/skript/lang/util/SimpleExpression.java
+++ b/src/main/java/ch/njol/skript/lang/util/SimpleExpression.java
@@ -200,8 +200,10 @@ public abstract class SimpleExpression<T> implements Expression<T> {
 	@Nullable
 	@SuppressWarnings("unchecked")
 	public <R> Expression<? extends R> getConvertedExpression(Class<R>... to) {
-		if (CollectionUtils.containsSuperclass(to, getReturnType()))
-			return (Expression<? extends R>) this;
+		for (Class<? extends T> type : this.possibleReturnTypes()) {
+			if (CollectionUtils.containsSuperclass(to, type))
+				return (Expression<? extends R>) this;
+		}
 		return this.getConvertedExpr(to);
 	}
 

--- a/src/main/java/ch/njol/skript/lang/util/SimpleExpression.java
+++ b/src/main/java/ch/njol/skript/lang/util/SimpleExpression.java
@@ -35,10 +35,13 @@ import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.skriptlang.skript.lang.converter.Converter;
+import org.skriptlang.skript.lang.converter.ConverterInfo;
 
 import java.lang.reflect.Array;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * An implementation of the {@link Expression} interface. You should usually extend this class to make a new expression.
@@ -200,10 +203,36 @@ public abstract class SimpleExpression<T> implements Expression<T> {
 	@Nullable
 	@SuppressWarnings("unchecked")
 	public <R> Expression<? extends R> getConvertedExpression(Class<R>... to) {
+		// check whether this expression is already of type R
+		if (CollectionUtils.containsSuperclass(to, getReturnType()))
+			return (Expression<? extends R>) this;
+
+		// we might be to cast some of the possible return types to R
+		List<ConverterInfo<? extends T, R>> infos = new ArrayList<>();
 		for (Class<? extends T> type : this.possibleReturnTypes()) {
-			if (CollectionUtils.containsSuperclass(to, type))
-				return (Expression<? extends R>) this;
+			if (CollectionUtils.containsSuperclass(to, type)) { // this type is of R
+				// build a converter that for casting to R
+				// safety check is present in the event that we do not get this type at runtime
+				final Class<R> toType = (Class<R>) type;
+				infos.add(new ConverterInfo<>(getReturnType(), toType, fromObject -> {
+					if (toType.isInstance(fromObject))
+						return (R) fromObject;
+					return null;
+				}, 0));
+			}
 		}
+		int size = infos.size();
+		if (size == 1) { // if there is only one info, there is no need to wrap it in a list
+			ConverterInfo<? extends T, R> info = infos.get(0);
+			//noinspection rawtypes
+			return new ConvertedExpression(this, info.getTo(), info);
+		}
+		if (size > 1) {
+			//noinspection rawtypes
+			return new ConvertedExpression(this, Utils.getSuperType(infos.stream().map(ConverterInfo::getTo).toArray(Class[]::new)), infos, false);
+		}
+
+		// attempt traditional conversion with proper converters
 		return this.getConvertedExpr(to);
 	}
 

--- a/src/main/java/ch/njol/skript/util/LiteralUtils.java
+++ b/src/main/java/ch/njol/skript/util/LiteralUtils.java
@@ -53,7 +53,7 @@ public class LiteralUtils {
 				newExpressions[i] = LiteralUtils.defendExpression(oldExpressions[i]);
 				returnTypes[i] = newExpressions[i].getReturnType();
 			}
-			return new ExpressionList<>(newExpressions, (Class<T>) Classes.getSuperClassInfo(returnTypes).getC(), expr.getAnd());
+			return new ExpressionList<>(newExpressions, (Class<T>) Classes.getSuperClassInfo(returnTypes).getC(), returnTypes, expr.getAnd());
 		} else if (expr instanceof UnparsedLiteral) {
 			Literal<?> parsedLiteral = ((UnparsedLiteral) expr).getConvertedExpression(Object.class);
 			return (Expression<T>) (parsedLiteral == null ? expr : parsedLiteral);

--- a/src/main/java/org/skriptlang/skript/lang/arithmetic/Arithmetics.java
+++ b/src/main/java/org/skriptlang/skript/lang/arithmetic/Arithmetics.java
@@ -29,6 +29,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Collection;
+import java.util.Set;
+import java.util.HashSet;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -264,6 +267,21 @@ public final class Arithmetics {
 	private static void assertIsOperationsDoneLoading() {
 		if (Skript.isAcceptRegistrations())
 			throw new SkriptAPIException("Operations cannot be retrieved until Skript has finished registrations.");
+	}
+
+	/**
+	 * All registered types that could be returned from a calculation using this operator.
+	 * This is used to fetch potential return types when unknown (variable) arguments are used in a sum.
+	 *
+	 * @param operator The operator to test
+	 * @return Every type this could return
+	 */
+	public static Collection<Class<?>> getAllReturnTypes(Operator operator) {
+		Set<Class<?>> types = new HashSet<>();
+		for (OperationInfo<?, ?, ?> info : getOperations_i(operator)) {
+			types.add(info.getReturnType());
+		}
+		return types;
 	}
 
 }

--- a/src/test/skript/tests/regressions/6623-wrong parsing order for math.sk
+++ b/src/test/skript/tests/regressions/6623-wrong parsing order for math.sk
@@ -7,7 +7,7 @@ test "wrong parsing order for math in object expr":
 	assert {_result} is set with "add result not calculated"
 	delete {_result}
 
-	set {_result} to health of {_e} / max health of {_e} # used to be parsed as `health of ({z} + max health of {z})`
+	set {_result} to health of {_e} / max health of {_e} # used to be parsed as `health of ({_e} / max health of {_e})`
 	assert {_result} is set with "divide result not calculated"
 
 	delete the last spawned zombie

--- a/src/test/skript/tests/regressions/6623-wrong parsing order for math.sk
+++ b/src/test/skript/tests/regressions/6623-wrong parsing order for math.sk
@@ -1,0 +1,13 @@
+
+test "wrong parsing order for math in object expr":
+	spawn a zombie at spawn of world "world"
+	set {_e} to the last spawned zombie
+
+	set {_result} to health of {_e} + max health of {_e}
+	assert {_result} is set with "add result not calculated"
+	delete {_result}
+
+	set {_result} to health of {_e} / max health of {_e}
+	assert {_result} is set with "divide result not calculated"
+
+	delete the last spawned zombie

--- a/src/test/skript/tests/regressions/6623-wrong parsing order for math.sk
+++ b/src/test/skript/tests/regressions/6623-wrong parsing order for math.sk
@@ -3,11 +3,11 @@ test "wrong parsing order for math in object expr":
 	spawn a zombie at spawn of world "world"
 	set {_e} to the last spawned zombie
 
-	set {_result} to health of {_e} + max health of {_e} # used to be parsed as `health of ({z} + max health of {z})`
+	set {_result} to health of {_e} + max health of {_e}
 	assert {_result} is set with "add result not calculated"
 	delete {_result}
 
-	set {_result} to health of {_e} / max health of {_e}
+	set {_result} to health of {_e} / max health of {_e} # used to be parsed as `health of ({z} + max health of {z})`
 	assert {_result} is set with "divide result not calculated"
 
 	delete the last spawned zombie

--- a/src/test/skript/tests/regressions/6623-wrong parsing order for math.sk
+++ b/src/test/skript/tests/regressions/6623-wrong parsing order for math.sk
@@ -3,7 +3,7 @@ test "wrong parsing order for math in object expr":
 	spawn a zombie at spawn of world "world"
 	set {_e} to the last spawned zombie
 
-	set {_result} to health of {_e} + max health of {_e}
+	set {_result} to health of {_e} + max health of {_e} # used to be parsed as `health of ({z} + max health of {z})`
 	assert {_result} is set with "add result not calculated"
 	delete {_result}
 

--- a/src/test/skript/tests/regressions/6623-wrong parsing order for math.sk
+++ b/src/test/skript/tests/regressions/6623-wrong parsing order for math.sk
@@ -1,4 +1,3 @@
-
 test "wrong parsing order for math in object expr":
 	spawn a zombie at spawn of world "world"
 	set {_e} to the last spawned zombie


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Fixes weird parse error from converted object return types.

`send health of {z} / max health of {z}` was originally interpreted as `send health of ({z} / max health of {z})` since the arithmetic has an Object return type, which is vacuously convertible to LivingEntity.

This change does several things:
1. Expressions can now return an array of multiple _possible_ return types (by default this is an array of the `getReturnType()`)
2. Expressions now have authority over whether something is a valid return type of theirs (by default this checks if it's assignable to one of the possible types)
3. Parser (and converted expressions) now use this method

This now means that: 1. fewer things are converted (when they don't need to be) 2. things are less likely to attempt a conversion when it's inconceivable for it to be correct.

**Note**: there should be no breaking changes for any existing syntax.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** fixes #6623 <!-- Links to related issues -->
