### PR TITLE
Aliases - add support for underscore in ItemType

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/Aliases.java
+++ b/src/main/java/ch/njol/skript/aliases/Aliases.java
@@ -244,6 +244,7 @@ public abstract class Aliases {
 	public static ItemType parseItemType(String s) {
 		if (s.isEmpty())
 			return null;
+		s = s.replace("_", " ");
 		s = "" + s.trim();
 		
 		final ItemType t = new ItemType();


### PR DESCRIPTION
### Description
This PR aims to add support for underscores in ItemType parsing.
I feel like this might be up for debate.
Figured it would be a nice little helper when people attempt to use minecraft names,
ie: `give player diamond_sword` 
Rather than getting an error, we get a YAY!!!

I put it on the patch branch as it's not a breaking change what-so-ever. (change if need be)

# HOLD
This is in fact a breaking change, will investigate

---
**Target Minecraft Versions:** any 
**Requirements:** none
**Related Issues:** none
