### PR TITLE
Treat beta releases the same as prereleases in update checker

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -329,7 +329,7 @@ task spigotResources(type: ProcessResources) {
 		include '**'
 		version = project.property('version')
 		def channel = 'stable'
-		if (version.contains('pre') || version.contains('beta'))
+		if (version.contains('-'))
 			channel = 'prerelease'
 		filter ReplaceTokens, tokens: [
 			'version'         : version,

--- a/build.gradle
+++ b/build.gradle
@@ -296,7 +296,7 @@ task githubResources(type: ProcessResources) {
 		include '**'
 		version = project.property('version')
 		def channel = 'stable'
-		if (version.contains('pre') || version.contains('beta'))
+		if (version.contains('-'))
 			channel = 'prerelease'
 		filter ReplaceTokens, tokens: [
 			'version'         : version,

--- a/build.gradle
+++ b/build.gradle
@@ -296,7 +296,7 @@ task githubResources(type: ProcessResources) {
 		include '**'
 		version = project.property('version')
 		def channel = 'stable'
-		if (version.contains('pre'))
+		if (version.contains('pre') || version.contains('beta'))
 			channel = 'prerelease'
 		filter ReplaceTokens, tokens: [
 			'version'         : version,
@@ -329,7 +329,7 @@ task spigotResources(type: ProcessResources) {
 		include '**'
 		version = project.property('version')
 		def channel = 'stable'
-		if (version.contains('pre'))
+		if (version.contains('pre') || version.contains('beta'))
 			channel = 'prerelease'
 		filter ReplaceTokens, tokens: [
 			'version'         : version,

--- a/src/main/java/ch/njol/skript/SkriptConfig.java
+++ b/src/main/java/ch/njol/skript/SkriptConfig.java
@@ -105,7 +105,7 @@ public class SkriptConfig {
 						break;
 					case "stable":
 						// TODO a better option would be to check that it is not a pre-release through GH API
-						channel = new ReleaseChannel((name) -> !name.contains("pre"), t);
+						channel = new ReleaseChannel((name) -> !(name.contains("pre") || name.contains("beta")), t);
 						break;
 					case "none":
 						channel = new ReleaseChannel((name) -> false, t);

--- a/src/main/java/ch/njol/skript/SkriptConfig.java
+++ b/src/main/java/ch/njol/skript/SkriptConfig.java
@@ -105,7 +105,7 @@ public class SkriptConfig {
 						break;
 					case "stable":
 						// TODO a better option would be to check that it is not a pre-release through GH API
-						channel = new ReleaseChannel((name) -> !(name.contains("pre") || name.contains("beta")), t);
+						channel = new ReleaseChannel((name) -> !(name.contains("-")), t);
 						break;
 					case "none":
 						channel = new ReleaseChannel((name) -> false, t);


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Avoids update checker thinking beta releases are stable.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #6714 <!-- Links to related issues -->
