### PR TITLE
Add name and world support to regions

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprName.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprName.java
@@ -24,6 +24,7 @@ import java.lang.invoke.MethodType;
 import java.util.ArrayList;
 import java.util.List;
 
+import ch.njol.skript.hooks.regions.classes.Region;
 import org.bukkit.Bukkit;
 import org.bukkit.GameRule;
 import org.bukkit.Nameable;
@@ -115,7 +116,7 @@ import net.md_5.bungee.api.chat.BaseComponent;
 	"\tset the player's tab list name to \"&lt;green&gt;%player's name%\"",
 	"set the name of the player's tool to \"Legendary Sword of Awesomeness\""
 })
-@Since("before 2.1, 2.2-dev20 (inventory name), 2.4 (non-living entity support, changeable inventory name), 2.7 (worlds)")
+@Since("before 2.1, 2.2-dev20 (inventory name), 2.4 (non-living entity support, changeable inventory name), 2.7 (worlds), INSERT VERSION (regions)")
 public class ExprName extends SimplePropertyExpression<Object, String> {
 
 	@Nullable
@@ -128,7 +129,7 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 				Skript.methodExists(Bukkit.class, "createInventory", InventoryHolder.class, int.class, Component.class))
 			serializer = BungeeComponentSerializer.get();
 		HAS_GAMERULES = Skript.classExists("org.bukkit.GameRule");
-		register(ExprName.class, String.class, "(1¦name[s]|2¦(display|nick|chat|custom)[ ]name[s])", "offlineplayers/entities/blocks/itemtypes/inventories/slots/worlds"
+		register(ExprName.class, String.class, "(1¦name[s]|2¦(display|nick|chat|custom)[ ]name[s])", "offlineplayers/entities/blocks/itemtypes/inventories/slots/worlds/regions"
 			+ (HAS_GAMERULES ? "/gamerules" : ""));
 		register(ExprName.class, String.class, "(3¦(player|tab)[ ]list name[s])", "players");
 	}
@@ -191,6 +192,8 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 			}
 		} else if (object instanceof World) {
 			return ((World) object).getName();
+		} else if (object instanceof Region){
+			return ((Region) object).getName();
 		} else if (HAS_GAMERULES && object instanceof GameRule) {
 			return ((GameRule) object).getName();
 		}

--- a/src/main/java/ch/njol/skript/expressions/ExprWorld.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprWorld.java
@@ -18,6 +18,7 @@
  */
 package ch.njol.skript.expressions;
 
+import ch.njol.skript.hooks.regions.classes.Region;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -51,11 +52,11 @@ import ch.njol.util.coll.CollectionUtils;
 		"teleport the player to the world's spawn",
 		"set the weather in the player's world to rain",
 		"set {_world} to world of event-chunk"})
-@Since("1.0")
+@Since("1.0, INSERT VERSION (regions)")
 public class ExprWorld extends PropertyExpression<Object, World> {
 
 	static {
-		Skript.registerExpression(ExprWorld.class, World.class, ExpressionType.PROPERTY, "[the] world [of %locations/entities/chunk%]", "%locations/entities/chunk%'[s] world");
+		Skript.registerExpression(ExprWorld.class, World.class, ExpressionType.PROPERTY, "[the] world [of %locations/entities/chunk/regions%]", "%locations/entities/chunk/regions%'[s] world");
 	}
 	
 	@Override
@@ -84,6 +85,8 @@ public class ExprWorld extends PropertyExpression<Object, World> {
 				return ((Location) obj).getWorld();
 			} else if (obj instanceof Chunk) {
 				return ((Chunk) obj).getWorld();
+			} else if (obj instanceof Region) {
+				return ((Region) obj).getWorld();
 			}
 			assert false : obj;
 			return null;

--- a/src/main/java/ch/njol/skript/hooks/regions/GriefPreventionHook.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/GriefPreventionHook.java
@@ -153,6 +153,16 @@ public class GriefPreventionHook extends RegionsPlugin<GriefPrevention> {
 		public boolean isMember(final OfflinePlayer p) {
 			return isOwner(p);
 		}
+
+		@Override
+		public String getName(){
+			return claim.getOwnerName();
+		}
+
+		@Override
+		public World getWorld(){
+			return claim.getLesserBoundaryCorner().getWorld();
+		}
 		
 		@Override
 		public Collection<OfflinePlayer> getMembers() {

--- a/src/main/java/ch/njol/skript/hooks/regions/PreciousStonesHook.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/PreciousStonesHook.java
@@ -112,6 +112,16 @@ public class PreciousStonesHook extends RegionsPlugin<PreciousStones> {
             return field.isInAllowedList(p.getName());
         }
 
+		@Override
+		public String getName(){
+			return field.getName();
+		}
+
+		@Override
+		public World getWorld(){
+			return Bukkit.getWorld(field.getWorld());
+		}
+
         @Override
         public Collection<OfflinePlayer> getMembers() {
             @SuppressWarnings("deprecation")

--- a/src/main/java/ch/njol/skript/hooks/regions/ResidenceHook.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/ResidenceHook.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
@@ -151,6 +152,16 @@ public class ResidenceHook extends RegionsPlugin<Residence> {
 		@Override
 		public boolean isMember(OfflinePlayer p) {
 			return res.getPermissions().playerHas(p.getName(), Flags.build, false);
+		}
+
+		@Override
+		public String getName(){
+			return res.getName();
+		}
+
+		@Override
+		public World getWorld(){
+			return world;
 		}
 
 		@SuppressWarnings("null")

--- a/src/main/java/ch/njol/skript/hooks/regions/WorldGuardHook.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/WorldGuardHook.java
@@ -110,7 +110,17 @@ public class WorldGuardHook extends RegionsPlugin<WorldGuardPlugin> {
 		public boolean isMember(final OfflinePlayer p) {
 			return region.isMember(plugin.wrapOfflinePlayer(p));
 		}
-		
+
+		@Override
+		public String getName(){
+			return region.getId();
+		}
+
+		@Override
+		public World getWorld(){
+			return world;
+		}
+
 		@Override
 		public Collection<OfflinePlayer> getMembers() {
 			final Collection<UUID> ids = region.getMembers().getUniqueIds();

--- a/src/main/java/ch/njol/skript/hooks/regions/classes/Region.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/classes/Region.java
@@ -124,6 +124,10 @@ public abstract class Region implements YggdrasilExtendedSerializable {
 	public abstract boolean contains(Location l);
 	
 	public abstract boolean isMember(OfflinePlayer p);
+
+	public abstract String getName();
+
+	public abstract World getWorld();
 	
 	public abstract Collection<OfflinePlayer> getMembers();
 	


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Added region support to ExprName and ExprWorld so you don't have to do `if region at player contains "region name"` or  `if region at player contains "world name"` and instead you can do `if name of region at player is "region name"` and `if world of region at player is "world name"`.
Same with world

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
