### PR TITLE
Copy the SimpleLiteral backing data instead of exposing it.

### DIFF
--- a/src/main/java/ch/njol/skript/lang/util/SimpleLiteral.java
+++ b/src/main/java/ch/njol/skript/lang/util/SimpleLiteral.java
@@ -38,6 +38,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.skriptlang.skript.lang.converter.Converters;
 
 import java.lang.reflect.Array;
+import java.util.Arrays;
 
 /**
  * Represents a literal, i.e. a static value like a number or a string.
@@ -95,24 +96,28 @@ public class SimpleLiteral<T> implements Literal<T>, DefaultExpression<T> {
 		return true;
 	}
 
+	private T[] data() {
+		return Arrays.copyOf(data, data.length);
+	}
+
 	@Override
 	public T[] getArray() {
-		return data;
+		return this.data();
 	}
 
 	@Override
 	public T[] getArray(Event event) {
-		return data;
+		return this.data();
 	}
 
 	@Override
 	public T[] getAll() {
-		return data;
+		return this.data();
 	}
 
 	@Override
 	public T[] getAll(Event event) {
-		return data;
+		return this.data();
 	}
 
 	@Override
@@ -136,7 +141,7 @@ public class SimpleLiteral<T> implements Literal<T>, DefaultExpression<T> {
 	public <R> Literal<? extends R> getConvertedExpression(Class<R>... to) {
 		if (CollectionUtils.containsSuperclass(to, type))
 			return (Literal<? extends R>) this;
-		R[] parsedData = Converters.convert(data, to, (Class<R>) Utils.getSuperType(to));
+		R[] parsedData = Converters.convert(this.data(), to, (Class<R>) Utils.getSuperType(to));
 		if (parsedData.length != data.length)
 			return null;
 		return new ConvertedLiteral<>(this, parsedData, (Class<R>) Utils.getSuperType(to));


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Instead of directly exposing the so-called "constant" data array, SimpleLiteral now returns an array copy of it.
This stops a malformed syntax (e.g. an addon syntax) from just doing `values[0] = ...` and permanently changing the literal value for all future reads.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** fixes #6682 <!-- Links to related issues -->
