### PR TITLE
Deprecate Checker and replace with Java's Predicate.

### DIFF
--- a/src/main/java/ch/njol/skript/classes/SerializableChecker.java
+++ b/src/main/java/ch/njol/skript/classes/SerializableChecker.java
@@ -19,9 +19,14 @@
 package ch.njol.skript.classes;
 
 import ch.njol.util.Checker;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.function.Predicate;
 
 /**
  * @author Peter Güttinger
  */
 @Deprecated
-public interface SerializableChecker<T> extends Checker<T> {}
+@FunctionalInterface
+@ApiStatus.ScheduledForRemoval
+public interface SerializableChecker<T> extends Checker<T>, Predicate<T> {}

--- a/src/main/java/ch/njol/skript/classes/SerializableChecker.java
+++ b/src/main/java/ch/njol/skript/classes/SerializableChecker.java
@@ -18,7 +18,6 @@
  */
 package ch.njol.skript.classes;
 
-import ch.njol.util.Checker;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.function.Predicate;
@@ -29,4 +28,4 @@ import java.util.function.Predicate;
 @Deprecated
 @FunctionalInterface
 @ApiStatus.ScheduledForRemoval
-public interface SerializableChecker<T> extends Checker<T>, Predicate<T> {}
+public interface SerializableChecker<T> extends ch.njol.util.Checker<T>, Predicate<T> {}

--- a/src/main/java/ch/njol/skript/conditions/CondCompare.java
+++ b/src/main/java/ch/njol/skript/conditions/CondCompare.java
@@ -49,9 +49,10 @@ import ch.njol.skript.registrations.Classes;
 import org.skriptlang.skript.lang.comparator.Comparators;
 import ch.njol.skript.util.Patterns;
 import ch.njol.skript.util.Utils;
-import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
 import org.skriptlang.skript.lang.util.Cyclical;
+
+import java.util.function.Predicate;
 
 @Name("Comparison")
 @Description({"A very general condition, it simply compares two values. Usually you can only compare for equality (e.g. block is/isn't of &lt;type&gt;), " +
@@ -64,7 +65,7 @@ import org.skriptlang.skript.lang.util.Cyclical;
 		"the creature is not an enderman or an ender dragon"})
 @Since("1.0")
 public class CondCompare extends Condition implements VerboseAssert {
-	
+
 	private final static Patterns<Relation> patterns = new Patterns<>(new Object[][]{
 			{"(1¦neither|) %objects% ((is|are)(|2¦(n't| not|4¦ neither)) ((greater|more|higher|bigger|larger) than|above)|\\>) %objects%", Relation.GREATER},
 			{"(1¦neither|) %objects% ((is|are)(|2¦(n't| not|4¦ neither)) (greater|more|higher|bigger|larger|above) [than] or (equal to|the same as)|\\>=) %objects%", Relation.GREATER_OR_EQUAL},
@@ -74,7 +75,7 @@ public class CondCompare extends Condition implements VerboseAssert {
 			{"(1¦neither|) %objects% (is|are|=) [(equal to|the same as)] %objects%", Relation.EQUAL},
 			{"(1¦neither|) %objects% (is|are) between %objects% and %objects%", Relation.EQUAL},
 			{"(1¦neither|) %objects% (2¦)(is not|are not|isn't|aren't) between %objects% and %objects%", Relation.EQUAL},
-			
+
 			{"(1¦neither|) %objects@-1% (was|were)(|2¦(n't| not|4¦ neither)) ((greater|more|higher|bigger|larger) than|above) %objects%", Relation.GREATER},
 			{"(1¦neither|) %objects@-1% (was|were)(|2¦(n't| not|4¦ neither)) (greater|more|higher|bigger|larger|above) [than] or (equal to|the same as) %objects%", Relation.GREATER_OR_EQUAL},
 			{"(1¦neither|) %objects@-1% (was|were)(|2¦(n't| not|4¦ neither)) ((less|smaller|lower) than|below) %objects%", Relation.SMALLER},
@@ -83,7 +84,7 @@ public class CondCompare extends Condition implements VerboseAssert {
 			{"(1¦neither|) %objects@-1% (was|were) [(equal to|the same as)] %objects%", Relation.EQUAL},
 			{"(1¦neither|) %objects@-1% (was|were) between %objects% and %objects%", Relation.EQUAL},
 			{"(1¦neither|) %objects@-1% (2¦)(was not|were not|wasn't|weren't) between %objects% and %objects%", Relation.EQUAL},
-			
+
 			{"(1¦neither|) %objects@1% (will be|2¦(will (not|4¦neither) be|won't be)) ((greater|more|higher|bigger|larger) than|above) %objects%", Relation.GREATER},
 			{"(1¦neither|) %objects@1% (will be|2¦(will (not|4¦neither) be|won't be)) (greater|more|higher|bigger|larger|above) [than] or (equal to|the same as) %objects%", Relation.GREATER_OR_EQUAL},
 			{"(1¦neither|) %objects@1% (will be|2¦(will (not|4¦neither) be|won't be)) ((less|smaller|lower) than|below) %objects%", Relation.SMALLER},
@@ -93,11 +94,11 @@ public class CondCompare extends Condition implements VerboseAssert {
 			{"(1¦neither|) %objects@1% will be between %objects% and %objects%", Relation.EQUAL},
 			{"(1¦neither|) %objects@1% (2¦)(will not be|won't be) between %objects% and %objects%", Relation.EQUAL}
 	});
-	
+
 	static {
 		Skript.registerCondition(CondCompare.class, patterns.getPatterns());
 	}
-	
+
 	private Expression<?> first;
 	private Expression<?> second;
 
@@ -109,7 +110,7 @@ public class CondCompare extends Condition implements VerboseAssert {
 	@Nullable
 	@SuppressWarnings("rawtypes")
 	private Comparator comparator;
-	
+
 	@Override
 	public boolean init(final Expression<?>[] vars, final int matchedPattern, final Kleenean isDelayed, final ParseResult parser) {
 		first = vars[0];
@@ -152,16 +153,16 @@ public class CondCompare extends Condition implements VerboseAssert {
 				}
 			}
 		}
-		
+
 		return true;
 	}
-	
+
 	public static String f(final Expression<?> e) {
 		if (e.getReturnType() == Object.class)
 			return e.toString(null, false);
 		return Classes.getSuperClassInfo(e.getReturnType()).getName().withIndefiniteArticle();
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	private boolean init(String expr) {
 		Expression<?> third = this.third;
@@ -217,11 +218,11 @@ public class CondCompare extends Condition implements VerboseAssert {
 			 * SkriptParser sees that CondCompare takes two objects. Most of the time,
 			 * this works fine. However, when there are multiple conflicting literals,
 			 * it just picks one of them at random.
-			 * 
+			 *
 			 * If our other parameter is not a literal, we can try parsing the other
 			 * explicitly with same return type. This is not guaranteed to succeed,
 			 * but will in work in some cases that were previously ambiguous.
-			 * 
+			 *
 			 * Some damage types not working (issue #2184) would be a good example
 			 * of issues that SkriptParser's lack of context can cause.
 			 */
@@ -236,7 +237,7 @@ public class CondCompare extends Condition implements VerboseAssert {
 					comparator = Comparators.getComparator(first.getReturnType(), secondReturnType);
 				}
 			}
-			
+
 		}
 
 		return comparator != null;
@@ -273,7 +274,7 @@ public class CondCompare extends Condition implements VerboseAssert {
 	 * For example 'fire' will be VisualEffect without this, but if the user attempts to compare 'fire'
 	 * with a block. This method will see if 'fire' can be compared to the block, and it will find ItemType.
 	 * Essentially solving something a human sees as comparable, but Skript doesn't understand.
-	 * 
+	 *
 	 * @param one The UnparsedLiteral expression to attempt to reconstruct.
 	 * @param two any expression to grab the return type from.
 	 * @return The newly formed Literal, will be SimpleLiteral in most cases.
@@ -307,7 +308,7 @@ public class CondCompare extends Condition implements VerboseAssert {
 	/*
 	 * # := condition (e.g. is, is less than, contains, is enchanted with, has permission, etc.)
 	 * !# := not #
-	 * 
+	 *
 	 * a and b # x === a # x && b # x
 	 * a or b # x === a # x || b # x
 	 * a # x and y === a # x && a # y
@@ -318,25 +319,25 @@ public class CondCompare extends Condition implements VerboseAssert {
 	 * a and b # x or y === a # x or y && b # x or y
 	 * a or b # x and y === a # x and y || b # x and y
 	 * a or b # x or y === a # x or y || b # x or y
-	 * 
-	 * 
+	 *
+	 *
 	 * a and b !# x === a !# x && b !# x
 	 * neither a nor b # x === a !# x && b !# x		// nor = and
 	 * a or b !# x === a !# x || b !# x
-	 * 
+	 *
 	 * a !# x and y === a !# x || a !# y							// e.g. "player doesn't have 2 emeralds and 5 gold ingots" == "NOT(player has 2 emeralds and 5 gold ingots)" == "player doesn't have 2 emeralds OR player doesn't have 5 gold ingots"
 	 * a # neither x nor y === a !# x && a !# y		// nor = or 	// e.g. "player has neither 2 emeralds nor 5 gold ingots" == "player doesn't have 2 emeralds AND player doesn't have 5 gold ingots"
 	 * a # neither x nor y === a !# x && a !# y		// nor = or 	// e.g. "player is neither the attacker nor the victim" == "player is not the attacker AND player is not the victim"
 	 * a !# x or y === a !# x && a !# y								// e.g. "player doesn't have 2 emeralds or 5 gold ingots" == "NOT(player has 2 emeralds or 5 gold ingots)" == "player doesn't have 2 emeralds AND player doesn't have 5 gold ingots"
-	 * 
+	 *
 	 * a and b !# x and y === a !# x and y && b !# x and y === (a !# x || a !# y) && (b !# x || b !# y)
 	 * a and b !# x or y === a !# x or y && b !# x or y
 	 * a and b # neither x nor y === a # neither x nor y && b # neither x nor y
-	 * 
+	 *
 	 * a or b !# x and y === a !# x and y || b !# x and y
 	 * a or b !# x or y === a !# x or y || b !# x or y
 	 * a or b # neither x nor y === a # neither x nor y || b # neither x nor y
-	 * 
+	 *
 	 * neither a nor b # x and y === a !# x and y && b !# x and y		// nor = and
 	 * neither a nor b # x or y === a !# x or y && b !# x or y			// nor = and
 	 */
@@ -351,11 +352,11 @@ public class CondCompare extends Condition implements VerboseAssert {
 				second.getAnd() && !second.isSingle())
 			return compareLists(event);
 
-		return first.check(event, (Checker<Object>) o1 ->
-			second.check(event, (Checker<Object>) o2 -> {
+		return first.check(event, (Predicate<Object>) o1 ->
+			second.check(event, (Predicate<Object>) o2 -> {
 				if (third == null)
 					return relation.isImpliedBy(comparator != null ? comparator.compare(o1, o2) : Comparators.compare(o1, o2));
-				return third.check(event, (Checker<Object>) o3 -> {
+				return third.check(event, (Predicate<Object>) o3 -> {
 					boolean isBetween;
 					if (comparator != null) {
 						if (o1 instanceof Cyclical<?> && o2 instanceof Cyclical<?> && o3 instanceof Cyclical<?>) {
@@ -436,5 +437,5 @@ public class CondCompare extends Condition implements VerboseAssert {
 			s += " (comparator: " + comparator + ")";
 		return s;
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsOfType.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsOfType.java
@@ -35,8 +35,9 @@ import ch.njol.skript.entity.EntityData;
 import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
+
+import java.util.function.Predicate;
 
 /**
  * @author Peter Güttinger
@@ -48,16 +49,16 @@ import ch.njol.util.Kleenean;
 		"victim is of type {villager type}"})
 @Since("1.4")
 public class CondIsOfType extends Condition {
-	
+
 	static {
 		PropertyCondition.register(CondIsOfType.class, "of type[s] %entitytypes/entitydatas%", "itemstacks/entities");
 	}
-	
+
 	@SuppressWarnings("null")
 	private Expression<?> what;
 	@SuppressWarnings("null")
 	private Expression<?> types;
-	
+
 	@SuppressWarnings("null")
 	@Override
 	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
@@ -66,12 +67,12 @@ public class CondIsOfType extends Condition {
 		setNegated(matchedPattern == 1);
 		return true;
 	}
-	
+
 	@Override
 	public boolean check(final Event e) {
 		return what.check(e,
-				(Checker<Object>) o1 -> types.check(e,
-						(Checker<Object>) o2 -> {
+				(Predicate<Object>) o1 -> types.check(e,
+						(Predicate<Object>) o2 -> {
 							if (o2 instanceof ItemType && o1 instanceof ItemType) {
 								return ((ItemType) o2).isSupertypeOf((ItemType) o1);
 							} else if (o2 instanceof EntityData && o1 instanceof Entity) {
@@ -84,11 +85,11 @@ public class CondIsOfType extends Condition {
 						}),
 				isNegated());
 	}
-	
+
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
 		return PropertyCondition.toString(this, PropertyType.BE, e, debug, what,
 				"of " + (types.isSingle() ? "type " : "types") + types.toString(e, debug));
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
+++ b/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
@@ -29,6 +29,8 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
 
+import java.util.function.Predicate;
+
 /**
  * This class can be used for an easier writing of conditions that contain only one type in the pattern,
  * and are in one of the following forms:
@@ -52,7 +54,7 @@ import ch.njol.util.Kleenean;
  * {@link PropertyCondition#register(Class, String, String)}, be aware that there can only be two patterns -
  * the first one needs to be a non-negated one and a negated one.
  */
-public abstract class PropertyCondition<T> extends Condition implements Checker<T> {
+public abstract class PropertyCondition<T> extends Condition implements Checker<T>, Predicate<T> {
 
 	/**
 	 * See {@link PropertyCondition} for more info
@@ -63,13 +65,13 @@ public abstract class PropertyCondition<T> extends Condition implements Checker<
 		 * also possibly in the negated form
 		 */
 		BE,
-		
+
 		/**
 		 * Indicates that the condition is in a form of <code>something can something</code>,
 		 * also possibly in the negated form
 		 */
 		CAN,
-		
+
 		/**
 		 * Indicates that the condition is in a form of <code>something has/have something</code>,
 		 * also possibly in the negated form
@@ -145,9 +147,13 @@ public abstract class PropertyCondition<T> extends Condition implements Checker<
 		return expr.check(event, this, isNegated());
 	}
 
-	@Override
 	public abstract boolean check(T value);
-	
+
+	@Override
+	public final boolean test(T value) {
+		return this.check(value);
+	}
+
 	protected abstract String getPropertyName();
 
 	protected PropertyType getPropertyType() {

--- a/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
+++ b/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
@@ -26,7 +26,6 @@ import ch.njol.skript.SkriptAPIException;
 import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
 
 import java.util.function.Predicate;
@@ -54,7 +53,7 @@ import java.util.function.Predicate;
  * {@link PropertyCondition#register(Class, String, String)}, be aware that there can only be two patterns -
  * the first one needs to be a non-negated one and a negated one.
  */
-public abstract class PropertyCondition<T> extends Condition implements Checker<T>, Predicate<T> {
+public abstract class PropertyCondition<T> extends Condition implements ch.njol.util.Checker<T>, Predicate<T> {
 
 	/**
 	 * See {@link PropertyCondition} for more info

--- a/src/main/java/ch/njol/skript/entity/EndermanData.java
+++ b/src/main/java/ch/njol/skript/entity/EndermanData.java
@@ -19,41 +19,39 @@
 package ch.njol.skript.entity;
 
 import java.util.Arrays;
+import java.util.function.Predicate;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Enderman;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.material.MaterialData;
 import org.eclipse.jdt.annotation.Nullable;
 
-import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.skript.localization.ArgsMessage;
 import ch.njol.skript.registrations.Classes;
-import ch.njol.util.Checker;
 import ch.njol.util.coll.CollectionUtils;
 
 @SuppressWarnings("deprecation")
 public class EndermanData extends EntityData<Enderman> {
-	
+
 	static {
 		EntityData.register(EndermanData.class, "enderman", Enderman.class, "enderman");
 	}
 
 	@Nullable
 	private ItemType[] hand = null;
-	
+
 	public EndermanData() {}
-	
+
 	public EndermanData(@Nullable ItemType[] hand) {
 		this.hand = hand;
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	@Override
 	protected boolean init(final Literal<?>[] exprs, final int matchedPattern, final ParseResult parseResult) {
@@ -61,7 +59,7 @@ public class EndermanData extends EntityData<Enderman> {
 			hand = ((Literal<ItemType>) exprs[0]).getAll();
 		return true;
 	}
-	
+
 	@Override
 	protected boolean init(final @Nullable Class<? extends Enderman> c, final @Nullable Enderman e) {
 		if (e != null) {
@@ -74,7 +72,7 @@ public class EndermanData extends EntityData<Enderman> {
 		}
 		return true;
 	}
-	
+
 	@Override
 	public void set(final Enderman entity) {
 		if (hand != null) {
@@ -86,28 +84,28 @@ public class EndermanData extends EntityData<Enderman> {
 				entity.setCarriedBlock(Bukkit.createBlockData(i.getType()));
 			}
 		}
-		
+
 	}
-	
+
 	@Override
 	public boolean match(final Enderman entity) {
-		return hand == null || SimpleExpression.check(hand, new Checker<ItemType>() {
+		return hand == null || SimpleExpression.check(hand, new Predicate<ItemType>() {
 			@SuppressWarnings("null")
 			@Override
-			public boolean check(final @Nullable ItemType t) {
+			public boolean test(final @Nullable ItemType t) {
 				// TODO {Block/Material}Data -> Material conversion is not 100% accurate, needs a better solution
 				return t != null && t.isOfType(entity.getCarriedBlock().getMaterial());
 			}
 		}, false, false);
 	}
-	
+
 	@Override
 	public Class<Enderman> getType() {
 		return Enderman.class;
 	}
-	
+
 	private final static ArgsMessage format = new ArgsMessage("entities.enderman.format");
-	
+
 	@Override
 	public String toString(final int flags) {
 		final ItemType[] hand = this.hand;
@@ -115,12 +113,12 @@ public class EndermanData extends EntityData<Enderman> {
 			return super.toString(flags);
 		return format.toString(super.toString(flags), Classes.toString(hand, false));
 	}
-	
+
 	@Override
 	protected int hashCode_i() {
 		return Arrays.hashCode(hand);
 	}
-	
+
 	@Override
 	protected boolean equals_i(final EntityData<?> obj) {
 		if (!(obj instanceof EndermanData))
@@ -128,7 +126,7 @@ public class EndermanData extends EntityData<Enderman> {
 		final EndermanData other = (EndermanData) obj;
 		return Arrays.equals(hand, other.hand);
 	}
-	
+
 //		if (hand == null)
 //			return "";
 //		final StringBuilder b = new StringBuilder();
@@ -162,23 +160,23 @@ public class EndermanData extends EntityData<Enderman> {
 		}
 		return false;
 	}
-	
+
 	private boolean isSubhand(final @Nullable ItemType[] sub) {
 		if (hand != null)
 			return sub != null && ItemType.isSubset(hand, sub);
 		return true;
 	}
-	
+
 	@Override
 	public boolean isSupertypeOf(final EntityData<?> e) {
 		if (e instanceof EndermanData)
 			return isSubhand(((EndermanData) e).hand);
 		return false;
 	}
-	
+
 	@Override
 	public EntityData getSuperType() {
 		return new EndermanData(hand);
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/events/EvtClick.java
+++ b/src/main/java/ch/njol/skript/events/EvtClick.java
@@ -42,8 +42,9 @@ import ch.njol.skript.entity.EntityData;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptEvent;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.util.Checker;
 import ch.njol.util.coll.CollectionUtils;
+
+import java.util.function.Predicate;
 
 public class EvtClick extends SkriptEvent {
 
@@ -124,11 +125,11 @@ public class EvtClick extends SkriptEvent {
 	public boolean check(Event event) {
 		Block block;
 		Entity entity;
-		
+
 		if (event instanceof PlayerInteractEntityEvent) {
 			PlayerInteractEntityEvent clickEvent = ((PlayerInteractEntityEvent) event);
 			Entity clicked = clickEvent.getRightClicked();
-			
+
 			// Usually, don't handle these events
 			if (clickEvent instanceof PlayerInteractAtEntityEvent) {
 				// But armor stands are an exception
@@ -136,22 +137,22 @@ public class EvtClick extends SkriptEvent {
 				if (!(clicked instanceof ArmorStand))
 					return false;
 			}
-			
+
 			if (click == LEFT) // Lefts clicks on entities don't work
 				return false;
-			
+
 			// PlayerInteractAtEntityEvent called only once for armor stands
 			if (!(event instanceof PlayerInteractAtEntityEvent)) {
 				if (!interactTracker.checkEvent(clickEvent.getPlayer(), clickEvent, clickEvent.getHand())) {
 					return false; // Not first event this tick
 				}
 			}
-			
+
 			entity = clicked;
 			block = null;
 		} else if (event instanceof PlayerInteractEvent) {
 			PlayerInteractEvent clickEvent = ((PlayerInteractEvent) event);
-			
+
 			// Figure out click type, filter non-click events
 			Action a = clickEvent.getAction();
 			int click;
@@ -170,23 +171,23 @@ public class EvtClick extends SkriptEvent {
 			}
 			if ((this.click & click) == 0)
 				return false; // We don't want to handle this kind of events
-			
+
 			EquipmentSlot hand = clickEvent.getHand();
 			assert hand != null; // Not PHYSICAL interaction
 			if (!interactTracker.checkEvent(clickEvent.getPlayer(), clickEvent, hand)) {
 				return false; // Not first event this tick
 			}
-			
+
 			block = clickEvent.getClickedBlock();
 			entity = null;
 		} else {
 			assert false;
 			return false;
 		}
-		
-		if (tools != null && !tools.check(event, new Checker<ItemType>() {
+
+		if (tools != null && !tools.check(event, new Predicate<ItemType>() {
 			@Override
-			public boolean check(final ItemType t) {
+			public boolean test(final ItemType t) {
 				if (event instanceof PlayerInteractEvent) {
 					return t.isOfType(((PlayerInteractEvent) event).getItem());
 				} else { // PlayerInteractEntityEvent doesn't have item associated with it
@@ -199,11 +200,11 @@ public class EvtClick extends SkriptEvent {
 		})) {
 			return false;
 		}
-		
+
 		if (type != null) {
-			return type.check(event, new Checker<Object>() {
+			return type.check(event, new Predicate<Object>() {
 				@Override
-				public boolean check(final Object o) {
+				public boolean test(final Object o) {
 					if (entity != null) {
 						return o instanceof EntityData ? ((EntityData<?>) o).isInstance(entity) : Relation.EQUAL.isImpliedBy(DefaultComparators.entityItemComparator.compare(EntityData.fromEntity(entity), (ItemType) o));
 					} else {

--- a/src/main/java/ch/njol/skript/events/EvtEntityBlockChange.java
+++ b/src/main/java/ch/njol/skript/events/EvtEntityBlockChange.java
@@ -24,7 +24,6 @@ import ch.njol.skript.entity.EntityData;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptEvent;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.util.Checker;
 
 import org.bukkit.entity.Enderman;
 import org.bukkit.entity.FallingBlock;
@@ -35,6 +34,7 @@ import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
+import java.util.function.Predicate;
 
 public class EvtEntityBlockChange extends SkriptEvent {
 
@@ -74,14 +74,14 @@ public class EvtEntityBlockChange extends SkriptEvent {
 		GENERIC("(entity|%*-entitydatas%) chang(e|ing) block[s]");
 
 		@Nullable
-		private final Checker<EntityChangeBlockEvent> checker;
+		private final Predicate<EntityChangeBlockEvent> checker;
 		private final String pattern;
 
 		ChangeEvent(String pattern) {
 			this(pattern, null);
 		}
 
-		ChangeEvent(String pattern, @Nullable Checker<EntityChangeBlockEvent> checker) {
+		ChangeEvent(String pattern, @Nullable Predicate<EntityChangeBlockEvent> checker) {
 			this.pattern = pattern;
 			this.checker = checker;
 		}
@@ -116,7 +116,7 @@ public class EvtEntityBlockChange extends SkriptEvent {
 			return false;
 		if (this.event.checker == null)
 			return true;
-		return this.event.checker.check((EntityChangeBlockEvent) event);
+		return this.event.checker.test((EntityChangeBlockEvent) event);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/events/EvtGameMode.java
+++ b/src/main/java/ch/njol/skript/events/EvtGameMode.java
@@ -19,6 +19,7 @@
 package ch.njol.skript.events;
 
 import java.util.Locale;
+import java.util.function.Predicate;
 
 import org.bukkit.GameMode;
 import org.bukkit.event.Event;
@@ -29,7 +30,6 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptEvent;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.util.Checker;
 
 /**
  * @author Peter Güttinger
@@ -41,33 +41,33 @@ public final class EvtGameMode extends SkriptEvent {
 				.examples("on gamemode change:", "on gamemode change to adventure:")
 				.since("1.0");
 	}
-	
+
 	@Nullable
 	private Literal<GameMode> mode;
-	
+
 	@SuppressWarnings("unchecked")
 	@Override
 	public boolean init(final Literal<?>[] args, final int matchedPattern, final ParseResult parser) {
 		mode = (Literal<GameMode>) args[0];
 		return true;
 	}
-	
+
 	@Override
 	public boolean check(final Event e) {
 		if (mode != null) {
-			return mode.check(e, new Checker<GameMode>() {
+			return mode.check(e, new Predicate<GameMode>() {
 				@Override
-				public boolean check(final GameMode m) {
+				public boolean test(final GameMode m) {
 					return ((PlayerGameModeChangeEvent) e).getNewGameMode().equals(m);
 				}
 			});
 		}
 		return true;
 	}
-	
+
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
 		return "gamemode change" + (mode != null ? " to " + mode.toString().toLowerCase(Locale.ENGLISH) : "");
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/events/EvtWeatherChange.java
+++ b/src/main/java/ch/njol/skript/events/EvtWeatherChange.java
@@ -28,8 +28,9 @@ import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptEvent;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.WeatherType;
-import ch.njol.util.Checker;
 import ch.njol.util.coll.CollectionUtils;
+
+import java.util.function.Predicate;
 
 /**
  * @author Peter Güttinger
@@ -42,16 +43,16 @@ public class EvtWeatherChange extends SkriptEvent {
 				.examples("on weather change:", "on weather change to sunny:")
 				.since("1.0");
 	}
-	
+
 	@Nullable
 	private Literal<WeatherType> types;
-	
+
 	@Override
 	public boolean init(final Literal<?>[] args, final int matchedPattern, final ParseResult parser) {
 		types = (Literal<WeatherType>) args[0];
 		return true;
 	}
-	
+
 	@SuppressWarnings("null")
 	@Override
 	public boolean check(final Event e) {
@@ -61,17 +62,17 @@ public class EvtWeatherChange extends SkriptEvent {
 			return false;
 		final boolean rain = e instanceof WeatherChangeEvent ? ((WeatherChangeEvent) e).toWeatherState() : ((ThunderChangeEvent) e).getWorld().hasStorm();
 		final boolean thunder = e instanceof ThunderChangeEvent ? ((ThunderChangeEvent) e).toThunderState() : ((WeatherChangeEvent) e).getWorld().isThundering();
-		return types.check(e, new Checker<WeatherType>() {
+		return types.check(e, new Predicate<WeatherType>() {
 			@Override
-			public boolean check(final WeatherType t) {
+			public boolean test(final WeatherType t) {
 				return t.isWeather(rain, thunder);
 			}
 		});
 	}
-	
+
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
 		return "weather change" + (types == null ? "" : " to " + types);
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/expressions/arithmetic/ArithmeticChain.java
+++ b/src/main/java/ch/njol/skript/expressions/arithmetic/ArithmeticChain.java
@@ -20,12 +20,12 @@ package ch.njol.skript.expressions.arithmetic;
 
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.bukkit.event.Event;
 
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.util.Utils;
-import ch.njol.util.Checker;
 import org.eclipse.jdt.annotation.Nullable;
 import org.skriptlang.skript.lang.arithmetic.Operation;
 import org.skriptlang.skript.lang.arithmetic.OperationInfo;
@@ -43,7 +43,7 @@ import org.skriptlang.skript.lang.converter.Converters;
 public class ArithmeticChain<L, R, T> implements ArithmeticGettable<T> {
 
 	@SuppressWarnings("unchecked")
-	private static final Checker<Object>[] CHECKERS = new Checker[] {
+	private static final Predicate<Object>[] CHECKERS = new Predicate[] {
 		o -> o.equals(Operator.ADDITION) || o.equals(Operator.SUBTRACTION),
 		o -> o.equals(Operator.MULTIPLICATION) || o.equals(Operator.DIVISION),
 		o -> o.equals(Operator.EXPONENTIATION)
@@ -129,7 +129,7 @@ public class ArithmeticChain<L, R, T> implements ArithmeticGettable<T> {
 	@Nullable
 	@SuppressWarnings("unchecked")
 	public static <L, R, T> ArithmeticGettable<T> parse(List<Object> chain) {
-		for (Checker<Object> checker : CHECKERS) {
+		for (Predicate<Object> checker : CHECKERS) {
 			int lastIndex = Utils.findLastIndex(chain, checker);
 
 			if (lastIndex != -1) {

--- a/src/main/java/ch/njol/skript/hooks/regions/conditions/CondCanBuild.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/conditions/CondCanBuild.java
@@ -29,12 +29,13 @@ import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.Direction;
-import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
+
+import java.util.function.Predicate;
 
 /**
  * @author Peter Güttinger
@@ -61,12 +62,12 @@ public class CondCanBuild extends Condition {
 				"%players% (can|(is|are) allowed to) build %directions% %locations%",
 				"%players% (can('t|not)|(is|are)(n't| not) allowed to) build %directions% %locations%");
 	}
-	
+
 	@SuppressWarnings("null")
 	private Expression<Player> players;
 	@SuppressWarnings("null")
 	Expression<Location> locations;
-	
+
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
 	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
@@ -75,25 +76,25 @@ public class CondCanBuild extends Condition {
 		setNegated(matchedPattern == 1);
 		return true;
 	}
-	
+
 	@Override
 	public boolean check(final Event e) {
-		return players.check(e, new Checker<Player>() {
+		return players.check(e, new Predicate<Player>() {
 			@Override
-			public boolean check(final Player p) {
-				return locations.check(e, new Checker<Location>() {
+			public boolean test(final Player p) {
+				return locations.check(e, new Predicate<Location>() {
 					@Override
-					public boolean check(final Location l) {
+					public boolean test(final Location l) {
 						return RegionsPlugin.canBuild(p, l);
 					}
 				}, isNegated());
 			}
 		});
 	}
-	
+
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
 		return players.toString(e, debug) + " can build " + locations.toString(e, debug);
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/hooks/regions/conditions/CondIsMember.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/conditions/CondIsMember.java
@@ -28,11 +28,12 @@ import ch.njol.skript.hooks.regions.classes.Region;
 import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
+
+import java.util.function.Predicate;
 
 /**
  * @author Peter Güttinger
@@ -54,14 +55,14 @@ public class CondIsMember extends Condition {
 				"%offlineplayers% (is|are) (0¦[a] member|1¦[(the|an)] owner) of [[the] region] %regions%",
 				"%offlineplayers% (is|are)(n't| not) (0¦[a] member|1¦[(the|an)] owner) of [[the] region] %regions%");
 	}
-	
+
 	@SuppressWarnings("null")
 	private Expression<OfflinePlayer> players;
 	@SuppressWarnings("null")
 	Expression<Region> regions;
-	
+
 	boolean owner;
-	
+
 	@SuppressWarnings({"null", "unchecked"})
 	@Override
 	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
@@ -71,22 +72,22 @@ public class CondIsMember extends Condition {
 		setNegated(matchedPattern == 1);
 		return true;
 	}
-	
+
 	@Override
 	public boolean check(final Event e) {
-		return players.check(e, new Checker<OfflinePlayer>() {
+		return players.check(e, new Predicate<OfflinePlayer>() {
 			@Override
-			public boolean check(final OfflinePlayer p) {
-				return regions.check(e, new Checker<Region>() {
+			public boolean test(final OfflinePlayer p) {
+				return regions.check(e, new Predicate<Region>() {
 					@Override
-					public boolean check(final Region r) {
+					public boolean test(final Region r) {
 						return owner ? r.isOwner(p) : r.isMember(p);
 					}
 				}, isNegated());
 			}
 		});
 	}
-	
+
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
 		return players.toString(e, debug) + " " + (players.isSingle() ? "is" : "are") + (isNegated() ? " not" : "") + " " + (owner ? "owner" : "member") + (players.isSingle() ? "" : "s") + " of " + regions.toString(e, debug);

--- a/src/main/java/ch/njol/skript/hooks/regions/conditions/CondRegionContains.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/conditions/CondRegionContains.java
@@ -29,11 +29,12 @@ import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.Direction;
-import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
 import org.bukkit.Location;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
+
+import java.util.function.Predicate;
 
 /**
  * @author Peter Güttinger
@@ -58,12 +59,12 @@ public class CondRegionContains extends Condition {
 				"[[the] region] %regions% contain[s] %directions% %locations%", "%locations% (is|are) ([contained] in|part of) [[the] region] %regions%",
 				"[[the] region] %regions% (do|does)(n't| not) contain %directions% %locations%", "%locations% (is|are)(n't| not) (contained in|part of) [[the] region] %regions%");
 	}
-	
+
 	@SuppressWarnings("null")
 	private Expression<Region> regions;
 	@SuppressWarnings("null")
 	Expression<Location> locs;
-	
+
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
 	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
@@ -77,25 +78,25 @@ public class CondRegionContains extends Condition {
 		setNegated(matchedPattern >= 2);
 		return true;
 	}
-	
+
 	@Override
 	public boolean check(final Event e) {
-		return regions.check(e, new Checker<Region>() {
+		return regions.check(e, new Predicate<Region>() {
 			@Override
-			public boolean check(final Region r) {
-				return locs.check(e, new Checker<Location>() {
+			public boolean test(final Region r) {
+				return locs.check(e, new Predicate<Location>() {
 					@Override
-					public boolean check(final Location l) {
+					public boolean test(final Location l) {
 						return r.contains(l);
 					}
 				}, isNegated());
 			}
 		});
 	}
-	
+
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
 		return regions.toString(e, debug) + " contain" + (regions.isSingle() ? "s" : "") + " " + locs.toString(e, debug);
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/lang/Condition.java
+++ b/src/main/java/ch/njol/skript/lang/Condition.java
@@ -20,11 +20,11 @@ package ch.njol.skript.lang;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.lang.util.SimpleExpression;
-import ch.njol.util.Checker;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
 import java.util.Iterator;
+import java.util.function.Predicate;
 
 /**
  * A condition which must be fulfilled for the trigger to continue. If the condition is in a section the behaviour depends on the section.
@@ -41,8 +41,8 @@ public abstract class Condition extends Statement {
 	 * Checks whether this condition is satisfied with the given event. This should not alter the event or the world in any way, as conditions are only checked until one returns
 	 * false. All subsequent conditions of the same trigger will then be omitted.<br/>
 	 * <br/>
-	 * You might want to use {@link SimpleExpression#check(Event, Checker)}
-	 * 
+	 * You might want to use {@link SimpleExpression#check(Event, Predicate)}
+	 *
 	 * @param event the event to check
 	 * @return <code>true</code> if the condition is satisfied, <code>false</code> otherwise or if the condition doesn't apply to this event.
 	 */
@@ -54,7 +54,7 @@ public abstract class Condition extends Statement {
 	}
 
 	/**
-	 * Sets the negation state of this condition. This will change the behaviour of {@link Expression#check(Event, Checker, boolean)}.
+	 * Sets the negation state of this condition. This will change the behaviour of {@link Expression#check(Event, Predicate, boolean)}.
 	 */
 	protected final void setNegated(boolean invert) {
 		negated = invert;

--- a/src/main/java/ch/njol/skript/lang/Expression.java
+++ b/src/main/java/ch/njol/skript/lang/Expression.java
@@ -28,7 +28,6 @@ import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.skript.log.ErrorQuality;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.util.slot.Slot;
-import ch.njol.util.Checker;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemStack;
 import org.eclipse.jdt.annotation.NonNull;
@@ -40,6 +39,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Spliterators;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -58,8 +58,8 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	 * This method may only return null if it always returns null for the given event, i.e. it is equivalent to getting a random element out of {@link #getAll(Event)} or null iff
 	 * that array is empty.
 	 * <p>
-	 * Do not use this in conditions, use {@link #check(Event, Checker, boolean)} instead.
-	 * 
+	 * Do not use this in conditions, use {@link #check(Event, Predicate, boolean)} instead.
+	 *
 	 * @param event The event
 	 * @return The value or null if this expression doesn't have any value for the event
 	 * @throws UnsupportedOperationException (optional) if this was called on a non-single expression
@@ -70,7 +70,7 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	/**
 	 * Get an optional of the single value of this expression.
 	 * <p>
-	 * Do not use this in conditions, use {@link #check(Event, Checker, boolean)} instead.
+	 * Do not use this in conditions, use {@link #check(Event, Predicate, boolean)} instead.
 	 *
 	 * @param event the event
 	 * @return an {@link Optional} containing the {@link #getSingle(Event) single value} of this expression for this event.
@@ -85,8 +85,8 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	 * <p>
 	 * The returned array must not contain any null values.
 	 * <p>
-	 * Do not use this in conditions, use {@link #check(Event, Checker, boolean)} instead.
-	 * 
+	 * Do not use this in conditions, use {@link #check(Event, Predicate, boolean)} instead.
+	 *
 	 * @param event The event
 	 * @return An array of values of this expression which must neither be null nor contain nulls, and which must not be an internal array.
 	 */
@@ -95,7 +95,7 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	/**
 	 * Gets all possible return values of this expression, i.e. it returns the same as {@link #getArray(Event)} if {@link #getAnd()} is true, otherwise all possible values for
 	 * {@link #getSingle(Event)}.
-	 * 
+	 *
 	 * @param event The event
 	 * @return An array of all possible values of this expression for the given event which must neither be null nor contain nulls, and which must not be an internal array.
 	 */
@@ -125,29 +125,29 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	 * or as the innermost check of nested checks.
 	 * <p>
 	 * Usual implementation (may differ, e.g. may return false for nonexistent values independent of <tt>negated</tt>):
-	 * 
+	 *
 	 * <pre>
-	 * return negated ^ {@link #check(Event, Checker)};
+	 * return negated ^ {@link #check(Event, Predicate)};
 	 * </pre>
-	 * 
+	 *
 	 * @param event The event to be used for evaluation
 	 * @param checker The checker that determines whether this expression matches
 	 * @param negated The checking condition's negated state. This is used to invert the output of the checker if set to true (i.e. <tt>negated ^ checker.check(...)</tt>)
 	 * @return Whether this expression matches or doesn't match the given checker depending on the condition's negated state.
-	 * @see SimpleExpression#check(Object[], Checker, boolean, boolean)
+	 * @see SimpleExpression#check(Object[], Predicate, boolean, boolean)
 	 */
-	boolean check(Event event, Checker<? super T> checker, boolean negated);
+	boolean check(Event event, Predicate<? super T> checker, boolean negated);
 
 	/**
-	 * Checks this expression against the given checker. This method must only be used around other checks, use {@link #check(Event, Checker, boolean)} for a simple check or the
+	 * Checks this expression against the given checker. This method must only be used around other checks, use {@link #check(Event, Predicate, boolean)} for a simple check or the
 	 * innermost check of a nested check.
-	 * 
+	 *
 	 * @param event The event to be used for evaluation
 	 * @param checker A checker that determines whether this expression matches
 	 * @return Whether this expression matches the given checker
-	 * @see SimpleExpression#check(Object[], Checker, boolean, boolean)
+	 * @see SimpleExpression#check(Object[], Predicate, boolean, boolean)
 	 */
-	boolean check(Event event, Checker<? super T> checker);
+	boolean check(Event event, Predicate<? super T> checker);
 
 	/**
 	 * Tries to convert this expression to the given type. This method can print an error prior to returning null to specify the cause.
@@ -157,7 +157,7 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	 * <p>
 	 * The returned expression should delegate this method to the original expression's method to prevent excessive converted expression chains (see also
 	 * {@link ConvertedExpression}).
-	 * 
+	 *
 	 * @param to The desired return type of the returned expression
 	 * @return Expression with the desired return type or null if the expression can't be converted to the given type. Returns the expression itself if it already returns the
 	 *         desired type.
@@ -170,7 +170,7 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 
 	/**
 	 * Gets the return type of this expression.
-	 * 
+	 *
 	 * @return A supertype of any objects returned by {@link #getSingle(Event)} and the component type of any arrays returned by {@link #getArray(Event)}
 	 */
 	Class<? extends T> getReturnType();
@@ -178,11 +178,11 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	/**
 	 * Returns true if this expression returns all possible values, false if it only returns some of them.
 	 * <p>
-	 * This method significantly influences {@link #check(Event, Checker)}, {@link #check(Event, Checker, boolean)} and {@link CondIsSet} and thus breaks conditions that use this
+	 * This method significantly influences {@link #check(Event, Predicate)}, {@link #check(Event, Predicate, boolean)} and {@link CondIsSet} and thus breaks conditions that use this
 	 * expression if it returns a wrong value.
 	 * <p>
 	 * This method must return true if this is a {@link #isSingle() single} expression. // TODO make this method irrelevant for single expressions
-	 * 
+	 *
 	 * @return Whether this expression returns all values at once or only part of them.
 	 */
 	boolean getAnd();
@@ -195,7 +195,7 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	 * <p>
 	 * If this method returns false the expression will be discarded and an error message is printed. Custom error messages must be of {@link ErrorQuality#SEMANTIC_ERROR} to be
 	 * printed (NB: {@link Skript#error(String)} always creates semantic errors).
-	 * 
+	 *
 	 * @param time -1 for past or 1 for future. 0 is never passed to this method as it represents the default state.
 	 * @return Whether this expression has distinct time states, e.g. a player never changes but a block can. This should be sensitive for the event (using
 	 *         {@link ch.njol.skript.lang.parser.ParserInstance#isCurrentEvent(Class)}).
@@ -215,14 +215,14 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	 * Returns whether this value represents the default value of its type for the event, i.e. it can be replaced with a call to event.getXyz() if one knows the event & value type.
 	 * <p>
 	 * This method might be removed in the future as it's better to check whether value == event.getXyz() for every value an expression returns.
-	 * 
+	 *
 	 * @return Whether this is the return types' default expression
 	 */
 	boolean isDefault();
 
 	/**
 	 * Returns the same as {@link #getArray(Event)} but as an iterator. This method should be overriden by expressions intended to be looped to increase performance.
-	 * 
+	 *
 	 * @param event The event to be used for evaluation
 	 * @return An iterator to iterate over all values of this expression which may be empty and/or null, but must not return null elements.
 	 */
@@ -234,7 +234,7 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	 * argument loop.
 	 * <p>
 	 * You should usually just return false as e.g. loop-block will automatically match the expression if its returnType is Block or a subtype of it.
-	 * 
+	 *
 	 * @param input The entered input string (the blank in loop-___)
 	 * @return Whether this loop matches the given string
 	 */
@@ -244,7 +244,7 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	 * Returns the original expression that was parsed, i.e. without any conversions done.
 	 * <p>
 	 * This method is undefined for simplified expressions.
-	 * 
+	 *
 	 * @return The unconverted source expression of this expression or this expression itself if it was never converted.
 	 */
 	Expression<?> getSource();
@@ -255,7 +255,7 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	 * After this method was used the toString methods are likely not useful anymore.
 	 * <p>
 	 * This method is not yet used but will be used to improve efficiency in the future.
-	 * 
+	 *
 	 * @return A reference to a simpler version of this expression. Can change this expression directly and return itself if applicable, i.e. no references to the expression before
 	 *         this method call should be kept!
 	 */
@@ -271,7 +271,7 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	 * <tt>super.change(...)</tt>.
 	 * <p>
 	 * Unlike {@link Changer#acceptChange(ChangeMode)} this method may print errors.
-	 * 
+	 *
 	 * @param mode The mode to check
 	 * @return An array of types that {@link #change(Event, Object[], ChangeMode)} accepts as its <code>delta</code> parameter (which can be arrays to denote that multiple of
 	 *         that type are accepted), or null if the given mode is not supported. For {@link ChangeMode#DELETE} and {@link ChangeMode#RESET} this can return any non-null array to
@@ -297,7 +297,7 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	/**
 	 * Changes the expression's value by the given amount. This will only be called on supported modes and with the desired <code>delta</code> type as returned by
 	 * {@link #acceptChange(ChangeMode)}
-	 * 
+	 *
 	 * @param event The event
 	 * @param delta An array with one or more instances of one or more of the classes returned by {@link #acceptChange(ChangeMode)} for the given change mode (null for
 	 *            {@link ChangeMode#DELETE} and {@link ChangeMode#RESET}). <b>This can be a Object[], thus casting is not allowed.</b>

--- a/src/main/java/ch/njol/skript/lang/ExpressionList.java
+++ b/src/main/java/ch/njol/skript/lang/ExpressionList.java
@@ -23,7 +23,6 @@ import ch.njol.skript.conditions.CondCompare;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleLiteral;
 import ch.njol.skript.registrations.Classes;
-import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.event.Event;
@@ -35,6 +34,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.function.Predicate;
 
 /**
  * A list of expressions.
@@ -150,7 +150,7 @@ public class ExpressionList<T> implements Expression<T> {
 	}
 
 	@Override
-	public boolean check(Event event, Checker<? super T> checker, boolean negated) {
+	public boolean check(Event event, Predicate<? super T> checker, boolean negated) {
 		for (Expression<? extends T> expr : expressions) {
 			boolean result = expr.check(event, checker) ^ negated;
 			// exit early if we find a FALSE and we're ANDing, or a TRUE and we're ORing
@@ -163,7 +163,7 @@ public class ExpressionList<T> implements Expression<T> {
 	}
 
 	@Override
-	public boolean check(Event event, Checker<? super T> checker) {
+	public boolean check(Event event, Predicate<? super T> checker) {
 		return check(event, checker, false);
 	}
 

--- a/src/main/java/ch/njol/skript/lang/UnparsedLiteral.java
+++ b/src/main/java/ch/njol/skript/lang/UnparsedLiteral.java
@@ -26,13 +26,13 @@ import ch.njol.skript.log.LogEntry;
 import ch.njol.skript.log.ParseLogHandler;
 import ch.njol.skript.log.SkriptLogger;
 import ch.njol.skript.registrations.Classes;
-import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import ch.njol.util.coll.iterator.NonNullIterator;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
+import java.util.function.Predicate;
 import java.util.logging.Level;
 
 /**
@@ -188,12 +188,12 @@ public class UnparsedLiteral implements Literal<Object> {
 	}
 
 	@Override
-	public boolean check(Event event, Checker<? super Object> checker) {
+	public boolean check(Event event, Predicate<? super Object> checker) {
 		throw invalidAccessException();
 	}
 
 	@Override
-	public boolean check(Event event, Checker<? super Object> checker, boolean negated) {
+	public boolean check(Event event, Predicate<? super Object> checker, boolean negated) {
 		throw invalidAccessException();
 	}
 

--- a/src/main/java/ch/njol/skript/lang/Variable.java
+++ b/src/main/java/ch/njol/skript/lang/Variable.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.TreeMap;
+import java.util.function.Predicate;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptAPIException;
@@ -47,7 +48,6 @@ import ch.njol.skript.util.StringMode;
 import ch.njol.skript.util.Utils;
 import ch.njol.skript.variables.TypeHints;
 import ch.njol.skript.variables.Variables;
-import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
 import ch.njol.util.Pair;
 import ch.njol.util.StringUtils;
@@ -703,12 +703,12 @@ public class Variable<T> implements Expression<T> {
 	}
 
 	@Override
-	public boolean check(Event event, Checker<? super T> checker, boolean negated) {
+	public boolean check(Event event, Predicate<? super T> checker, boolean negated) {
 		return SimpleExpression.check(getAll(event), checker, negated, getAnd());
 	}
 
 	@Override
-	public boolean check(Event event, Checker<? super T> checker) {
+	public boolean check(Event event, Predicate<? super T> checker) {
 		return SimpleExpression.check(getAll(event), checker, false, getAnd());
 	}
 

--- a/src/main/java/ch/njol/skript/lang/VariableString.java
+++ b/src/main/java/ch/njol/skript/lang/VariableString.java
@@ -19,7 +19,6 @@
 package ch.njol.skript.lang;
 
 import ch.njol.skript.Skript;
-import ch.njol.skript.SkriptConfig;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.expressions.ExprColoured;
@@ -36,14 +35,12 @@ import ch.njol.skript.util.StringMode;
 import ch.njol.skript.util.Utils;
 import ch.njol.skript.util.chat.ChatMessages;
 import ch.njol.skript.util.chat.MessageComponent;
-import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
 import ch.njol.util.StringUtils;
 import ch.njol.util.coll.CollectionUtils;
 import ch.njol.util.coll.iterator.SingleItemIterator;
 import com.google.common.collect.Lists;
 import org.bukkit.ChatColor;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 import org.jetbrains.annotations.NotNull;
@@ -53,6 +50,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -83,7 +81,7 @@ public class VariableString implements Expression<String> {
 
 	/**
 	 * Creates a new VariableString which does not contain variables.
-	 * 
+	 *
 	 * @param input Content for string.
 	 */
 	private VariableString(String input) {
@@ -103,7 +101,7 @@ public class VariableString implements Expression<String> {
 
 	/**
 	 * Creates a new VariableString which contains variables.
-	 * 
+	 *
 	 * @param original Original string (unparsed).
 	 * @param strings Objects, some of them are variables.
 	 * @param mode String mode.
@@ -151,7 +149,7 @@ public class VariableString implements Expression<String> {
 	/**
 	 * Creates an instance of VariableString by parsing given string.
 	 * Prints errors and returns null if it is somehow invalid.
-	 * 
+	 *
 	 * @param original Unquoted string to parse.
 	 * @return A new VariableString instance.
 	 */
@@ -285,7 +283,7 @@ public class VariableString implements Expression<String> {
 	/**
 	 * Tests whether a string is correctly quoted, i.e. only has doubled double quotes in it.
 	 * Singular double quotes are only allowed between percentage signs.
-	 * 
+	 *
 	 * @param string The string to test
 	 * @param withQuotes Whether the string must be surrounded by double quotes or not
 	 * @return Whether the string is quoted correctly
@@ -316,7 +314,7 @@ public class VariableString implements Expression<String> {
 
 	/**
 	 * Removes quoted quotes from a string.
-	 * 
+	 *
 	 * @param string The string to remove quotes from
 	 * @param surroundingQuotes Whether the string has quotes at the start & end that should be removed
 	 * @return The string with double quotes replaced with single ones and optionally with removed surrounding quotes.
@@ -330,7 +328,7 @@ public class VariableString implements Expression<String> {
 
 	/**
 	 * Copied from {@code SkriptParser#nextBracket(String, char, char, int, boolean)}, but removed escaping & returns -1 on error.
-	 * 
+	 *
 	 * @param string The string to search in
 	 * @param start Index after the opening bracket
 	 * @return The next closing curly bracket
@@ -485,7 +483,7 @@ public class VariableString implements Expression<String> {
 
 	/**
 	 * Parses all expressions in the string and returns it in chat JSON format.
-	 * 
+	 *
 	 * @param event Event to pass to the expressions.
 	 * @return The input string with all expressions replaced.
 	 */
@@ -513,7 +511,7 @@ public class VariableString implements Expression<String> {
 	/**
 	 * Parses all expressions in the string and returns it.
 	 * If this is a simple string, the event may be null.
-	 * 
+	 *
 	 * @param event Event to pass to the expressions.
 	 * @return The input string with all expressions replaced.
 	 */
@@ -573,7 +571,7 @@ public class VariableString implements Expression<String> {
 
 	/**
 	 * Builds all possible default variable type hints based on the super type of the expression.
-	 * 
+	 *
 	 * @return List<String> of all possible super class code names.
 	 */
 	@NotNull
@@ -664,12 +662,12 @@ public class VariableString implements Expression<String> {
 	}
 
 	@Override
-	public boolean check(Event event, Checker<? super String> checker, boolean negated) {
+	public boolean check(Event event, Predicate<? super String> checker, boolean negated) {
 		return SimpleExpression.check(getAll(event), checker, negated, false);
 	}
 
 	@Override
-	public boolean check(Event event, Checker<? super String> checker) {
+	public boolean check(Event event, Predicate<? super String> checker) {
 		return SimpleExpression.check(getAll(event), checker, false, false);
 	}
 

--- a/src/main/java/ch/njol/skript/lang/util/ConvertedExpression.java
+++ b/src/main/java/ch/njol/skript/lang/util/ConvertedExpression.java
@@ -24,7 +24,6 @@ import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.registrations.Classes;
-import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.event.Event;
@@ -35,6 +34,7 @@ import org.skriptlang.skript.lang.converter.Converters;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.function.Predicate;
 
 /**
  * Represents a expression converted to another type. This, and not Expression, is the required return type of {@link SimpleExpression#getConvertedExpr(Class...)} because this
@@ -43,7 +43,7 @@ import java.util.NoSuchElementException;
  * <li>automatically lets the source expression handle everything apart from the get() methods</li>
  * <li>will never convert itself to another type, but rather request a new converted expression from the source expression.</li>
  * </ol>
- * 
+ *
  * @author Peter Güttinger
  */
 public class ConvertedExpression<F, T> implements Expression<T> {
@@ -166,18 +166,18 @@ public class ConvertedExpression<F, T> implements Expression<T> {
 	}
 
 	@Override
-	public boolean check(Event event, Checker<? super T> checker, boolean negated) {
+	public boolean check(Event event, Predicate<? super T> checker, boolean negated) {
 		return negated ^ check(event, checker);
 	}
 
 	@Override
-	public boolean check(Event event, Checker<? super T> checker) {
-		return source.check(event, (Checker<F>) value -> {
+	public boolean check(Event event, Predicate<? super T> checker) {
+		return source.check(event, (Predicate<F>) value -> {
 			T convertedValue = converter.convert(value);
 			if (convertedValue == null) {
 				return false;
 			}
-			return checker.check(convertedValue);
+			return checker.test(convertedValue);
 		});
 	}
 

--- a/src/main/java/ch/njol/skript/lang/util/ConvertedLiteral.java
+++ b/src/main/java/ch/njol/skript/lang/util/ConvertedLiteral.java
@@ -21,7 +21,6 @@ package ch.njol.skript.lang.util;
 import ch.njol.skript.SkriptAPIException;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.registrations.Classes;
-import ch.njol.util.Checker;
 import ch.njol.util.coll.CollectionUtils;
 import ch.njol.util.coll.iterator.ArrayIterator;
 import org.bukkit.event.Event;
@@ -30,6 +29,7 @@ import org.skriptlang.skript.lang.converter.ConverterInfo;
 import org.skriptlang.skript.lang.converter.Converters;
 
 import java.util.Iterator;
+import java.util.function.Predicate;
 
 /**
  * @see SimpleLiteral
@@ -93,12 +93,12 @@ public class ConvertedLiteral<F, T> extends ConvertedExpression<F, T> implements
 	}
 
 	@Override
-	public boolean check(Event event, Checker<? super T> checker) {
+	public boolean check(Event event, Predicate<? super T> checker) {
 		return SimpleExpression.check(data, checker, false, getAnd());
 	}
 
 	@Override
-	public boolean check(Event event, Checker<? super T> checker, boolean negated) {
+	public boolean check(Event event, Predicate<? super T> checker, boolean negated) {
 		return SimpleExpression.check(data, checker, negated, getAnd());
 	}
 

--- a/src/main/java/ch/njol/skript/lang/util/SimpleExpression.java
+++ b/src/main/java/ch/njol/skript/lang/util/SimpleExpression.java
@@ -39,10 +39,11 @@ import org.skriptlang.skript.lang.converter.Converter;
 import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.function.Predicate;
 
 /**
  * An implementation of the {@link Expression} interface. You should usually extend this class to make a new expression.
- * 
+ *
  * @see Skript#registerExpression(Class, Class, ExpressionType, String...)
  */
 public abstract class SimpleExpression<T> implements Expression<T> {
@@ -133,7 +134,7 @@ public abstract class SimpleExpression<T> implements Expression<T> {
 	/**
 	 * This is the internal method to get an expression's values.<br>
 	 * To get the expression's value from the outside use {@link #getSingle(Event)} or {@link #getArray(Event)}.
-	 * 
+	 *
 	 * @param event The event with which this expression is evaluated.
 	 * @return An array of values for this event. May not contain nulls.
 	 */
@@ -141,17 +142,17 @@ public abstract class SimpleExpression<T> implements Expression<T> {
 	protected abstract T[] get(Event event);
 
 	@Override
-	public final boolean check(Event event, Checker<? super T> checker) {
+	public final boolean check(Event event, Predicate<? super T> checker) {
 		return check(event, checker, false);
 	}
 
 	@Override
-	public final boolean check(Event event, Checker<? super T> checker, boolean negated) {
+	public final boolean check(Event event, Predicate<? super T> checker, boolean negated) {
 		return check(get(event), checker, negated, getAnd());
 	}
 
 	// TODO return a kleenean (UNKNOWN if 'values' is null or empty)
-	public static <T> boolean check(@Nullable T[] values, Checker<? super T> checker, boolean invert, boolean and) {
+	public static <T> boolean check(@Nullable T[] values, Predicate<? super T> checker, boolean invert, boolean and) {
 		if (values == null)
 			return invert;
 		boolean hasElement = false;
@@ -159,7 +160,7 @@ public abstract class SimpleExpression<T> implements Expression<T> {
 			if (value == null)
 				continue;
 			hasElement = true;
-			boolean b = checker.check(value);
+			boolean b = checker.test(value);
 			if (and && !b)
 				return invert;
 			if (!and && b)
@@ -174,7 +175,7 @@ public abstract class SimpleExpression<T> implements Expression<T> {
 	 * Converts this expression to another type. Unless the expression is special, the default implementation is sufficient.
 	 * <p>
 	 * This method is never called with a supertype of the return type of this expression, or the return type itself.
-	 * 
+	 *
 	 * @param to The desired return type of the returned expression
 	 * @return Expression with the desired return type or null if it can't be converted to the given type
 	 * @see Expression#getConvertedExpression(Class...)
@@ -236,7 +237,7 @@ public abstract class SimpleExpression<T> implements Expression<T> {
 	 * {@inheritDoc}
 	 * <p>
 	 * This implementation sets the time but returns false.
-	 * 
+	 *
 	 * @see #setTime(int, Class, Expression...)
 	 * @see #setTime(int, Expression, Class...)
 	 */

--- a/src/main/java/ch/njol/skript/lang/util/SimpleExpression.java
+++ b/src/main/java/ch/njol/skript/lang/util/SimpleExpression.java
@@ -27,7 +27,6 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.util.Utils;
-import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import ch.njol.util.coll.iterator.ArrayIterator;

--- a/src/main/java/ch/njol/skript/lang/util/SimpleLiteral.java
+++ b/src/main/java/ch/njol/skript/lang/util/SimpleLiteral.java
@@ -29,7 +29,6 @@ import ch.njol.skript.lang.UnparsedLiteral;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.util.StringMode;
 import ch.njol.skript.util.Utils;
-import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import ch.njol.util.coll.iterator.NonNullIterator;
@@ -38,6 +37,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.skriptlang.skript.lang.converter.Converters;
 
 import java.lang.reflect.Array;
+import java.util.function.Predicate;
 
 /**
  * Represents a literal, i.e. a static value like a number or a string.
@@ -165,12 +165,12 @@ public class SimpleLiteral<T> implements Literal<T>, DefaultExpression<T> {
 	}
 
 	@Override
-	public boolean check(Event event, Checker<? super T> checker, boolean negated) {
+	public boolean check(Event event, Predicate<? super T> checker, boolean negated) {
 		return SimpleExpression.check(data, checker, negated, getAnd());
 	}
 
 	@Override
-	public boolean check(Event event, Checker<? super T> checker) {
+	public boolean check(Event event, Predicate<? super T> checker) {
 		return SimpleExpression.check(data, checker, false, getAnd());
 	}
 

--- a/src/main/java/ch/njol/skript/util/Utils.java
+++ b/src/main/java/ch/njol/skript/util/Utils.java
@@ -55,7 +55,6 @@ import ch.njol.skript.effects.EffTeleport;
 import ch.njol.skript.localization.Language;
 import ch.njol.skript.localization.LanguageChangeListener;
 import ch.njol.skript.registrations.Classes;
-import ch.njol.util.Checker;
 import ch.njol.util.NonNullPair;
 import ch.njol.util.Pair;
 import ch.njol.util.StringUtils;
@@ -66,15 +65,15 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Utility class.
- * 
+ *
  * @author Peter Güttinger
  */
 public abstract class Utils {
-	
+
 	private Utils() {}
-	
+
 	public final static Random random = new Random();
-	
+
 	public static String join(final Object[] objects) {
 		assert objects != null;
 		final StringBuilder b = new StringBuilder();
@@ -85,7 +84,7 @@ public abstract class Utils {
 		}
 		return "" + b.toString();
 	}
-	
+
 	public static String join(final Iterable<?> objects) {
 		assert objects != null;
 		final StringBuilder b = new StringBuilder();
@@ -99,12 +98,12 @@ public abstract class Utils {
 		}
 		return "" + b.toString();
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	public static <T> boolean isEither(@Nullable T compared, @Nullable T... types) {
 		return CollectionUtils.contains(types, compared);
 	}
-	
+
 	public static Pair<String, Integer> getAmount(String s) {
 		if (s.matches("\\d+ of .+")) {
 			return new Pair<>(s.split(" ", 3)[2], Utils.parseInt("" + s.split(" ", 2)[0]));
@@ -115,7 +114,7 @@ public abstract class Utils {
 		}
 		return new Pair<>(s, Integer.valueOf(-1));
 	}
-	
+
 //	public final static class AmountResponse {
 //		public final String s;
 //		public final int amount;
@@ -163,7 +162,7 @@ public abstract class Utils {
 
 	/**
 	 * Loads classes of the plugin by package. Useful for registering many syntax elements like Skript does it.
-	 * 
+	 *
 	 * @param basePackage The base package to add to all sub packages, e.g. <tt>"ch.njol.skript"</tt>.
 	 * @param subPackages Which subpackages of the base package should be loaded, e.g. <tt>"expressions", "conditions", "effects"</tt>. Subpackages of these packages will be loaded
 	 *            as well. Use an empty array to load all subpackages of the base package.
@@ -216,7 +215,7 @@ public abstract class Utils {
 
 	/**
 	 * The first invocation of this method uses reflection to invoke the protected method {@link JavaPlugin#getFile()} to get the plugin's jar file.
-	 * 
+	 *
 	 * @return The jar file of the plugin.
 	 */
 	@Nullable
@@ -240,12 +239,12 @@ public abstract class Utils {
 	}
 
 	private final static String[][] plurals = {
-			
+
 			{"fe", "ves"},// most -f words' plurals can end in -fs as well as -ves
-			
+
 			{"axe", "axes"},
 			{"x", "xes"},
-			
+
 			{"ay", "ays"},
 			{"ey", "eys"},
 			{"iy", "iys"},
@@ -254,28 +253,28 @@ public abstract class Utils {
 			{"kie", "kies"},
 			{"zombie", "zombies"},
 			{"y", "ies"},
-			
+
 			{"h", "hes"},
-			
+
 			{"man", "men"},
-			
+
 			{"us", "i"},
-			
+
 			{"hoe", "hoes"},
 			{"toe", "toes"},
 			{"o", "oes"},
-			
+
 			{"alias", "aliases"},
 			{"gas", "gases"},
-			
+
 			{"child", "children"},
-			
+
 			{"sheep", "sheep"},
-			
+
 			// general ending
 			{"", "s"},
 	};
-	
+
 	/**
 	 * @param s trimmed string
 	 * @return Pair of singular string + boolean whether it was plural
@@ -293,10 +292,10 @@ public abstract class Utils {
 		}
 		return new NonNullPair<>(s, Boolean.FALSE);
 	}
-	
+
 	/**
 	 * Gets the english plural of a word.
-	 * 
+	 *
 	 * @param s
 	 * @return The english plural of the given word
 	 */
@@ -309,10 +308,10 @@ public abstract class Utils {
 		assert false;
 		return s + "s";
 	}
-	
+
 	/**
 	 * Gets the plural of a word (or not if p is false)
-	 * 
+	 *
 	 * @param s
 	 * @param p
 	 * @return The english plural of the given word, or the word itself if p is false.
@@ -322,10 +321,10 @@ public abstract class Utils {
 			return toEnglishPlural(s);
 		return s;
 	}
-	
+
 	/**
 	 * Adds 'a' or 'an' to the given string, depending on the first character of the string.
-	 * 
+	 *
 	 * @param s The string to add the article to
 	 * @return The given string with an appended a/an and a space at the beginning
 	 * @see #A(String)
@@ -334,10 +333,10 @@ public abstract class Utils {
 	public static String a(final String s) {
 		return a(s, false);
 	}
-	
+
 	/**
 	 * Adds 'A' or 'An' to the given string, depending on the first character of the string.
-	 * 
+	 *
 	 * @param s The string to add the article to
 	 * @return The given string with an appended A/An and a space at the beginning
 	 * @see #a(String)
@@ -346,10 +345,10 @@ public abstract class Utils {
 	public static String A(final String s) {
 		return a(s, true);
 	}
-	
+
 	/**
 	 * Adds 'a' or 'an' to the given string, depending on the first character of the string.
-	 * 
+	 *
 	 * @param s The string to add the article to
 	 * @param capA Whether to use a capital a or not
 	 * @return The given string with an appended a/an (or A/An if capA is true) and a space at the beginning
@@ -367,14 +366,14 @@ public abstract class Utils {
 			return "a " + s;
 		}
 	}
-	
+
 	/**
 	 * Gets the collision height of solid or partially-solid blocks at the center of the block.
 	 * This is mostly for use in the {@link EffTeleport teleport effect}.
 	 * <p>
 	 * This version operates on numeric ids, thus only working on
 	 * Minecraft 1.12 or older.
-	 * 
+	 *
 	 * @param type
 	 * @return The block's height at the center
 	 */
@@ -530,14 +529,14 @@ public abstract class Utils {
 
 		return completableFuture;
 	}
-	
+
 	final static ChatColor[] styles = {ChatColor.BOLD, ChatColor.ITALIC, ChatColor.STRIKETHROUGH, ChatColor.UNDERLINE, ChatColor.MAGIC, ChatColor.RESET};
 	final static Map<String, String> chat = new HashMap<>();
 	final static Map<String, String> englishChat = new HashMap<>();
-	
+
 	public final static boolean HEX_SUPPORTED = Skript.isRunningMinecraft(1, 16);
 	public final static boolean COPY_SUPPORTED = Skript.isRunningMinecraft(1, 15);
-	
+
 	static {
 		Language.addListener(new LanguageChangeListener() {
 			@Override
@@ -554,21 +553,21 @@ public abstract class Utils {
 			}
 		});
 	}
-	
+
 	@Nullable
 	public static String getChatStyle(final String s) {
 		SkriptColor color = SkriptColor.fromName(s);
-		
+
 		if (color != null)
 			return color.getFormattedChat();
 		return chat.get(s);
 	}
-	
+
 	private final static Pattern stylePattern = Pattern.compile("<([^<>]+)>");
-	
+
 	/**
 	 * Replaces &lt;chat styles&gt; in the message
-	 * 
+	 *
 	 * @param message
 	 * @return message with localised chat styles converted to Minecraft's format
 	 */
@@ -602,11 +601,11 @@ public abstract class Utils {
 		m = ChatColor.translateAlternateColorCodes('&', "" + m);
 		return "" + m;
 	}
-	
+
 	/**
 	 * Replaces english &lt;chat styles&gt; in the message. This is used for messages in the language file as the language of colour codes is not well defined while the language is
 	 * changing, and for some hardcoded messages.
-	 * 
+	 *
 	 * @param message
 	 * @return message with english chat styles converted to Minecraft's format
 	 */
@@ -653,7 +652,7 @@ public abstract class Utils {
 	public static ChatColor parseHexColor(String hex) {
 		if (!HEX_SUPPORTED || !HEX_PATTERN.matcher(hex).matches()) // Proper hex code validation
 			return null;
-		
+
 		hex = hex.replace("#", "");
 		try {
 			return ChatColor.of('#' + hex.substring(0, 6));
@@ -661,10 +660,10 @@ public abstract class Utils {
 			return null;
 		}
 	}
-	
+
 	/**
 	 * Gets a random value between <tt>start</tt> (inclusive) and <tt>end</tt> (exclusive)
-	 * 
+	 *
 	 * @param start
 	 * @param end
 	 * @return <tt>start + random.nextInt(end - start)</tt>
@@ -733,12 +732,12 @@ public abstract class Utils {
 		// See #1747 to learn how it broke returning items from functions
 		return (Class<Found>) (chosen == Cloneable.class ? bestGuess : chosen == Object.class ? bestGuess : chosen);
 	}
-	
+
 	/**
 	 * Parses a number that was validated to be an integer but might still result in a {@link NumberFormatException} when parsed with {@link Integer#parseInt(String)} due to
 	 * overflow.
 	 * This method will return {@link Integer#MIN_VALUE} or {@link Integer#MAX_VALUE} respectively if that happens.
-	 * 
+	 *
 	 * @param s
 	 * @return The parsed integer, {@link Integer#MIN_VALUE} or {@link Integer#MAX_VALUE} respectively
 	 */
@@ -750,12 +749,12 @@ public abstract class Utils {
 			return s.startsWith("-") ? Integer.MIN_VALUE : Integer.MAX_VALUE;
 		}
 	}
-	
+
 	/**
 	 * Parses a number that was validated to be an integer but might still result in a {@link NumberFormatException} when parsed with {@link Long#parseLong(String)} due to
 	 * overflow.
 	 * This method will return {@link Long#MIN_VALUE} or {@link Long#MAX_VALUE} respectively if that happens.
-	 * 
+	 *
 	 * @param s
 	 * @return The parsed long, {@link Long#MIN_VALUE} or {@link Long#MAX_VALUE} respectively
 	 */
@@ -767,7 +766,7 @@ public abstract class Utils {
 			return s.startsWith("-") ? Long.MIN_VALUE : Long.MAX_VALUE;
 		}
 	}
-	
+
 	/**
 	 * Gets class for name. Throws RuntimeException instead of checked one.
 	 * Use this only when absolutely necessary.
@@ -783,18 +782,18 @@ public abstract class Utils {
 			throw new RuntimeException("Class not found!");
 		}
 	}
-	
+
 	/**
-	 * Finds the index of the last in a {@link List} that matches the given {@link Checker}.
+	 * Finds the index of the last in a {@link List} that matches the given {@link Predicate}.
 	 *
 	 * @param list the {@link List} to search.
-	 * @param checker the {@link Checker} to match elements against.
+	 * @param checker the {@link Predicate} to match elements against.
 	 * @return the index of the element found, or -1 if no matching element was found.
 	 */
-	public static <T> int findLastIndex(List<T> list, Checker<T> checker) {
+	public static <T> int findLastIndex(List<T> list, Predicate<T> checker) {
 		int lastIndex = -1;
 		for (int i = 0; i < list.size(); i++) {
-			if (checker.check(list.get(i)))
+			if (checker.test(list.get(i)))
 				lastIndex = i;
 		}
 		return lastIndex;
@@ -807,5 +806,5 @@ public abstract class Utils {
 		}
 		return true;
 	}
-	
+
 }

--- a/src/main/java/ch/njol/util/Checker.java
+++ b/src/main/java/ch/njol/util/Checker.java
@@ -18,9 +18,16 @@
  */
 package ch.njol.util;
 
+import java.util.function.Predicate;
+
 @FunctionalInterface
-public interface Checker<T> {
-	
-	public boolean check(T o);
-	
+public interface Checker<T> extends Predicate<T> {
+
+	boolean check(T o);
+
+	@Override
+	default boolean test(T t) {
+		return this.check(t);
+	}
+
 }

--- a/src/main/java/ch/njol/util/Checker.java
+++ b/src/main/java/ch/njol/util/Checker.java
@@ -18,9 +18,13 @@
  */
 package ch.njol.util;
 
+import org.jetbrains.annotations.ApiStatus;
+
 import java.util.function.Predicate;
 
+@Deprecated
 @FunctionalInterface
+@ApiStatus.ScheduledForRemoval
 public interface Checker<T> extends Predicate<T> {
 
 	boolean check(T o);

--- a/src/main/java/ch/njol/util/NullableChecker.java
+++ b/src/main/java/ch/njol/util/NullableChecker.java
@@ -20,16 +20,18 @@ package ch.njol.util;
 
 import org.eclipse.jdt.annotation.Nullable;
 
-public interface NullableChecker<T> extends Checker<T> {
-	
+import java.util.function.Predicate;
+
+public interface NullableChecker<T> extends Checker<T>, Predicate<T> {
+
 	@Override
 	public boolean check(@Nullable T o);
-	
+
 	public static final NullableChecker<Object> nullChecker = new NullableChecker<Object>() {
 		@Override
 		public boolean check(final @Nullable Object o) {
 			return o != null;
 		}
 	};
-	
+
 }

--- a/src/main/java/ch/njol/util/NullableChecker.java
+++ b/src/main/java/ch/njol/util/NullableChecker.java
@@ -22,10 +22,10 @@ import org.eclipse.jdt.annotation.Nullable;
 
 import java.util.function.Predicate;
 
-public interface NullableChecker<T> extends Checker<T>, Predicate<T> {
+public interface NullableChecker<T> extends ch.njol.util.Checker<T>, Predicate<T> {
 
 	@Override
-	public boolean check(@Nullable T o);
+	boolean check(@Nullable T o);
 
 	public static final NullableChecker<Object> nullChecker = new NullableChecker<Object>() {
 		@Override

--- a/src/main/java/ch/njol/util/Predicate.java
+++ b/src/main/java/ch/njol/util/Predicate.java
@@ -18,13 +18,18 @@
  */
 package ch.njol.util;
 
+import org.jetbrains.annotations.ApiStatus;
+
 import javax.annotation.Nullable;
 
 /**
  * @author Peter G�ttinger
  *
  */
-public abstract interface Predicate<T> {
-  public abstract boolean test(@Nullable T paramT);
+@Deprecated
+@FunctionalInterface
+@ApiStatus.ScheduledForRemoval
+public interface Predicate<T> extends java.util.function.Predicate<T> {
+  boolean test(@Nullable T paramT);
 }
 


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Replaces all uses of the pointless checker class with Java's predicate.

This is _technically_ a breaking change: if something implements Expression directly (rather than one of its common subclasses, e.g. SimpleExpression, PropertyExpression) then it will have to change its Checker methods to Predicate methods.

To preserve compatibility everywhere else, the deprecated Checker now extends Predicate and forwards the method call itself, so addons can still feed old Checkers into the new Predicate arguments.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
