### PR TITLE
Deprecate outdated utils/validate

### DIFF
--- a/src/main/java/ch/njol/skript/command/Commands.java
+++ b/src/main/java/ch/njol/skript/command/Commands.java
@@ -30,7 +30,6 @@ import ch.njol.skript.log.RetainingLogHandler;
 import ch.njol.skript.log.SkriptLogger;
 import ch.njol.skript.util.SkriptColor;
 import ch.njol.skript.variables.Variables;
-import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
@@ -330,7 +329,8 @@ public abstract class Commands {
 			this.aliasFor = aliasFor.startsWith("/") ? aliasFor : "/" + aliasFor;
 			this.helpMap = helpMap;
 			name = alias.startsWith("/") ? alias : "/" + alias;
-			Validate.isTrue(!name.equals(this.aliasFor), "Command " + name + " cannot be alias for itself");
+			if (name.equals(this.aliasFor))
+				throw new IllegalArgumentException("Command " + name + " cannot be alias for itself");
 			shortText = ChatColor.YELLOW + "Alias for " + ChatColor.WHITE + this.aliasFor;
 		}
 

--- a/src/main/java/ch/njol/skript/command/Commands.java
+++ b/src/main/java/ch/njol/skript/command/Commands.java
@@ -30,6 +30,7 @@ import ch.njol.skript.log.RetainingLogHandler;
 import ch.njol.skript.log.SkriptLogger;
 import ch.njol.skript.util.SkriptColor;
 import ch.njol.skript.variables.Variables;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
@@ -329,8 +330,7 @@ public abstract class Commands {
 			this.aliasFor = aliasFor.startsWith("/") ? aliasFor : "/" + aliasFor;
 			this.helpMap = helpMap;
 			name = alias.startsWith("/") ? alias : "/" + alias;
-			if (name.equals(this.aliasFor))
-				throw new IllegalArgumentException("Command " + name + " cannot be alias for itself");
+			Preconditions.checkState(!name.equals(this.aliasFor), "Command " + name + " cannot be alias for itself");
 			shortText = ChatColor.YELLOW + "Alias for " + ChatColor.WHITE + this.aliasFor;
 		}
 

--- a/src/main/java/ch/njol/skript/command/ScriptCommand.java
+++ b/src/main/java/ch/njol/skript/command/ScriptCommand.java
@@ -43,7 +43,6 @@ import ch.njol.skript.util.chat.BungeeConverter;
 import ch.njol.skript.util.chat.MessageComponent;
 import ch.njol.skript.variables.Variables;
 import ch.njol.util.StringUtils;
-import ch.njol.util.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
@@ -136,7 +135,6 @@ public class ScriptCommand implements TabExecutor {
 		@Nullable VariableString cooldownMessage, String cooldownBypass,
 		@Nullable VariableString cooldownStorage, int executableBy, SectionNode node
 	) {
-		Validate.notNull(name, pattern, arguments, description, usage, aliases, node);
 		this.name = name;
 		label = "" + name.toLowerCase(Locale.ENGLISH);
 		this.permission = permission;

--- a/src/main/java/ch/njol/skript/command/ScriptCommand.java
+++ b/src/main/java/ch/njol/skript/command/ScriptCommand.java
@@ -43,6 +43,7 @@ import ch.njol.skript.util.chat.BungeeConverter;
 import ch.njol.skript.util.chat.MessageComponent;
 import ch.njol.skript.variables.Variables;
 import ch.njol.util.StringUtils;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
@@ -135,6 +136,13 @@ public class ScriptCommand implements TabExecutor {
 		@Nullable VariableString cooldownMessage, String cooldownBypass,
 		@Nullable VariableString cooldownStorage, int executableBy, SectionNode node
 	) {
+		Preconditions.checkNotNull(name);
+		Preconditions.checkNotNull(pattern);
+		Preconditions.checkNotNull(arguments);
+		Preconditions.checkNotNull(description);
+		Preconditions.checkNotNull(usage);
+		Preconditions.checkNotNull(aliases);
+		Preconditions.checkNotNull(node);
 		this.name = name;
 		label = "" + name.toLowerCase(Locale.ENGLISH);
 		this.permission = permission;

--- a/src/main/java/ch/njol/skript/events/bukkit/PreScriptLoadEvent.java
+++ b/src/main/java/ch/njol/skript/events/bukkit/PreScriptLoadEvent.java
@@ -19,6 +19,7 @@
 package ch.njol.skript.events.bukkit;
 
 import ch.njol.skript.config.Config;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -36,6 +37,7 @@ public class PreScriptLoadEvent extends Event {
 
     public PreScriptLoadEvent(List<Config> scripts) {
         super(!Bukkit.isPrimaryThread());
+	    Preconditions.checkNotNull(scripts);
         this.scripts = scripts;
     }
 

--- a/src/main/java/ch/njol/skript/events/bukkit/PreScriptLoadEvent.java
+++ b/src/main/java/ch/njol/skript/events/bukkit/PreScriptLoadEvent.java
@@ -18,14 +18,12 @@
  */
 package ch.njol.skript.events.bukkit;
 
-import java.util.List;
-
+import ch.njol.skript.config.Config;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
-import ch.njol.skript.config.Config;
-import ch.njol.util.Validate;
+import java.util.List;
 
 /**
  * This event has no guarantee of being on the main thread.
@@ -38,7 +36,6 @@ public class PreScriptLoadEvent extends Event {
 
     public PreScriptLoadEvent(List<Config> scripts) {
         super(!Bukkit.isPrimaryThread());
-        Validate.notNull(scripts);
         this.scripts = scripts;
     }
 

--- a/src/main/java/ch/njol/util/Validate.java
+++ b/src/main/java/ch/njol/util/Validate.java
@@ -18,64 +18,65 @@
  */
 package ch.njol.util;
 
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.ApiStatus;
+
 import java.util.Collection;
 
-import org.eclipse.jdt.annotation.Nullable;
+@ApiStatus.Internal
+public final class Validate {
 
-/**
- * @author Peter Güttinger
- */
-public abstract class Validate {
-	
-	public static void notNull(final Object... objects) {
+	private Validate() {}
+
+	public static void notNull(Object... objects) {
 		for (int i = 0; i < objects.length; i++) {
 			if (objects[i] == null)
 				throw new IllegalArgumentException("the " + StringUtils.fancyOrderNumber(i + 1) + " parameter must not be null");
 		}
 	}
 	
-	public static void notNull(final @Nullable Object object, final String name) {
+	public static void notNull(@Nullable Object object, String name) {
 		if (object == null)
 			throw new IllegalArgumentException(name + " must not be null");
 	}
 	
-	public static void isTrue(final boolean b, final String error) {
-		if (!b)
+	public static void isTrue(boolean value, String error) {
+		if (!value)
 			throw new IllegalArgumentException(error);
 	}
 	
-	public static void isFalse(final boolean b, final String error) {
-		if (b)
+	public static void isFalse(boolean value, String error) {
+		if (value)
 			throw new IllegalArgumentException(error);
 	}
 	
-	public static void notNullOrEmpty(final @Nullable String s, final String name) {
-		if (s == null || s.isEmpty())
+	public static void notNullOrEmpty(@Nullable String value, final String name) {
+		if (value == null || value.isEmpty())
 			throw new IllegalArgumentException(name + " must neither be null nor empty");
 	}
 	
-	public static void notNullOrEmpty(final @Nullable Object[] array, final String name) {
+	public static void notNullOrEmpty(Object @Nullable [] array, String name) {
 		if (array == null || array.length == 0)
 			throw new IllegalArgumentException(name + " must neither be null nor empty");
 	}
 	
-	public static void notNullOrEmpty(final @Nullable Collection<?> collection, final String name) {
+	public static void notNullOrEmpty(@Nullable Collection<?> collection, String name) {
 		if (collection == null || collection.isEmpty())
 			throw new IllegalArgumentException(name + " must neither be null nor empty");
 	}
 	
-	public static void notEmpty(final @Nullable String s, final String name) {
-		if (s != null && s.isEmpty())
+	public static void notEmpty(@Nullable String value, String name) {
+		if (value != null && value.isEmpty())
 			throw new IllegalArgumentException(name + " must not be empty");
 	}
 	
-	public static void notEmpty(final Object[] array, final String name) {
+	public static void notEmpty(Object[] array, String name) {
 		if (array.length == 0)
 			throw new IllegalArgumentException(name + " must not be empty");
 	}
 	
-	public static void notEmpty(final int[] nums, final String name) {
-		if (nums.length == 0)
+	public static void notEmpty(int[] array, String name) {
+		if (array.length == 0)
 			throw new IllegalArgumentException(name + " must not be empty");
 	}
 	

--- a/src/main/java/ch/njol/util/Validate.java
+++ b/src/main/java/ch/njol/util/Validate.java
@@ -23,7 +23,8 @@ import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Collection;
 
-@ApiStatus.Internal
+@Deprecated
+@ApiStatus.ScheduledForRemoval
 public final class Validate {
 
 	private Validate() {}


### PR DESCRIPTION
Technically does change some behaviour (no longer checks for null parameters in some cases) but as these are marked with the NotNull annotation developers should not expect it to work when null gets passed anyways.

I did keep the validation in CommandAliasHelpTopic since it actually checks something that isn't covered by annotations