### PR TITLE
Correct some non-optional US spellings.

### DIFF
--- a/src/main/java/ch/njol/skript/events/EvtWorld.java
+++ b/src/main/java/ch/njol/skript/events/EvtWorld.java
@@ -44,7 +44,7 @@ public class EvtWorld extends SkriptEvent {
 				.since("1.0, 2.8.0 (defining worlds)");
 
 		// World Init Event
-		Skript.registerEvent("World Init", EvtWorld.class, WorldInitEvent.class, "world init[ialization] [of %-worlds%]")
+		Skript.registerEvent("World Init", EvtWorld.class, WorldInitEvent.class, "world init[iali(z|s)ation] [of %-worlds%]")
 				.description("Called when a world is initialized. As all default worlds are initialized before",
 					"any scripts are loaded, this event is only called for newly created worlds.",
 					"World management plugins might change the behaviour of this event though.")

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorNormalize.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorNormalize.java
@@ -42,8 +42,8 @@ public class ExprVectorNormalize extends SimpleExpression<Vector> {
 
 	static {
 		Skript.registerExpression(ExprVectorNormalize.class, Vector.class, ExpressionType.COMBINED,
-				"normalize[d] %vector%",
-				"%vector% normalized");
+				"normali(z|s)e[d] %vector%",
+				"%vector% normali(z|s)ed");
 	}
 
 	@SuppressWarnings("null")


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
When some syntax was added, it was overlooked that its patterns only supported americani`(s|z)`ed spellings.

Usually, Skript is pretty good at spotting these. This mainly occurred in syntax merged from addons (e.g. bi0aq's vectors) where some things weren't scrutini`(s|z)`ed in the pull request.

I'm still looking for the other hidden offenders.
I've added the non-US spellings for the ones I found, but if anybody sees any others (I'm sure there are) please feel free to include them.

Common ones include:
- No 's' option in `-ize` words (e.g. `normalize`, `synchronize`.)
- No 'c' option in noun forms of `-se` words (e.g. `advise`, `practise`, `license`, etc.)
- No British 'u' option in `-or` words (e.g. `color`, `favor`, etc.)

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
