### PR TITLE
Cleaning ExprDirection patterns

### DIFF
--- a/.github/workflows/docs/setup-docs/action.yml
+++ b/.github/workflows/docs/setup-docs/action.yml
@@ -26,7 +26,7 @@ runs:
         ssh-key: ${{ inputs.docs_deploy_key }}
     - uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'adopt'
         cache: gradle
     - shell: bash

--- a/.github/workflows/java-17-builds.yml
+++ b/.github/workflows/java-17-builds.yml
@@ -1,4 +1,4 @@
-name: Java 17 CI (MC 1.17+)
+name: Java 17 CI (MC 1.17-1.20.4)
 
 on:
     push:
@@ -17,10 +17,10 @@ jobs:
                   submodules: recursive
             - name: validate gradle wrapper
               uses: gradle/wrapper-validation-action@v2
-            - name: Set up JDK 17
-              uses: actions/setup-java@v3
+            - name: Set up JDK 21
+              uses: actions/setup-java@v4
               with:
-                  java-version: '17'
+                  java-version: '21'
                   distribution: 'adopt'
                   cache: gradle
             - name: Grant execute permission for gradlew

--- a/.github/workflows/java-21-builds.yml
+++ b/.github/workflows/java-21-builds.yml
@@ -1,4 +1,4 @@
-name: Java 8 CI (MC 1.13-1.16)
+name: Java 21 CI (MC 1.20.6+)
 
 on:
     push:
@@ -26,7 +26,7 @@ jobs:
             - name: Grant execute permission for gradlew
               run: chmod +x gradlew
             - name: Build Skript and run test scripts
-              run: ./gradlew clean skriptTestJava8
+              run: ./gradlew clean skriptTestJava21
             - name: Upload Nightly Build
               uses: actions/upload-artifact@v4
               if: success()

--- a/.github/workflows/junit-17-builds.yml
+++ b/.github/workflows/junit-17-builds.yml
@@ -1,4 +1,4 @@
-name: JUnit (MC 1.17+)
+name: JUnit (MC 1.17-1.20.4)
 
 on:
     push:
@@ -17,10 +17,10 @@ jobs:
                   submodules: recursive
             - name: validate gradle wrapper
               uses: gradle/wrapper-validation-action@v2
-            - name: Set up JDK 17
+            - name: Set up JDK 21
               uses: actions/setup-java@v4
               with:
-                  java-version: '17'
+                  java-version: '21'
                   distribution: 'adopt'
                   cache: gradle
             - name: Grant execute permission for gradlew

--- a/.github/workflows/junit-21-builds.disabled
+++ b/.github/workflows/junit-21-builds.disabled
@@ -1,4 +1,6 @@
-name: Java 8 CI (MC 1.13-1.16)
+# Disabled as EasyMock 5.2.0 is required for Java 21 support
+# However, we are currently using 5.0.1 (see https://github.com/SkriptLang/Skript/pull/6204#discussion_r1405302009)
+name: JUnit (MC 1.20.6+)
 
 on:
     push:
@@ -25,11 +27,5 @@ jobs:
                   cache: gradle
             - name: Grant execute permission for gradlew
               run: chmod +x gradlew
-            - name: Build Skript and run test scripts
-              run: ./gradlew clean skriptTestJava8
-            - name: Upload Nightly Build
-              uses: actions/upload-artifact@v4
-              if: success()
-              with:
-                  name: skript-nightly
-                  path: build/libs/*
+            - name: Build Skript and run JUnit
+              run: ./gradlew clean JUnitJava21

--- a/.github/workflows/junit-8-builds.yml
+++ b/.github/workflows/junit-8-builds.yml
@@ -17,10 +17,10 @@ jobs:
                   submodules: recursive
             - name: validate gradle wrapper
               uses: gradle/wrapper-validation-action@v2
-            - name: Set up JDK 17
+            - name: Set up JDK 21
               uses: actions/setup-java@v4
               with:
-                  java-version: '17'
+                  java-version: '21'
                   distribution: 'adopt'
                   cache: gradle
             - name: Grant execute permission for gradlew

--- a/.github/workflows/repo.yml
+++ b/.github/workflows/repo.yml
@@ -13,10 +13,10 @@ jobs:
                   submodules: recursive
             - name: validate gradle wrapper
               uses: gradle/wrapper-validation-action@v2
-            - name: Set up JDK 17
+            - name: Set up JDK 21
               uses: actions/setup-java@v4
               with:
-                  java-version: '17'
+                  java-version: '21'
                   distribution: 'adopt'
                   cache: gradle
             - name: Publish Skript

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "skript-aliases"]
 	path = skript-aliases
 	url = https://github.com/SkriptLang/skript-aliases
+	branch = patch/1.20.5-support

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "skript-aliases"]
 	path = skript-aliases
 	url = https://github.com/SkriptLang/skript-aliases
-	branch = patch/1.20.5-support

--- a/README.md
+++ b/README.md
@@ -77,13 +77,15 @@ Skript has some tests written in Skript. Running them requires a Minecraft
 server, but our build script will create one for you. Running the tests is easy:
 
 ```
-./gradlew (quickTest|skriptTest|skriptTestJava8|skriptTestJava21)
+./gradlew (quickTest|skriptTest|skriptTestJava8|skriptTestJava17|skriptTestJava21)
 ```
 
 <code>quickTest</code> runs the test suite on newest supported server version.
-<code>skriptTestJava21</code> (1.17+) runs the tests on the latest supported Java version.
-<code>skriptTestJava8</code> (1.13-1.16) runs the tests on the oldest supported Java version.
-<code>skriptTest</code> runs both skriptTestJava8 and skriptTestJava21
+<code>skriptTestJava21</code> (1.20.6+) runs the tests on Java 21 supported versions.
+<code>skriptTestJava17</code> (1.17-1.20.4) runs the tests on Java 17 supported versions.
+<code>skriptTestJava8</code> (1.13-1.16) runs the tests on Java 8 supported versions.
+<code>skriptTest</code> runs the tests on all versions.
+That is, it runs skriptTestJava8, skriptTestJava17, and skriptTestJava21.
 
 By running the tests, you agree to Mojang's End User License Agreement.
 

--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ Skript has some tests written in Skript. Running them requires a Minecraft
 server, but our build script will create one for you. Running the tests is easy:
 
 ```
-./gradlew (quickTest|skriptTest|skriptTestJava8|skriptTestJava17)
+./gradlew (quickTest|skriptTest|skriptTestJava8|skriptTestJava21)
 ```
 
 <code>quickTest</code> runs the test suite on newest supported server version.
-<code>skriptTestJava17</code> (1.17+) runs the tests on the latest supported Java version.
+<code>skriptTestJava21</code> (1.17+) runs the tests on the latest supported Java version.
 <code>skriptTestJava8</code> (1.13-1.16) runs the tests on the oldest supported Java version.
-<code>skriptTest</code> runs both skriptTestJava8 and skriptTestJava17
+<code>skriptTest</code> runs both skriptTestJava8 and skriptTestJava21
 
 By running the tests, you agree to Mojang's End User License Agreement.
 

--- a/build.gradle
+++ b/build.gradle
@@ -62,12 +62,12 @@ task testJar(type: ShadowJar) {
 
 task jar(overwrite: true, type: ShadowJar) {
 	dependsOn checkAliases
-	archiveFileName = jarName ? 'Skript.jar' : jarName
+	archiveFileName = jarName ? 'Skript-' + project.version + '.jar' : jarName
 	from sourceSets.main.output
 }
 
 task build(overwrite: true, type: ShadowJar) {
-	archiveFileName = jarName ? 'Skript.jar' : jarName
+	archiveFileName = jarName ? 'Skript-' + project.version + '.jar' : jarName
 	from sourceSets.main.output
 }
 
@@ -325,7 +325,7 @@ task githubResources(type: ProcessResources) {
 task githubRelease(type: ShadowJar) {
 	from sourceSets.main.output
 	dependsOn githubResources
-	archiveFileName = 'Skript-github.jar'
+	archiveFileName = 'Skript-' + version +'.jar'
 	manifest {
 		attributes(
 			'Name': 'ch/njol/skript',

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ allprojects {
 		maven { url 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/' }
 		maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
 		maven { url 'https://repo.papermc.io/repository/maven-public/' }
+		maven { url = 'https://s01.oss.sonatype.org/content/repositories/snapshots/' } // needed for paper adventure snapshot
 		maven { url 'https://ci.emc.gs/nexus/content/groups/aikar/' }
 	}
 }
@@ -29,7 +30,7 @@ dependencies {
 	shadow group: 'org.bstats', name: 'bstats-bukkit', version: '3.0.2'
 	shadow group: 'net.kyori', name: 'adventure-text-serializer-bungeecord', version: '4.3.2'
 
-	implementation group: 'io.papermc.paper', name: 'paper-api', version: '1.20.4-R0.1-SNAPSHOT'
+	implementation group: 'io.papermc.paper', name: 'paper-api', version: '1.20.6-R0.1-SNAPSHOT'
 	implementation group: 'org.eclipse.jdt', name: 'org.eclipse.jdt.annotation', version: '2.2.700'
 	implementation group: 'com.google.code.findbugs', name: 'findbugs', version: '3.0.1'
 	implementation group: 'com.sk89q.worldguard', name: 'worldguard-legacy', version: '7.0.0-SNAPSHOT'
@@ -70,7 +71,7 @@ task build(overwrite: true, type: ShadowJar) {
 	from sourceSets.main.output
 }
 
-// Excludes the tests for the build task. Should be using junit, junitJava17, junitJava8, skriptTest, quickTest.
+// Excludes the tests for the build task. Should be using junit, junitJava21, junitJava8, skriptTest, quickTest.
 // We do not want tests to run for building. That's time consuming and annoying. Especially in development.
 test {
 	exclude '**/*'
@@ -250,9 +251,16 @@ void createTestTask(String name, String desc, String environments, int javaVersi
 	}
 }
 
-def latestEnv = 'java17/paper-1.20.4.json'
-def latestJava = 17
-def oldestJava = 8
+def java21 = 21
+def java17 = 17
+def java8 = 8
+
+def latestEnv = 'java21/paper-1.20.6.json'
+def latestJava = java21
+def oldestJava = java8
+
+def latestJUnitEnv = 'java17/paper-1.20.4.json'
+def latestJUnitJava = java17
 
 java {
     toolchain.languageVersion.set(JavaLanguageVersion.of(latestJava))
@@ -270,23 +278,27 @@ String environments = 'src/test/skript/environments/';
 String env = project.property('testEnv') == null ? latestEnv : project.property('testEnv') + '.json'
 int envJava = project.property('testEnvJavaVersion') == null ? latestJava : Integer.parseInt(project.property('testEnvJavaVersion') as String)
 createTestTask('quickTest', 'Runs tests on one environment being the latest supported Java and Minecraft.', environments + latestEnv, latestJava, 0)
-createTestTask('skriptTestJava17', 'Runs tests on all Java 17 environments.', environments + 'java17', latestJava, 0)
-createTestTask('skriptTestJava8', 'Runs tests on all Java 8 environments.', environments + 'java8', oldestJava, 0)
+createTestTask('skriptTestJava21', 'Runs tests on all Java 21 environments.', environments + 'java21', java21, 0)
+createTestTask('skriptTestJava17', 'Runs tests on all Java 17 environments.', environments + 'java17', java17, 0)
+createTestTask('skriptTestJava8', 'Runs tests on all Java 8 environments.', environments + 'java8', java8, 0)
 createTestTask('skriptTestDev', 'Runs testing server and uses \'system.in\' for command input, stop server to finish.', environments + env, envJava, 0, Modifiers.DEV_MODE, Modifiers.DEBUG)
 createTestTask('skriptProfile', 'Starts the testing server with JProfiler support.', environments + latestEnv, latestJava, -1, Modifiers.PROFILE)
 createTestTask('genNightlyDocs', 'Generates the Skript documentation website html files.', environments + env, envJava, 0, Modifiers.GEN_NIGHTLY_DOCS)
 createTestTask('genReleaseDocs', 'Generates the Skript documentation website html files for a release.', environments + env, envJava, 0, Modifiers.GEN_RELEASE_DOCS)
 tasks.register('skriptTest') {
 	description = 'Runs tests on all environments.'
-	dependsOn skriptTestJava8, skriptTestJava17
+	dependsOn skriptTestJava8, skriptTestJava17, skriptTestJava21
 }
 
-createTestTask('JUnitQuick', 'Runs JUnit tests on one environment being the latest supported Java and Minecraft.', environments + latestEnv, latestJava, 0, Modifiers.JUNIT)
-createTestTask('JUnitJava17', 'Runs JUnit tests on all Java 17 environments.', environments + 'java17', latestJava, 0, Modifiers.JUNIT)
-createTestTask('JUnitJava8', 'Runs JUnit tests on all Java 8 environments.', environments + 'java8', oldestJava, 0, Modifiers.JUNIT)
+createTestTask('JUnitQuick', 'Runs JUnit tests on one environment being the latest supported Java and Minecraft.', environments + latestJUnitEnv, latestJUnitJava, 0, Modifiers.JUNIT)
+// Disabled as EasyMock 5.2.0 is required for Java 21 support
+// However, we are currently using 5.0.1 (see https://github.com/SkriptLang/Skript/pull/6204#discussion_r1405302009)
+//createTestTask('JUnitJava21', 'Runs JUnit tests on all Java 21 environments.', environments + 'java21', java21, 0, Modifiers.JUNIT)
+createTestTask('JUnitJava17', 'Runs JUnit tests on all Java 17 environments.', environments + 'java17', java17, 0, Modifiers.JUNIT)
+createTestTask('JUnitJava8', 'Runs JUnit tests on all Java 8 environments.', environments + 'java8', java8, 0, Modifiers.JUNIT)
 tasks.register('JUnit') {
 	description = 'Runs JUnit tests on all environments.'
-	dependsOn JUnitJava8, JUnitJava17
+	dependsOn JUnitJava8, JUnitJava17//, JUnitJava21
 }
 
 // Build flavor configurations

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ task build(overwrite: true, type: ShadowJar) {
 	from sourceSets.main.output
 }
 
-// Excludes the tests for the build task. Should be using junit, junitJava21, junitJava8, skriptTest, quickTest.
+// Excludes the tests for the build task. Should be using junit, junitJava17, junitJava8, skriptTest, quickTest.
 // We do not want tests to run for building. That's time consuming and annoying. Especially in development.
 test {
 	exclude '**/*'

--- a/code-conventions.md
+++ b/code-conventions.md
@@ -163,9 +163,9 @@ Your comments should look something like these:
 ## Language Features
 
 ### Compatibility
-* Contributions should maintain Java 8 source/binary compatibility, even though compiling Skript requires Java 17
+* Contributions should maintain Java 8 source/binary compatibility, even though compiling Skript requires Java 21
   - Users must not need JRE newer than version 8
-* Versions up to and including Java 17 should work too
+* Versions up to and including Java 21 should work too
   - Please avoid using unsafe reflection
 * It is recommended to make fields final, if they are effectively final
 * Local variables and method parameters should not be declared final

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.parallel=true
 
 groupid=ch.njol
 name=skript
-version=2.8.4
+version=2.8.5
 jarName=Skript.jar
 testEnv=java21/paper-1.20.6
 testEnvJavaVersion=21

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ groupid=ch.njol
 name=skript
 version=2.8.4
 jarName=Skript.jar
-testEnv=java17/paper-1.20.4
-testEnvJavaVersion=17
+testEnv=java21/paper-1.20.4
+testEnvJavaVersion=21

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ groupid=ch.njol
 name=skript
 version=2.8.4
 jarName=Skript.jar
-testEnv=java21/paper-1.20.4
+testEnv=java21/paper-1.20.6
 testEnvJavaVersion=21

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -1159,7 +1159,9 @@ public final class Skript extends JavaPlugin implements Listener {
 				// 1.19 mapping is u and 1.18 is v
 				String isRunningMethod = "isRunning";
 
-				if (Skript.isRunningMinecraft(1, 20)) {
+				if (Skript.isRunningMinecraft(1, 20, 5)) {
+					isRunningMethod = "x";
+				} else if (Skript.isRunningMinecraft(1, 20)) {
 					isRunningMethod = "v";
 				} else if (Skript.isRunningMinecraft(1, 19)) {
 					isRunningMethod = "u";

--- a/src/main/java/ch/njol/skript/aliases/Aliases.java
+++ b/src/main/java/ch/njol/skript/aliases/Aliases.java
@@ -58,6 +58,8 @@ import java.util.regex.Pattern;
 
 public abstract class Aliases {
 
+	static final boolean USING_ITEM_COMPONENTS = Skript.isRunningMinecraft(1, 20, 5);
+
 	private static final AliasesProvider provider = createProvider(10000, null);
 	private static final AliasesParser parser = createParser(provider);
 	

--- a/src/main/java/ch/njol/skript/aliases/AliasesParser.java
+++ b/src/main/java/ch/njol/skript/aliases/AliasesParser.java
@@ -218,9 +218,20 @@ public class AliasesParser {
 				throw new AssertionError("missing space between id and tags in " + item);
 			}
 			id = item.substring(0, firstBracket - 1);
-			String json = item.substring(firstBracket);
-			assert json != null;
-			tags = provider.parseMojangson(json);
+			String json;
+			int jsonEndIndex = item.indexOf("} ["); // may also have block states/data
+			if (jsonEndIndex == -1) {
+				json = item.substring(firstBracket);
+			} else {
+				json = item.substring(firstBracket, jsonEndIndex + 1);
+				id = id + item.substring(jsonEndIndex + 2); // essentially rips out json part
+			}
+			if (Aliases.USING_ITEM_COMPONENTS) {
+				json = "[" + json.substring(1, json.length() - 1) + "]"; // replace brackets (not json :))
+				tags = Collections.singletonMap("components", json);
+			} else {
+				tags = provider.parseMojangson(json);
+			}
 		}
 		
 		// Separate block state from id

--- a/src/main/java/ch/njol/skript/aliases/AliasesProvider.java
+++ b/src/main/java/ch/njol/skript/aliases/AliasesProvider.java
@@ -218,9 +218,18 @@ public class AliasesProvider {
 			return flags;
 		
 		// Apply random tags using JSON
-		String json = gson.toJson(tags);
-		assert json != null;
-		BukkitUnsafe.modifyItemStack(stack, json);
+		if (Aliases.USING_ITEM_COMPONENTS) {
+			String components = (String) tags.get("components"); // only components are supported for modifying a stack
+			assert components != null;
+			// for modifyItemStack to work, you have to include an item id ... e.g. "minecraft:dirt[<components>]"
+			// just to be safe we use the same one as the provided stack
+			components = stack.getType().getKey() + components;
+			BukkitUnsafe.modifyItemStack(stack, components);
+		} else {
+			String json = gson.toJson(tags);
+			assert json != null;
+			BukkitUnsafe.modifyItemStack(stack, json);
+		}
 		flags |= ItemFlags.CHANGED_TAGS;
 		
 		return flags;
@@ -269,6 +278,14 @@ public class AliasesProvider {
 		ItemType typeOfId = getAlias(id);
 		EntityData<?> related = null;
 		List<ItemData> datas;
+
+		// check whether deduplication will occur
+		boolean deduplicate = true;
+		String deduplicateFlag = blockStates.remove("deduplicate");
+		if (deduplicateFlag != null) {
+			deduplicate = !deduplicateFlag.equals("false");
+		}
+
 		if (typeOfId != null) { // If it exists, use datas from it
 			datas = typeOfId.getTypes();
 		} else { // ... but quite often, we just got Vanilla id
@@ -301,11 +318,13 @@ public class AliasesProvider {
 			data.itemFlags = itemFlags;
 			
 			// Deduplicate item data if this has been loaded before
-			AliasesMap.Match canonical = aliasesMap.exactMatch(data);
-			if (canonical.getQuality().isAtLeast(MatchQuality.EXACT)) {
-				AliasesMap.AliasData aliasData = canonical.getData();
-				assert aliasData != null; // Match quality guarantees this
-				data = aliasData.getItem();
+			if (deduplicate) {
+				AliasesMap.Match canonical = aliasesMap.exactMatch(data);
+				if (canonical.getQuality().isAtLeast(MatchQuality.EXACT)) {
+					AliasesMap.AliasData aliasData = canonical.getData();
+					assert aliasData != null; // Match quality guarantees this
+					data = aliasData.getItem();
+				}
 			}
 			
 			datas = Collections.singletonList(data);

--- a/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
@@ -18,14 +18,14 @@
  */
 package ch.njol.skript.bukkitutil;
 
+import ch.njol.skript.Skript;
+import ch.njol.skript.aliases.ItemType;
 import org.bukkit.Material;
 import org.bukkit.TreeType;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.eclipse.jdt.annotation.Nullable;
-
-import ch.njol.skript.Skript;
 
 import java.util.HashMap;
 
@@ -36,27 +36,53 @@ public class ItemUtils {
 
 	/**
 	 * Gets damage/durability of an item, or 0 if it does not have damage.
-	 * @param stack Item.
+	 * @param itemStack Item.
 	 * @return Damage.
 	 */
-	public static int getDamage(ItemStack stack) {
-		ItemMeta meta = stack.getItemMeta();
+	public static int getDamage(ItemStack itemStack) {
+		ItemMeta meta = itemStack.getItemMeta();
 		if (meta instanceof Damageable)
 			return ((Damageable) meta).getDamage();
-		return 0; // Not damageable item
+		return 0; // Non damageable item
 	}
-	
+
 	/**
 	 * Sets damage/durability of an item if possible.
-	 * @param stack Item to modify.
+	 * @param itemStack Item to modify.
 	 * @param damage New damage. Note that on some Minecraft versions,
 	 * this might be truncated to short.
 	 */
-	public static void setDamage(ItemStack stack, int damage) {
-		ItemMeta meta = stack.getItemMeta();
+	public static void setDamage(ItemStack itemStack, int damage) {
+		ItemMeta meta = itemStack.getItemMeta();
 		if (meta instanceof Damageable) {
 			((Damageable) meta).setDamage(damage);
-			stack.setItemMeta(meta);
+			itemStack.setItemMeta(meta);
+		}
+	}
+
+	/**
+	 * Gets damage/durability of an item, or 0 if it does not have damage.
+	 * @param itemType Item.
+	 * @return Damage.
+	 */
+	public static int getDamage(ItemType itemType) {
+		ItemMeta meta = itemType.getItemMeta();
+		if (meta instanceof Damageable)
+			return ((Damageable) meta).getDamage();
+		return 0; // Non damageable item
+	}
+
+	/**
+	 * Sets damage/durability of an item if possible.
+	 * @param itemType Item to modify.
+	 * @param damage New damage. Note that on some Minecraft versions,
+	 * this might be truncated to short.
+	 */
+	public static void setDamage(ItemType itemType, int damage) {
+		ItemMeta meta = itemType.getItemMeta();
+		if (meta instanceof Damageable) {
+			((Damageable) meta).setDamage(damage);
+			itemType.setItemMeta(meta);
 		}
 	}
 

--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -18,6 +18,9 @@
  */
 package ch.njol.skript.classes.data;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -62,6 +65,7 @@ import org.bukkit.block.BlockState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.AbstractVillager;
+import org.bukkit.entity.AreaEffectCloud;
 import org.bukkit.entity.Egg;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Firework;
@@ -169,7 +173,9 @@ import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.Recipe;
+import org.bukkit.potion.PotionData;
 import org.bukkit.potion.PotionEffectType;
+import org.bukkit.potion.PotionType;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
@@ -655,10 +661,36 @@ public final class BukkitEventValues {
 			}
 		}, EventValues.TIME_NOW);
 		EventValues.registerEventValue(AreaEffectCloudApplyEvent.class, PotionEffectType.class, new Getter<PotionEffectType, AreaEffectCloudApplyEvent>() {
+			@Nullable
+			private final MethodHandle BASE_POTION_DATA_HANDLE;
+
+			{
+				MethodHandle basePotionDataHandle = null;
+				if (Skript.methodExists(AreaEffectCloud.class, "getBasePotionData")) {
+					try {
+						basePotionDataHandle = MethodHandles.lookup().findVirtual(AreaEffectCloud.class, "getBasePotionData", MethodType.methodType(PotionData.class));
+					} catch (NoSuchMethodException | IllegalAccessException e) {
+						Skript.exception(e, "Failed to load legacy potion data support. Potions may not work as expected.");
+					}
+				}
+				BASE_POTION_DATA_HANDLE = basePotionDataHandle;
+			}
+
 			@Override
 			@Nullable
 			public PotionEffectType get(AreaEffectCloudApplyEvent e) {
-				return e.getEntity().getBasePotionData().getType().getEffectType(); // Whoops this is a bit long call...
+				if (BASE_POTION_DATA_HANDLE != null) {
+					try {
+						return ((PotionData) BASE_POTION_DATA_HANDLE.invoke(e.getEntity())).getType().getEffectType();
+					} catch (Throwable ex) {
+						throw Skript.exception(ex, "An error occurred while trying to invoke legacy area effect cloud potion effect support.");
+					}
+				} else {
+					PotionType base = e.getEntity().getBasePotionType();
+					if (base != null) // TODO this is deprecated... this should become a multi-value event value
+						return base.getEffectType();
+				}
+				return null;
 			}
 		}, 0);
 		// ItemSpawnEvent

--- a/src/main/java/ch/njol/skript/entity/SimpleEntityData.java
+++ b/src/main/java/ch/njol/skript/entity/SimpleEntityData.java
@@ -27,11 +27,13 @@ import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.Allay;
 import org.bukkit.entity.Animals;
 import org.bukkit.entity.AreaEffectCloud;
+import org.bukkit.entity.Armadillo;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Bat;
 import org.bukkit.entity.Blaze;
 import org.bukkit.entity.BlockDisplay;
+import org.bukkit.entity.Bogged;
 import org.bukkit.entity.Breeze;
 import org.bukkit.entity.Camel;
 import org.bukkit.entity.CaveSpider;
@@ -315,6 +317,11 @@ public class SimpleEntityData extends EntityData<Entity> {
 		if (Skript.isRunningMinecraft(1, 20, 3)) {
 			addSimpleEntity("breeze", Breeze.class);
 			addSimpleEntity("wind charge", WindCharge.class);
+		}
+
+		if (Skript.isRunningMinecraft(1,20,5)) {
+			addSimpleEntity("armadillo", Armadillo.class);
+			addSimpleEntity("bogged", Bogged.class);
 		}
 
 		// Register zombie after Husk and Drowned to make sure both work

--- a/src/main/java/ch/njol/skript/events/SimpleEvents.java
+++ b/src/main/java/ch/njol/skript/events/SimpleEvents.java
@@ -426,14 +426,14 @@ public class SimpleEvents {
 				Skript.registerEvent("Entity Mount", SimpleEvent.class, mountEventClass, "mount[ing]")
 					.description("Called when entity starts riding another.")
 					.examples("on mount:",
-						"\tcancel event")
+							"\tcancel event")
 					.since("2.2-dev13b");
 			}
 			if (dismountEventClass != null) {
 				Skript.registerEvent("Entity Dismount", SimpleEvent.class, dismountEventClass, "dismount[ing]")
 					.description("Called when an entity dismounts.")
 					.examples("on dismount:",
-						"\tkill event-entity")
+							"\tkill event-entity")
 					.since("2.2-dev13b");
 			}
 		}

--- a/src/main/java/ch/njol/skript/events/SimpleEvents.java
+++ b/src/main/java/ch/njol/skript/events/SimpleEvents.java
@@ -23,6 +23,7 @@ import com.destroystokyo.paper.event.player.PlayerReadyArrowEvent;
 import io.papermc.paper.event.player.PlayerStopUsingItemEvent;
 import io.papermc.paper.event.player.PlayerDeepSleepEvent;
 import io.papermc.paper.event.player.PlayerInventorySlotChangeEvent;
+import org.bukkit.event.Event;
 import org.bukkit.event.block.BlockCanBuildEvent;
 import org.bukkit.event.block.BlockDamageEvent;
 import org.bukkit.event.block.BlockFertilizeEvent;
@@ -42,7 +43,9 @@ import org.bukkit.event.entity.AreaEffectCloudApplyEvent;
 import org.bukkit.event.entity.CreeperPowerEvent;
 import org.bukkit.event.entity.EntityBreakDoorEvent;
 import org.bukkit.event.entity.EntityCombustEvent;
+import org.bukkit.event.entity.EntityDismountEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
+import org.bukkit.event.entity.EntityMountEvent;
 import org.bukkit.event.entity.EntityPortalEnterEvent;
 import org.bukkit.event.entity.EntityPortalEvent;
 import org.bukkit.event.entity.EntityRegainHealthEvent;
@@ -105,8 +108,6 @@ import org.bukkit.event.world.ChunkUnloadEvent;
 import org.bukkit.event.world.LootGenerateEvent;
 import org.bukkit.event.world.PortalCreateEvent;
 import org.bukkit.event.world.SpawnChangeEvent;
-import org.spigotmc.event.entity.EntityDismountEvent;
-import org.spigotmc.event.entity.EntityMountEvent;
 
 import com.destroystokyo.paper.event.entity.ProjectileCollideEvent;
 import com.destroystokyo.paper.event.player.PlayerArmorChangeEvent;
@@ -407,17 +408,34 @@ public class SimpleEvents {
 						"\tif event-entity is a spider:",
 						"\t\tkill event-entity")
 				.since("1.0");
-		if (Skript.classExists("org.spigotmc.event.entity.EntityMountEvent")) {
-			Skript.registerEvent("Entity Mount", SimpleEvent.class, EntityMountEvent.class, "mount[ing]")
+		if (Skript.classExists("org.bukkit.event.entity.EntityMountEvent") || Skript.classExists("org.spigotmc.event.entity.EntityMountEvent")) {
+			Class<? extends Event> mountEventClass = null;
+			Class<? extends Event> dismountEventClass = null;
+			if (Skript.classExists("org.bukkit.event.entity.EntityMountEvent")) {
+				mountEventClass = EntityMountEvent.class;
+				dismountEventClass = EntityDismountEvent.class;
+			} else {
+				try {
+					mountEventClass = (Class<? extends Event>) Class.forName("org.spigotmc.event.entity.EntityMountEvent");
+					dismountEventClass = (Class<? extends Event>) Class.forName("org.spigotmc.event.entity.EntityDismountEvent");
+				} catch (ClassNotFoundException e) {
+					Skript.exception(e, "Failed to load legacy mount/dismount event classes. These events may not work.");
+				}
+			}
+			if (mountEventClass != null) {
+				Skript.registerEvent("Entity Mount", SimpleEvent.class, mountEventClass, "mount[ing]")
 					.description("Called when entity starts riding another.")
 					.examples("on mount:",
-							"\tcancel event")
+						"\tcancel event")
 					.since("2.2-dev13b");
-			Skript.registerEvent("Entity Dismount", SimpleEvent.class, EntityDismountEvent.class, "dismount[ing]")
+			}
+			if (dismountEventClass != null) {
+				Skript.registerEvent("Entity Dismount", SimpleEvent.class, dismountEventClass, "dismount[ing]")
 					.description("Called when an entity dismounts.")
 					.examples("on dismount:",
-							"\tkill event-entity")
+						"\tkill event-entity")
 					.since("2.2-dev13b");
+			}
 		}
 		if (Skript.classExists("org.bukkit.event.entity.EntityToggleGlideEvent")) {
 			Skript.registerEvent("Gliding State Change", SimpleEvent.class, EntityToggleGlideEvent.class, "(gliding state change|toggl(e|ing) gliding)")

--- a/src/main/java/ch/njol/skript/expressions/ExprDirection.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDirection.java
@@ -62,10 +62,10 @@ public class ExprDirection extends SimpleExpression<Direction> {
 	private static final Patterns<BlockFace> PATTERNS = new Patterns<>(new Object[][]{
 		// northeast, northwest, southeast and southwest need to be registered before normal usages otherwise `[-%direction%]` is given priority
 		// naturally doesn't matter however this should help a bit with parsing "north west north west north west..."
-		{"[%-number% [(block|meter|metre)[s]]] [to the] north[-| ]east[er(n|ly)|ward[s|ly]] [[side] of] [%-direction%]", BlockFace.NORTH_EAST},
-		{"[%-number% [(block|meter|metre)[s]]] [to the] north[-| ]west[er(n|ly)|ward[s|ly]] [[side] of] [%-direction%]", BlockFace.NORTH_WEST},
-		{"[%-number% [(block|meter|metre)[s]]] [to the] south[-| ]east[er(n|ly)|ward[s|ly]] [[side] of] [%-direction%]", BlockFace.SOUTH_EAST},
-		{"[%-number% [(block|meter|metre)[s]]] [to the] south[-| ]west[er(n|ly)|ward[s|ly]] [[side] of] [%-direction%]", BlockFace.SOUTH_WEST},
+		{"[%-number% [(block|meter|metre)[s]]] [to the] north[-| ]east[er(n|ly)|ward[s|ly]] [[side] of] [[and|,] %-direction%]", BlockFace.NORTH_EAST},
+		{"[%-number% [(block|meter|metre)[s]]] [to the] north[-| ]west[er(n|ly)|ward[s|ly]] [[side] of] [[and|,] %-direction%]", BlockFace.NORTH_WEST},
+		{"[%-number% [(block|meter|metre)[s]]] [to the] south[-| ]east[er(n|ly)|ward[s|ly]] [[side] of] [[and|,] %-direction%]", BlockFace.SOUTH_EAST},
+		{"[%-number% [(block|meter|metre)[s]]] [to the] south[-| ]west[er(n|ly)|ward[s|ly]] [[side] of] [[and|,] %-direction%]", BlockFace.SOUTH_WEST},
 		{"[%-number% [(block|meter|metre)[s]]] [to the] north[er(n|ly)|ward[s|ly]] [[side] of] [%-direction%]", BlockFace.NORTH},
 		{"[%-number% [(block|meter|metre)[s]]] [to the] east[er(n|ly)|ward[s|ly]] [[side] of] [%-direction%]", BlockFace.EAST},
 		{"[%-number% [(block|meter|metre)[s]]] [to the] south[er(n|ly)|ward[s|ly]] [[side] of] [%-direction%]", BlockFace.SOUTH},
@@ -76,7 +76,8 @@ public class ExprDirection extends SimpleExpression<Direction> {
 		{"[%-number% [(block|meter|metre)[s]]] [in] %entity/block%'[s] [:horizontal] (direction|:facing) [of|from]", BlockFace.SELF},
 		{"[%-number% [(block|meter|metre)[s]]] [horizontal:horizontally] (in[ ]front [of]|forward[s])", BlockFace.SELF},
 		{"[%-number% [(block|meter|metre)[s]]] [horizontal:horizontally] (2:(behind|backwards))", BlockFace.SELF},
-		{"[%-number% [(block|meter|metre)[s]]] [horizontal:horizontally] [to the] (1:right|-1:left) [[side] of]", BlockFace.SELF}
+		{"[%-number% [(block|meter|metre)[s]]] [horizontal:horizontally] [to the] (1:right) [[side] of]", BlockFace.SELF},
+		{"[%-number% [(block|meter|metre)[s]]] [horizontal:horizontally] [to the] (-1:left) [[side] of]", BlockFace.SELF}
 	});
 
 	static {
@@ -114,6 +115,7 @@ public class ExprDirection extends SimpleExpression<Direction> {
 			case 12:
 			case 13:
 			case 14:
+			case 15:
 				yaw = Math.PI / 2 * parseResult.mark;
 				break;
 			default:
@@ -153,7 +155,7 @@ public class ExprDirection extends SimpleExpression<Direction> {
 			if (relativeObject instanceof Block) {
 				BlockFace blockFace = Direction.getFacing((Block) relativeObject);
 				if (blockFace == BlockFace.SELF || isHorizontal && (blockFace == BlockFace.UP || blockFace == BlockFace.DOWN))
-					return new Direction[]{Direction.ZERO}; // new Direction(BlockFace.SELF.getDirection().clone())
+					return new Direction[]{Direction.ZERO};
 				return new Direction[]{new Direction(blockFace, meterLength)};
 			} else if (relativeObject instanceof Entity) {
 				Location relativeEntityLoc = ((Entity) relativeObject).getLocation();

--- a/src/main/java/ch/njol/skript/expressions/ExprDirection.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDirection.java
@@ -130,7 +130,7 @@ public class ExprDirection extends SimpleExpression<Direction> {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		amount = (Expression<Number>) exprs[0];
 		isHorizontal = parseResult.hasTag("horizontal");
 		isFacing = parseResult.hasTag("facing");

--- a/src/main/java/ch/njol/skript/expressions/ExprDirection.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDirection.java
@@ -119,8 +119,6 @@ public class ExprDirection extends SimpleExpression<Direction> {
 	public Expression<Number> amount;
 
 	@Nullable
-	private DirectionMapping expectedDirection;
-	@Nullable
 	private Vector directionVector;
 	@Nullable
 	private ExprDirection nextDirection;
@@ -142,8 +140,8 @@ public class ExprDirection extends SimpleExpression<Direction> {
 			case 1:
 				String parseDirection = parseResult.tags.get(parseResult.tags.size() - 1);
 				if (parseDirection == null) return false;
-				expectedDirection = DirectionMapping.DIRECTION_NAMES.get(parseDirection.toLowerCase(Locale.ROOT));
-				directionVector = expectedDirection.getBlockFace().getDirection().clone();
+				DirectionMapping directionEnum = DirectionMapping.DIRECTION_NAMES.get(parseDirection.toLowerCase(Locale.ROOT));
+				directionVector = directionEnum.getBlockFace().getDirection().clone();
 				if (exprs[1] != null && (!(exprs[1] instanceof ExprDirection) || ((ExprDirection) exprs[1]).directionVector == null)) {
 					return false;
 				}

--- a/src/main/java/ch/njol/skript/expressions/ExprDirection.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDirection.java
@@ -58,7 +58,6 @@ import java.util.Locale;
 		"open the inventory of the block 2 blocks below the player to the player",
 		"teleport the clicked entity behind the player",
 		"grow a regular tree 2 meters horizontally behind the player"})
-
 @Since("1.0 (basic), 2.0 (extended)")
 public class ExprDirection extends SimpleExpression<Direction> {
 
@@ -104,7 +103,6 @@ public class ExprDirection extends SimpleExpression<Direction> {
 	}
 
 	static {
-
 		// TODO think about parsing statically & dynamically (also in general)
 		// "at": see LitAt
 		// TODO direction of %location% (from|relative to) %location%
@@ -143,9 +141,8 @@ public class ExprDirection extends SimpleExpression<Direction> {
 				if (parseDirection == null) return false;
 				DirectionMapping directionEnum = DirectionMapping.DIRECTION_NAMES.get(parseDirection.toLowerCase(Locale.ROOT));
 				directionVector = directionEnum.getBlockFace().getDirection().clone();
-				if (exprs[1] != null && (!(exprs[1] instanceof ExprDirection) || ((ExprDirection) exprs[1]).directionVector == null)) {
+				if (exprs[1] != null && (!(exprs[1] instanceof ExprDirection) || ((ExprDirection) exprs[1]).directionVector == null))
 					return false;
-				}
 				nextDirection = (ExprDirection) exprs[1];
 				break;
 			case 2:
@@ -233,8 +230,7 @@ public class ExprDirection extends SimpleExpression<Direction> {
 	public String toString(@Nullable Event event, boolean debug) {
 		return String.format("%s%s%s%s",
 			this.amount != null ? amount.toString(event, debug) + " meter(s) " : "",
-			(isHorizontal ? "horizontally " : ""),
-			(isFacing ? "facing " : ""),
+			(isHorizontal ? "horizontally " : ""), (isFacing ? "facing " : ""),
 			this.directionVector != null ? Direction.toString(directionVector) :
 				this.relativeTo != null ? "of " + relativeTo.toString(event, debug) :
 					Direction.toString(0, yaw, 1)

--- a/src/main/java/ch/njol/skript/expressions/ExprDirection.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDirection.java
@@ -109,8 +109,8 @@ public class ExprDirection extends SimpleExpression<Direction> {
 		// "at": see LitAt
 		// TODO direction of %location% (from|relative to) %location%
 		Skript.registerExpression(ExprDirection.class, Direction.class, ExpressionType.COMBINED,
-				"[%-number% [(block|met(er|re))[s]]] [to the]] (:(north[[-| ](east|west)]|east|south[[ |-](east|west)]|west))[ward[s|ly]|er(n|ly)] [of] [%-direction%]",
-				"[%-number% [(block|met(er|re))[s]]] [to the]] (up:(above|over|up[ward[s|ly]])|down:(down[ward[s|ly]]|below|under[neath]|beneath)) [%-direction%]",
+				"[%-number% [(block|met(er|re))[s]]] [to the] (:(north[[-| ](east|west)]|east|south[[ |-](east|west)]|west))[ward[s|ly]|er(n|ly)] [of] [%-direction%]",
+				"[%-number% [(block|met(er|re))[s]]] [to the] (up:(above|over|up[ward[s|ly]])|down:(down[ward[s|ly]]|below|under[neath]|beneath)) [%-direction%]",
 				"[%-number% [(block|met(er|re))[s]]] in [the] [:horizontal] (direction|:facing) of %entity/block% [of|from]",
 				"[%-number% [(block|met(er|re))[s]]] in %entity/block%'[s] [:horizontal] (direction|:facing) [of|from]",
 				"[%-number% [(block|met(er|re))[s]]] [horizontal:horizontal[ly]] (in[ ]front [of]|forward[s]|2:(behind|backwards)|[to the] (1:right|-1:left) [of])");

--- a/src/main/java/ch/njol/skript/expressions/ExprDirection.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDirection.java
@@ -109,12 +109,11 @@ public class ExprDirection extends SimpleExpression<Direction> {
 		// "at": see LitAt
 		// TODO direction of %location% (from|relative to) %location%
 		Skript.registerExpression(ExprDirection.class, Direction.class, ExpressionType.COMBINED,
-			"[%-number% [(block|met(er|re))[s]]] [to the]] (:(north[[-| ](east|west)]|east|south[[ |-](east|west)]|west))[ward[s|ly]|er(n|ly)] [of] [%-direction%]",
-			"[%-number% [(block|met(er|re))[s]]] [to the]] (up:(above|over|up[ward[s|ly]])|down:(down[ward[s|ly]]|below|under[neath]|beneath)) [%-direction%]",
-			"[%-number% [(block|met(er|re))[s]]] in [the] [:horizontal] (direction|:facing) of %entity/block% [of|from]",
-			"[%-number% [(block|met(er|re))[s]]] in %entity/block%'[s] [:horizontal] (direction|:facing) [of|from]",
-			"[%-number% [(block|met(er|re))[s]]] [horizontal:horizontal[ly]] ((in[ ]front [of]|forward[s])|2:(behind|backwards)|[to the] (1:right|-1:left) [of])"
-		);
+				"[%-number% [(block|met(er|re))[s]]] [to the]] (:(north[[-| ](east|west)]|east|south[[ |-](east|west)]|west))[ward[s|ly]|er(n|ly)] [of] [%-direction%]",
+				"[%-number% [(block|met(er|re))[s]]] [to the]] (up:(above|over|up[ward[s|ly]])|down:(down[ward[s|ly]]|below|under[neath]|beneath)) [%-direction%]",
+				"[%-number% [(block|met(er|re))[s]]] in [the] [:horizontal] (direction|:facing) of %entity/block% [of|from]",
+				"[%-number% [(block|met(er|re))[s]]] in %entity/block%'[s] [:horizontal] (direction|:facing) [of|from]",
+				"[%-number% [(block|met(er|re))[s]]] [horizontal:horizontal[ly]] (in[ ]front [of]|forward[s]|2:(behind|backwards)|[to the] (1:right|-1:left) [of])");
 	}
 
 	@Nullable

--- a/src/main/java/ch/njol/skript/expressions/ExprDirection.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDirection.java
@@ -18,14 +18,6 @@
  */
 package ch.njol.skript.expressions;
 
-import org.bukkit.Location;
-import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
-import org.bukkit.entity.Entity;
-import org.bukkit.event.Event;
-import org.bukkit.util.Vector;
-import org.eclipse.jdt.annotation.Nullable;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -38,175 +30,216 @@ import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.skript.util.Direction;
 import ch.njol.util.Kleenean;
 import ch.njol.util.Math2;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Event;
+import org.bukkit.util.Vector;
+import org.eclipse.jdt.annotation.Nullable;
 
-/**
- * @author Peter Güttinger
- */
+import java.util.HashMap;
+import java.util.Locale;
+
 @Name("Direction")
 @Description("A helper expression for the <a href='classes.html#direction'>direction type</a>.")
 @Examples({"thrust the player upwards",
-		"set the block behind the player to water",
-		"loop blocks above the player:",
-		"	set {_rand} to a random integer between 1 and 10",
-		"	set the block {_rand} meters south east of the loop-block to stone",
-		"block in horizontal facing of the clicked entity from the player is air",
-		"spawn a creeper 1.5 meters horizontally behind the player",
-		"spawn a TNT 5 meters above and 2 meters horizontally behind the player",
-		"thrust the last spawned TNT in the horizontal direction of the player with speed 0.2",
-		"push the player upwards and horizontally forward at speed 0.5",
-		"push the clicked entity in in the direction of the player at speed -0.5",
-		"open the inventory of the block 2 blocks below the player to the player",
-		"teleport the clicked entity behind the player",
-		"grow a regular tree 2 meters horizontally behind the player"})
+	"set the block behind the player to water",
+	"loop blocks above the player:",
+	"	set {_rand} to a random integer between 1 and 10",
+	"	set the block {_rand} meters south east of the loop-block to stone",
+	"block in horizontal facing of the clicked entity from the player is air",
+	"spawn a creeper 1.5 meters horizontally behind the player",
+	"spawn a TNT 5 meters above and 2 meters horizontally behind the player",
+	"thrust the last spawned TNT in the horizontal direction of the player with speed 0.2",
+	"push the player upwards and horizontally forward at speed 0.5",
+	"push the clicked entity in in the direction of the player at speed -0.5",
+	"open the inventory of the block 2 blocks below the player to the player",
+	"teleport the clicked entity behind the player",
+	"grow a regular tree 2 meters horizontally behind the player"})
 @Since("1.0 (basic), 2.0 (extended)")
 public class ExprDirection extends SimpleExpression<Direction> {
-	
-	private final static BlockFace[] byMark = new BlockFace[] {
-			BlockFace.UP, BlockFace.DOWN,
-			BlockFace.NORTH, BlockFace.SOUTH, BlockFace.EAST, BlockFace.WEST,
-			BlockFace.NORTH_EAST, BlockFace.NORTH_WEST, BlockFace.SOUTH_EAST, BlockFace.SOUTH_WEST};
-	private final static int UP = 0, DOWN = 1,
-			NORTH = 2, SOUTH = 3, EAST = 4, WEST = 5,
-			NORTH_EAST = 6, NORTH_WEST = 7, SOUTH_EAST = 8, SOUTH_WEST = 9;
-	
+
+	private enum DirectionMapping {
+
+		UP(BlockFace.UP, "up"),
+		DOWN(BlockFace.DOWN, "down"),
+
+		NORTH(BlockFace.NORTH, "north"),
+		SOUTH(BlockFace.SOUTH, "south"),
+		EAST(BlockFace.EAST, "east"),
+		WEST(BlockFace.WEST, "west"),
+
+		// When using `(:blah[blah2])` the `tag` will be `blah` or `blahblah2` depending on if the optional is used
+		// as a workaround for this we'll be adding all possible patterns into a map.
+		NORTH_EAST(BlockFace.NORTH_EAST, "northeast", "north east", "north-east"),
+		NORTH_WEST(BlockFace.NORTH_WEST, "northwest", "north west", "north-west"),
+		SOUTH_EAST(BlockFace.SOUTH_EAST, "southeast", "south east", "south-east"),
+		SOUTH_WEST(BlockFace.SOUTH_WEST, "southwest", "south west", "south-west");
+
+		public static final HashMap<String, DirectionMapping> DIRECTION_NAMES = new HashMap<>();
+
+		static {
+			for (DirectionMapping direction : values()) {
+				for (String tag : direction.tags) {
+					DIRECTION_NAMES.putIfAbsent(tag.toLowerCase(Locale.ROOT), direction);
+				}
+			}
+		}
+
+		private final BlockFace blockFace;
+		private final String[] tags;
+
+		DirectionMapping(BlockFace blockFace, String ...tags) {
+			this.blockFace = blockFace;
+			this.tags = tags;
+		}
+
+		public BlockFace getBlockFace() {
+			return this.blockFace;
+		}
+
+	}
+
 	static {
+
 		// TODO think about parsing statically & dynamically (also in general)
 		// "at": see LitAt
 		// TODO direction of %location% (from|relative to) %location%
 		Skript.registerExpression(ExprDirection.class, Direction.class, ExpressionType.COMBINED,
-				"[%-number% [(block|met(er|re))[s]] [to the]] (" +
-						NORTH + "¦north[(-| |)(" + (NORTH_EAST ^ NORTH) + "¦east|" + (NORTH_WEST ^ NORTH) + "¦west)][(ward(s|ly|)|er(n|ly|))] [of]" +
-						"|" + SOUTH + "¦south[(-| |)(" + (SOUTH_EAST ^ SOUTH) + "¦east|" + (SOUTH_WEST ^ SOUTH) + "¦west)][(ward(s|ly|)|er(n|ly|))] [of]" +
-						"|(" + EAST + "¦east|" + WEST + "¦west)[(ward(s|ly|)|er(n|ly|))] [of]" +
-						"|" + UP + "¦above|" + UP + "¦over|(" + UP + "¦up|" + DOWN + "¦down)[ward(s|ly|)]|" + DOWN + "¦below|" + DOWN + "¦under[neath]|" + DOWN + "¦beneath" +
-						") [%-direction%]",
-				"[%-number% [(block|met(er|re))[s]]] in [the] (0¦direction|1¦horizontal direction|2¦facing|3¦horizontal facing) of %entity/block% (of|from|)",
-				"[%-number% [(block|met(er|re))[s]]] in %entity/block%'[s] (0¦direction|1¦horizontal direction|2¦facing|3¦horizontal facing) (of|from|)",
-				"[%-number% [(block|met(er|re))[s]]] (0¦in[ ]front [of]|0¦forward[s]|2¦behind|2¦backwards|[to the] (1¦right|-1¦left) [of])",
-				"[%-number% [(block|met(er|re))[s]]] horizontal[ly] (0¦in[ ]front [of]|0¦forward[s]|2¦behind|2¦backwards|to the (1¦right|-1¦left) [of])");
+			"[%-number% [(block|met(er|re))[s]]] [to the]] (:(north[[-| ](east|west)]|east|south[[ |-](east|west)]|west))[ward[s|ly]|er(n|ly)] [of] [%-direction%]",
+			"[%-number% [(block|met(er|re))[s]]] [to the]] (up:(above|over|up[ward[s|ly]])|down:(down[ward[s|ly]]|below|under[neath]|beneath)) [%-direction%]",
+			"[%-number% [(block|met(er|re))[s]]] in [the] [:horizontal] (direction|:facing) of %entity/block% [of|from]",
+			"[%-number% [(block|met(er|re))[s]]] in %entity/block%'[s] [:horizontal] (direction|:facing) [of|from]",
+			"[%-number% [(block|met(er|re))[s]]] [horizontal:horizontal[ly]] ((in[ ]front [of]|forward[s])|2:(behind|backwards)|[to the] (1:right|-1:left) [of])"
+		);
 	}
-	
+
 	@Nullable
-	Expression<Number> amount;
-	
+	public Expression<Number> amount;
+
 	@Nullable
-	private Vector direction;
+	private DirectionMapping expectedDirection;
 	@Nullable
-	private ExprDirection next;
-	
+	private Vector directionVector;
+	@Nullable
+	private ExprDirection nextDirection;
+
 	@Nullable
 	private Expression<?> relativeTo;
-	boolean horizontal;
-	boolean facing;
-	
+	private boolean isHorizontal, isFacing;
 	private double yaw;
-	
+
 	@SuppressWarnings("unchecked")
 	@Override
 	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
 		amount = (Expression<Number>) exprs[0];
+		isHorizontal = parseResult.hasTag("horizontal");
+		isFacing = parseResult.hasTag("facing");
+
 		switch (matchedPattern) {
 			case 0:
-				direction = new Vector(byMark[parseResult.mark].getModX(), byMark[parseResult.mark].getModY(), byMark[parseResult.mark].getModZ());
-				if (exprs[1] != null) {
-					if (!(exprs[1] instanceof ExprDirection) || ((ExprDirection) exprs[1]).direction == null)
-						return false;
-					next = (ExprDirection) exprs[1];
-				}
-				break;
 			case 1:
-			case 2:
-				relativeTo = exprs[1];
-				horizontal = parseResult.mark % 2 != 0;
-				facing = parseResult.mark >= 2;
+				String parseDirection = parseResult.tags.get(parseResult.tags.size() - 1);
+				if (parseDirection == null) return false;
+				expectedDirection = DirectionMapping.DIRECTION_NAMES.get(parseDirection.toLowerCase(Locale.ROOT));
+				directionVector = expectedDirection.getBlockFace().getDirection().clone();
+				if (exprs[1] != null && (!(exprs[1] instanceof ExprDirection) || ((ExprDirection) exprs[1]).directionVector == null)) {
+					return false;
+				}
+				nextDirection = (ExprDirection) exprs[1];
 				break;
+			case 2:
 			case 3:
+				relativeTo = exprs[1];
+				break;
 			case 4:
 				yaw = Math.PI / 2 * parseResult.mark;
-				horizontal = matchedPattern == 4;
+				break;
 		}
 		return true;
 	}
-	
+
 	@Override
 	@Nullable
-	protected Direction[] get(final Event e) {
-		final Number n = amount != null ? amount.getSingle(e) : 1;
-		if (n == null)
+	protected Direction[] get(Event event) {
+		Number numAmount = amount != null ? amount.getSingle(event) : 1;
+		if (numAmount == null)
 			return new Direction[0];
-		final double ln = n.doubleValue();
-		if (direction != null) {
-			final Vector v = direction.clone().multiply(ln);
-			ExprDirection d = next;
-			while (d != null) {
-				final Number n2 = d.amount != null ? d.amount.getSingle(e) : 1;
-				if (n2 == null)
+		double meterLength = numAmount.doubleValue();
+		if (this.directionVector != null) {
+			Vector directionVector = this.directionVector.multiply(meterLength);
+			ExprDirection nextDirection = this.nextDirection;
+			while (nextDirection != null) {
+				numAmount = nextDirection.amount != null ? nextDirection.amount.getSingle(event) : 1;
+				if (numAmount == null)
 					return new Direction[0];
-				assert d.direction != null; // checked in init()
-				v.add(d.direction.clone().multiply(n2.doubleValue()));
-				d = d.next;
+				assert nextDirection.directionVector != null; // this is checked in the init() method
+				directionVector.add(nextDirection.directionVector.multiply(numAmount.doubleValue()));
+				nextDirection = nextDirection.nextDirection;
 			}
-			assert v != null;
-			return new Direction[] {new Direction(v)};
-		} else if (relativeTo != null) {
-			final Object o = relativeTo.getSingle(e);
-			if (o == null)
+			return new Direction[]{new Direction(directionVector)};
+		} else if (this.relativeTo != null) {
+			Object relativeObject = relativeTo.getSingle(event);
+			if (relativeObject == null)
 				return new Direction[0];
-			if (o instanceof Block) {
-				final BlockFace f = Direction.getFacing((Block) o);
-				if (f == BlockFace.SELF || horizontal && (f == BlockFace.UP || f == BlockFace.DOWN))
-					return new Direction[] {Direction.ZERO};
-				return new Direction[] {new Direction(f, ln)};
-			} else {
-				final Location l = ((Entity) o).getLocation();
-				if (!horizontal) {
-					if (!facing) {
-						final Vector v = l.getDirection().normalize().multiply(ln);
-						assert v != null;
-						return new Direction[] {new Direction(v)};
-					}
-					final double pitch = Direction.pitchToRadians(l.getPitch());
+
+			if (relativeObject instanceof Block) {
+				BlockFace blockFace = Direction.getFacing((Block) relativeObject);
+				if (blockFace == BlockFace.SELF || isHorizontal && (blockFace == BlockFace.UP || blockFace == BlockFace.DOWN))
+					return new Direction[]{Direction.ZERO}; // new Direction(BlockFace.SELF.getDirection().clone())
+				return new Direction[]{new Direction(blockFace, meterLength)};
+			} else if (relativeObject instanceof Entity) {
+				Location relativeEntityLoc = ((Entity) relativeObject).getLocation();
+				if (isHorizontal && isFacing) {
+					double yaw = Direction.yawToRadians(relativeEntityLoc.getYaw());
+					yaw = Math2.mod(yaw, 2 * Math.PI);
+					if (yaw >= Math.PI / 4 && yaw < 3 * Math.PI / 4)
+						return new Direction[]{new Direction(0, 0, meterLength)};
+					if (yaw >= 3 * Math.PI / 4 && yaw < 5 * Math.PI / 4)
+						return new Direction[]{new Direction(-meterLength, 0, 0)};
+					if (yaw >= 5 * Math.PI / 4 && yaw < 7 * Math.PI / 4)
+						return new Direction[]{new Direction(0, 0, -meterLength)};
+					assert yaw >= 0 && yaw < Math.PI / 4 || yaw >= 7 * Math.PI / 4 && yaw < 2 * Math.PI;
+					return new Direction[]{new Direction(meterLength, 0, 0)};
+				} else if (isHorizontal) {
+					return new Direction[] {new Direction(new double[] {Math.cos(yaw) * meterLength, 0, Math.sin(yaw) * meterLength})};
+				} else if (isFacing) {
+					double pitch = Direction.pitchToRadians(relativeEntityLoc.getPitch());
 					assert pitch >= -Math.PI / 2 && pitch <= Math.PI / 2;
 					if (pitch > Math.PI / 4)
-						return new Direction[] {new Direction(new double[] {0, ln, 0})};
+						return new Direction[]{new Direction(new double[]{0, meterLength, 0})};
 					if (pitch < -Math.PI / 4)
-						return new Direction[] {new Direction(new double[] {0, -ln, 0})};
+						return new Direction[]{new Direction(new double[]{0, -meterLength, 0})};
 				}
-				double yaw = Direction.yawToRadians(l.getYaw());
-				if (horizontal && !facing) {
-					return new Direction[] {new Direction(new double[] {Math.cos(yaw) * ln, 0, Math.sin(yaw) * ln})};
-				}
-				yaw = Math2.mod(yaw, 2 * Math.PI);
-				if (yaw >= Math.PI / 4 && yaw < 3 * Math.PI / 4)
-					return new Direction[] {new Direction(new double[] {0, 0, ln})};
-				if (yaw >= 3 * Math.PI / 4 && yaw < 5 * Math.PI / 4)
-					return new Direction[] {new Direction(new double[] {-ln, 0, 0})};
-				if (yaw >= 5 * Math.PI / 4 && yaw < 7 * Math.PI / 4)
-					return new Direction[] {new Direction(new double[] {0, 0, -ln})};
-				assert yaw >= 0 && yaw < Math.PI / 4 || yaw >= 7 * Math.PI / 4 && yaw < 2 * Math.PI;
-				return new Direction[] {new Direction(new double[] {ln, 0, 0})};
+				return new Direction[]{new Direction(relativeEntityLoc.getDirection().normalize().multiply(meterLength))};
 			}
 		} else {
-			return new Direction[] {new Direction(horizontal ? Direction.IGNORE_PITCH : 0, yaw, ln)};
+			return new Direction[]{new Direction(isHorizontal ? Direction.IGNORE_PITCH : 0, yaw, meterLength)};
 		}
+		return new Direction[0];
 	}
-	
+
 	@Override
 	public boolean isSingle() {
 		return true;
 	}
-	
+
 	@Override
 	public Class<? extends Direction> getReturnType() {
 		return Direction.class;
 	}
-	
+
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		final Expression<?> relativeTo = this.relativeTo;
-		return (amount != null ? amount.toString(e, debug) + " meter(s) " : "") + (direction != null ? Direction.toString(direction) :
-				relativeTo != null ? " in " + (horizontal ? "horizontal " : "") + (facing ? "facing" : "direction") + " of " + relativeTo.toString(e, debug) :
-						(horizontal ? "horizontally " : "") + Direction.toString(0, yaw, 1));
+	public String toString(@Nullable Event event, boolean debug) {
+		return String.format("%s%s%s%s",
+			this.amount != null ? amount.toString(event, debug) + " meter(s) " : "",
+			(isHorizontal ? "horizontally " : ""),
+			(isFacing ? "facing " : ""),
+			this.directionVector != null ? Direction.toString(directionVector) :
+				this.relativeTo != null ? "of " + relativeTo.toString(event, debug) :
+					Direction.toString(0, yaw, 1)
+		);
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprDirection.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDirection.java
@@ -43,20 +43,22 @@ import java.util.Locale;
 
 @Name("Direction")
 @Description("A helper expression for the <a href='classes.html#direction'>direction type</a>.")
-@Examples({"thrust the player upwards",
-	"set the block behind the player to water",
-	"loop blocks above the player:",
-	"	set {_rand} to a random integer between 1 and 10",
-	"	set the block {_rand} meters south east of the loop-block to stone",
-	"block in horizontal facing of the clicked entity from the player is air",
-	"spawn a creeper 1.5 meters horizontally behind the player",
-	"spawn a TNT 5 meters above and 2 meters horizontally behind the player",
-	"thrust the last spawned TNT in the horizontal direction of the player with speed 0.2",
-	"push the player upwards and horizontally forward at speed 0.5",
-	"push the clicked entity in in the direction of the player at speed -0.5",
-	"open the inventory of the block 2 blocks below the player to the player",
-	"teleport the clicked entity behind the player",
-	"grow a regular tree 2 meters horizontally behind the player"})
+@Examples({
+		"thrust the player upwards",
+		"set the block behind the player to water",
+		"loop blocks above the player:",
+			"\tset {_rand} to a random integer between 1 and 10",
+			"\tset the block {_rand} meters south east of the loop-block to stone",
+		"block in horizontal facing of the clicked entity from the player is air",
+		"spawn a creeper 1.5 meters horizontally behind the player",
+		"spawn a TNT 5 meters above and 2 meters horizontally behind the player",
+		"thrust the last spawned TNT in the horizontal direction of the player with speed 0.2",
+		"push the player upwards and horizontally forward at speed 0.5",
+		"push the clicked entity in in the direction of the player at speed -0.5",
+		"open the inventory of the block 2 blocks below the player to the player",
+		"teleport the clicked entity behind the player",
+		"grow a regular tree 2 meters horizontally behind the player"})
+
 @Since("1.0 (basic), 2.0 (extended)")
 public class ExprDirection extends SimpleExpression<Direction> {
 

--- a/src/main/java/ch/njol/skript/util/PotionDataUtils.java
+++ b/src/main/java/ch/njol/skript/util/PotionDataUtils.java
@@ -34,32 +34,32 @@ public enum PotionDataUtils {
 	
 	FIRE_RESISTANCE(PotionType.FIRE_RESISTANCE, false, false, 3600, 0),
 	FIRE_RESISTANCE_LONG(PotionType.FIRE_RESISTANCE, true, false, 9600, 0),
-	HARMING(PotionType.INSTANT_DAMAGE, false, false, 1, 0),
-	HARMING_STRONG(PotionType.INSTANT_DAMAGE, false, true, 1, 1),
-	HEALING(PotionType.INSTANT_HEAL, false, false, 1, 0),
-	HEALING_STRONG(PotionType.INSTANT_HEAL, false, true, 1, 1),
+	HARMING(PotionEffectUtils.HAS_OLD_POTION_FIELDS ? "INSTANT_DAMAGE" : "HARMING", false, false, 1, 0),
+	HARMING_STRONG(PotionEffectUtils.HAS_OLD_POTION_FIELDS ? "INSTANT_DAMAGE" : "HARMING", false, true, 1, 1),
+	HEALING(PotionEffectUtils.HAS_OLD_POTION_FIELDS ? "INSTANT_HEAL" : "HEALING", false, false, 1, 0),
+	HEALING_STRONG(PotionEffectUtils.HAS_OLD_POTION_FIELDS ? "INSTANT_HEAL" : "HEALING", false, true, 1, 1),
 	INVISIBILITY(PotionType.INVISIBILITY, false, false, 3600, 0),
 	INVISIBILITY_LONG(PotionType.INVISIBILITY, true, false, 9600, 0),
-	LEAPING(PotionType.JUMP, false, false, 3600, 0),
-	LEAPING_LONG(PotionType.JUMP, true, false, 9600, 0),
-	LEAPING_STRONG(PotionType.JUMP, false, true, 1800, 1),
+	LEAPING(PotionEffectUtils.HAS_OLD_POTION_FIELDS ? "JUMP" : "LEAPING", false, false, 3600, 0),
+	LEAPING_LONG(PotionEffectUtils.HAS_OLD_POTION_FIELDS ? "JUMP" : "LEAPING", true, false, 9600, 0),
+	LEAPING_STRONG(PotionEffectUtils.HAS_OLD_POTION_FIELDS ? "JUMP" : "LEAPING", false, true, 1800, 1),
 	LUCK(PotionType.LUCK, false, false, 6000, 0),
 	NIGHT_VISION(PotionType.NIGHT_VISION, false, false, 3600, 0),
 	NIGHT_VISION_LONG(PotionType.NIGHT_VISION, true, false, 9600, 0),
 	POISON(PotionType.POISON, false, false, 900, 0),
 	POISON_LONG(PotionType.POISON, true, false, 1800, 0),
 	POISON_STRONG(PotionType.POISON, false, true, 432, 1),
-	REGENERATION(PotionType.REGEN, false, false, 900, 0),
-	REGENERATION_LONG(PotionType.REGEN, true, false, 1800, 0),
-	REGENERATION_STRONG(PotionType.REGEN, false, true, 450, 1),
+	REGENERATION(PotionEffectUtils.HAS_OLD_POTION_FIELDS ? "REGEN" : "REGENERATION", false, false, 900, 0),
+	REGENERATION_LONG(PotionEffectUtils.HAS_OLD_POTION_FIELDS ? "REGEN" : "REGENERATION", true, false, 1800, 0),
+	REGENERATION_STRONG(PotionEffectUtils.HAS_OLD_POTION_FIELDS ? "REGEN" : "REGENERATION", false, true, 450, 1),
 	SLOW_FALLING("SLOW_FALLING", false, false, 1800, 0), // Added in 1.13
 	SLOW_FALLING_LONG("SLOW_FALLING", true, false, 4800, 0),
 	SLOWNESS(PotionType.SLOWNESS, false, false, 1800, 0),
 	SLOWNESS_LONG(PotionType.SLOWNESS, true, false, 4800, 0),
 	SLOWNESS_STRONG(PotionType.SLOWNESS, false, true, 400, 3),
-	SWIFTNESS(PotionType.SPEED, false, false, 3600, 0),
-	SWIFTNESS_LONG(PotionType.SPEED, true, false, 9600, 0),
-	SWIFTNESS_STRONG(PotionType.SPEED, false, true, 1800, 1),
+	SWIFTNESS(PotionEffectUtils.HAS_OLD_POTION_FIELDS ? "SPEED" : "SWIFTNESS", false, false, 3600, 0),
+	SWIFTNESS_LONG(PotionEffectUtils.HAS_OLD_POTION_FIELDS ? "SPEED" : "SWIFTNESS", true, false, 9600, 0),
+	SWIFTNESS_STRONG(PotionEffectUtils.HAS_OLD_POTION_FIELDS ? "SPEED" : "SWIFTNESS", false, true, 1800, 1),
 	STRENGTH(PotionType.STRENGTH, false, false, 3600, 0),
 	STRENGTH_LONG(PotionType.STRENGTH, true, false, 9600, 0),
 	STRENGTH_STRONG(PotionType.STRENGTH, false, true, 1800, 1),
@@ -70,6 +70,8 @@ public enum PotionDataUtils {
 	WATER_BREATHING_LONG(PotionType.WATER_BREATHING, true, false, 9600, 0),
 	WEAKNESS(PotionType.WEAKNESS, false, false, 1800, 0),
 	WEAKNESS_LONG(PotionType.WEAKNESS, false, false, 4800, 0);
+
+
 	
 	@Nullable
 	private String name;
@@ -124,6 +126,9 @@ public enum PotionDataUtils {
 		}
 		return potionEffects;
 	}
+
+	private static final PotionEffectType SLOW = PotionEffectUtils.HAS_OLD_POTION_FIELDS ? PotionEffectType.getByName("SLOW") : PotionEffectType.SLOWNESS;
+	private static final PotionEffectType DAMAGE_RESISTANCE = PotionEffectUtils.HAS_OLD_POTION_FIELDS ? PotionEffectType.getByName("DAMAGE_RESISTANCE") : PotionEffectType.RESISTANCE;
 	
 	// Bukkit does not account for the fact that Turtle Master has 2 potion effects
 	@SuppressWarnings("null")
@@ -134,8 +139,8 @@ public enum PotionDataUtils {
 		int resistanceAmp = data.upgraded ? 3 : 2;
 		
 		// This is a stupid bandaid because for some reason Skript wont compare these with potion effects from Skript
-		PotionEffectType slow = PotionEffectUtils.parseByEffectType(PotionEffectType.SLOW);
-		PotionEffectType damage = PotionEffectUtils.parseByEffectType(PotionEffectType.DAMAGE_RESISTANCE);
+		PotionEffectType slow = PotionEffectUtils.parseByEffectType(SLOW);
+		PotionEffectType damage = PotionEffectUtils.parseByEffectType(DAMAGE_RESISTANCE);
 		if (slow != null || damage != null) {
 			potionEffects.add(new PotionEffect(slow, duration, slowAmp, false));
 			potionEffects.add(new PotionEffect(damage, duration, resistanceAmp, false));

--- a/src/main/java/ch/njol/skript/util/PotionDataUtils.java
+++ b/src/main/java/ch/njol/skript/util/PotionDataUtils.java
@@ -70,8 +70,6 @@ public enum PotionDataUtils {
 	WATER_BREATHING_LONG(PotionType.WATER_BREATHING, true, false, 9600, 0),
 	WEAKNESS(PotionType.WEAKNESS, false, false, 1800, 0),
 	WEAKNESS_LONG(PotionType.WEAKNESS, false, false, 4800, 0);
-
-
 	
 	@Nullable
 	private String name;

--- a/src/main/java/ch/njol/skript/util/PotionEffectUtils.java
+++ b/src/main/java/ch/njol/skript/util/PotionEffectUtils.java
@@ -18,6 +18,9 @@
  */
 package ch.njol.skript.util;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -30,6 +33,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.inventory.meta.SuspiciousStewMeta;
 import org.bukkit.potion.Potion;
+import org.bukkit.potion.PotionData;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.potion.PotionType;
@@ -44,6 +48,7 @@ import ch.njol.skript.localization.LanguageChangeListener;
 public abstract class PotionEffectUtils {
 
 	private static final boolean HAS_SUSPICIOUS_META = Skript.classExists("org.bukkit.inventory.meta.SuspiciousStewMeta");
+	static final boolean HAS_OLD_POTION_FIELDS = Skript.fieldExists(PotionEffectType.class, "SLOW");
 
 	private PotionEffectUtils() {}
 
@@ -69,7 +74,10 @@ public abstract class PotionEffectUtils {
 				for (final PotionEffectType t : PotionEffectType.values()) {
 					if (t == null)
 						continue;
-					final String[] ls = Language.getList("potions." + t.getName());
+					String name = t.getName();
+					if (name.startsWith("minecraft:")) // seems to be the case for experimental entries...
+						name = name.substring(10); // trim off namespace
+					final String[] ls = Language.getList("potions." + name);
 					names[t.getId()] = ls[0];
 					for (final String l : ls) {
 						types.put(l.toLowerCase(Locale.ENGLISH), t);
@@ -139,13 +147,15 @@ public abstract class PotionEffectUtils {
 	 * Unused currently, will be used soon (TM).
 	 * @param name Name of potion type
 	 * @return
+	 * @deprecated To be removed in a future version.
 	 */
 	@Nullable
+	@Deprecated
 	public static PotionType checkPotionType(String name) {
 		switch (name) {
 			case "uncraftable":
 			case "empty":
-				return PotionType.UNCRAFTABLE;
+				return PotionType.valueOf("uncraftable");
 			case "mundane":
 				return PotionType.MUNDANE;
 			case "thick":
@@ -157,13 +167,13 @@ public abstract class PotionEffectUtils {
 				return PotionType.INVISIBILITY;
 			case "leaping":
 			case "jump boost":
-				return PotionType.JUMP;
+				return HAS_OLD_POTION_FIELDS ? PotionType.valueOf("JUMP") : PotionType.LEAPING;
 			case "fire resistance":
 			case "fire immunity":
 				return PotionType.FIRE_RESISTANCE;
 			case "swiftness":
 			case "speed":
-				return PotionType.SPEED;
+				return HAS_OLD_POTION_FIELDS ? PotionType.valueOf("SPEED") : PotionType.SWIFTNESS;
 			case "slowness":
 				return PotionType.SLOWNESS;
 			case "water breathing":
@@ -171,16 +181,16 @@ public abstract class PotionEffectUtils {
 			case "instant health":
 			case "healing":
 			case "health":
-				return PotionType.INSTANT_HEAL;
+				return HAS_OLD_POTION_FIELDS ? PotionType.valueOf("INSTANT_HEAL") : PotionType.HEALING;
 			case "instant damage":
 			case "harming":
 			case "damage":
-				return PotionType.INSTANT_DAMAGE;
+				return HAS_OLD_POTION_FIELDS ? PotionType.valueOf("INSTANT_DAMAGE") : PotionType.HARMING;
 			case "poison":
 				return PotionType.POISON;
 			case "regeneration":
 			case "regen":
-				return PotionType.REGEN;
+				return HAS_OLD_POTION_FIELDS ? PotionType.valueOf("REGEN") : PotionType.REGENERATION;
 			case "strength":
 				return PotionType.STRENGTH;
 			case "weakness":
@@ -335,7 +345,22 @@ public abstract class PotionEffectUtils {
 		}
 		itemType.setItemMeta(meta);
 	}
-	
+
+	@Nullable
+	private static final MethodHandle BASE_POTION_DATA_HANDLE;
+
+	static {
+		MethodHandle basePotionDataHandle = null;
+		if (Skript.methodExists(PotionMeta.class, "getBasePotionData")) {
+			try {
+				basePotionDataHandle = MethodHandles.lookup().findVirtual(PotionMeta.class, "getBasePotionData", MethodType.methodType(PotionData.class));
+			} catch (NoSuchMethodException | IllegalAccessException e) {
+				Skript.exception(e, "Failed to load legacy potion data support. Potions may not work as expected.");
+			}
+		}
+		BASE_POTION_DATA_HANDLE = basePotionDataHandle;
+	}
+
 	/**
 	 * Get all the PotionEffects of an ItemType
 	 *
@@ -350,7 +375,17 @@ public abstract class PotionEffectUtils {
 		if (meta instanceof PotionMeta) {
 			PotionMeta potionMeta = ((PotionMeta) meta);
 			effects.addAll(potionMeta.getCustomEffects());
-			effects.addAll(PotionDataUtils.getPotionEffects(potionMeta.getBasePotionData()));
+			if (BASE_POTION_DATA_HANDLE != null) {
+				try {
+					effects.addAll(PotionDataUtils.getPotionEffects((PotionData) BASE_POTION_DATA_HANDLE.invoke(meta)));
+				} catch (Throwable e) {
+					throw Skript.exception(e, "An error occurred while trying to invoke legacy potion data support.");
+				}
+			} else if (potionMeta.hasBasePotionType()) {
+				//noinspection ConstantConditions - checked via hasBasePotionType
+				effects.addAll(potionMeta.getBasePotionType().getPotionEffects());
+			}
+
 		} else if (HAS_SUSPICIOUS_META && meta instanceof SuspiciousStewMeta)
 			effects.addAll(((SuspiciousStewMeta) meta).getCustomEffects());
 		return effects;

--- a/src/main/java/ch/njol/skript/util/visual/VisualEffect.java
+++ b/src/main/java/ch/njol/skript/util/visual/VisualEffect.java
@@ -100,7 +100,7 @@ public class VisualEffect implements SyntaxElement, YggdrasilSerializable {
 			}
 
 			// Some particles use offset as RGB color codes
-			if (type.isColorable() && (!HAS_REDSTONE_DATA || particle != Particle.REDSTONE) && data instanceof ParticleOption) {
+			if (type.isColorable() && (!HAS_REDSTONE_DATA || particle != (VisualEffects.OLD_REDSTONE_PARTICLE != null ? VisualEffects.OLD_REDSTONE_PARTICLE : Particle.DUST)) && data instanceof ParticleOption) {
 				ParticleOption option = ((ParticleOption) data);
 				dX = option.getRed();
 				dY = option.getGreen();

--- a/src/main/java/ch/njol/skript/util/visual/VisualEffects.java
+++ b/src/main/java/ch/njol/skript/util/visual/VisualEffects.java
@@ -120,6 +120,28 @@ public class VisualEffects {
 		effectTypeModifiers.put(id, consumer);
 	}
 
+	@Nullable
+	static final Particle OLD_REDSTONE_PARTICLE;
+	@Nullable
+	static final Particle OLD_ITEM_CRACK_PARTICLE;
+
+	static {
+		Particle oldRedstoneParticle = null;
+		Particle oldItemCrackParticle = null;
+		if (Skript.fieldExists(Particle.class, "REDSTONE")) { // initialize legacy particle support
+			try {
+				oldRedstoneParticle = Particle.valueOf("REDSTONE");
+				oldItemCrackParticle = Particle.valueOf("ITEM_CRACK");
+			} catch (IllegalArgumentException e) {
+				oldRedstoneParticle = null;
+				oldItemCrackParticle = null;
+				Skript.exception(e, "Failed to initialize legacy particle support. Some particles may not work as expected.");
+			}
+		}
+		OLD_REDSTONE_PARTICLE = oldRedstoneParticle;
+		OLD_ITEM_CRACK_PARTICLE = oldItemCrackParticle;
+	}
+
 	static {
 		Language.addListener(() -> {
 			if (visualEffectTypes != null) // Already registered
@@ -152,7 +174,7 @@ public class VisualEffects {
 				Color color = raw == null ? defaultColor : (Color) raw;
 				ParticleOption particleOption = new ParticleOption(color, 1);
 
-				if (HAS_REDSTONE_DATA && Particle.REDSTONE.getDataType() == Particle.DustOptions.class) {
+				if (HAS_REDSTONE_DATA && (OLD_REDSTONE_PARTICLE == null || OLD_REDSTONE_PARTICLE.getDataType() == Particle.DustOptions.class)) {
 					return new Particle.DustOptions(particleOption.getBukkitColor(), particleOption.size);
 				} else {
 					return particleOption;
@@ -174,7 +196,7 @@ public class VisualEffects {
 				}
 
 				assert itemStack != null;
-				if (Particle.ITEM_CRACK.getDataType() == Material.class)
+				if (OLD_ITEM_CRACK_PARTICLE == null || OLD_ITEM_CRACK_PARTICLE.getDataType() == Material.class)
 					return itemStack.getType();
 				return itemStack;
 			});

--- a/src/main/java/ch/njol/util/coll/CyclicList.java
+++ b/src/main/java/ch/njol/util/coll/CyclicList.java
@@ -62,19 +62,18 @@ public final class CyclicList<E> extends AbstractList<E> {
 	
 	@Override
 	public boolean add(final @Nullable E e) {
-		return addLast(e);
+		addLast(e);
+		return true;
 	}
 	
-	public boolean addFirst(final @Nullable E e) {
+	public void addFirst(final @Nullable E e) {
 		start = Math2.mod(start - 1, items.length);
 		items[start] = e;
-		return true;
 	}
 	
-	public boolean addLast(final @Nullable E e) {
+	public void addLast(final @Nullable E e) {
 		items[start] = e;
 		start = Math2.mod(start + 1, items.length);
-		return true;
 	}
 	
 	@SuppressWarnings("null")

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -1260,6 +1260,13 @@ entities:
 	wind charge:
 		name: wind charge¦s
 		pattern: wind charge(|1¦s)
+	# 1.20.5 Entities
+	armadillo:
+		name: armadillo¦s @an
+		pattern: <age> armadillo(|1¦s)|(4¦)armadillo (kid(|1¦s)|child(|1¦ren))
+	bogged:
+		name: bogged
+		pattern: bogged
 
 # -- Heal Reasons --
 heal reasons:

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -95,6 +95,10 @@ enchantments:
 		soul_speed: Soul Speed
 		# new 1.19 Enchantment
 		swift_sneak: Swift Sneak
+		# new 1.21 Enchantments (added in 1.20.5 experimental)
+		density: Density
+		breach: Breach
+		wind_burst: Wind Burst
 
 # -- Potion Effects --
 potions:
@@ -137,6 +141,14 @@ potions:
 
 	# 1.19 potion effect types
 	darkness: darkness
+
+	# 1.21 potion effect types (added in 1.20.5 experimental)
+	wind_charged: wind charged
+	raid_omen: bad omen, raid omen
+	infested: infested
+	weaving: weaving
+	trial_omen: trial omen
+	oozing: oozing
 
 # -- Weather --
 weather:

--- a/src/test/skript/environments/java21/paper-1.20.6.json
+++ b/src/test/skript/environments/java21/paper-1.20.6.json
@@ -1,0 +1,17 @@
+{
+	"name": "paper-1.20.6",
+	"resources": [
+		{"source": "server.properties.generic", "target": "server.properties"}
+	],
+	"paperDownloads": [
+		{
+			"version": "1.20.6",
+			"target": "paperclip.jar"
+		}
+	],
+	"skriptTarget": "plugins/Skript.jar",
+	"commandLine": [
+		"-Dcom.mojang.eula.agree=true",
+		"-jar", "paperclip.jar", "--nogui"
+	]
+}

--- a/src/test/skript/tests/regressions/3284-itemcrack particle.sk
+++ b/src/test/skript/tests/regressions/3284-itemcrack particle.sk
@@ -1,3 +1,3 @@
-test "item crack particles":
+test "item crack particles" when running below minecraft "1.20.5":
 	set {_loc} to location of spawn of world "world"
 	play diamond sword item crack at {_loc}

--- a/src/test/skript/tests/regressions/3284-itemcrack particle.sk
+++ b/src/test/skript/tests/regressions/3284-itemcrack particle.sk
@@ -1,3 +1,3 @@
-test "item crack particles" when running below minecraft "1.20.5":
+test "item crack particles" when running below minecraft "1.20.5": # item crack does not exist on 1.20.5
 	set {_loc} to location of spawn of world "world"
 	play diamond sword item crack at {_loc}

--- a/src/test/skript/tests/regressions/6612-nearest entity cast error.sk
+++ b/src/test/skript/tests/regressions/6612-nearest entity cast error.sk
@@ -1,0 +1,18 @@
+test "charge creeper nearest entity cast":
+	set {_location} to spawn of world "world"
+	spawn a creeper at {_location}
+	set {_creeper} to last spawned creeper
+	assert {_creeper} is not charged with "spawning a normal creeper shouldn't spawn a charged one"
+	make (nearest creeper to {_location}) charged # this used to throw an exception
+	assert {_creeper} is charged with "a creeper should be charged after it is set as charged"
+	uncharge the nearest creeper to {_location} # this would also throw an exception
+	assert {_creeper} is not charged with "uncharging a charged creeper should uncharge it"
+	delete the last spawned creeper
+
+test "poison nearest entity cast":
+	set {_location} to spawn of world "world"
+	spawn a creeper at {_location}
+	set {_creeper} to last spawned creeper
+	poison (nearest entity to {_location}) # this never threw an exception
+	poison (nearest creeper to {_location}) # this used to throw an exception
+	delete the last spawned creeper

--- a/src/test/skript/tests/regressions/pull-6586-effhealth item mutation.sk
+++ b/src/test/skript/tests/regressions/pull-6586-effhealth item mutation.sk
@@ -1,0 +1,14 @@
+
+# Test not related to a made issue. Details at pull request.
+test "EffHealth item mutation fix":
+	set {_item1} and {_item1Copy} to diamond sword with damage 100
+	set {_item2} and {_item2Copy} to iron sword
+	repair {_item2} and {_item1}
+	assert {_item1} is iron sword to fail with "{_item1} is an iron sword even though it was diamond before repair"
+	assert {_item2} is {_item2Copy} with "{_item2} was no longer the same item"
+
+	set {_item1} to diamond sword with damage 100
+	set {_item2} to diamond with damage 10
+	repair {_item1}, {_item2}
+	assert {_item1} is diamond sword with damage 0 with "{_item1} was incorrectly repaired"
+	assert {_item2} is diamond with "{_item2} was no longer a diamond"

--- a/src/test/skript/tests/syntaxes/expressions/ExprDirection.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprDirection.sk
@@ -1,0 +1,278 @@
+#
+# Due to the amount that ExprDirection is used in syntax this is a full test or intended to be a full test this test
+# should cover every pattern and *most of* every possible usage to always be sure when an error occurs that it's 100% unintended
+#
+
+# Syntax testing, checking for a pattern error
+test "ExprDirection - syntax validation pt1":
+	parse:
+		# don't care if receiver is null just ensuring syntax is working as intended so parsing is being tested
+
+		# NORTH
+		send north to {_null}
+		send north of to {_null}
+		send north side of to {_null}
+		send to the north to {_null}
+		send northern to {_null}
+		send northerly to {_null}
+		send northward to {_null}
+		send northwards to {_null}
+		send 1 north to {_null}
+		send 1 block north to {_null}
+		send 1 metre north to {_null}
+		send 1 meter north to {_null}
+		send 2 meters north to {_null}
+
+		# EAST
+		send east to {_null}
+		send east of to {_null}
+		send east side of to {_null}
+		send to the east to {_null}
+		send eastern to {_null}
+		send easterly to {_null}
+		send eastward to {_null}
+		send eastwards to {_null}
+		send 1 east to {_null}
+		send 1 block east to {_null}
+		send 1 metre east to {_null}
+		send 1 meter east to {_null}
+		send 2 meters east to {_null}
+
+		# SOUTH
+		send south to {_null}
+		send south of to {_null}
+		send south side of to {_null}
+		send to the south to {_null}
+		send southern to {_null}
+		send southerly to {_null}
+		send southward to {_null}
+		send southwards to {_null}
+		send 1 south to {_null}
+		send 1 block south to {_null}
+		send 1 metre south to {_null}
+		send 1 meter south to {_null}
+		send 2 meters south to {_null}
+
+		# WEST
+		send west to {_null}
+		send west of to {_null}
+		send west side of to {_null}
+		send to the west to {_null}
+		send western to {_null}
+		send westerly to {_null}
+		send westward to {_null}
+		send westwards to {_null}
+		send 1 west to {_null}
+		send 1 block west to {_null}
+		send 1 metre west to {_null}
+		send 1 meter west to {_null}
+		send 2 meters west to {_null}
+
+		# NORTH WEST/EAST
+		send northwest to {_null}
+		send north-west to {_null}
+		send north west to {_null}
+		send northwest of to {_null}
+		send northwest side of to {_null}
+		send to the northwest to {_null}
+		send northwestern to {_null}
+		send northwesterly to {_null}
+		send northwestward to {_null}
+		send northwestwards to {_null}
+		send northwestwardly to {_null}
+		send 1 northwest to {_null}
+		send 1 block northwest to {_null}
+		send 1 metre northwest to {_null}
+		send 1 meter northwest to {_null}
+		send 2 meters northwest to {_null}
+
+		send northeast to {_null}
+		send north-east to {_null}
+		send north east to {_null}
+		send northeast of to {_null}
+		send northeast side of to {_null}
+		send to the northeast to {_null}
+		send northeastern to {_null}
+		send northeasterly to {_null}
+		send northeastward to {_null}
+		send northeastwards to {_null}
+		send northeastwardly to {_null}
+		send 1 northeast to {_null}
+		send 1 block northeast to {_null}
+		send 1 metre northeast to {_null}
+		send 1 meter northeast to {_null}
+		send 2 meters northeast to {_null}
+
+		# SOUTH WEST/EAST
+		send south west to {_null}
+		send south-west to {_null}
+		send southwest to {_null}
+		send south western to {_null}
+		send south westerly to {_null}
+		send south westward to {_null}
+		send south westwards to {_null}
+		send south westwardly to {_null}
+		send south west of to {_null}
+		send south west side of to {_null}
+		send to the south west to {_null}
+		send 1 south west to {_null}
+		send 1 block south west to {_null}
+		send 1 metre south west to {_null}
+		send 1 meter south west to {_null}
+		send 2 meters south west to {_null}
+
+		send south east to {_null}
+		send south-east to {_null}
+		send southeast to {_null}
+		send south eastern to {_null}
+		send south easterly to {_null}
+		send south eastward to {_null}
+		send south eastwards to {_null}
+		send south eastwardly to {_null}
+		send south east of to {_null}
+		send south east side of to {_null}
+		send to the south east to {_null}
+		send 1 south east to {_null}
+		send 1 block south east to {_null}
+		send 1 metre south east to {_null}
+		send 1 meter south east to {_null}
+		send 2 meters south east to {_null}
+
+		# UP
+		send above to {_null}
+		send over to {_null}
+		send up to {_null}
+		send upward to {_null}
+		send upwards to {_null}
+		send upwardly to {_null}
+		send 1 above to {_null}
+		send 1 block above to {_null}
+		send 1 meter above to {_null}
+		send 1 metre above to {_null}
+		send 2 meters above to {_null}
+
+		# DOWN
+		send below to {_null}
+		send under to {_null}
+		send down to {_null}
+		send downward to {_null}
+		send downwards to {_null}
+		send downwardly to {_null}
+		send 1 below to {_null}
+		send 1 block below to {_null}
+		send 1 metre below to {_null}
+		send 1 meter below to {_null}
+		send 2 meters below to {_null}
+
+
+		# FACING/DIRECTION
+		send direction of {_ent} to {_null}
+		send facing of {_ent} to {_null}
+		send horizontal direction of {_ent} to {_null}
+		send 1 direction of {_ent} to {_null}
+		send 1 block facing of {_ent} to {_null}
+		send 1 metre facing of {_ent} to {_null}
+		send 1 meter facing of {_ent} to {_null}
+		send 2 meters facing of {_ent} to {_null}
+		send in direction of {_ent} to {_null}
+		send in the direction of {_ent} to {_null}
+		send in the horizontal direction of {_ent} to {_null}
+		send facing of {_ent} of to {_null}
+		send facing of {_ent} from to {_null}
+
+		send {_ent}'s direction to {_null}
+		send {_ent}'s facing to {_null}
+		send {_ent}'s horizontal direction to {_null}
+		send 1 {_ent}'s direction to {_null}
+		send in {_ent}'s facing to {_null}
+		send 1 metre in {_ent}'s facing to {_null}
+		send 1 meter {_ent}'s facing to {_null}
+		send 2 meters {_ent}'s facing to {_null}
+		send in {_ent}'s direction to {_null}
+		send in {_ent}'s horizontal direction to {_null}
+		send {_ent}'s facing of to {_null}
+		send {_ent}'s facing from to {_null}
+
+		# LEFT/RIGHT
+		send right to {_null}
+		send left to {_null}
+		send right side of to {_null}
+		send left of to {_null}
+		send 1 right to {_null}
+		send 1 block left to {_null}
+		send 1 metre right to {_null}
+		send 1 meter left to {_null}
+		send 2 meters right to {_null}
+		send 1 block horizontally left to {_null}
+		send 1 block horizontally to the left to {_null}
+
+		# INFRONT
+		send in front to {_null}
+		send infront to {_null}
+		send in front of to {_null}
+		send forwards to {_null}
+		send horizontally in front of to {_null}
+		send 1 infront to {_null}
+		send 1 block infront of to {_null}
+		send 1 metre infront of to {_null}
+		send 1 meter infront of to {_null}
+		send 2 meters infront of to {_null}
+
+		# BEHIND
+		send behind to {_null}
+		send backwards to {_null}
+		send horizontally backwards to {_null}
+		send 1 behind to {_null}
+		send 1 block behind to {_null}
+		send 1 metre behind to {_null}
+		send 1 meter behind to {_null}
+		send 2 meters behind to {_null}
+	assert last parse logs is not set with "there was a parse error: %last parse logs%"
+
+test "ExprDirection - syntax validation pt2":
+	set {_block} to block 50 blocks above spawn of world "world"
+
+	assert block north of {_block} is block at {_block} ~ vector(0,0,-1) with "The block north of {_block} is not correct vector offset"
+	assert block east of {_block} is block at {_block} ~ vector(1,0,0) with "The block east of {_block} is not correct vector offset"
+	assert block south of {_block} is block at {_block} ~ vector(0,0,1) with "The block south of {_block} is not correct vector offset"
+	assert block west of {_block} is block at {_block} ~ vector(-1,0,0) with "The block west of {_block} is not correct vector offset"
+
+	assert block north west of {_block} is block at {_block} ~ vector(-1,0,-1) with "the block north west of {_block} is not correct vector offset"
+	assert block north east of {_block} is block at {_block} ~ vector(1,0,-1) with "the block north east of {_block} is not correct vector offset"
+	assert block south west of {_block} is block at {_block} ~ vector(-1,0,1) with "the block south west of {_block} is not correct vector offset"
+	assert block south east of {_block} is block at {_block} ~ vector(1,0,1) with "the block south east of {_block} is not correct vector offset"
+
+	assert block north north west of {_block} is block at {_block} ~ vector(-1,0,-2) with "the block north north west of {_block} is not correct vector offset"
+	assert block north north east of {_block} is block at {_block} ~ vector(1,0,-2) with "the block north north east of {_block} is not correct vector offset"
+	assert block south south west of {_block} is block at {_block} ~ vector(-1,0,2) with "the block south south west of {_block} is not correct vector offset"
+	assert block south south east of {_block} is block at {_block} ~ vector(1,0,2) with "the block south south east of {_block} is not correct vector offset"
+
+	# These test will pass, however these are dependent on existing behavior i.e. no facing and using infront of = south
+	assert block below {_block} is block at {_block} ~ vector(0,-1,0) with "the block below {_block} is not correct vector offset"
+	assert block above {_block} is block at {_block} ~ vector(0,1,0) with "the block above {_block} is not correct vector offset"
+	assert block behind {_block} is block at {_block} ~ vector(1,0,0) with "the block behind {_block} is not correct vector offset"
+	assert block in front of {_block} is block at {_block} ~ vector(-1,0,0) with "the block in front of {_block} is not correct vector offset"
+	assert block left of {_block} is block at {_block} ~ vector(0,0,1) with "the block left of {_block} is not correct vector offset"
+	assert block right of {_block} is block at {_block} ~ vector(0,0,-1) with "the block right of {_block} is not correct vector offset"
+
+	# the cheatsheet is entirely useless for this section of the test as all directions have been changed to a new orientation
+
+	set block at {_block} to top westward oak wood stair
+	assert {_block} is top westward oak wood stair with "Block was not a 'top westward oak wood stair' block"
+
+	assert block below {_block} is block at {_block} ~ vector(0,-1,0) with "Part2 - the block below {_block} is not correct vector offset"
+	assert block above {_block} is block at {_block} ~ vector(0,1,0) with "Part2 - the block above {_block} is not correct vector offset"
+	assert block behind {_block} is block at {_block} ~ vector(1,0,0) with "Part2 - the block behind {_block} is not correct vector offset"
+	assert block in front of {_block} is block at {_block} ~ vector(-1,0,0) with "Part2 - the block in front of {_block} is not correct vector offset"
+	assert block left of {_block} is block at {_block} ~ vector(0,0,1) with "Part2 - the block left of {_block} is not correct vector offset"
+	assert block right of {_block} is block at {_block} ~ vector(0,0,-1) with "Part2 - he block right of {_block} is not correct vector offset"
+
+	assert block 10 blocks infront of {_block} is block at {_block} ~ vector(-10,0,0) with "Part2 - the block 10 in front of {_block} is not correct vector offset"
+	assert block 11 blocks left of {_block} is block at {_block} ~ vector(0,0,11) with "Part2 - the block 11 left of {_block} is not correct vector offset"
+	assert block 5 blocks left of {_block} is block at {_block} ~ vector(0,0,5) with "Part2 - the 5 blocks left of {_block} is not correct vector offset"
+	assert block -5 block right of {_block} is block at {_block} ~ vector(0,0,5) with "Part2 - the -5 blocks right of {_block} is not correct vector offset"
+
+	# there is currently a skript bug where -anything right/left causes parser to fail
+	set {_block2} to block -10 meters north of {_block}
+	assert block -5 meters right of {_block2} is block at {_block} ~ vector(5,0,10) with "Part2 - the block -10 north and -5 right of {_block} is not correct vector offset"
+	set block at {_block} to air


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
This PR aims to try and cleanup some of the mess in ExprDirection more notably the patterns where it was basically unreadable to anyone regardless how much you try to split it up. I intended to cause no breaking changes however if a breaking change appears please let me know so I can change it 

The biggest change is gonna be where `north`, `east`, `south`, `west`, `up`, `down` pattern was. They been split up into
general direction and up/down. This should provide an easier time in reading while also making the most of parse tags.

Now I'm sure there's gonna be a bit of concern about the enum and "tags" field used however as I stated in the comment I saw no other workaround for this, I'm already using a mildly janky pattern to support every direction without causing any breaking changes. All while trying not to use parse marks just to save source code readability couldn't stand seeing `blah ^ blah` everywhere just for some basic `north west`, `north east` support

I would however love some feedback on a better enum name as "DirectionMapping" was simply a placeholder or suppose to be.

## Pattern Before/After
*these were edited to the way they appear on the docs as such bits might of been accidently removed*
I didn't realize `[to the]` was apart of the `[%number ....]` until I added this however since `to the south` makes sense I have no intention of moving it back

### Before
```applescript
[%number% [(block|met(er|re))[s]] [to the]] (north[[(-| )](east|west)][(ward[(s|ly)]|er[(n|ly)])] [of]|south[[(-| )](east|west)][(ward[(s|ly)]|er[(n|ly)])] [of]|(east|west)[(ward[(s|ly)]|er[(n|ly)])] [of]|above|over|(up|down)[ward[(s|ly)]]|below|under[neath]|beneath) [%direction%]
[%number% [(block|met(er|re))[s]]] in [the] (direction|horizontal direction|facing|horizontal facing) of %entity/block% [(of|from)]
[%number% [(block|met(er|re))[s]]] in %entity/block%'[s] (direction|horizontal direction|facing|horizontal facing) [(of|from)]
[%number% [(block|met(er|re))[s]]] (in[ ]front [of]|forward[s]|behind|backwards|[to the] (right|left) [of])
[%number% [(block|met(er|re))[s]]] horizontal[ly] (in[ ]front [of]|forward[s]|behind|backwards|to the (right|left) [of])
```
### After
```applescript
[%number% [(block|met(er|re))[s]]] [to the] (:(north[[-| ](east|west)]|east|south[[ |-](east|west)]|west))[ward[s|ly]|er(n|ly)] [of] [%direction%]
[%number% [(block|met(er|re))[s]]] [to the] (up:(above|over|up[ward[s|ly]])|down:(down[ward[s|ly]]|below|under[neath]|beneath)) [%direction%]
[%number% [(block|met(er|re))[s]]] in [the] [horizontal] (direction|facing) of %entity/block% [of|from]
[%number% [(block|met(er|re))[s]]] in %entity/block%'[s] [horizontal] (direction|facing) [of|from]
[%number% [(block|met(er|re))[s]]] [horizontal[ly]] (in[ ]front [of]|forward[s]|(behind|backwards)|[to the] (right|left) [of])
```

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
