### PR TITLE
Basic Experience API Enhancement

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.Locale;
 import java.util.regex.Pattern;
 
+import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
@@ -624,6 +625,35 @@ public class SkriptClasses {
 				.usage("[&lt;number&gt;] ([e]xp|experience [point[s]])")
 				.examples("give 10 xp to the player")
 				.since("2.0")
+				.changer(new Changer<Experience>() {
+					@Override
+					@Nullable
+					public Class<?>[] acceptChange(ChangeMode mode) {
+                        switch (mode) {
+                            case ADD:
+                            case SET:
+                            case REMOVE:
+								return CollectionUtils.array(Number.class, Experience.class);
+							default:
+								return null;
+                        }
+					}
+
+					@Override
+					public void change(Experience[] xps, @Nullable Object[] delta, ChangeMode mode) {
+						if (delta == null)
+							return;
+						int change;
+						if (delta[0] instanceof Experience) {
+							change = ((Experience) delta[0]).getXP();
+						} else {
+							change = ((Number) delta[0]).intValue();
+						}
+						for (Experience xp : xps) {
+							xp.setInternalXP(xp.getInternalXP() + change);
+						}
+					}
+				})
 				.parser(new Parser<Experience>() {
 					private final RegexMessage pattern = new RegexMessage("types.experience.pattern", Pattern.CASE_INSENSITIVE);
 					

--- a/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
@@ -633,7 +633,7 @@ public class SkriptClasses {
                             case ADD:
                             case SET:
                             case REMOVE:
-								return CollectionUtils.array(Number.class, Experience.class);
+								return CollectionUtils.array(Experience.class, Number.class);
 							default:
 								return null;
                         }

--- a/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
@@ -649,8 +649,16 @@ public class SkriptClasses {
 						} else {
 							change = ((Number) delta[0]).intValue();
 						}
+						change = Math.max(0, change);
+						if (mode == ChangeMode.REMOVE) {
+							change = -change;
+						}
 						for (Experience xp : xps) {
-							xp.setInternalXP(xp.getInternalXP() + change);
+							if (mode == ChangeMode.SET) {
+								xp.setInternalXP(change);
+							} else {
+								xp.setInternalXP(xp.getInternalXP() + change);
+							}
 						}
 					}
 				})

--- a/src/main/java/ch/njol/skript/expressions/ExprTotalExperience.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTotalExperience.java
@@ -79,7 +79,7 @@ public class ExprTotalExperience extends SimplePropertyExpression<Entity, Intege
 			case SET:
 			case DELETE:
 			case RESET:
-				return CollectionUtils.array(Number.class, Experience.class);
+				return CollectionUtils.array(Experience.class, Number.class);
 			case REMOVE_ALL:
 			default:
 				return null;

--- a/src/main/java/ch/njol/skript/expressions/ExprTotalExperience.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTotalExperience.java
@@ -25,6 +25,8 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.util.Experience;
+import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.ExperienceOrb;
 import org.bukkit.entity.Player;
@@ -40,16 +42,17 @@ import org.eclipse.jdt.annotation.Nullable;
 	"set total experience of player to 100",
 	"",
 	"add 100 to player's experience",
+	"add 100 xp to player's xp",
 	"",
 	"if player's total experience is greater than 100:",
-	"\tset player's total experience to 0",
-	"\tgive player 1 diamond"
+		"\tset player's total experience to 0",
+		"\tgive player 1 diamond"
 })
 @Since("2.7")
 public class ExprTotalExperience extends SimplePropertyExpression<Entity, Integer> {
 
 	static {
-		register(ExprTotalExperience.class, Integer.class, "[total] experience", "entities");
+		register(ExprTotalExperience.class, Integer.class, "[total] (experience|xp)", "entities");
 	}
 
 	@Override
@@ -76,7 +79,7 @@ public class ExprTotalExperience extends SimplePropertyExpression<Entity, Intege
 			case SET:
 			case DELETE:
 			case RESET:
-				return new Class[]{Number.class};
+				return CollectionUtils.array(Number.class, Experience.class);
 			case REMOVE_ALL:
 			default:
 				return null;
@@ -85,7 +88,14 @@ public class ExprTotalExperience extends SimplePropertyExpression<Entity, Intege
 
 	@Override
 	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
-		int change = delta == null ? 0 : ((Number) delta[0]).intValue();
+		int change = 0;
+		if (delta != null) {
+			if (delta[0] instanceof Experience) {
+				change = ((Experience) delta[0]).getXP();
+			} else {
+				change = ((Number) delta[0]).intValue();
+			}
+		}
 		switch (mode) {
 			case RESET:
 			case DELETE:

--- a/src/main/java/ch/njol/skript/util/Experience.java
+++ b/src/main/java/ch/njol/skript/util/Experience.java
@@ -27,13 +27,13 @@ import ch.njol.yggdrasil.YggdrasilSerializable;
  */
 public class Experience implements YggdrasilSerializable {
 	
-	private final int xp;
+	private int xp;
 	
 	public Experience() {
 		xp = -1;
 	}
 	
-	public Experience(final int xp) {
+	public Experience(int xp) {
 		this.xp = xp;
 	}
 	
@@ -43,6 +43,10 @@ public class Experience implements YggdrasilSerializable {
 	
 	public int getInternalXP() {
 		return xp;
+	}
+
+	public void setInternalXP(int xp) {
+		this.xp = xp;
 	}
 	
 	@Override
@@ -59,17 +63,15 @@ public class Experience implements YggdrasilSerializable {
 	}
 	
 	@Override
-	public boolean equals(final @Nullable Object obj) {
+	public boolean equals(@Nullable Object obj) {
 		if (this == obj)
 			return true;
 		if (obj == null)
 			return false;
 		if (!(obj instanceof Experience))
 			return false;
-		final Experience other = (Experience) obj;
-		if (xp != other.xp)
-			return false;
-		return true;
-	}
+		Experience other = (Experience) obj;
+        return xp == other.xp;
+    }
 	
 }

--- a/src/test/skript/tests/misc/experience.sk
+++ b/src/test/skript/tests/misc/experience.sk
@@ -1,0 +1,12 @@
+test "experience":
+	assert 10 xp is 10 xp with "xp comparison failed ##1"
+
+	set {_xp} to 10 xp
+	assert {_xp} is not {_null} with "xp comparison failed ##2"
+	assert {_xp} is 10 xp with "xp comparison failed ##3"
+
+	add 10 xp to {_xp}
+	assert {_xp} is 20 xp with "xp comparison failed ##4"
+
+	remove 10 xp from {_xp}
+	assert {_xp} is 10 xp with "xp comparison failed ##5"


### PR DESCRIPTION
### Description
This PR provides light enhancements to Skript's Experience API with:
- Allowing Experience object into ExprTotalExperience (`add 10 xp to player's total xp`)
- Add changers to Experience objects (`set {-xp} to 10 xp`, `add 10 xp to {-xp}`; results `20 xp`)
*and top it off with some dusting in Experience class.*

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #6649
