### PR TITLE
Adds reset/delete changers to ExprYawPitch

### DIFF
--- a/src/test/skript/tests/syntaxes/expressions/ExprYawPitch.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprYawPitch.sk
@@ -3,3 +3,5 @@ test "yaw and pitch":
 	assert yaw of {_test} is 0 with "The yaw of the spawn location was not 0"
 	set yaw of {_test} to 90
 	assert yaw of {_test} is 90 with "The yaw of the spawn location was not set to 90"
+	reset yaw of {_test}
+	assert yaw of {_test} is 0 with "The yaw of the spawn location was not reset (to 0)"


### PR DESCRIPTION
### Description
Adds reset and delete changers to ExprYawPitch, which just set back to 0.
Also updated the test to try this, and added some new examples.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** [discord message](https://discord.com/channels/135877399391764480/836220422223036467/1241774692965286058)