### PR TITLE
Adds Enchantment Glint Syntaxes

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffForceEnchantmentGlint.java
+++ b/src/main/java/ch/njol/skript/effects/EffForceEnchantmentGlint.java
@@ -1,23 +1,55 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
 package ch.njol.skript.effects;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.RequiredPlugins;
+import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
+@Name("Force Enchantment Glint")
+@Description("Forces the items to glint or not.")
+@Examples({
+	"force {_items::*} to glint",
+	"force the player's tool to stop glinting"
+})
+@RequiredPlugins("Spigot 1.20.5+")
+@Since("INSERT VERSION")
 public class EffForceEnchantmentGlint extends Effect {
 
 	static {
 		Skript.registerEffect(EffForceEnchantmentGlint.class,
-			"(force|make) %itemtypes% to (:start|stop|not) glint[ing]"
-			);
+			"(force|make) %itemtypes% to [start] glint[ing]",
+			"(force|make) %itemtypes% to (not|stop) glint[ing]");
 	}
 
+	@SuppressWarnings("NotNullFieldNotInitialized")
 	private Expression<ItemType> itemtypes;
 	private boolean glint;
 
@@ -25,7 +57,7 @@ public class EffForceEnchantmentGlint extends Effect {
 	@SuppressWarnings("unchecked")
 	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		itemtypes = (Expression<ItemType>) expressions[0];
-		glint = parseResult.hasTag("start");
+		glint = matchedPattern == 0;
 		return true;
 	}
 

--- a/src/main/java/ch/njol/skript/effects/EffForceEnchantmentGlint.java
+++ b/src/main/java/ch/njol/skript/effects/EffForceEnchantmentGlint.java
@@ -1,0 +1,46 @@
+package ch.njol.skript.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.eclipse.jdt.annotation.Nullable;
+
+public class EffForceEnchantmentGlint extends Effect {
+
+	static {
+		Skript.registerEffect(EffForceEnchantmentGlint.class,
+			"(force|make) %itemtypes% to (:start|stop|not) glint[ing]"
+			);
+	}
+
+	private Expression<ItemType> itemtypes;
+	private boolean glint;
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		itemtypes = (Expression<ItemType>) expressions[0];
+		glint = parseResult.hasTag("start");
+		return true;
+	}
+
+	@Override
+	protected void execute(Event event) {
+		for (ItemType itemType : this.itemtypes.getArray(event)) {
+			ItemMeta meta = itemType.getItemMeta();
+			meta.setEnchantmentGlintOverride(glint);
+			itemType.setItemMeta(meta);
+		}
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "force the " + itemtypes.toString(event, debug) + " to " + (glint ? "start" : "stop") + " glinting";
+	}
+
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprEnchantmentGlint.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEnchantmentGlint.java
@@ -1,0 +1,70 @@
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.event.Event;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.Nullable;
+
+public class ExprEnchantmentGlint extends SimplePropertyExpression<ItemType, Boolean> {
+
+	static {
+		register(ExprEnchantmentGlint.class, Boolean.class, "enchantment glint", "itemtypes");
+	}
+
+	@Override
+	@Nullable
+	public Boolean convert(ItemType item) {
+		ItemMeta meta = item.getItemMeta();
+		if (!meta.hasEnchantmentGlintOverride())
+			return null;
+		// Spigot claims this does not return null, hence we return null ourselves
+		return meta.getEnchantmentGlintOverride();
+	}
+
+	@Override
+	@Nullable
+	public Class<?>[] acceptChange(ChangeMode mode) {
+		switch (mode) {
+			case SET:
+			case DELETE:
+				return CollectionUtils.array(Boolean.class);
+			default:
+				return null;
+		}
+	}
+
+	@Override
+	public void change(Event event, Object @Nullable [] delta, ChangeMode mode) {
+		switch (mode) {
+			case SET:
+				if (!(delta[0] instanceof Boolean))
+					return;
+				for (ItemType itemType : getExpr().getArray(event)) {
+					ItemMeta meta = itemType.getItemMeta();
+					meta.setEnchantmentGlintOverride((Boolean) delta[0]);
+					itemType.setItemMeta(meta);
+				}
+				break;
+			case DELETE:
+				for (ItemType itemType : getExpr().getArray(event)) {
+					ItemMeta meta = itemType.getItemMeta();
+					meta.setEnchantmentGlintOverride(null);
+					itemType.setItemMeta(meta);
+				}
+		}
+	}
+
+	@Override
+	public Class<? extends Boolean> getReturnType() {
+		return Boolean.class;
+	}
+
+	@Override
+	protected String getPropertyName() {
+		return "enchantment glint";
+	}
+
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprEnchantmentGlint.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEnchantmentGlint.java
@@ -1,13 +1,50 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
 package ch.njol.skript.expressions;
 
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.RequiredPlugins;
+import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
 import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.Nullable;
 
+@Name("Enchantment Glint")
+@Description({
+	"Sets the 'enchantment_glint_override' on items.",
+	"If true, the item will glint, even without enchantments.",
+	"if false, the item will not glint, even with enchantments.",
+	"If cleared, the glint enforcement will be cleared."
+})
+@Examples({
+	"set the enchantment glint of player's tool to true",
+	"set the enchantment glint of {_items::*} to false",
+	"clear the enchantment glint of player's tool"
+})
+@RequiredPlugins("Spigot 1.20.5+")
+@Since("INSERT VERSION")
 public class ExprEnchantmentGlint extends SimplePropertyExpression<ItemType, Boolean> {
 
 	static {
@@ -37,7 +74,7 @@ public class ExprEnchantmentGlint extends SimplePropertyExpression<ItemType, Boo
 	}
 
 	@Override
-	public void change(Event event, Object @Nullable [] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		switch (mode) {
 			case SET:
 				if (!(delta[0] instanceof Boolean))


### PR DESCRIPTION
### Description
This PR adds the [enchantment glint syntaxes](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/inventory/meta/ItemMeta.html#getEnchantmentGlintOverride()) into Skript!

---
**Target Minecraft Versions:** Minecraft 1.20.5
**Requirements:** Spigot 1.20.5
**Related Issues:** none
