### PR TITLE
Remove 1.13 version checks from effects.

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffMakeFly.java
+++ b/src/main/java/ch/njol/skript/effects/EffMakeFly.java
@@ -40,11 +40,9 @@ import ch.njol.util.Kleenean;
 public class EffMakeFly extends Effect {
 
 	static {
-		if (Skript.methodExists(Player.class, "setFlying", boolean.class)) {
-			Skript.registerEffect(EffMakeFly.class, "force %players% to [(start|1¦stop)] fly[ing]",
-												"make %players% (start|1¦stop) flying",
-												"make %players% fly");
-		}
+		Skript.registerEffect(EffMakeFly.class, "force %players% to [(start|1¦stop)] fly[ing]",
+				"make %players% (start|1¦stop) flying",
+				"make %players% fly");
 	}
 
 	@SuppressWarnings("null")

--- a/src/main/java/ch/njol/skript/effects/EffPlayerVisibility.java
+++ b/src/main/java/ch/njol/skript/effects/EffPlayerVisibility.java
@@ -26,11 +26,9 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
-import ch.njol.skript.lang.util.SimpleLiteral;
 import ch.njol.skript.expressions.ExprHiddenPlayers;
 import ch.njol.util.Kleenean;
 import org.bukkit.Bukkit;
-import org.bukkit.plugin.Plugin;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
@@ -49,8 +47,6 @@ import org.eclipse.jdt.annotation.Nullable;
 @Since("2.3")
 public class EffPlayerVisibility extends Effect {
 
-	private static final boolean USE_DEPRECATED_METHOD = !Skript.methodExists(Player.class, "hidePlayer", Plugin.class, Player.class);
-	
 	static {
 		Skript.registerEffect(EffPlayerVisibility.class,
 				"hide %players% [(from|for) %-players%]",
@@ -59,10 +55,10 @@ public class EffPlayerVisibility extends Effect {
 
 	@SuppressWarnings("null")
 	private Expression<Player> players;
-	
+
 	@Nullable
 	private Expression<Player> targetPlayers;
-	
+
 	private boolean reveal;
 
 	@SuppressWarnings({"unchecked", "null"})
@@ -84,15 +80,9 @@ public class EffPlayerVisibility extends Effect {
         for (Player targetPlayer : targets) {
             for (Player player : players.getArray(e)) {
                 if (reveal) {
-                    if (USE_DEPRECATED_METHOD)
-                        targetPlayer.showPlayer(player);
-                    else
-                        targetPlayer.showPlayer(Skript.getInstance(), player);
+                    targetPlayer.showPlayer(Skript.getInstance(), player);
                 } else {
-                    if (USE_DEPRECATED_METHOD)
-                        targetPlayer.hidePlayer(player);
-                    else
-                        targetPlayer.hidePlayer(Skript.getInstance(), player);
+                    targetPlayer.hidePlayer(Skript.getInstance(), player);
                 }
             }
         }

--- a/src/main/java/ch/njol/skript/effects/EffSendBlockChange.java
+++ b/src/main/java/ch/njol/skript/effects/EffSendBlockChange.java
@@ -18,8 +18,6 @@
  */
 package ch.njol.skript.effects;
 
-import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Player;
@@ -44,19 +42,9 @@ import ch.njol.util.Kleenean;
 @Since("2.2-dev37c, 2.5.1 (block data support)")
 public class EffSendBlockChange extends Effect {
 
-	private static final boolean BLOCK_DATA_SUPPORT = Skript.classExists("org.bukkit.block.data.BlockData");
-	private static final boolean SUPPORTED =
-			Skript.methodExists(
-					Player.class,
-					"sendBlockChange",
-					Location.class,
-					Material.class,
-					byte.class
-			);
-
 	static {
 		Skript.registerEffect(EffSendBlockChange.class,
-				BLOCK_DATA_SUPPORT ? "make %players% see %blocks% as %itemtype/blockdata%" : "make %players% see %blocks% as %itemtype%"
+			"make %players% see %blocks% as %itemtype/blockdata%"
 		);
 	}
 
@@ -68,17 +56,10 @@ public class EffSendBlockChange extends Effect {
 
 	@SuppressWarnings("null")
 	private Expression<Object> as;
-	
+
 	@Override
 	@SuppressWarnings("unchecked")
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
-		if (!SUPPORTED) {
-			Skript.error("The send block change effect is not supported on this version. " +
-				"If Spigot has added a replacement method without magic values " +
-				"please open an issue at https://github.com/SkriptLang/Skript/issues " +
-				"and support will be added for it.");
-			return false;
-		}
 		players = (Expression<Player>) exprs[0];
 		blocks = (Expression<Block>) exprs[1];
 		as = (Expression<Object>) exprs[2];
@@ -95,7 +76,7 @@ public class EffSendBlockChange extends Effect {
 					itemType.sendBlockChange(player, block.getLocation());
 				}
 			}
-		} else if (BLOCK_DATA_SUPPORT && object instanceof BlockData) {
+		} else if (object instanceof BlockData) {
 			BlockData blockData = (BlockData) object;
 			for (Player player : players.getArray(e)) {
 				for (Block block : blocks.getArray(e)) {

--- a/src/main/java/ch/njol/skript/effects/EffSendTitle.java
+++ b/src/main/java/ch/njol/skript/effects/EffSendTitle.java
@@ -52,20 +52,13 @@ import ch.njol.util.Kleenean;
 })
 @Since("2.3")
 public class EffSendTitle extends Effect {
-	
-	private final static boolean TIME_SUPPORTED = Skript.methodExists(Player.class,"sendTitle", String.class, String.class, int.class, int.class, int.class);
-	
+
 	static {
-		if (TIME_SUPPORTED)
-			Skript.registerEffect(EffSendTitle.class,
-					"send title %string% [with subtitle %-string%] [to %players%] [for %-timespan%] [with fade[(-| )]in %-timespan%] [[and] [with] fade[(-| )]out %-timespan%]",
-					"send subtitle %string% [to %players%] [for %-timespan%] [with fade[(-| )]in %-timespan%] [[and] [with] fade[(-| )]out %-timespan%]");
-		else
-			Skript.registerEffect(EffSendTitle.class,
-					"send title %string% [with subtitle %-string%] [to %players%]",
-					"send subtitle %string% [to %players%]");
+		Skript.registerEffect(EffSendTitle.class,
+				"send title %string% [with subtitle %-string%] [to %players%] [for %-timespan%] [with fade[(-| )]in %-timespan%] [[and] [with] fade[(-| )]out %-timespan%]",
+				"send subtitle %string% [to %players%] [for %-timespan%] [with fade[(-| )]in %-timespan%] [[and] [with] fade[(-| )]out %-timespan%]");
 	}
-	
+
 	@Nullable
 	private Expression<String> title;
 	@Nullable
@@ -74,54 +67,48 @@ public class EffSendTitle extends Effect {
 	private Expression<Player> recipients;
 	@Nullable
 	private Expression<Timespan> fadeIn, stay, fadeOut;
-	
+
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
 	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parser) {
 		title = matchedPattern == 0 ? (Expression<String>) exprs[0] : null;
 		subtitle = (Expression<String>) exprs[1 - matchedPattern];
 		recipients = (Expression<Player>) exprs[2 - matchedPattern];
-		if (TIME_SUPPORTED) {
-			stay = (Expression<Timespan>) exprs[3 - matchedPattern];
-			fadeIn = (Expression<Timespan>) exprs[4 - matchedPattern];
-			fadeOut = (Expression<Timespan>) exprs[5 - matchedPattern];
-		}
+		stay = (Expression<Timespan>) exprs[3 - matchedPattern];
+		fadeIn = (Expression<Timespan>) exprs[4 - matchedPattern];
+		fadeOut = (Expression<Timespan>) exprs[5 - matchedPattern];
 		return true;
 	}
-	
+
 	@SuppressWarnings("null")
 	@Override
 	protected void execute(final Event e) {
 		String title = this.title != null ? this.title.getSingle(e) : null;
 		String subtitle = this.subtitle != null ? this.subtitle.getSingle(e) : null;
-		
-		if (TIME_SUPPORTED) {
-			int fadeIn, stay, fadeOut;
-			fadeIn = stay = fadeOut = -1;
 
-			if (this.fadeIn != null) {
-				Timespan t = this.fadeIn.getSingle(e);
-				fadeIn = t != null ? (int) t.getTicks() : -1;
-			}
+		int fadeIn, stay, fadeOut;
+		fadeIn = stay = fadeOut = -1;
 
-			if (this.stay != null) {
-				Timespan t = this.stay.getSingle(e);
-				stay = t != null ? (int) t.getTicks() : -1;
-			}
-
-			if (this.fadeOut != null) {
-				Timespan t = this.fadeOut.getSingle(e);
-				fadeOut = t != null ? (int) t.getTicks() : -1;
-			}
-			
-			for (Player p : recipients.getArray(e))
-				p.sendTitle(title, subtitle, fadeIn, stay, fadeOut);
-		} else {
-			for (Player p : recipients.getArray(e))
-				p.sendTitle(title, subtitle);
+		if (this.fadeIn != null) {
+			Timespan t = this.fadeIn.getSingle(e);
+			fadeIn = t != null ? (int) t.getTicks() : -1;
 		}
+
+		if (this.stay != null) {
+			Timespan t = this.stay.getSingle(e);
+			stay = t != null ? (int) t.getTicks() : -1;
+		}
+
+		if (this.fadeOut != null) {
+			Timespan t = this.fadeOut.getSingle(e);
+			fadeOut = t != null ? (int) t.getTicks() : -1;
+		}
+
+		for (Player p : recipients.getArray(e))
+			p.sendTitle(title, subtitle, fadeIn, stay, fadeOut);
+
 	}
-	
+
 	// TODO: util method to simplify this
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
@@ -131,9 +118,8 @@ public class EffSendTitle extends Effect {
 		stay = this.stay != null ? this.stay.toString(e, debug) : "",
 		out = fadeOut != null ? this.fadeOut.toString(e, debug) : "";
 		return ("send title " + title +
-				sub == "" ? "" : " with subtitle " + sub) + " to " +
-				recipients.toString(e, debug) + (TIME_SUPPORTED ?
-				" for " + stay + " with fade in " + in + " and fade out" + out : "");
+				(sub.isEmpty() ? "" : " with subtitle " + sub)) + " to " +
+				recipients.toString(e, debug) + (" for " + stay + " with fade in " + in + " and fade out" + out);
 	}
-	
+
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Removes the 1.13 version checks from old effects, since Skript does not support versions under 1.13.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #6641 <!-- Links to related issues -->
