### PR TITLE
Fix compilation error due to Spigot changes to EntityDeathEvent

### DIFF
--- a/src/test/java/org/skriptlang/skript/test/tests/lang/CancelledEventsTest.java
+++ b/src/test/java/org/skriptlang/skript/test/tests/lang/CancelledEventsTest.java
@@ -20,12 +20,8 @@ package org.skriptlang.skript.test.tests.lang;
 
 import ch.njol.skript.test.runner.SkriptJUnitTest;
 import org.bukkit.Bukkit;
-import org.bukkit.entity.Pig;
 import org.bukkit.event.block.BlockFormEvent;
-import org.bukkit.event.entity.EntityDeathEvent;
 import org.junit.Test;
-
-import java.util.ArrayList;
 
 public class CancelledEventsTest extends SkriptJUnitTest {
 

--- a/src/test/java/org/skriptlang/skript/test/tests/lang/CancelledEventsTest.java
+++ b/src/test/java/org/skriptlang/skript/test/tests/lang/CancelledEventsTest.java
@@ -21,6 +21,7 @@ package org.skriptlang.skript.test.tests.lang;
 import ch.njol.skript.test.runner.SkriptJUnitTest;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Pig;
+import org.bukkit.event.block.BlockFormEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.junit.Test;
 
@@ -35,8 +36,7 @@ public class CancelledEventsTest extends SkriptJUnitTest {
 
 	@Test
 	public void callCancelledEvent() {
-		Pig pig = spawnTestPig();
-		EntityDeathEvent event = new EntityDeathEvent(pig, new ArrayList<>());
+		BlockFormEvent event = new BlockFormEvent(getBlock(), getBlock().getState());
 
 		// call cancelled event
 		event.setCancelled(true);

--- a/src/test/skript/junit/CancelledEventTest.sk
+++ b/src/test/skript/junit/CancelledEventTest.sk
@@ -13,17 +13,17 @@ test "ExprDropsJUnit" when running JUnit:
 on load:
 	set {-cancelled-event-test::call-count} to 0
 
-on death of pig:
+on form:
 	junit test is {@test}
 
 	complete objective "listen for uncancelled event" for {@test}
 
-on cancelled death of pig:
+on cancelled form:
 	junit test is {@test}
 
 	complete objective "listen for cancelled event" for {@test}
 
-on any death of pig:
+on any form:
 	junit test is {@test}
 
 	add 1 to {-cancelled-event-test::call-count}


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Switched to BlockFormEvent to avoid any versioning issues.
~~Unsure why the bell tests are failing.
@bluelhf any ideas?~~
Perhaps the failures were just on my local builds for some reason.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
