### PR TITLE
Removed some redundant exists checks and formatting stuff

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -115,7 +115,6 @@ public class BukkitClasses {
 	public static final Pattern UUID_PATTERN = Pattern.compile("(?i)[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}");
 
 	static {
-		final boolean GET_ENTITY_METHOD_EXISTS = Skript.methodExists(Bukkit.class, "getEntity", UUID.class);
 		Classes.registerClass(new ClassInfo<>(Entity.class, "entity")
 				.user("entit(y|ies)")
 				.name("Entity")
@@ -140,18 +139,7 @@ public class BukkitClasses {
 						} catch (IllegalArgumentException iae) {
 							return null;
 						}
-						if (GET_ENTITY_METHOD_EXISTS) {
-							return Bukkit.getEntity(uuid);
-						} else {
-							for (World world : Bukkit.getWorlds()) {
-								for (Entity entity : world.getEntities()) {
-									if (entity.getUniqueId().equals(uuid)) {
-										return entity;
-									}
-								}
-							}
-						}
-						return null;
+						return Bukkit.getEntity(uuid);
 					}
 					
 					@Override

--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -663,35 +663,12 @@ public final class BukkitEventValues {
 			}
 		}, EventValues.TIME_NOW);
 		EventValues.registerEventValue(AreaEffectCloudApplyEvent.class, PotionEffectType.class, new Getter<PotionEffectType, AreaEffectCloudApplyEvent>() {
-			@Nullable
-			private final MethodHandle BASE_POTION_DATA_HANDLE;
-
-			{
-				MethodHandle basePotionDataHandle = null;
-				if (Skript.methodExists(AreaEffectCloud.class, "getBasePotionData")) {
-					try {
-						basePotionDataHandle = MethodHandles.lookup().findVirtual(AreaEffectCloud.class, "getBasePotionData", MethodType.methodType(PotionData.class));
-					} catch (NoSuchMethodException | IllegalAccessException e) {
-						Skript.exception(e, "Failed to load legacy potion data support. Potions may not work as expected.");
-					}
-				}
-				BASE_POTION_DATA_HANDLE = basePotionDataHandle;
-			}
-
 			@Override
 			@Nullable
 			public PotionEffectType get(AreaEffectCloudApplyEvent e) {
-				if (BASE_POTION_DATA_HANDLE != null) {
-					try {
-						return ((PotionData) BASE_POTION_DATA_HANDLE.invoke(e.getEntity())).getType().getEffectType();
-					} catch (Throwable ex) {
-						throw Skript.exception(ex, "An error occurred while trying to invoke legacy area effect cloud potion effect support.");
-					}
-				} else {
-					PotionType base = e.getEntity().getBasePotionType();
-					if (base != null) // TODO this is deprecated... this should become a multi-value event value
-						return base.getEffectType();
-				}
+				PotionType base = e.getEntity().getBasePotionType();
+				if (base != null) // TODO this is deprecated... this should become a multi-value event value
+					return base.getEffectType();
 				return null;
 			}
 		}, 0);

--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -18,6 +18,9 @@
  */
 package ch.njol.skript.classes.data;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -62,6 +65,7 @@ import org.bukkit.block.BlockState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.AbstractVillager;
+import org.bukkit.entity.AreaEffectCloud;
 import org.bukkit.entity.Egg;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Firework;
@@ -171,6 +175,7 @@ import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.Recipe;
+import org.bukkit.potion.PotionData;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.potion.PotionType;
 import org.eclipse.jdt.annotation.Nullable;
@@ -658,12 +663,35 @@ public final class BukkitEventValues {
 			}
 		}, EventValues.TIME_NOW);
 		EventValues.registerEventValue(AreaEffectCloudApplyEvent.class, PotionEffectType.class, new Getter<PotionEffectType, AreaEffectCloudApplyEvent>() {
+			@Nullable
+			private final MethodHandle BASE_POTION_DATA_HANDLE;
+
+			{
+				MethodHandle basePotionDataHandle = null;
+				if (Skript.methodExists(AreaEffectCloud.class, "getBasePotionData")) {
+					try {
+						basePotionDataHandle = MethodHandles.lookup().findVirtual(AreaEffectCloud.class, "getBasePotionData", MethodType.methodType(PotionData.class));
+					} catch (NoSuchMethodException | IllegalAccessException e) {
+						Skript.exception(e, "Failed to load legacy potion data support. Potions may not work as expected.");
+					}
+				}
+				BASE_POTION_DATA_HANDLE = basePotionDataHandle;
+			}
+
 			@Override
 			@Nullable
 			public PotionEffectType get(AreaEffectCloudApplyEvent e) {
-				PotionType base = e.getEntity().getBasePotionType();
-				if (base != null) // TODO this is deprecated... this should become a multi-value event value
-					return base.getEffectType();
+				if (BASE_POTION_DATA_HANDLE != null) {
+					try {
+						return ((PotionData) BASE_POTION_DATA_HANDLE.invoke(e.getEntity())).getType().getEffectType();
+					} catch (Throwable ex) {
+						throw Skript.exception(ex, "An error occurred while trying to invoke legacy area effect cloud potion effect support.");
+					}
+				} else {
+					PotionType base = e.getEntity().getBasePotionType();
+					if (base != null) // TODO this is deprecated... this should become a multi-value event value
+						return base.getEffectType();
+				}
 				return null;
 			}
 		}, 0);

--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -18,9 +18,6 @@
  */
 package ch.njol.skript.classes.data;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -65,7 +62,6 @@ import org.bukkit.block.BlockState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.AbstractVillager;
-import org.bukkit.entity.AreaEffectCloud;
 import org.bukkit.entity.Egg;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Firework;
@@ -175,7 +171,6 @@ import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.Recipe;
-import org.bukkit.potion.PotionData;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.potion.PotionType;
 import org.eclipse.jdt.annotation.Nullable;

--- a/src/main/java/ch/njol/skript/events/SimpleEvents.java
+++ b/src/main/java/ch/njol/skript/events/SimpleEvents.java
@@ -122,6 +122,7 @@ import org.bukkit.event.world.SpawnChangeEvent;
  * @author Peter Güttinger
  */
 public class SimpleEvents {
+
 	static {
 		Skript.registerEvent("Can Build Check", SimpleEvent.class, BlockCanBuildEvent.class, "[block] can build check")
 				.description("Called when a player rightclicks on a block while holding a block or a placeable item. You can either cancel the event to prevent the block from being built, or uncancel it to allow it.",
@@ -154,8 +155,8 @@ public class SimpleEvents {
 						"Please note that using this event might cause quite some lag since it gets called extremely often.")
 				.examples("# prevents sand from falling",
 						"on block physics:",
-						"	block is sand",
-						"	cancel event")
+						"\tblock is sand",
+						"\tcancel event")
 				.since("1.4.6");
 		Skript.registerEvent("Piston Extend", SimpleEvent.class, BlockPistonExtendEvent.class, "piston extend[ing]")
 				.description("Called when a piston is about to extend.")
@@ -204,7 +205,6 @@ public class SimpleEvents {
 				.description("Called when an entity (a primed TNT or a creeper) explodes.")
 				.examples("on explosion:")
 				.since("1.0");
-//		Skript.registerEvent(SimpleEvent.class, EntityInteractEvent.class, "interact");// = entity interacts with block, e.g. endermen?; player -> PlayerInteractEvent // likely tripwires, pressure plates, etc.
 		Skript.registerEvent("Portal Enter", SimpleEvent.class, EntityPortalEnterEvent.class, "portal enter[ing]", "entering [a] portal")
 				.description("Called when an entity enters a nether portal or an end portal. Please note that this event will be fired many times for a nether portal.")
 				.examples("on portal enter:")
@@ -231,7 +231,7 @@ public class SimpleEvents {
 				.examples("on fuel burning:")
 				.since("1.0");
 		Skript.registerEvent("Smelt", SimpleEvent.class, FurnaceSmeltEvent.class, "[ore] smelt[ing]", "smelt[ing] of ore") //TODO SkriptEvent for "smelt[ing] of %itemtype%"
-		.description("Called when a furnace smelts an item in its <a href='expressions.html#ExprFurnaceSlot'>ore slot</a>.")
+				.description("Called when a furnace smelts an item in its <a href='expressions.html#ExprFurnaceSlot'>ore slot</a>.")
 				.examples("on smelt:")
 				.since("1.0");
 		Skript.registerEvent("Leaves Decay", SimpleEvent.class, LeavesDecayEvent.class, "leaves decay[ing]")
@@ -255,18 +255,16 @@ public class SimpleEvents {
 				.examples("on player leaving a bed:")
 				.since("1.0");
 		Skript.registerEvent("Bucket Empty", SimpleEvent.class, PlayerBucketEmptyEvent.class, "bucket empty[ing]", "[player] empty[ing] [a] bucket")//TODO , "emptying bucket [of %itemtype%]", "emptying %itemtype% bucket") -> place of water/lava)
-		.description("Called when a player empties a bucket. You can also use the <a href='#place'>place event</a> with a check for water or lava.")
+				.description("Called when a player empties a bucket. You can also use the <a href='#place'>place event</a> with a check for water or lava.")
 				.examples("on bucket empty:")
 				.since("1.0");
 		Skript.registerEvent("Bucket fill", SimpleEvent.class, PlayerBucketFillEvent.class, "bucket fill[ing]", "[player] fill[ing] [a] bucket")//TODO , "filling bucket [(with|of) %itemtype%]", "filling %itemtype% bucket");)
-		.description("Called when a player fills a bucket.")
+				.description("Called when a player fills a bucket.")
 				.examples("on player filling a bucket:")
 				.since("1.0");
 		Skript.registerEvent("Egg Throw", SimpleEvent.class, PlayerEggThrowEvent.class, "throw[ing] [of] [an] egg", "[player] egg throw")
-				.description(
-						"Called when a player throws an egg and it lands. You can just use the <a href='#shoot'>shoot event</a> in most cases." +
-						" However, this event allows modification of properties like the hatched entity type and the number of entities to hatch."
-				)
+				.description("Called when a player throws an egg and it lands. You can just use the <a href='#shoot'>shoot event</a> in most cases." +
+						" However, this event allows modification of properties like the hatched entity type and the number of entities to hatch.")
 				.examples("on throw of an egg:")
 				.since("1.0");
 		// TODO improve - on fish [of %entitydata%] (and/or itemtype), on reel, etc.
@@ -275,13 +273,11 @@ public class SimpleEvents {
 				.description("Called when a player fishes something. This is not of much use yet.")
 				.examples("on fish:")
 				.since("1.0");
-		if (Skript.classExists("org.bukkit.event.player.PlayerItemBreakEvent")) {
-			Skript.registerEvent("Item Break", SimpleEvent.class, PlayerItemBreakEvent.class, "[player] tool break[ing]", "[player] break[ing] (a|the|) tool")
-					.description("Called when a player breaks their tool because its damage reached the maximum value.",
-							"This event cannot be cancelled.")
-					.examples("on tool break:")
-					.since("2.1.1");
-		}
+		Skript.registerEvent("Item Break", SimpleEvent.class, PlayerItemBreakEvent.class, "[player] tool break[ing]", "[player] break[ing] (a|the|) tool")
+				.description("Called when a player breaks their tool because its damage reached the maximum value.",
+						"This event cannot be cancelled.")
+				.examples("on tool break:")
+				.since("2.1.1");
 		Skript.registerEvent("Item Damage", SimpleEvent.class, PlayerItemDamageEvent.class, "item damag(e|ing)")
 				.description("Called when an item is damaged. Most tools are damaged by using them; armor is damaged when the wearer takes damage.")
 				.examples("on item damage:",
@@ -294,15 +290,15 @@ public class SimpleEvents {
 		Skript.registerEvent("Join", SimpleEvent.class, PlayerJoinEvent.class, "[player] (login|logging in|join[ing])")
 				.description("Called when the player joins the server. The player is already in a world when this event is called, so if you want to prevent players from joining you should prefer <a href='#connect'>on connect</a> over this event.")
 				.examples("on join:",
-						"	message \"Welcome on our awesome server!\"",
-						"	broadcast \"%player% just joined the server!\"")
+						"\tmessage \"Welcome on our awesome server!\"",
+						"\tbroadcast \"%player% just joined the server!\"")
 				.since("1.0");
 		Skript.registerEvent("Connect", SimpleEvent.class, PlayerLoginEvent.class, "[player] connect[ing]")
 				.description("Called when the player connects to the server. This event is called before the player actually joins the server, so if you want to prevent players from joining you should prefer this event over <a href='#join'>on join</a>.")
 				.examples("on connect:",
-						"	player doesn't have permission \"VIP\"",
-						"	number of players is greater than 15",
-						"	kick the player due to \"The last 5 slots are reserved for VIP players.\"")
+						"\tplayer doesn't have permission \"VIP\"",
+						"\tnumber of players is greater than 15",
+						"\tkick the player due to \"The last 5 slots are reserved for VIP players.\"")
 				.since("2.0");
 		Skript.registerEvent("Kick", SimpleEvent.class, PlayerKickEvent.class, "[player] (kick|being kicked)")
 				.description("Called when a player is kicked from the server. You can change the <a href='expressions.html#ExprMessage'>kick message</a> or <a href='effects.html#EffCancelEvent'>cancel the event</a> entirely.")
@@ -333,14 +329,14 @@ public class SimpleEvents {
 				.description("Called when a player starts or stops sneaking. Use <a href='conditions.html#CondIsSneaking'>is sneaking</a> to get whether the player was sneaking before the event was called.")
 				.examples("# make players that stop sneaking jump",
 						"on sneak toggle:",
-						"	player is sneaking",
-						"	push the player upwards at speed 0.5")
+						"\tplayer is sneaking",
+						"\tpush the player upwards at speed 0.5")
 				.since("1.0");
 		Skript.registerEvent("Sprint Toggle", SimpleEvent.class, PlayerToggleSprintEvent.class, "[player] toggl(e|ing) sprint", "[player] sprint toggl(e|ing)")
 				.description("Called when a player starts or stops sprinting. Use <a href='conditions.html#CondIsSprinting'>is sprinting</a> to get whether the player was sprinting before the event was called.")
 				.examples("on sprint toggle:",
-						"	player is not sprinting",
-						"	send \"Run!\"")
+						"\tplayer is not sprinting",
+						"\tsend \"Run!\"")
 				.since("1.0");
 		Skript.registerEvent("Portal Create", SimpleEvent.class, PortalCreateEvent.class, "portal creat(e|ion)")
 				.description("Called when a portal is created, either by a player or mob lighting an obsidian frame on fire, or by a nether portal creating its teleportation target in the nether/overworld.",
@@ -358,13 +354,13 @@ public class SimpleEvents {
 						"\tdelete event-projectile")
 				.since("1.0");
 		
-		if(Skript.classExists("com.destroystokyo.paper.event.entity.ProjectileCollideEvent"))
+		if (Skript.classExists("com.destroystokyo.paper.event.entity.ProjectileCollideEvent"))
 			Skript.registerEvent("Projectile Collide", SimpleEvent.class, ProjectileCollideEvent.class, "projectile collide")
-			.description("Called when a projectile collides with an entity.")
-			.requiredPlugins("Paper")
-			.examples("on projectile collide:",
-				"\tteleport shooter of event-projectile to event-entity")
-			.since("2.5");
+					.description("Called when a projectile collides with an entity.")
+					.requiredPlugins("Paper")
+					.examples("on projectile collide:",
+							"\tteleport shooter of event-projectile to event-entity")
+					.since("2.5");
 		Skript.registerEvent("Shoot", SimpleEvent.class, ProjectileLaunchEvent.class, "[projectile] shoot")
 				.description("Called whenever a <a href='classes.html#projectile'>projectile</a> is shot. Use the <a href='expressions.html#ExprShooter'>shooter expression</a> to get who shot the projectile.")
 				.examples("on shoot:",
@@ -374,8 +370,8 @@ public class SimpleEvents {
 		Skript.registerEvent("Sign Change", SimpleEvent.class, SignChangeEvent.class, "sign (chang[e]|edit)[ing]", "[player] (chang[e]|edit)[ing] [a] sign")
 				.description("As signs are placed empty, this event is called when a player is done editing a sign.")
 				.examples("on sign change:",
-						"	line 2 is empty",
-						"	set line 1 to \"&lt;red&gt;%line 1%\"")
+						"\tline 2 is empty",
+						"\tset line 1 to \"&lt;red&gt;%line 1%\"")
 				.since("1.0");
 		Skript.registerEvent("Spawn Change", SimpleEvent.class, SpawnChangeEvent.class, "[world] spawn change")
 				.description("Called when the spawn point of a world changes.")
@@ -436,17 +432,16 @@ public class SimpleEvents {
 					.since("2.2-dev13b");
 			}
 		}
-		if (Skript.classExists("org.bukkit.event.entity.EntityToggleGlideEvent")) {
-			Skript.registerEvent("Gliding State Change", SimpleEvent.class, EntityToggleGlideEvent.class, "(gliding state change|toggl(e|ing) gliding)")
-					.description("Called when an entity toggles glider on or off, or when server toggles gliding state of an entity forcibly.")
-					.examples("on toggling gliding:",
-							"	cancel the event # bad idea, but you CAN do it!")
-					.since("2.2-dev21");
-			Skript.registerEvent("AoE Cloud Effect", SimpleEvent.class, AreaEffectCloudApplyEvent.class, "(area|AoE) [cloud] effect")
-					.description("Called when area effect cloud applies its potion effect. This happens every 5 ticks by default.")
-					.examples("on area cloud effect:")
-					.since("2.2-dev21");
-		}
+		Skript.registerEvent("Gliding State Change", SimpleEvent.class, EntityToggleGlideEvent.class, "(gliding state change|toggl(e|ing) gliding)")
+				.description("Called when an entity toggles glider on or off, or when server toggles gliding state of an entity forcibly.")
+				.examples("on toggling gliding:",
+					"\tcancel the event # bad idea, but you CAN do it!")
+				.since("2.2-dev21");
+		Skript.registerEvent("AoE Cloud Effect", SimpleEvent.class, AreaEffectCloudApplyEvent.class, "(area|AoE) [cloud] effect")
+				.description("Called when area effect cloud applies its potion effect. This happens every 5 ticks by default.")
+				.examples("on area cloud effect:")
+				.keywords("potion")
+				.since("2.2-dev21");
 		Skript.registerEvent("Sheep Regrow Wool", SimpleEvent.class, SheepRegrowWoolEvent.class, "sheep [re]grow[ing] wool")
 				.description("Called when sheep regrows its sheared wool back.")
 				.examples("on sheep grow wool:",
@@ -480,46 +475,40 @@ public class SimpleEvents {
 		Skript.registerEvent("Player World Change", SimpleEvent.class, PlayerChangedWorldEvent.class, "[player] world chang(ing|e[d])")
 				.description("Called when a player enters a world. Does not work with other entities!")
 				.examples("on player world change:",
-						"	world is \"city\"",
-					 	"	send \"Welcome to the City!\"")
+						"\tworld is \"city\"",
+					 	"\tsend \"Welcome to the City!\"")
 				.since("2.2-dev28");
 		Skript.registerEvent("Flight Toggle", SimpleEvent.class, PlayerToggleFlightEvent.class, "[player] flight toggl(e|ing)", "[player] toggl(e|ing) flight")
 				.description("Called when a players stops/starts flying.")
 				.examples("on flight toggle:",
-						"	if {game::%player%::playing} exists:",
-						"		cancel event")
+						"\tif {game::%player%::playing} exists:",
+						"\tcancel event")
 				.since("2.2-dev36");
-		if (Skript.classExists("org.bukkit.event.player.PlayerLocaleChangeEvent")) {
-			Skript.registerEvent("Language Change", SimpleEvent.class, PlayerLocaleChangeEvent.class, "[player] (language|locale) chang(e|ing)", "[player] chang(e|ing) (language|locale)")
-					.description("Called after a player changed their language in the game settings. You can use the <a href='expressions.html#ExprLanguage'>language</a> expression to get the current language of the player.",
-							"This event requires Minecraft 1.12+.")
-					.examples("on language change:",
-							"	if player's language starts with \"en\":",
-							"		send \"Hello!\"")
-					.since("2.3");
-		}
-		if (Skript.classExists("com.destroystokyo.paper.event.player.PlayerJumpEvent")) {
+		Skript.registerEvent("Language Change", SimpleEvent.class, PlayerLocaleChangeEvent.class, "[player] (language|locale) chang(e|ing)", "[player] chang(e|ing) (language|locale)")
+				.description("Called after a player changed their language in the game settings. You can use the <a href='expressions.html#ExprLanguage'>language</a> expression to get the current language of the player.")
+				.examples("on language change:",
+						"\tif player's language starts with \"en\":",
+						"\t\tsend \"Hello!\"")
+				.since("2.3");
+		if (Skript.classExists("com.destroystokyo.paper.event.player.PlayerJumpEvent"))
 			Skript.registerEvent("Jump", SimpleEvent.class, PlayerJumpEvent.class, "[player] jump[ing]")
-					.description("Called whenever a player jumps.",
-							"This event requires PaperSpigot.")
+					.description("Called whenever a player jumps. This event requires PaperSpigot.")
 					.examples("on jump:",
-							"	event-player does not have permission \"jump\"",
-							"	cancel event")
+							"\tevent-player does not have permission \"jump\"",
+							"\tcancel event")
 					.since("2.3");
-		}
-		if (Skript.classExists("org.bukkit.event.player.PlayerSwapHandItemsEvent")) {
+		if (Skript.classExists("org.bukkit.event.player.PlayerSwapHandItemsEvent"))
 			Skript.registerEvent("Hand Item Swap", SimpleEvent.class, PlayerSwapHandItemsEvent.class, "swap[ping of] [(hand|held)] item[s]")
 					.description("Called whenever a player swaps the items in their main- and offhand slots.",
-						     "Works also when one or both of the slots are empty.",
-						     "The event is called before the items are actually swapped,",
-						     "so when you use the player's tool or player's offtool expressions,",
-						     "they will return the values before the swap -",
-						     "this enables you to cancel the event before anything happens.")
+							"Works also when one or both of the slots are empty.",
+							"The event is called before the items are actually swapped,",
+							"so when you use the player's tool or player's offtool expressions,",
+							"they will return the values before the swap -",
+							"this enables you to cancel the event before anything happens.")
 					.examples("on swap hand items:",
-							"	event-player's tool is a diamond sword",
-							"	cancel event")
+							"\tevent-player's tool is a diamond sword",
+							"\tcancel event")
 					.since("2.3");
-		}
 		Skript.registerEvent("Server List Ping", SimpleEvent.class, (Skript.classExists("com.destroystokyo.paper.event.server.PaperServerListPingEvent") ? PaperServerListPingEvent.class : ServerListPingEvent.class), "server [list] ping")
 				.description("Called when a server list ping is coming in, generally when a Minecraft client pings the server to show its information in the server list.",
 						"The <a href='expressions.html#ExprIP'>IP</a> expression can be used to get the IP adress of the pinger.",
@@ -530,129 +519,117 @@ public class SimpleEvents {
 						"<a href='expressions.html#ExprVersionString'>Version String</a>, <a href='expressions.html#ExprHoverList'>Hover List</a> and <a href='expressions.html#ExprServerIcon'>Server Icon</a> " +
 						"expressions, and <a href='effects.html#EffPlayerInfoVisibility'>Player Info Visibility</a> and <a href='effects.html#EffHidePlayerFromServerList'>Hide Player from Server List</a> effects to modify the server list.")
 				.examples("on server list ping:",
-						"	set the motd to \"Welcome %{player-by-IP::%ip%}%! Join now!\" if {player-by-IP::%ip%} is set, else \"Join now!\"",
-						"	set the fake max players count to (online players count + 1)",
-						"	set the shown icon to a random server icon out of {server-icons::*}")
+						"\tset the motd to \"Welcome %{player-by-IP::%ip%}%! Join now!\" if {player-by-IP::%ip%} is set, else \"Join now!\"",
+						"\tset the fake max players count to (online players count + 1)",
+						"\tset the shown icon to a random server icon out of {server-icons::*}")
 				.since("2.3");
-		if (Skript.classExists("org.bukkit.event.entity.EntityToggleSwimEvent")) {
-			Skript.registerEvent("Swim Toggle", SimpleEvent.class, EntityToggleSwimEvent.class, "[entity] toggl(e|ing) swim",
-					"[entity] swim toggl(e|ing)")
-					.description("Called when an entity swims or stops swimming.")
-					.requiredPlugins("1.13 or newer")
-					.examples("on swim toggle:",
-							"	event-entity does not have permission \"swim\"",
-							"	cancel event")
-					.since("2.3");
-		}
-		if (Skript.classExists("org.bukkit.event.player.PlayerRiptideEvent")) {
+		Skript.registerEvent("Swim Toggle", SimpleEvent.class, EntityToggleSwimEvent.class, "[entity] toggl(e|ing) swim",
+				"[entity] swim toggl(e|ing)")
+				.description("Called when an entity swims or stops swimming.")
+				.requiredPlugins("1.13+")
+				.examples("on swim toggle:",
+						"\tevent-entity does not have permission \"swim\"",
+						"\tcancel event")
+				.since("2.3");
+		if (Skript.classExists("org.bukkit.event.player.PlayerRiptideEvent"))
 			Skript.registerEvent("Riptide", SimpleEvent.class, PlayerRiptideEvent.class, "[use of] riptide [enchant[ment]]")
-				.description("Called when the player activates the riptide enchantment, using their trident to propel them through the air.",
-					"Note: the riptide action is performed client side, so manipulating the player in this event may have undesired effects.")
-				.examples("on riptide:",
-					"	send \"You are riptiding!\"")
-				.since("2.5");
-		}
-		if (Skript.classExists("com.destroystokyo.paper.event.player.PlayerArmorChangeEvent")) {
-			Skript.registerEvent("Armor Change", SimpleEvent.class, PlayerArmorChangeEvent.class, "[player] armo[u]r change[d]")
-				.description("Called when armor pieces of a player are changed.")
-				.requiredPlugins("Paper")
-				.keywords("armour")
-				.examples(
-						"on armor change:",
-							"\tsend \"You equipped %event-item%!\""
-				).since("2.5");
-		}
-		if (Skript.classExists("org.bukkit.event.block.SpongeAbsorbEvent")) {
-			Skript.registerEvent("Sponge Absorb", SimpleEvent.class, SpongeAbsorbEvent.class, "sponge absorb")
-					.description("Called when a sponge absorbs blocks.")
-					.requiredPlugins("Minecraft 1.13 or newer")
-					.examples("on sponge absorb:",
-							"\tloop absorbed blocks:",
-							"\t\tbroadcast \"%loop-block% was absorbed by a sponge\"!")
+					.description("Called when the player activates the riptide enchantment, using their trident to propel them through the air.",
+							"Note: the riptide action is performed client side, so manipulating the player in this event may have undesired effects.")
+					.examples("on riptide:",
+							"\tsend \"You are riptiding!\"")
 					.since("2.5");
-		}
+		if (Skript.classExists("com.destroystokyo.paper.event.player.PlayerArmorChangeEvent"))
+			Skript.registerEvent("Armor Change", SimpleEvent.class, PlayerArmorChangeEvent.class, "[player] armo[u]r change[d]")
+					.description("Called when armor pieces of a player are changed.")
+					.requiredPlugins("Paper")
+					.keywords("armour")
+					.examples(
+							"on armor change:",
+							"\tsend \"You equipped %event-item%!\""
+					)
+					.since("2.5");
+		Skript.registerEvent("Sponge Absorb", SimpleEvent.class, SpongeAbsorbEvent.class, "sponge absorb")
+				.description("Called when a sponge absorbs blocks.")
+				.requiredPlugins("Minecraft 1.13+")
+				.examples("on sponge absorb:",
+						"\tloop absorbed blocks:",
+						"\t\tbroadcast \"%loop-block% was absorbed by a sponge\"!")
+				.since("2.5");
 		Skript.registerEvent("Enchant Prepare", SimpleEvent.class, PrepareItemEnchantEvent.class, "[item] enchant prepare")
-			.description("Called when a player puts an item into enchantment table. This event may be called multiple times.",
-				" To get the enchant item, see the <a href='expressions.html#ExprEnchantEventsEnchantItem'>enchant item expression</a>")
-			.examples("on enchant prepare:",
-				"\tset enchant offer 1 to sharpness 1",
-				"\tset the cost of enchant offer 1 to 10 levels")
-			.since("2.5");
+				.description("Called when a player puts an item into enchantment table. This event may be called multiple times.",
+						" To get the enchant item, see the <a href='expressions.html#ExprEnchantEventsEnchantItem'>enchant item expression</a>")
+				.examples("on enchant prepare:",
+					"\tset enchant offer 1 to sharpness 1",
+					"\tset the cost of enchant offer 1 to 10 levels")
+				.since("2.5");
 		Skript.registerEvent("Enchant", SimpleEvent.class, EnchantItemEvent.class, "[item] enchant")
-		.description("Called when a player successfully enchants an item.",
-			" To get the enchanted item, see the <a href='expressions.html#ExprEnchantEventsEnchantItem'>enchant item expression</a>")
-		.examples("on enchant:",
-			"\tif the clicked button is 1: # offer 1",
-			"\t\tset the applied enchantments to sharpness 10 and unbreaking 10")
-		.since("2.5");
+				.description("Called when a player successfully enchants an item.",
+						" To get the enchanted item, see the <a href='expressions.html#ExprEnchantEventsEnchantItem'>enchant item expression</a>")
+				.examples("on enchant:",
+						"\tif the clicked button is 1: # offer 1",
+						"\t\tset the applied enchantments to sharpness 10 and unbreaking 10")
+				.since("2.5");
 		Skript.registerEvent("Inventory Pickup", SimpleEvent.class, InventoryPickupItemEvent.class, "inventory pick[ ]up")
 				.description("Called when an inventory (a hopper, a hopper minecart, etc.) picks up an item")
 				.examples("on inventory pickup:")
 				.since("2.5.1");
 		Skript.registerEvent("Horse Jump", SimpleEvent.class, HorseJumpEvent.class, "horse jump")
-			.description("Called when a horse jumps.")
-			.examples("on horse jump:", "\tpush event-entity upwards at speed 2")
-			.since("2.5.1");
-		if(Skript.classExists("org.bukkit.event.block.BlockFertilizeEvent"))
-			Skript.registerEvent("Block Fertilize", SimpleEvent.class, BlockFertilizeEvent.class, "[block] fertilize")
-			.description("Called when a player fertilizes blocks.")
-			.requiredPlugins("Minecraft 1.13 or newer")
-			.examples("on block fertilize:",
-				"\tsend \"Fertilized %size of fertilized blocks% blocks got fertilized.\"")
-			.since("2.5");
-		Skript.registerEvent("Arm Swing", SimpleEvent.class, PlayerAnimationEvent.class, "[player] arm swing")
-			.description("Called when a player swings their arm.")
-			.examples("on arm swing:",
-				"\tsend \"You swung your arm!\"")
-			.since("2.5.1");
-		if (Skript.classExists("org.bukkit.event.player.PlayerItemMendEvent")) {
-			Skript.registerEvent("Item Mend", SimpleEvent.class, PlayerItemMendEvent.class, "item mend[ing]")
-				.description("Called when a player has an item repaired via the Mending enchantment.")
-				.requiredPlugins("Minecraft 1.13 or newer")
-				.examples("on item mend:",
-					"\tchance of 50%:",
-					"\t\tcancel the event",
-					"\t\tsend \"Oops! Mending failed!\" to player")
+				.description("Called when a horse jumps.")
+				.examples("on horse jump:", "\tpush event-entity upwards at speed 2")
 				.since("2.5.1");
-		}
+		Skript.registerEvent("Block Fertilize", SimpleEvent.class, BlockFertilizeEvent.class, "[block] fertilize")
+				.description("Called when a player fertilizes blocks.")
+				.requiredPlugins("Minecraft 1.13+")
+				.examples("on block fertilize:",
+						"\tsend \"Fertilized %size of fertilized blocks% blocks got fertilized.\"")
+				.since("2.5");
+		Skript.registerEvent("Arm Swing", SimpleEvent.class, PlayerAnimationEvent.class, "[player] arm swing")
+				.description("Called when a player swings their arm.")
+				.examples("on arm swing:",
+						"\tsend \"You swung your arm!\"")
+				.since("2.5.1");
+		Skript.registerEvent("Item Mend", SimpleEvent.class, PlayerItemMendEvent.class, "item mend[ing]")
+				.description("Called when a player has an item repaired via the Mending enchantment.")
+				.requiredPlugins("Minecraft 1.13+")
+				.examples("on item mend:",
+						"\tchance of 50%:",
+						"\t\tcancel the event",
+						"\t\tsend \"Oops! Mending failed!\" to player")
+				.since("2.5.1");
 		Skript.registerEvent("Anvil Prepare", SimpleEvent.class, PrepareAnvilEvent.class, "anvil prepar(e|ing)")
-			.description("Called when an item is put in a slot for repair by an anvil. Please note that this event is called multiple times in a single item slot move.")
-			.examples("on anvil prepare:",
-				"\tevent-item is set # result item",
-				"\tchance of 5%:",
-				"\t\tset repair cost to repair cost * 50%",
-				"\t\tsend \"You're LUCKY! You got 50% discount.\" to player")
-			.since("2.7");
-		if (Skript.classExists("io.papermc.paper.event.player.PlayerTradeEvent")) {
+				.description("Called when an item is put in a slot for repair by an anvil. Please note that this event is called multiple times in a single item slot move.")
+				.examples("on anvil prepare:",
+						"\tevent-item is set # result item",
+						"\tchance of 5%:",
+						"\t\tset repair cost to repair cost * 50%",
+						"\t\tsend \"You're LUCKY! You got 50% discount.\" to player")
+				.since("2.7");
+		if (Skript.classExists("io.papermc.paper.event.player.PlayerTradeEvent"))
 			Skript.registerEvent("Player Trade", SimpleEvent.class, PlayerTradeEvent.class, "player trad(e|ing)")
-				.description("Called when a player has traded with a villager.")
-				.requiredPlugins("Paper 1.16.5+")
-				.examples("on player trade:",
-					"\tchance of 50%:",
-					"\t\tcancel event",
-					"\t\tsend \"The trade was somehow denied!\" to player")
-				.since("2.7");
-		}
-		if (Skript.classExists("com.destroystokyo.paper.event.entity.EntityJumpEvent")) {
+					.description("Called when a player has traded with a villager.")
+					.requiredPlugins("Paper 1.16.5+")
+					.examples("on player trade:",
+							"\tchance of 50%:",
+							"\t\tcancel event",
+							"\t\tsend \"The trade was somehow denied!\" to player")
+					.since("2.7");
+		if (Skript.classExists("com.destroystokyo.paper.event.entity.EntityJumpEvent"))
 			Skript.registerEvent("Entity Jump", SimpleEvent.class, EntityJumpEvent.class, "entity jump[ing]")
-				.description("Called when an entity jumps.")
-				.requiredPlugins("Paper 1.15.2+")
-				.examples("on entity jump:",
-					"\tif entity is a wither skeleton:",
-					"\t\tcancel event")
-				.since("2.7");
-		}
-		if (Skript.classExists("com.destroystokyo.paper.event.block.AnvilDamagedEvent")) {
+					.description("Called when an entity jumps.")
+					.requiredPlugins("Paper 1.15.2+")
+					.examples("on entity jump:",
+							"\tif entity is a wither skeleton:",
+							"\t\tcancel event")
+					.since("2.7");
+		if (Skript.classExists("com.destroystokyo.paper.event.block.AnvilDamagedEvent"))
 			Skript.registerEvent("Anvil Damage", SimpleEvent.class, AnvilDamagedEvent.class, "anvil damag(e|ing)")
-				.description("Called when an anvil is damaged/broken from being used to repair/rename items.",
-					 		 "Note: this does not include anvil damage from falling.")
-				.requiredPlugins("Paper")
-				.examples("on anvil damage:",
-					"\tcancel the event")
-				.since("2.7");
-		}
-
-		if (Skript.classExists("io.papermc.paper.event.player.PlayerStopUsingItemEvent")) {
+					.description("Called when an anvil is damaged/broken from being used to repair/rename items.",
+							"Note: this does not include anvil damage from falling.")
+					.requiredPlugins("Paper")
+					.examples("on anvil damage:",
+							"\tcancel the event")
+					.since("2.7");
+		if (Skript.classExists("io.papermc.paper.event.player.PlayerStopUsingItemEvent"))
 			Skript.registerEvent("Stop Using Item", SimpleEvent.class, PlayerStopUsingItemEvent.class,
 							"[player] (stop|end) (using item|item use)")
 					.description("Called when a player stops using an item. For example, when the player releases the " +
@@ -660,71 +637,64 @@ public class SimpleEvents {
 							"Note that event-timespan will return the time the item was used for.")
 					.requiredPlugins("Paper 1.18.2+")
 					.examples(
-						"on player stop using item:",
+							"on player stop using item:",
 							"\tbroadcast \"%player% used %event-item% for %event-timespan%.\"")
 					.since("2.8.0");
-		}
-
-		if (Skript.classExists("com.destroystokyo.paper.event.player.PlayerReadyArrowEvent")) {
+		if (Skript.classExists("com.destroystokyo.paper.event.player.PlayerReadyArrowEvent"))
 			Skript.registerEvent("Ready Arrow", SimpleEvent.class, PlayerReadyArrowEvent.class, "[player] ((ready|choose|draw|load) arrow|arrow (choose|draw|load))")
 					.description("Called when a player is firing a bow and the server is choosing an arrow to use.",
 							"Cancelling this event will skip the current arrow item and fire a new event for the next arrow item.",
 							"The arrow and bow in the event can be accessed with the Readied Arrow/Bow expression.")
 					.requiredPlugins("Paper")
 					.examples(
-						"on player ready arrow:",
+							"on player ready arrow:",
 							"\tselected bow's name is \"Spectral Bow\"",
 							"\tif selected arrow is not a spectral arrow:",
-								"\t\tcancel event"
+							"\t\tcancel event"
 					)
 					.since("2.8.0");
-		}
-
-		if (Skript.classExists("io.papermc.paper.event.player.PlayerInventorySlotChangeEvent")) {
+		if (Skript.classExists("io.papermc.paper.event.player.PlayerInventorySlotChangeEvent"))
 			Skript.registerEvent("Inventory Slot Change", SimpleEvent.class, PlayerInventorySlotChangeEvent.class, "[player] inventory slot chang(e|ing)")
 					.description("Called when a slot in a player's inventory is changed.", "Warning: setting the event-slot to a new item can result in an infinite loop.")
 					.requiredPlugins("Paper 1.19.2+")
 					.examples(
-						"on inventory slot change:",
+							"on inventory slot change:",
 							"\tif event-item is a diamond:",
-								"\t\tsend \"You obtained a diamond!\" to player"
+							"\t\tsend \"You obtained a diamond!\" to player"
 					)
 					.since("2.7");
-		}
-    
 		//noinspection deprecation
 		Skript.registerEvent("Chat", SimpleEvent.class, AsyncPlayerChatEvent.class, "chat")
-			.description(
-				"Called whenever a player chats.",
-				"Use <a href='./expressions.html#ExprChatFormat'>chat format</a> to change message format.",
-				"Use <a href='./expressions.html#ExprChatRecipients'>chat recipients</a> to edit chat recipients."
-			)
-			.examples(
-				"on chat:",
-				"\tif player has permission \"owner\":",
-				"\t\tset chat format to \"&lt;red&gt;[player]&lt;light gray&gt;: &lt;light red&gt;[message]\"",
-				"\telse if player has permission \"admin\":",
-				"\t\tset chat format to \"&lt;light red&gt;[player]&lt;light gray&gt;: &lt;orange&gt;[message]\"",
-				"\telse: #default message format",
-				"\t\tset chat format to \"&lt;orange&gt;[player]&lt;light gray&gt;: &lt;white&gt;[message]\""
-			)
-			.since("1.4.1");
-		if (Skript.classExists("org.bukkit.event.world.LootGenerateEvent")) {
+				.description(
+						"Called whenever a player chats.",
+						"Use <a href='./expressions.html#ExprChatFormat'>chat format</a> to change message format.",
+						"Use <a href='./expressions.html#ExprChatRecipients'>chat recipients</a> to edit chat recipients."
+				)
+				.examples(
+						"on chat:",
+						"\tif player has permission \"owner\":",
+						"\t\tset chat format to \"&lt;red&gt;[player]&lt;light gray&gt;: &lt;light red&gt;[message]\"",
+						"\telse if player has permission \"admin\":",
+						"\t\tset chat format to \"&lt;light red&gt;[player]&lt;light gray&gt;: &lt;orange&gt;[message]\"",
+						"\telse: #default message format",
+						"\t\tset chat format to \"&lt;orange&gt;[player]&lt;light gray&gt;: &lt;white&gt;[message]\""
+				)
+				.since("1.4.1");
+		if (Skript.classExists("org.bukkit.event.world.LootGenerateEvent"))
 			Skript.registerEvent("Loot Generate", SimpleEvent.class, LootGenerateEvent.class, "loot generat(e|ing)")
 					.description(
-						"Called when a loot table of an inventory is generated in the world.",
-						"For example, when opening a shipwreck chest."
+							"Called when a loot table of an inventory is generated in the world.",
+							"For example, when opening a shipwreck chest."
 					)
 					.examples(
-						"on loot generate:",
-						"\tchance of 10%",
-						"\tadd 64 diamonds to the loot",
-						"\tsend \"You hit the jackpot at %event-location%!\""
+							"on loot generate:",
+							"\tchance of 10%",
+							"\tadd 64 diamonds to the loot",
+							"\tsend \"You hit the jackpot at %event-location%!\""
 					)
 					.since("2.7")
 					.requiredPlugins("MC 1.16+");
-		}
-		if (Skript.classExists("io.papermc.paper.event.player.PlayerDeepSleepEvent")) {
+		if (Skript.classExists("io.papermc.paper.event.player.PlayerDeepSleepEvent"))
 			Skript.registerEvent("Player Deep Sleep", SimpleEvent.class, PlayerDeepSleepEvent.class, "[player] deep sleep[ing]")
 					.description(
 							"Called when a player has slept long enough to count as passing the night/storm.",
@@ -736,18 +706,15 @@ public class SimpleEvents {
 					)
 					.since("2.7")
 					.requiredPlugins("Paper 1.16+");
-		}
-
 		Skript.registerEvent("Player Pickup Arrow", SimpleEvent.class, PlayerPickupArrowEvent.class, "[player] (pick[ing| ]up [an] arrow|arrow pick[ing| ]up)")
 				.description("Called when a player picks up an arrow from the ground.")
 				.examples(
 						"on arrow pickup:",
-								"\tcancel the event",
-								"\tteleport event-projectile to block 5 above event-projectile"
+						"\tcancel the event",
+						"\tteleport event-projectile to block 5 above event-projectile"
 				)
 				.since("2.8.0")
 				.requiredPlugins("Minecraft 1.14+ (event-projectile)");
-
 		Skript.registerEvent("Inventory Drag", SimpleEvent.class, InventoryDragEvent.class, "inventory drag[ging]")
 				.description("Called when a player drags an item in their cursor across the inventory.")
 				.examples(
@@ -757,9 +724,8 @@ public class SimpleEvents {
 						"\t\tcancel event"
 				)
 				.since("2.7");
-
 		{
-			final Class<? extends Event> eventClass;
+			Class<? extends Event> eventClass;
 			if (Skript.classExists("org.bukkit.event.block.BellRingEvent")) {
 				eventClass = org.bukkit.event.block.BellRingEvent.class;
 			} else if (Skript.classExists("io.papermc.paper.event.block.BellRingEvent")) {
@@ -769,34 +735,30 @@ public class SimpleEvents {
 				eventClass = null;
 			}
 
-			if (eventClass != null) {
+			if (eventClass != null)
 				Skript.registerEvent("Bell Ring", SimpleEvent.class, eventClass, "bell ring[ing]")
 						.description("Called when a bell is rung.")
 						.examples(
-							"on bell ring:",
+								"on bell ring:",
 								"\tsend \"<gold>Ding-dong!<reset>\" to all players in radius 10 of event-block"
 						)
 						.since("INSERT VERSION")
 						.requiredPlugins("Spigot 1.19.4+ or Paper 1.16.5+ (no event-direction)");
-			}
 		}
-
 		/*
 		* Paper supported this in 1.16.5 via io.papermc.paper.event.block.BellRevealRaiderEvent.
 		* The Paper event, however, is called for each raider, while the Spigot event is called once for all raiders.
 		* Supporting both would cause confusing behaviour, with the event being triggered in different ways depending
 		* on the server software and version, so we're only supporting the Spigot event.
 		*/
-		if (Skript.classExists("org.bukkit.event.block.BellResonateEvent")) {
+		if (Skript.classExists("org.bukkit.event.block.BellResonateEvent"))
 			Skript.registerEvent("Bell Resonate", SimpleEvent.class, org.bukkit.event.block.BellResonateEvent.class, "bell resonat(e|ing)")
 					.description("Called when a bell resonates, highlighting nearby raiders.")
 					.examples(
-						"on bell resonate:",
+							"on bell resonate:",
 							"\tsend \"<red>Raiders are nearby!\" to all players in radius 32 around event-block"
 					)
 					.since("INSERT VERSION")
 					.requiredPlugins("Spigot 1.19.4+");
-		}
 	}
-
 }


### PR DESCRIPTION
### Description
This PR removes some redundant exists checks for BukkitClasses, SimpleEvents and BukkitEventValues.

- BukkitEventValues: just the AoE cloud handles were removed. The behaviour should (I think) be the same, but reflection is no longer needed.
- BukkitClasses: removes the getEntity exists check, as it should always exist in 1.13+
- SimpleEvents: initially didn't plan on including this in this PR, but saw some exists checks that could be removed. Then I saw that the formatting was a bit random at times, so I made it a bit more consistent. Happy to revert this file to what it was before if the formatting stuff is out of the scope of this housekeeping stuff.


---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #6676 #6641 
