### PR TITLE
Fix EffHealth - slot durability not accounting correctly 

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffHealth.java
+++ b/src/main/java/ch/njol/skript/effects/EffHealth.java
@@ -103,7 +103,7 @@ public class EffHealth extends Effect {
 				if (this.amount == null) {
 					ItemUtils.setDamage(itemStack, 0);
 				} else {
-					int damageAmt = (int) Math2.fit(0, (isHealing ? -amount : amount), itemStack.getType().getMaxDurability());
+					int damageAmt = (int) Math2.fit(0, (ItemUtils.getDamage(itemStack) + (isHealing ? -amount : amount)), itemStack.getType().getMaxDurability());
 					ItemUtils.setDamage(itemStack, damageAmt);
 				}
 

--- a/src/test/skript/tests/regressions/6643-effhealth slot not accounting existing damage
+++ b/src/test/skript/tests/regressions/6643-effhealth slot not accounting existing damage
@@ -1,0 +1,8 @@
+test "slot damage accountability":
+	set {_inv} to chest inventory named "slot accountability"
+	set slot 0 of {_inv} to diamond sword with damage 100
+
+	repair slot 0 of {_inv} by 10
+	assert damage of slot 0 of {_inv} is 90 with "Durability of slot 0, was not updated correctly"
+	repair slot 0 of {_inv}
+	assert durability of slot 0 of {_inv} is maximum durability of slot 0 of {_inv} with "Durability of slot 0, was not fully repaired"


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
This PR aims to fix my mistake in #6586 where I forgot to update slot durability accordingly.

Do we believe this pr should also include the 1.20.5/6 changes to durability? Based off my testing earlier this morning they are pretty bugged and adding support for at least being functional isn't out of the scope entirely.

It's possible I didn't test this correctly as the related issue is very hard for me to read with how much random junk is included in it.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #6643 <!-- Links to related issues -->
