### PR TITLE
Deprecate and replace Setter with Java's Consumer.

### DIFF
--- a/src/main/java/ch/njol/skript/config/Option.java
+++ b/src/main/java/ch/njol/skript/config/Option.java
@@ -19,6 +19,7 @@
 package ch.njol.skript.config;
 
 import java.util.Locale;
+import java.util.function.Consumer;
 
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -28,25 +29,24 @@ import org.skriptlang.skript.lang.converter.Converter;
 import ch.njol.skript.classes.Parser;
 import ch.njol.skript.lang.ParseContext;
 import ch.njol.skript.registrations.Classes;
-import ch.njol.util.Setter;
 
 /**
  * @author Peter Güttinger
  */
 public class Option<T> {
-	
+
 	public final String key;
 	private boolean optional = false;
-	
+
 	@Nullable
 	private String value = null;
 	private final Converter<String, ? extends T> parser;
 	private final T defaultValue;
 	private T parsedValue;
-	
+
 	@Nullable
-	private Setter<? super T> setter;
-	
+	private Consumer<? super T> setter;
+
 	public Option(final String key, final T defaultValue) {
 		this.key = "" + key.toLowerCase(Locale.ENGLISH);
 		this.defaultValue = defaultValue;
@@ -79,24 +79,24 @@ public class Option<T> {
 			};
 		}
 	}
-	
+
 	public Option(final String key, final T defaultValue, final Converter<String, ? extends T> parser) {
 		this.key = "" + key.toLowerCase(Locale.ENGLISH);
 		this.defaultValue = defaultValue;
 		parsedValue = defaultValue;
 		this.parser = parser;
 	}
-	
-	public final Option<T> setter(final Setter<? super T> setter) {
+
+	public final Option<T> setter(final Consumer<? super T> setter) {
 		this.setter = setter;
 		return this;
 	}
-	
+
 	public final Option<T> optional(final boolean optional) {
 		this.optional = optional;
 		return this;
 	}
-	
+
 	public final void set(final Config config, final String path) {
 		final String oldValue = value;
 		value = config.getByPath(path + key);
@@ -110,18 +110,18 @@ public class Option<T> {
 			onValueChange();
 		}
 	}
-	
+
 	protected void onValueChange() {
 		if (setter != null)
-			setter.set(parsedValue);
+			setter.accept(parsedValue);
 	}
-	
+
 	public final T value() {
 		return parsedValue;
 	}
-	
+
 	public final boolean isOptional() {
 		return optional;
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/config/validate/EntryValidator.java
+++ b/src/main/java/ch/njol/skript/config/validate/EntryValidator.java
@@ -24,24 +24,25 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.config.EntryNode;
 import ch.njol.skript.config.Node;
 import ch.njol.skript.log.SkriptLogger;
-import ch.njol.util.Setter;
+
+import java.util.function.Consumer;
 
 /**
  * @author Peter Güttinger
  */
 public class EntryValidator implements NodeValidator {
-	
+
 	@Nullable
-	private final Setter<String> setter;
-	
+	private final Consumer<String> setter;
+
 	public EntryValidator() {
 		setter = null;
 	}
-	
-	public EntryValidator(final Setter<String> setter) {
+
+	public EntryValidator(final Consumer<String> setter) {
 		this.setter = setter;
 	}
-	
+
 	@Override
 	public boolean validate(final Node node) {
 		if (!(node instanceof EntryNode)) {
@@ -49,10 +50,10 @@ public class EntryValidator implements NodeValidator {
 			return false;
 		}
 		if (setter != null)
-			setter.set(((EntryNode) node).getValue());
+			setter.accept(((EntryNode) node).getValue());
 		return true;
 	}
-	
+
 	public static void notAnEntryError(final Node node) {
 		notAnEntryError(node, node.getConfig().getSeparator());
 	}
@@ -61,5 +62,5 @@ public class EntryValidator implements NodeValidator {
 		SkriptLogger.setNode(node);
 		Skript.error("'" + node.getKey() + "' is not an entry (like 'name " + separator + " value')");
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/config/validate/EnumEntryValidator.java
+++ b/src/main/java/ch/njol/skript/config/validate/EnumEntryValidator.java
@@ -19,25 +19,24 @@
 package ch.njol.skript.config.validate;
 
 import java.util.Locale;
+import java.util.function.Consumer;
 
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.config.EntryNode;
 import ch.njol.skript.config.Node;
-import ch.njol.util.Setter;
 
 /**
  * @author Peter Güttinger
  */
 public class EnumEntryValidator<E extends Enum<E>> extends EntryValidator {
-	
+
 	private final Class<E> enumType;
-	private final Setter<E> setter;
-	@Nullable
-	private String allowedValues = null;
-	
-	public EnumEntryValidator(final Class<E> enumType, final Setter<E> setter) {
+	private final Consumer<E> setter;
+	private @Nullable String allowedValues = null;
+
+	public EnumEntryValidator(final Class<E> enumType, final Consumer<E> setter) {
 		assert enumType != null;
 		this.enumType = enumType;
 		this.setter = setter;
@@ -51,14 +50,14 @@ public class EnumEntryValidator<E extends Enum<E>> extends EntryValidator {
 			allowedValues = "" + b.toString();
 		}
 	}
-	
-	public EnumEntryValidator(final Class<E> enumType, final Setter<E> setter, final String allowedValues) {
+
+	public EnumEntryValidator(final Class<E> enumType, final Consumer<E> setter, final String allowedValues) {
 		assert enumType != null;
 		this.enumType = enumType;
 		this.setter = setter;
 		this.allowedValues = allowedValues;
 	}
-	
+
 	@Override
 	public boolean validate(final Node node) {
 		if (!super.validate(node))
@@ -68,12 +67,12 @@ public class EnumEntryValidator<E extends Enum<E>> extends EntryValidator {
 			final E e = Enum.valueOf(enumType, n.getValue().toUpperCase(Locale.ENGLISH).replace(' ', '_'));
 			assert e != null;
 //			if (setter != null)
-			setter.set(e);
+			setter.accept(e);
 		} catch (final IllegalArgumentException e) {
 			Skript.error("'" + n.getValue() + "' is not a valid value for '" + n.getKey() + "'" + (allowedValues == null ? "" : ". Allowed values are: " + allowedValues));
 			return false;
 		}
 		return true;
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/config/validate/ParsedEntryValidator.java
+++ b/src/main/java/ch/njol/skript/config/validate/ParsedEntryValidator.java
@@ -22,23 +22,24 @@ import ch.njol.skript.classes.Parser;
 import ch.njol.skript.config.EntryNode;
 import ch.njol.skript.config.Node;
 import ch.njol.skript.lang.ParseContext;
-import ch.njol.util.Setter;
+
+import java.util.function.Consumer;
 
 /**
  * @author Peter Güttinger
  */
 public class ParsedEntryValidator<T> extends EntryValidator {
-	
+
 	private final Parser<? extends T> parser;
-	private final Setter<T> setter;
-	
-	public ParsedEntryValidator(final Parser<? extends T> parser, final Setter<T> setter) {
+	private final Consumer<T> setter;
+
+	public ParsedEntryValidator(final Parser<? extends T> parser, final Consumer<T> setter) {
 		assert parser != null;
 		assert setter != null;
 		this.parser = parser;
 		this.setter = setter;
 	}
-	
+
 	@Override
 	public boolean validate(final Node node) {
 		if (!super.validate(node))
@@ -46,8 +47,8 @@ public class ParsedEntryValidator<T> extends EntryValidator {
 		final T t = parser.parse(((EntryNode) node).getValue(), ParseContext.CONFIG);
 		if (t == null)
 			return false;
-		setter.set(t);
+		setter.accept(t);
 		return true;
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/config/validate/SectionValidator.java
+++ b/src/main/java/ch/njol/skript/config/validate/SectionValidator.java
@@ -21,6 +21,7 @@ package ch.njol.skript.config.validate;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map.Entry;
+import java.util.function.Consumer;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Parser;
@@ -28,56 +29,55 @@ import ch.njol.skript.config.EntryNode;
 import ch.njol.skript.config.Node;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.log.SkriptLogger;
-import ch.njol.util.Setter;
 
 /**
  * @author Peter Güttinger
  */
 public class SectionValidator implements NodeValidator {
-	
+
 	private final static class NodeInfo {
 		public NodeValidator v;
 		public boolean optional;
-		
+
 		public NodeInfo(final NodeValidator v, final boolean optional) {
 			this.v = v;
 			this.optional = optional;
 		}
 	}
-	
+
 	private final HashMap<String, NodeInfo> nodes = new HashMap<>();
 	private boolean allowUndefinedSections = false;
 	private boolean allowUndefinedEntries = false;
-	
+
 	public SectionValidator() {}
-	
+
 	public SectionValidator addNode(final String name, final NodeValidator v, final boolean optional) {
 		assert name != null;
 		assert v != null;
 		nodes.put(name.toLowerCase(Locale.ENGLISH), new NodeInfo(v, optional));
 		return this;
 	}
-	
+
 	public SectionValidator addEntry(final String name, final boolean optional) {
 		addNode(name, new EntryValidator(), optional);
 		return this;
 	}
-	
-	public SectionValidator addEntry(final String name, final Setter<String> setter, final boolean optional) {
+
+	public SectionValidator addEntry(final String name, final Consumer<String> setter, final boolean optional) {
 		addNode(name, new EntryValidator(setter), optional);
 		return this;
 	}
-	
-	public <T> SectionValidator addEntry(final String name, final Parser<? extends T> parser, final Setter<T> setter, final boolean optional) {
+
+	public <T> SectionValidator addEntry(final String name, final Parser<? extends T> parser, final Consumer<T> setter, final boolean optional) {
 		addNode(name, new ParsedEntryValidator<>(parser, setter), optional);
 		return this;
 	}
-	
+
 	public SectionValidator addSection(final String name, final boolean optional) {
 		addNode(name, new SectionValidator().setAllowUndefinedEntries(true).setAllowUndefinedSections(true), optional);
 		return this;
 	}
-	
+
 	@Override
 	public boolean validate(final Node node) {
 		if (!(node instanceof SectionNode)) {
@@ -111,20 +111,20 @@ public class SectionValidator implements NodeValidator {
 		SkriptLogger.setNode(null);
 		return ok;
 	}
-	
+
 	public static void notASectionError(final Node node) {
 		SkriptLogger.setNode(node);
 		Skript.error("'" + node.getKey() + "' is not a section (like 'name:', followed by one or more indented lines)");
 	}
-	
+
 	public SectionValidator setAllowUndefinedSections(final boolean b) {
 		allowUndefinedSections = b;
 		return this;
 	}
-	
+
 	public SectionValidator setAllowUndefinedEntries(final boolean b) {
 		allowUndefinedEntries = b;
 		return this;
 	}
-	
+
 }

--- a/src/main/java/ch/njol/util/Setter.java
+++ b/src/main/java/ch/njol/util/Setter.java
@@ -18,11 +18,19 @@
  */
 package ch.njol.util;
 
-/**
- * @author Peter Güttinger
- */
-public interface Setter<T> {
-	
-	public void set(T t);
-	
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.function.Consumer;
+
+@Deprecated
+@FunctionalInterface
+@ApiStatus.ScheduledForRemoval
+public interface Setter<T> extends Consumer<T> {
+
+	void set(T t);
+
+	@Override
+	default void accept(T t) {
+		this.set(t);
+	}
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Replaces Setters with Java's Consumer. These were only used inside validators.
Setter also extends Consumer, so anything using it will be accepted by the new methods.

This could be considered a breaking change: something that extended one of the validator classes will need to rebuild the plugin (because the method signature accepts a Consumer rather than a Setter.)

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
