### PR TITLE
Add dynamic usage messages for commands

### DIFF
--- a/src/main/java/ch/njol/skript/command/CommandUsage.java
+++ b/src/main/java/ch/njol/skript/command/CommandUsage.java
@@ -1,0 +1,75 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.command;
+
+import ch.njol.skript.lang.VariableString;
+import ch.njol.skript.util.Utils;
+import com.google.errorprone.annotations.Var;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Holds info about the usage of a command.
+ * TODO: replace with record when java 17
+ */
+public class CommandUsage {
+
+	/**
+	 * A dynamic usage message that can contain expressions.
+	 */
+	private final VariableString usage;
+
+	/**
+	 * A fallback usage message that can be used in non-event environments,
+	 * like when registering the Bukkit command.
+	 */
+	private final String defaultUsage;
+
+	/**
+	 * @param usage The dynamic usage message, can contain expressions.
+	 * @param defaultUsage A fallback usage message for use in non-event environments.
+	 */
+	public CommandUsage(VariableString usage, String defaultUsage) {
+		this.usage = usage;
+		this.defaultUsage = Utils.replaceChatStyles(defaultUsage);
+	}
+
+	/**
+	 * @return The usage message as a {@link VariableString}
+	 */
+	public VariableString getRawUsage() {
+		return usage;
+	}
+
+	/**
+	 * @param event The event used to evaluate the usage message.
+	 * @return The evaluated usage message.
+	 */
+	public String getUsage(Event event) {
+		return usage.getSingle(event);
+	}
+
+	/**
+	 * @return The fallback usage message, only for use in environments without access to an event.
+	 */
+	public String getDefaultUsage() {
+		return defaultUsage;
+	}
+}

--- a/src/main/java/ch/njol/skript/command/CommandUsage.java
+++ b/src/main/java/ch/njol/skript/command/CommandUsage.java
@@ -20,9 +20,7 @@ package ch.njol.skript.command;
 
 import ch.njol.skript.lang.VariableString;
 import ch.njol.skript.util.Utils;
-import com.google.errorprone.annotations.Var;
 import org.bukkit.event.Event;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -77,6 +75,11 @@ public class CommandUsage {
 		if (event != null || usage.isSimple())
 			return usage.toString(event);
 		return defaultUsage;
+	}
+
+	@Override
+	public String toString() {
+		return getUsage();
 	}
 
 }

--- a/src/main/java/ch/njol/skript/command/CommandUsage.java
+++ b/src/main/java/ch/njol/skript/command/CommandUsage.java
@@ -46,30 +46,37 @@ public class CommandUsage {
 	 * @param usage The dynamic usage message, can contain expressions.
 	 * @param defaultUsage A fallback usage message for use in non-event environments.
 	 */
-	public CommandUsage(VariableString usage, String defaultUsage) {
+	public CommandUsage(@Nullable VariableString usage, String defaultUsage) {
+		if (usage == null) {
+			usage = VariableString.newInstance(defaultUsage);
+			assert usage != null;
+		}
 		this.usage = usage;
 		this.defaultUsage = Utils.replaceChatStyles(defaultUsage);
 	}
 
 	/**
-	 * @return The usage message as a {@link VariableString}
+	 * @return The usage message as a {@link VariableString}.
 	 */
 	public VariableString getRawUsage() {
 		return usage;
+	}
+	/**
+	 * Get the usage message without an event to evaluate it.
+	 * @return The evaluated usage message.
+	 */
+	public String getUsage() {
+		return getUsage(null);
 	}
 
 	/**
 	 * @param event The event used to evaluate the usage message.
 	 * @return The evaluated usage message.
 	 */
-	public String getUsage(Event event) {
-		return usage.getSingle(event);
-	}
-
-	/**
-	 * @return The fallback usage message, only for use in environments without access to an event.
-	 */
-	public String getDefaultUsage() {
+	public String getUsage(@Nullable Event event) {
+		if (event != null || usage.isSimple())
+			return usage.toString(event);
 		return defaultUsage;
 	}
+
 }

--- a/src/main/java/ch/njol/skript/command/ScriptCommand.java
+++ b/src/main/java/ch/njol/skript/command/ScriptCommand.java
@@ -205,7 +205,7 @@ public class ScriptCommand implements TabExecutor {
 			// We can only set the message if it's simple (doesn't contains expressions)
 			if (permissionMessage.isSimple())
 				bukkitCommand.setPermissionMessage(permissionMessage.toString(null));
-			bukkitCommand.setUsage(usage.getDefaultUsage());
+			bukkitCommand.setUsage(usage.getUsage());
 			bukkitCommand.setExecutor(this);
 			return bukkitCommand;
 		} catch (final Exception e) {
@@ -342,7 +342,7 @@ public class ScriptCommand implements TabExecutor {
 	public void sendHelp(final CommandSender sender) {
 		if (!description.isEmpty())
 			sender.sendMessage(description);
-		sender.sendMessage(ChatColor.GOLD + "Usage" + ChatColor.RESET + ": " + usage);
+		sender.sendMessage(ChatColor.GOLD + "Usage" + ChatColor.RESET + ": " + usage.getUsage());
 	}
 
 	/**

--- a/src/main/java/ch/njol/skript/command/ScriptCommand.java
+++ b/src/main/java/ch/njol/skript/command/ScriptCommand.java
@@ -115,12 +115,13 @@ public class ScriptCommand implements TabExecutor {
 
 	private Map<UUID,Date> lastUsageMap = new HashMap<>();
 
+	//<editor-fold default-state="collapsed" desc="public ScriptCommand(... String usage ...)">
 	/**
 	 * Creates a new ScriptCommand.
-	 * Deprecated in favor of using the new CommandUsage class for the usage parameter.
+	 * Prefer using the CommandUsage class for the usage parameter.
 	 *
 	 * @param name /name
-	 * @param pattern
+	 * @param pattern the Skript pattern used to parse the input into arguments.
 	 * @param arguments the list of Arguments this command takes
 	 * @param description description to display in /help
 	 * @param prefix the prefix of the command
@@ -130,7 +131,6 @@ public class ScriptCommand implements TabExecutor {
 	 * @param permissionMessage message to display if the player doesn't have the given permission
 	 * @param node the node to parse and load into a Trigger
 	 */
-	@Deprecated(forRemoval = true)
 	public ScriptCommand(
 		Script script, String name, String pattern, List<Argument<?>> arguments,
 		String description, @Nullable String prefix, String usage, List<String> aliases,
@@ -142,6 +142,7 @@ public class ScriptCommand implements TabExecutor {
 				aliases, permission, permissionMessage, cooldown, cooldownMessage, cooldownBypass,
 				cooldownStorage, executableBy, node);
 	}
+	//</editor-fold>
 
 	/**
 	 * Creates a new ScriptCommand.

--- a/src/main/java/ch/njol/skript/command/ScriptCommand.java
+++ b/src/main/java/ch/njol/skript/command/ScriptCommand.java
@@ -116,10 +116,38 @@ public class ScriptCommand implements TabExecutor {
 	private Map<UUID,Date> lastUsageMap = new HashMap<>();
 
 	/**
-	 * Creates a new SkriptCommand.
+	 * Creates a new ScriptCommand.
+	 * Deprecated in favor of using the new CommandUsage class for the usage parameter.
 	 *
 	 * @param name /name
 	 * @param pattern
+	 * @param arguments the list of Arguments this command takes
+	 * @param description description to display in /help
+	 * @param prefix the prefix of the command
+	 * @param usage message to display if the command was used incorrectly
+	 * @param aliases /alias1, /alias2, ...
+	 * @param permission permission or null if none
+	 * @param permissionMessage message to display if the player doesn't have the given permission
+	 * @param node the node to parse and load into a Trigger
+	 */
+	@Deprecated(forRemoval = true)
+	public ScriptCommand(
+		Script script, String name, String pattern, List<Argument<?>> arguments,
+		String description, @Nullable String prefix, String usage, List<String> aliases,
+		String permission, @Nullable VariableString permissionMessage, @Nullable Timespan cooldown,
+		@Nullable VariableString cooldownMessage, String cooldownBypass,
+		@Nullable VariableString cooldownStorage, int executableBy, SectionNode node
+	) {
+		this(script, name, pattern, arguments, description, prefix, new CommandUsage(null, usage),
+				aliases, permission, permissionMessage, cooldown, cooldownMessage, cooldownBypass,
+				cooldownStorage, executableBy, node);
+	}
+
+	/**
+	 * Creates a new ScriptCommand.
+	 *
+	 * @param name /name
+	 * @param pattern the Skript pattern used to parse the input into arguments.
 	 * @param arguments the list of Arguments this command takes
 	 * @param description description to display in /help
 	 * @param prefix the prefix of the command

--- a/src/main/java/ch/njol/skript/command/ScriptCommand.java
+++ b/src/main/java/ch/njol/skript/command/ScriptCommand.java
@@ -101,7 +101,7 @@ public class ScriptCommand implements TabExecutor {
 	private final String cooldownBypass;
 	@Nullable
 	private final Expression<String> cooldownStorage;
-	final String usage;
+	final CommandUsage usage;
 
 	private final Trigger trigger;
 
@@ -131,7 +131,7 @@ public class ScriptCommand implements TabExecutor {
 	 */
 	public ScriptCommand(
 		Script script, String name, String pattern, List<Argument<?>> arguments,
-		String description, @Nullable String prefix, String usage, List<String> aliases,
+		String description, @Nullable String prefix, CommandUsage usage, List<String> aliases,
 		String permission, @Nullable VariableString permissionMessage, @Nullable Timespan cooldown,
 		@Nullable VariableString cooldownMessage, String cooldownBypass,
 		@Nullable VariableString cooldownStorage, int executableBy, SectionNode node
@@ -180,7 +180,7 @@ public class ScriptCommand implements TabExecutor {
 		activeAliases = new ArrayList<>(aliases);
 
 		this.description = Utils.replaceEnglishChatStyles(description);
-		this.usage = Utils.replaceEnglishChatStyles(usage);
+		this.usage = usage;
 
 		this.executableBy = executableBy;
 
@@ -205,7 +205,7 @@ public class ScriptCommand implements TabExecutor {
 			// We can only set the message if it's simple (doesn't contains expressions)
 			if (permissionMessage.isSimple())
 				bukkitCommand.setPermissionMessage(permissionMessage.toString(null));
-			bukkitCommand.setUsage(usage);
+			bukkitCommand.setUsage(usage.getDefaultUsage());
 			bukkitCommand.setExecutor(this);
 			return bukkitCommand;
 		} catch (final Exception e) {
@@ -300,7 +300,7 @@ public class ScriptCommand implements TabExecutor {
 				final LogEntry e = log.getError();
 				if (e != null)
 					sender.sendMessage(ChatColor.DARK_RED + e.toString());
-				sender.sendMessage(usage);
+				sender.sendMessage(usage.getUsage(event));
 				log.clear();
 				return false;
 			}

--- a/src/main/java/ch/njol/skript/structures/StructCommand.java
+++ b/src/main/java/ch/njol/skript/structures/StructCommand.java
@@ -93,10 +93,10 @@ public class StructCommand extends Structure {
 		Skript.registerStructure(
 			StructCommand.class,
 			EntryValidator.builder()
+				.addEntryData(new VariableStringEntryData("usage", null, true))
 				.addEntry("description", "", true)
 				.addEntry("prefix", null, true)
 				.addEntry("permission", "", true)
-				.addEntryData(new VariableStringEntryData("usage", null, true))
 				.addEntryData(new VariableStringEntryData("permission message", null, true))
 				.addEntryData(new KeyValueEntryData<List<String>>("aliases", new ArrayList<>(), true) {
 					private final Pattern pattern = Pattern.compile("\\s*,\\s*/?");

--- a/src/main/java/ch/njol/skript/structures/StructCommand.java
+++ b/src/main/java/ch/njol/skript/structures/StructCommand.java
@@ -24,6 +24,7 @@ import ch.njol.skript.bukkitutil.CommandReloader;
 import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.classes.Parser;
 import ch.njol.skript.command.Argument;
+import ch.njol.skript.command.CommandUsage;
 import ch.njol.skript.command.Commands;
 import ch.njol.skript.command.ScriptCommand;
 import ch.njol.skript.command.ScriptCommandEvent;
@@ -34,6 +35,7 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.ParseContext;
+import org.bukkit.command.Command;
 import org.skriptlang.skript.lang.script.Script;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -92,10 +94,10 @@ public class StructCommand extends Structure {
 		Skript.registerStructure(
 			StructCommand.class,
 			EntryValidator.builder()
-				.addEntry("usage", null, true)
 				.addEntry("description", "", true)
 				.addEntry("prefix", null, true)
 				.addEntry("permission", "", true)
+				.addEntryData(new VariableStringEntryData("usage", null, true))
 				.addEntryData(new VariableStringEntryData("permission message", null, true))
 				.addEntryData(new KeyValueEntryData<List<String>>("aliases", new ArrayList<>(), true) {
 					private final Pattern pattern = Pattern.compile("\\s*,\\s*/?");
@@ -261,10 +263,12 @@ public class StructCommand extends Structure {
 		});
 		desc = Commands.unescape(desc).trim();
 
-		String usage = entryContainer.getOptional("usage", String.class, false);
-		if (usage == null) {
-			usage = Commands.m_correct_usage + " " + desc;
-		}
+		VariableString usageMessage = entryContainer.getOptional("usage", VariableString.class, false);
+		String defaultUsageMessage = Commands.m_correct_usage + " " + desc;
+		if (usageMessage == null)
+			usageMessage = VariableString.newInstance(defaultUsageMessage);
+		assert usageMessage != null;
+		CommandUsage usage = new CommandUsage(usageMessage, defaultUsageMessage);
 
 		String description = entryContainer.get("description", String.class, true);
 		String prefix = entryContainer.getOptional("prefix", String.class, false);

--- a/src/main/java/ch/njol/skript/structures/StructCommand.java
+++ b/src/main/java/ch/njol/skript/structures/StructCommand.java
@@ -265,8 +265,11 @@ public class StructCommand extends Structure {
 
 		VariableString usageMessage = entryContainer.getOptional("usage", VariableString.class, false);
 		String defaultUsageMessage = Commands.m_correct_usage + " " + desc;
-		if (usageMessage == null)
+		if (usageMessage == null) {
 			usageMessage = VariableString.newInstance(defaultUsageMessage);
+		} else if (usageMessage.isSimple()) {
+			defaultUsageMessage = usageMessage.toString();
+		}
 		assert usageMessage != null;
 		CommandUsage usage = new CommandUsage(usageMessage, defaultUsageMessage);
 

--- a/src/main/java/ch/njol/skript/structures/StructCommand.java
+++ b/src/main/java/ch/njol/skript/structures/StructCommand.java
@@ -265,12 +265,6 @@ public class StructCommand extends Structure {
 
 		VariableString usageMessage = entryContainer.getOptional("usage", VariableString.class, false);
 		String defaultUsageMessage = Commands.m_correct_usage + " " + desc;
-		if (usageMessage == null) {
-			usageMessage = VariableString.newInstance(defaultUsageMessage);
-		} else if (usageMessage.isSimple()) {
-			defaultUsageMessage = usageMessage.toString();
-		}
-		assert usageMessage != null;
 		CommandUsage usage = new CommandUsage(usageMessage, defaultUsageMessage);
 
 		String description = entryContainer.get("description", String.class, true);

--- a/src/main/java/ch/njol/skript/structures/StructCommand.java
+++ b/src/main/java/ch/njol/skript/structures/StructCommand.java
@@ -35,7 +35,6 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.ParseContext;
-import org.bukkit.command.Command;
 import org.skriptlang.skript.lang.script.Script;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.SkriptParser.ParseResult;


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

This changes the usage field in StructCommand to use VariableString, allowing the input of expressions.
The Bukkit command registration wants a static usage message, though, so a default usage message is also supplied (if the varString is simple, it's the varString, otherwise the default usage message for the command)

I'd prefer this to have more features, like a whole section for usage validation based on what arguments were misused, but that's for the command rework, not now.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
