### PR TITLE
Remove 1.13 method/version checks from conditions.

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondHasResourcePack.java
+++ b/src/main/java/ch/njol/skript/conditions/CondHasResourcePack.java
@@ -37,8 +37,7 @@ import ch.njol.skript.doc.Since;
 public class CondHasResourcePack extends PropertyCondition<Player> {
 
 	static {
-		if (Skript.methodExists(Player.class, "hasResourcePack"))
-			register(CondHasResourcePack.class, PropertyType.HAVE, "[a] resource pack [(loaded|installed)]", "players");
+		register(CondHasResourcePack.class, PropertyType.HAVE, "[a] resource pack [(loaded|installed)]", "players");
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/conditions/CondIgnitionProcess.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIgnitionProcess.java
@@ -42,12 +42,10 @@ import ch.njol.util.Kleenean;
 public class CondIgnitionProcess extends PropertyCondition<LivingEntity> {
 
 	static {
-		if (Skript.methodExists(Creeper.class, "isIgnited")) {
-			Skript.registerCondition(CondIgnitionProcess.class,
-					"[creeper[s]] %livingentities% ((is|are)|1¦(isn't|is not|aren't|are not)) going to explode",
-					"[creeper[s]] %livingentities% ((is|are)|1¦(isn't|is not|aren't|are not)) in the (ignition|explosion) process",
-					"creeper[s] %livingentities% ((is|are)|1¦(isn't|is not|aren't|are not)) ignited");
-		}
+		Skript.registerCondition(CondIgnitionProcess.class,
+			"[creeper[s]] %livingentities% ((is|are)|1¦(isn't|is not|aren't|are not)) going to explode",
+			"[creeper[s]] %livingentities% ((is|are)|1¦(isn't|is not|aren't|are not)) in the (ignition|explosion) process",
+			"creeper[s] %livingentities% ((is|are)|1¦(isn't|is not|aren't|are not)) ignited");
 	}
 
 	@SuppressWarnings({"unchecked", "null"})

--- a/src/main/java/ch/njol/skript/conditions/CondIsFuel.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsFuel.java
@@ -40,21 +40,19 @@ import ch.njol.skript.doc.Since;
 @Since("2.5.1")
 @RequiredPlugins("Minecraft 1.11.2+")
 public class CondIsFuel extends PropertyCondition<ItemType> {
-	
+
 	static {
-		if (Skript.methodExists(Material.class, "isFuel")) {
-			register(CondIsFuel.class, "[furnace] fuel", "itemtypes");
-		}
+		register(CondIsFuel.class, "[furnace] fuel", "itemtypes");
 	}
-	
+
 	@Override
 	public boolean check(ItemType item) {
 		return item.getMaterial().isFuel();
 	}
-	
+
 	@Override
 	protected String getPropertyName() {
 		return "fuel";
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsInteractable.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsInteractable.java
@@ -39,18 +39,16 @@ import ch.njol.skript.doc.Since;
 @Since("2.5.2")
 @RequiredPlugins("Minecraft 1.13+")
 public class CondIsInteractable extends PropertyCondition<ItemType> {
-	
+
 	static {
-		if (Skript.methodExists(Material.class, "isInteractable")) {
-			register(CondIsInteractable.class, "interactable", "itemtypes");
-		}
+		register(CondIsInteractable.class, "interactable", "itemtypes");
 	}
-	
+
 	@Override
 	public boolean check(ItemType item) {
 		return item.getMaterial().isInteractable();
 	}
-	
+
 	@Override
 	protected String getPropertyName() {
 		return "interactable";

--- a/src/main/java/ch/njol/skript/conditions/CondIsPassable.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsPassable.java
@@ -38,21 +38,19 @@ import ch.njol.skript.doc.Since;
 @Since("2.5.1")
 @RequiredPlugins("Minecraft 1.13.2+")
 public class CondIsPassable extends PropertyCondition<Block> {
-	
+
 	static {
-		if (Skript.methodExists(Block.class, "isPassable")) {
-			register(CondIsPassable.class, "passable", "blocks");
-		}
+		register(CondIsPassable.class, "passable", "blocks");
 	}
-	
+
 	@Override
 	public boolean check(Block block) {
 		return block.isPassable();
 	}
-	
+
 	@Override
 	protected String getPropertyName() {
 		return "passable";
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/conditions/CondIsSwimming.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsSwimming.java
@@ -34,20 +34,19 @@ import ch.njol.skript.doc.Since;
 @RequiredPlugins("1.13 or newer")
 @Since("2.3")
 public class CondIsSwimming extends PropertyCondition<LivingEntity> {
-	
+
 	static {
-		if (Skript.methodExists(LivingEntity.class, "isSwimming"))
-			register(CondIsSwimming.class, "swimming", "livingentities");
+		register(CondIsSwimming.class, "swimming", "livingentities");
 	}
-	
+
 	@Override
-	public boolean check(final LivingEntity e) {
-		return e.isSwimming();
+	public boolean check(final LivingEntity entity) {
+		return entity.isSwimming();
 	}
-	
+
 	@Override
 	protected String getPropertyName() {
 		return "swimming";
 	}
-	
+
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Removes the 1.13 version checks from conditions that still have them.
Skript doesn't run on versions below 1.13 so the condition isn't helping.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #6641 <!-- Links to related issues -->
