### PR TITLE
EffHealth - fix max damage on custom items

### DIFF
--- a/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
@@ -34,6 +34,8 @@ import java.util.HashMap;
  */
 public class ItemUtils {
 
+	public static final boolean HAS_MAX_DAMAGE = Skript.methodExists(Damageable.class, "getMaxDamage");
+
 	/**
 	 * Gets damage/durability of an item, or 0 if it does not have damage.
 	 * @param itemStack Item.
@@ -44,6 +46,18 @@ public class ItemUtils {
 		if (meta instanceof Damageable)
 			return ((Damageable) meta).getDamage();
 		return 0; // Non damageable item
+	}
+
+	/** Gets the max damage/durability of an item
+	 * <p>NOTE: Will account for custom damageable items in MC 1.20.5+</p>
+	 * @param itemStack Item to grab durability from
+	 * @return Max amount of damage this item can take
+	 */
+	public static int getMaxDamage(ItemStack itemStack) {
+		ItemMeta meta = itemStack.getItemMeta();
+		if (HAS_MAX_DAMAGE && meta instanceof Damageable && ((Damageable) meta).hasMaxDamage())
+			return ((Damageable) meta).getMaxDamage();
+		return itemStack.getType().getMaxDurability();
 	}
 
 	/**
@@ -70,6 +84,18 @@ public class ItemUtils {
 		if (meta instanceof Damageable)
 			return ((Damageable) meta).getDamage();
 		return 0; // Non damageable item
+	}
+
+	/** Gets the max damage/durability of an item
+	 * <p>NOTE: Will account for custom damageable items in MC 1.20.5+</p>
+	 * @param itemType Item to grab durability from
+	 * @return Max amount of damage this item can take
+	 */
+	public static int getMaxDamage(ItemType itemType) {
+		ItemMeta meta = itemType.getItemMeta();
+		if (HAS_MAX_DAMAGE && meta instanceof Damageable && ((Damageable) meta).hasMaxDamage())
+			return ((Damageable) meta).getMaxDamage();
+		return itemType.getMaterial().getMaxDurability();
 	}
 
 	/**

--- a/src/main/java/ch/njol/skript/effects/EffHealth.java
+++ b/src/main/java/ch/njol/skript/effects/EffHealth.java
@@ -90,7 +90,7 @@ public class EffHealth extends Effect {
 				if (this.amount == null) {
 					ItemUtils.setDamage(itemType, 0);
 				} else {
-					ItemUtils.setDamage(itemType, (int) Math2.fit(0, (ItemUtils.getDamage(itemType) + (isHealing ? -amount : amount)), itemType.getMaterial().getMaxDurability()));
+					ItemUtils.setDamage(itemType, (int) Math2.fit(0, (ItemUtils.getDamage(itemType) + (isHealing ? -amount : amount)), ItemUtils.getMaxDamage(itemType)));
 				}
 
 			} else if (obj instanceof Slot) {
@@ -103,7 +103,7 @@ public class EffHealth extends Effect {
 				if (this.amount == null) {
 					ItemUtils.setDamage(itemStack, 0);
 				} else {
-					int damageAmt = (int) Math2.fit(0, (isHealing ? -amount : amount), itemStack.getType().getMaxDurability());
+					int damageAmt = (int) Math2.fit(0, (ItemUtils.getDamage(itemStack) + (isHealing ? -amount : amount)), ItemUtils.getMaxDamage(itemStack));
 					ItemUtils.setDamage(itemStack, damageAmt);
 				}
 


### PR DESCRIPTION
### Description
This PR aims to fix an issue with max damage on custom damageable items.
EX: In MC 1.20.5+ I can create an apple that is able to take damage.
This checks the max damage from ItemMeta (if available) otherwise falls back to max durability from Material

(ive also taken into account Fuse's PR fixing the other bug in the same class since the PR isn't merged.)

---
**Target Minecraft Versions:** 1.20.5+
**Requirements:** none 
**Related Issues:** none
