### PR TITLE
Allow any script in `using` condition.

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondIsUsingFeature.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsUsingFeature.java
@@ -1,21 +1,3 @@
-/**
- *   This file is part of Skript.
- *
- *  Skript is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  Skript is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Copyright Peter Güttinger, SkriptLang team and contributors
- */
 package ch.njol.skript.conditions;
 
 import ch.njol.skript.Skript;
@@ -30,9 +12,9 @@ import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.skriptlang.skript.lang.experiment.Experimented;
+import org.skriptlang.skript.lang.experiment.ExperimentSet;
+import org.skriptlang.skript.lang.script.Script;
 
-@SuppressWarnings("NotNullFieldNotInitialized")
 @Name("Is Using Experimental Feature")
 @Description("Checks whether a script is using an experimental feature by name.")
 @Examples({"the script is using \"example feature\"",
@@ -44,20 +26,23 @@ public class CondIsUsingFeature extends Condition {
 
 	static {
 		Skript.registerCondition(CondIsUsingFeature.class,
-				"[the] [current] script is using %strings%",
-				"[the] [current] script is(n't| not) using %strings%");
+				"%script% is using %strings%",
+				"%scripts% are using %strings%",
+				"%script% is(n't| not) using %strings%",
+				"%scripts% are(n't| not) using %strings%");
 	}
 
 	private Expression<String> names;
-	private Experimented snapshot;
+	private Expression<Script> scripts;
 
 	@SuppressWarnings("null")
 	@Override
 	public boolean init(Expression<?>[] expressions, int pattern, Kleenean delayed, ParseResult result) {
 		//noinspection unchecked
-		this.names = (Expression<String>) expressions[0];
-		this.setNegated(pattern == 1);
-		this.snapshot = this.getParser().experimentSnapshot();
+		this.names = (Expression<String>) expressions[1];
+		//noinspection unchecked
+		this.scripts = (Expression<Script>) expressions[0];
+		this.setNegated(pattern > 1);
 		return true;
 	}
 
@@ -67,15 +52,26 @@ public class CondIsUsingFeature extends Condition {
 		if (array.length == 0)
 			return true;
 		boolean isUsing = true;
-		for (@NotNull String object : array) {
-			isUsing &= snapshot.hasExperiment(object);
+		for (Script script : this.scripts.getArray(event)) {
+			ExperimentSet data = script.getData(ExperimentSet.class);
+			if (data == null) {
+				isUsing = false;
+			} else {
+				for (@NotNull String object : array) {
+					isUsing &= data.hasExperiment(object);
+				}
+			}
 		}
 		return isUsing ^ this.isNegated();
 	}
 
 	@Override
 	public String toString(@Nullable Event event, boolean debug) {
-		return "the current script " + (isNegated() ? "isn't" : "is") + " using " + names.toString(event, debug);
+		String whether = scripts.isSingle()
+				? (isNegated() ? "isn't" : "is")
+				: (isNegated() ? "aren't" : "are");
+		return scripts.toString(event, debug) + " "
+				+ whether + " using " + names.toString(event, debug);
 	}
 
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
The original purpose of the `is using` condition was to be able to test other scripts. Initially, this wasn't really possible (so it just supported the current script) but with script references it is.

Based on #6702, the only actual change is in `ch.njol.skript.conditions.CondIsUsingFeature`.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** requires #6702 <!-- Links to related issues -->
