### PR TITLE
Remove redundant exists checks in some expressions

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprBlockData.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBlockData.java
@@ -23,7 +23,6 @@ import org.bukkit.block.data.BlockData;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
-import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -43,8 +42,7 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprBlockData extends SimplePropertyExpression<Block, BlockData> {
 	
 	static {
-		if (Skript.classExists("org.bukkit.block.data.BlockData"))
-			register(ExprBlockData.class, BlockData.class, "block[ ]data", "blocks");
+		register(ExprBlockData.class, BlockData.class, "block[ ]data", "blocks");
 	}
 	
 	@Nullable

--- a/src/main/java/ch/njol/skript/expressions/ExprBlockHardness.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBlockHardness.java
@@ -18,7 +18,6 @@
  */
 package ch.njol.skript.expressions;
 
-import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -38,8 +37,7 @@ import org.jetbrains.annotations.Nullable;
 public class ExprBlockHardness extends SimplePropertyExpression<ItemType, Number> {
 
 	static {
-		if (Skript.methodExists(Material.class, "getHardness"))
-			register(ExprBlockHardness.class, Number.class, "[block] hardness", "itemtypes");
+		register(ExprBlockHardness.class, Number.class, "[block] hardness", "itemtypes");
 	}
 
 	@Nullable

--- a/src/main/java/ch/njol/skript/expressions/ExprClientViewDistance.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprClientViewDistance.java
@@ -21,7 +21,6 @@ package ch.njol.skript.expressions;
 import org.bukkit.entity.Player;
 import org.eclipse.jdt.annotation.Nullable;
 
-import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -38,9 +37,7 @@ import ch.njol.skript.expressions.base.SimplePropertyExpression;
 public class ExprClientViewDistance extends SimplePropertyExpression<Player, Long> {
 	
 	static {
-		if (Skript.methodExists(Player.class, "getClientViewDistance")) {
-			register(ExprClientViewDistance.class, Long.class, "client view distance[s]", "players");
-		}
+		register(ExprClientViewDistance.class, Long.class, "client view distance[s]", "players");
 	}
 	
 	@Nullable

--- a/src/main/java/ch/njol/skript/expressions/ExprCreeperMaxFuseTicks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCreeperMaxFuseTicks.java
@@ -23,7 +23,6 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
-import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -39,8 +38,7 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprCreeperMaxFuseTicks extends SimplePropertyExpression<LivingEntity, Long> {
 	
 	static {
-		if(Skript.methodExists(LivingEntity.class, "getMaxFuseTicks"))
-			register(ExprCreeperMaxFuseTicks.class, Long.class, "[creeper] max[imum] fuse tick[s]", "livingentities");
+		register(ExprCreeperMaxFuseTicks.class, Long.class, "[creeper] max[imum] fuse tick[s]", "livingentities");
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprEnchantmentOffer.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEnchantmentOffer.java
@@ -51,16 +51,14 @@ import ch.njol.util.coll.CollectionUtils;
 			"\tsend \"Your enchantment offers are: %the enchantment offers%\" to player"})
 @Since("2.5")
 @Events("enchant prepare")
-@RequiredPlugins("1.11 or newer")
+@RequiredPlugins("1.11+")
 public class ExprEnchantmentOffer extends SimpleExpression<EnchantmentOffer> {
 
 	static {
-		if (Skript.classExists("org.bukkit.enchantments.EnchantmentOffer")) {
-			Skript.registerExpression(ExprEnchantmentOffer.class, EnchantmentOffer.class, ExpressionType.SIMPLE, 
-					"[all [of]] [the] enchant[ment] offers",
-					"enchant[ment] offer[s] %numbers%",
-					"[the] %number%(st|nd|rd|th) enchant[ment] offer");
-		}
+		Skript.registerExpression(ExprEnchantmentOffer.class, EnchantmentOffer.class, ExpressionType.SIMPLE,
+				"[all [of]] [the] enchant[ment] offers",
+				"enchant[ment] offer[s] %numbers%",
+				"[the] %number%(st|nd|rd|th) enchant[ment] offer");
 	}
 
 	@SuppressWarnings("null")

--- a/src/main/java/ch/njol/skript/expressions/ExprEnchantmentOfferCost.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEnchantmentOfferCost.java
@@ -22,7 +22,6 @@ import org.bukkit.enchantments.EnchantmentOffer;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
-import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -46,8 +45,7 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprEnchantmentOfferCost extends SimplePropertyExpression<EnchantmentOffer, Long> {
 
 	static {
-		if (Skript.classExists("org.bukkit.enchantments.EnchantmentOffer"))
-			register(ExprEnchantmentOfferCost.class, Long.class, "[enchant[ment]] cost", "enchantmentoffers");
+		register(ExprEnchantmentOfferCost.class, Long.class, "[enchant[ment]] cost", "enchantmentoffers");
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprExplosiveYield.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprExplosiveYield.java
@@ -24,7 +24,6 @@ import org.bukkit.entity.Explosive;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
-import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -47,13 +46,11 @@ public class ExprExplosiveYield extends SimplePropertyExpression<Entity, Number>
 		register(ExprExplosiveYield.class, Number.class, "explosive (yield|radius|size)", "entities");
 	}
 
-	private final static boolean CREEPER_USABLE = Skript.methodExists(Creeper.class, "getExplosionRadius");
-
 	@Override
 	public Number convert(Entity e) {
 		if (e instanceof Explosive)
 			return ((Explosive) e).getYield();
-		if (CREEPER_USABLE && e instanceof Creeper)
+		if (e instanceof Creeper)
 			return ((Creeper) e).getExplosionRadius();
 		return 0;
 	}
@@ -103,7 +100,7 @@ public class ExprExplosiveYield extends SimplePropertyExpression<Entity, Number>
 					default:
 						assert false;
 				}
-			} else if (CREEPER_USABLE && entity instanceof Creeper) {
+			} else if (entity instanceof Creeper) {
 				Creeper c = (Creeper) entity;
 				int i = change.intValue();
 				if (i < 0) // Negative values will throw an error.

--- a/src/main/java/ch/njol/skript/expressions/ExprFertilizedBlocks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFertilizedBlocks.java
@@ -48,8 +48,7 @@ import ch.njol.util.Kleenean;
 public class ExprFertilizedBlocks extends SimpleExpression<BlockStateBlock> {
 	
 	static {
-		if (Skript.classExists("org.bukkit.event.block.BlockFertilizeEvent"))
-			Skript.registerExpression(ExprFertilizedBlocks.class, BlockStateBlock.class, ExpressionType.SIMPLE, "[all] [the] fertilized blocks");
+		Skript.registerExpression(ExprFertilizedBlocks.class, BlockStateBlock.class, ExpressionType.SIMPLE, "[all] [the] fertilized blocks");
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprGameRule.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprGameRule.java
@@ -46,17 +46,16 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprGameRule extends SimpleExpression<GameruleValue> {
 	
 	static {
-		if (Skript.classExists("org.bukkit.GameRule")) {
-			Skript.registerExpression(ExprGameRule.class, GameruleValue.class, ExpressionType.COMBINED,
-				"[the] gamerule %gamerule% of %worlds%");
-		}
+		Skript.registerExpression(ExprGameRule.class, GameruleValue.class, ExpressionType.COMBINED,
+			"[the] gamerule %gamerule% of %worlds%");
 	}
 	
 	@SuppressWarnings("null")
 	private Expression<GameRule> gamerule;
 	@SuppressWarnings("null")
 	private Expression<World> world;
-	
+
+	@SuppressWarnings("unchecked")
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		gamerule = (Expression<GameRule>) exprs[0];

--- a/src/main/java/ch/njol/skript/expressions/ExprInventoryInfo.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprInventoryInfo.java
@@ -52,14 +52,15 @@ public class ExprInventoryInfo extends SimpleExpression<Object> {
 	
 	static {
 		Skript.registerExpression(ExprInventoryInfo.class, Object.class, ExpressionType.PROPERTY,
-				"(" + HOLDER + "¦holder[s]|" + VIEWERS + "¦viewers|" + ROWS + "¦[amount of] rows|" + SLOTS + "¦[amount of] slots)" + " of %inventories%",
-				"%inventories%'[s] (" + HOLDER + "¦holder[s]|" + VIEWERS + "¦viewers|" + ROWS + "¦[amount of] rows|" + SLOTS + "¦[amount of] slots)");
+				"(" + HOLDER + ":holder[s]|" + VIEWERS + ":viewers|" + ROWS + ":[amount of] rows|" + SLOTS + ":[amount of] slots)" + " of %inventories%",
+				"%inventories%'[s] (" + HOLDER + ":holder[s]|" + VIEWERS + ":viewers|" + ROWS + ":[amount of] rows|" + SLOTS + ":[amount of] slots)");
 	}
 	
 	@SuppressWarnings("null")
 	private Expression<Inventory> inventories;
 	private int type;
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		inventories = (Expression<Inventory>) exprs[0];

--- a/src/main/java/ch/njol/skript/expressions/ExprPlayerlistHeaderFooter.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPlayerlistHeaderFooter.java
@@ -22,7 +22,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
-import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -42,12 +41,11 @@ import ch.njol.util.coll.CollectionUtils;
 			"send \"%the player's tab list header%\" to player",
 			"reset all players' tab list header"})
 @Since("2.4")
-@RequiredPlugins("Minecraft 1.13 or newer")
+@RequiredPlugins("Minecraft 1.13+")
 public class ExprPlayerlistHeaderFooter extends SimplePropertyExpression<Player, String> {
 	
 	static {
-		if (Skript.methodExists(Player.class, "setPlayerListHeaderFooter", String.class, String.class)) //This method is only present if the header and footer methods we use are
-			PropertyExpression.register(ExprPlayerlistHeaderFooter.class, String.class, "(player|tab)[ ]list (header|1¦footer) [(text|message)]", "players");
+		PropertyExpression.register(ExprPlayerlistHeaderFooter.class, String.class, "(player|tab)[ ]list (header|1¦footer) [(text|message)]", "players");
 	}
 	
 	private static final int HEADER = 0, FOOTER = 1;

--- a/src/main/java/ch/njol/skript/expressions/ExprSkull.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSkull.java
@@ -22,7 +22,6 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.eclipse.jdt.annotation.Nullable;
 
-import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.Aliases;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.doc.Description;
@@ -42,18 +41,13 @@ import ch.njol.util.Kleenean;
 @Examples({"give the victim's skull to the attacker",
 		"set the block at the entity to the entity's skull"})
 @Since("2.0")
-public class ExprSkull extends SimplePropertyExpression<Object, ItemType> {
+public class ExprSkull extends SimplePropertyExpression<OfflinePlayer, ItemType> {
 	
 	static {
 		register(ExprSkull.class, ItemType.class, "(head|skull)", "offlineplayers");
 	}
 	
 	private static final ItemType playerSkull = Aliases.javaItemType("player skull");
-	
-	/**
-	 * In 2017, SkullMeta finally got a method that takes OfflinePlayer.
-	 */
-	private static final boolean newSkullOwner = Skript.methodExists(SkullMeta.class, "setOwningPlayer", OfflinePlayer.class);
 	
 	@Override
 	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
@@ -63,13 +57,10 @@ public class ExprSkull extends SimplePropertyExpression<Object, ItemType> {
 	@SuppressWarnings("deprecation")
 	@Override
 	@Nullable
-	public ItemType convert(final Object o) {
+	public ItemType convert(OfflinePlayer o) {
 		ItemType skull = playerSkull.clone();
 		SkullMeta meta = (SkullMeta) skull.getItemMeta();
-		if (newSkullOwner)
-			meta.setOwningPlayer((OfflinePlayer) o);
-		else
-			meta.setOwner(((OfflinePlayer) o).getName());
+		meta.setOwningPlayer(o);
 		skull.setItemMeta(meta);
 		return skull;
 	}


### PR DESCRIPTION
### Description
Mainly removes unnecessary existing checks in some expression classes. Also made some small other changes with broken pipe and parseMark related stuff, but happy to revert them if they're out of the scope of this PR.

This wasn't a super thorough look-through of all the expressions, so some might be missing.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #6641 #6676 
