### PR TITLE
Particle Compatibility Improvements

### DIFF
--- a/src/main/java/ch/njol/skript/util/visual/VisualEffect.java
+++ b/src/main/java/ch/njol/skript/util/visual/VisualEffect.java
@@ -20,11 +20,14 @@
 package ch.njol.skript.util.visual;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.aliases.Aliases;
+import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.SyntaxElement;
 import ch.njol.util.Kleenean;
 import ch.njol.yggdrasil.YggdrasilSerializable;
+import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Particle;
@@ -45,6 +48,9 @@ public class VisualEffect implements SyntaxElement, YggdrasilSerializable {
 	private float speed = 0f;
 	private float dX, dY, dZ = 0f;
 
+	private static final ItemType barrier = Aliases.javaItemType("barrier");
+	private static final ItemType light = Aliases.javaItemType("light");
+
 	public VisualEffect() {}
 	
 	@SuppressWarnings({"null", "ConstantConditions"})
@@ -54,6 +60,10 @@ public class VisualEffect implements SyntaxElement, YggdrasilSerializable {
 
 		if (exprs.length > 4 && exprs[0] != null) {
 			data = exprs[0].getSingle(null);
+		} else if (parseResult.hasTag("barrierbm")) { // barrier backcompat
+			data = Bukkit.createBlockData(barrier.getMaterial());
+		} else if (parseResult.hasTag("lightbm")) { // light backcompat
+			data = Bukkit.createBlockData(light.getMaterial());
 		}
 
 		if ((parseResult.mark & 1) != 0) {

--- a/src/main/java/ch/njol/skript/util/visual/VisualEffect.java
+++ b/src/main/java/ch/njol/skript/util/visual/VisualEffect.java
@@ -25,6 +25,7 @@ import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.SyntaxElement;
+import ch.njol.skript.lang.util.ContextlessEvent;
 import ch.njol.util.Kleenean;
 import ch.njol.yggdrasil.YggdrasilSerializable;
 import org.bukkit.Bukkit;
@@ -59,7 +60,17 @@ public class VisualEffect implements SyntaxElement, YggdrasilSerializable {
 		type = VisualEffects.get(matchedPattern);
 
 		if (exprs.length > 4 && exprs[0] != null) {
-			data = exprs[0].getSingle(null);
+			int exprCount = exprs.length - 4; // some effects might have multiple expressions
+			ContextlessEvent event = ContextlessEvent.get();
+			if (exprCount == 1) {
+				data = exprs[0].getSingle(event);
+			} else { // provide an array of expression values
+				Object[] dataArray = new Object[exprCount];
+				for (int i = 0; i < exprCount; i++) {
+					dataArray[i] = exprs[i].getSingle(event);
+				}
+				data = dataArray;
+			}
 		} else if (parseResult.hasTag("barrierbm")) { // barrier backcompat
 			data = Bukkit.createBlockData(barrier.getMaterial());
 		} else if (parseResult.hasTag("lightbm")) { // light backcompat

--- a/src/main/java/ch/njol/skript/util/visual/VisualEffect.java
+++ b/src/main/java/ch/njol/skript/util/visual/VisualEffect.java
@@ -53,7 +53,7 @@ public class VisualEffect implements SyntaxElement, YggdrasilSerializable {
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		type = VisualEffects.get(matchedPattern);
 
-		if (exprs.length > 4 && exprs[0] != null) {
+		if (exprs.length > 4) {
 			int exprCount = exprs.length - 4; // some effects might have multiple expressions
 			ContextlessEvent event = ContextlessEvent.get();
 			if (exprCount == 1) {
@@ -64,7 +64,9 @@ public class VisualEffect implements SyntaxElement, YggdrasilSerializable {
 					dataArray[i] = exprs[i] != null ? exprs[i].getSingle(event) : null;
 				data = dataArray;
 			}
-		} else if (parseResult.hasTag("barrierbm")) { // barrier backcompat
+		}
+
+		if (parseResult.hasTag("barrierbm")) { // barrier backcompat
 			data = Bukkit.createBlockData(Material.BARRIER);
 		} else if (parseResult.hasTag("lightbm")) { // light backcompat
 			data = Bukkit.createBlockData(Material.LIGHT);

--- a/src/main/java/ch/njol/skript/util/visual/VisualEffect.java
+++ b/src/main/java/ch/njol/skript/util/visual/VisualEffect.java
@@ -66,9 +66,9 @@ public class VisualEffect implements SyntaxElement, YggdrasilSerializable {
 			}
 		}
 
-		if (parseResult.hasTag("barrierbm")) { // barrier backcompat
+		if (parseResult.hasTag("barrierbm")) { // barrier compatibility
 			data = Bukkit.createBlockData(Material.BARRIER);
-		} else if (parseResult.hasTag("lightbm")) { // light backcompat
+		} else if (parseResult.hasTag("lightbm")) { // light compatibility
 			data = Bukkit.createBlockData(Material.LIGHT);
 		}
 

--- a/src/main/java/ch/njol/skript/util/visual/VisualEffects.java
+++ b/src/main/java/ch/njol/skript/util/visual/VisualEffects.java
@@ -225,6 +225,12 @@ public class VisualEffects {
 			registerDataSupplier("Particle.BLOCK_DUST", crackDustBiFunction);
 			registerDataSupplier("Particle.FALLING_DUST", crackDustBiFunction);
 
+			registerDataSupplier("Particle.BLOCK_MARKER", (raw, location) -> {
+				if (raw == null)
+					return Bukkit.createBlockData(Material.AIR);
+				return raw;
+			});
+
 			generateTypes();
 		});
 	}

--- a/src/main/java/ch/njol/skript/util/visual/VisualEffects.java
+++ b/src/main/java/ch/njol/skript/util/visual/VisualEffects.java
@@ -239,26 +239,32 @@ public class VisualEffects {
 				return delay;
 			});
 
-			registerDataSupplier("Particle.VIBRATION", (raw, location) -> {
-				Object[] data = (Object[]) raw;
-				int arrivalTime = -1;
-				if (data[1] != null)
-					arrivalTime = (int) Math.min(Math.max(((Timespan) data[1]).getTicks(), 0), Integer.MAX_VALUE);
-				if (data[0] instanceof Entity) {
-					Entity entity = (Entity) data[0];
-					if (arrivalTime == -1)
-						arrivalTime = (int) (location.distance(entity.getLocation()) / 20);
-					return new Vibration(new Vibration.Destination.EntityDestination(entity), arrivalTime);
-				}
-				// assume it's a location
-				Location destination = data[0] != null ? (Location) data[0] : location;
-				if (arrivalTime == -1)
-					arrivalTime = (int) (location.distance(destination) / 20);
-				return new Vibration(new Vibration.Destination.BlockDestination(destination), arrivalTime);
-			});
+			registerDataSupplier("Particle.VIBRATION", (raw, location) -> VibrationUtils.buildVibration((Object[]) raw, location));
 
 			generateTypes();
 		});
+	}
+
+	// exists to avoid NoClassDefFoundError from Vibration
+	private static final class VibrationUtils {
+		private static Vibration buildVibration(Object[] data, Location location) {
+			int arrivalTime = -1;
+			if (data[1] != null)
+				arrivalTime = (int) Math.min(Math.max(((Timespan) data[1]).getTicks(), 0), Integer.MAX_VALUE);
+			if (data[0] instanceof Entity) {
+				Entity entity = (Entity) data[0];
+				if (arrivalTime == -1)
+					arrivalTime = (int) (location.distance(entity.getLocation()) / 20);
+				//noinspection removal - new constructor only exists on newer versions
+				return new Vibration(location, new Vibration.Destination.EntityDestination(entity), arrivalTime);
+			}
+			// assume it's a location
+			Location destination = data[0] != null ? (Location) data[0] : location;
+			if (arrivalTime == -1)
+				arrivalTime = (int) (location.distance(destination) / 20);
+			//noinspection removal - new constructor only exists on newer versions
+			return new Vibration(location, new Vibration.Destination.BlockDestination(destination), arrivalTime);
+		}
 	}
 
 }

--- a/src/main/java/ch/njol/skript/util/visual/VisualEffects.java
+++ b/src/main/java/ch/njol/skript/util/visual/VisualEffects.java
@@ -149,7 +149,7 @@ public class VisualEffects {
 			// Colorables
 			registerColorable("Particle.SPELL_MOB");
 			registerColorable("Particle.SPELL_MOB_AMBIENT");
-			registerColorable("Particle.REDSTONE");
+			registerColorable(OLD_REDSTONE_PARTICLE != null ? "Particle.REDSTONE" : "Particle.DUST");
 			registerColorable("Particle.NOTE");
 
 			// Data suppliers
@@ -170,7 +170,7 @@ public class VisualEffects {
 				Color color = raw == null ? defaultColor : (Color) raw;
 				return new ParticleOption(color, 1);
 			});
-			registerDataSupplier("Particle.REDSTONE", (raw, location) -> {
+			registerDataSupplier(OLD_REDSTONE_PARTICLE != null ? "Particle.REDSTONE" : "Particle.DUST", (raw, location) -> {
 				Color color = raw == null ? defaultColor : (Color) raw;
 				ParticleOption particleOption = new ParticleOption(color, 1);
 
@@ -185,7 +185,7 @@ public class VisualEffects {
 				ColorRGB color = new ColorRGB(colorValue, 0, 0);
 				return new ParticleOption(color, 1);
 			});
-			registerDataSupplier("Particle.ITEM_CRACK", (raw, location) -> {
+			registerDataSupplier(OLD_ITEM_CRACK_PARTICLE != null ? "Particle.ITEM_CRACK" : "Particle.ITEM", (raw, location) -> {
 				ItemStack itemStack = Aliases.javaItemType("iron sword").getRandom();
 				if (raw instanceof ItemType) {
 					ItemStack rand = ((ItemType) raw).getRandom();
@@ -196,7 +196,7 @@ public class VisualEffects {
 				}
 
 				assert itemStack != null;
-				if (OLD_ITEM_CRACK_PARTICLE == null || OLD_ITEM_CRACK_PARTICLE.getDataType() == Material.class)
+				if (OLD_ITEM_CRACK_PARTICLE != null && OLD_ITEM_CRACK_PARTICLE.getDataType() == Material.class)
 					return itemStack.getType();
 				return itemStack;
 			});

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -1397,15 +1397,6 @@ visual effects:
 		iron_golem_rose:
 			name: iron golem offering rose @an
 			pattern: (iron golem [offering] rose|rose in hand)
-		villager_heart:
-			name: villager hearts @x
-			pattern: villager hearts
-		villager_angry:
-			name: angry villager entity @an
-			pattern: angry villager entity
-		villager_happy:
-			name: happy villager entity @a
-			pattern: happy villager entity
 		witch_magic:
 			name: witch magic @-
 			pattern: witch magic
@@ -1458,39 +1449,15 @@ visual effects:
 			name: hurt by explosion @-
 			pattern: (hurt|damage) by explosion
 	particle:
-		fireworks_spark:
-			name: firework's spark @-
-			pattern: firework['s] spark
 		crit:
 			name: critical hit @a
 			pattern: (critical hit|crit) [spark]
-		crit_magic:
-			name: magical critical hit @a
-			pattern: (magic[al]|blue) (critical hit|crit) [spark]
-		spell_mob:
-			name: potion swirl @a
-			pattern: [%-color%] potion swirl
-		spell_mob_ambient:
-			name: transparent potion swirl @a
-			pattern: [%-color%] transparent potion swirl
-		spell:
-			name: spell @a
-			pattern: (spell|thrown potion|lingering potion)
-		spell_instant:
-			name: spell @a
-			pattern: instant (spell|thrown potion)
-		spell_witch:
-			name: witch spell @-
-			pattern: (witch (magic|spell)|purple spark)
 		note:
 			name: note @a
 			pattern: note [(of|with) [colo[u]r] %number%]
 		portal:
 			name: portal @a
 			pattern: [nether] portal
-		enchantment_table:
-			name: flying glyph @a
-			pattern: (flying (glyph|letter)|enchantment table)
 		flame:
 			name: flame @-
 			pattern: (flame|fire)
@@ -1500,69 +1467,12 @@ visual effects:
 		footstep:
 			name: footstep @x
 			pattern: footsteps
-		water_splash:
-			name: water splash @a
-			pattern: [water] splash
-		smoke_normal:
-			name: smoke particle @a
-			pattern: smoke particle
-		explosion_huge:
-			name: huge explosion @a
-			pattern: huge explosion
-		explosion_large:
-			name: large explosion @a
-			pattern: large explosion
-		explosion_normal:
-			name: explosion @an
-			pattern: explosion
-		suspended_depth:
-			name: void fog @-
-			pattern: void fog
-		town_aura:
-			name: small smoke @-
-			pattern: (small smoke|town aura)
 		cloud:
 			name: cloud @a
 			pattern: cloud
-		redstone:
-			name: coloured dust @-
-			pattern: [%-color%] [colo[u]red] dust
-		snowball:
-			name: snowball break @a
-			pattern: snowball break
-		drip_water:
-			name: water drip @a
-			pattern: water drip
-		drip_lava:
-			name: lava drip @a
-			pattern: lava drip
-		snow_shovel:
-			name: snow shovel @-
-			pattern: (snow shovel|snow(man| golem) spawn)
-		slime:
-			name: slime @-
-			pattern: slime
 		heart:
 			name: heart @a
 			pattern: heart
-		villager_angry:
-			name: angry villager @a
-			pattern: (angry villager|[villager] thundercloud)
-		villager_happy:
-			name: happy villager @-
-			pattern: (happy villager|green spark)
-		smoke_large:
-			name: large smoke @-
-			pattern: large smoke
-		item_crack:
-			name: item crack @-
-			pattern: %itemtype% item (break|crack)[ing]
-		block_crack:
-			name: block break @-
-			pattern: %itemtype% break[ing]
-		block_dust:
-			name: block dust @-
-			pattern: [sprinting] dust of [%itemtype%]
 		end_rod:
 			name: end rod @-
 			pattern: end rod
@@ -1571,9 +1481,6 @@ visual effects:
 			pattern: falling dust of [%itemtype%]
 
 		# 1.11 particles
-		totem:
-			name: totem @-
-			pattern: totem
 		spit:
 			name: spit @-
 			pattern: spit
@@ -1632,24 +1539,9 @@ visual effects:
 		dragon_breath:
 			name: dragon breath @-
 			pattern: dragon[s] breath
-		mob_appearance:
-			name: mob appearance @-
-			pattern: (mob appearance|guardian ghost)
-		suspended:
-			name: suspended @-
-			pattern: (suspended|underwater)
 		sweep_attack:
 			name: sweep attack @-
 			pattern: sweep attack
-		water_bubble:
-			name: water bubble @-
-			pattern: water bubble
-		water_wake:
-			name: water wake @-
-			pattern: water wake
-		water_drop:
-			name: water drop @-
-			pattern: water drop
 
 		# 1.15 particles
 		dripping_honey:
@@ -1765,7 +1657,7 @@ visual effects:
 		shriek:
 			name: shriek @-
 			pattern: shriek
-		
+
 		# 1.19.4 particles
 		dripping_cherry_leaves:
 			name: dripping cherry leaves @-
@@ -1776,6 +1668,232 @@ visual effects:
 		landing_cherry_leaves:
 			name: landing cherry leaves @-
 			pattern: landing cherry leaves
+		cherry_leaves: # previously dripping_cherry_leaves/falling_cherry_leaves/landing_cherry_leaves, changed in 1.20
+			name: cherry leaves @-
+			pattern: (dripping|falling|landing) cherry leaves
+
+		# 1.20.5 particle changes
+		# many particles were removed and replaced with their modern names
+
+		smoke_normal:
+			name: smoke particle @a
+			pattern: smoke particle
+		smoke: # previously smoke_normal, changed in 1.20.5
+			name: smoke particle @a
+			pattern: smoke particle
+
+		smoke_large:
+			name: large smoke @-
+			pattern: large smoke
+		large_smoke: # previous smoke_large, changed in 1.20.5
+			name: large smoke @-
+			pattern: large smoke
+
+		item_crack:
+			name: item crack @-
+			pattern: %itemtype% item (break|crack)[ing]
+		item: # previously item_crack, changed in 1.20.5
+			name: item crack @-
+			pattern: %itemtype% item (break|crack)[ing]
+
+		block_crack:
+			name: block break @-
+			pattern: %itemtype% break[ing]
+		block_dust:
+			name: block dust @-
+			pattern: [sprinting] dust of [%itemtype%]
+		block: # previously block_crack/block_dust, changed in 1.20.5
+			name: block @-
+			pattern: (%itemtype% break[ing]|[sprinting] dust of [%itemtype%])
+
+		crit_magic:
+			name: magical critical hit @a
+			pattern: (magic[al]|blue) (critical hit|crit) [spark]
+		enchanted_hit: # previously crit_magic, changed in 1.20.5
+			name: magical critical hit @a
+			pattern: (magic[al]|blue) (critical hit|crit) [spark]
+
+		drip_water:
+			name: water drip @a
+			pattern: water drip
+		dripping_water: # previously drip_water, changed in 1.20.5
+			name: water drip @a
+			pattern: water drip
+
+		drip_lava:
+			name: lava drip @a
+			pattern: lava drip
+		dripping_lava: # previously drip_lava, changed in 1.20.5
+			name: lava drip @a
+			pattern: lava drip
+
+		enchantment_table:
+			name: flying glyph @a
+			pattern: (flying (glyph|letter)|enchantment table)
+		enchant: # previously enchantment_table, changed in 1.20.5
+			name: flying glyph @a
+			pattern: (flying (glyph|letter)|enchantment table)
+
+		explosion_normal:
+			name: explosion @an
+			pattern: explosion
+		poof: # previously explosion_normal, changed in 1.20.5
+			name: explosion @an
+			pattern: explosion
+
+		explosion_large:
+			name: large explosion @a
+			pattern: large explosion
+		explosion: # previously explosion_large, changed in 1.20.5
+			name: large explosion @a
+			pattern: large explosion
+
+		explosion_huge:
+			name: huge explosion @a
+			pattern: huge explosion
+		explosion_emitter: # previously explosion_huge, changed in 1.20.5
+			name: huge explosion @a
+			pattern: huge explosion
+
+		fireworks_spark:
+			name: firework's spark @-
+			pattern: firework['s] spark
+		firework: # previously fireworks_spark, changed in 1.20.5
+			name: firework @-
+			pattern: firework['s] spark
+
+		mob_appearance:
+			name: mob appearance @-
+			pattern: (mob appearance|guardian ghost)
+		elder_guardian: # previously mob_appearance, changed in 1.20.5
+			name: elder guardian @-
+			pattern: (mob appearance|guardian ghost)
+
+		redstone:
+			name: coloured dust @-
+			pattern: [%-color%] [colo[u]red] dust
+		dust: # previously redstone, changed in 1.20.5
+			name: coloured dust @-
+			pattern: [%-color%] [colo[u]red] dust
+
+		slime:
+			name: slime @-
+			pattern: slime
+		item_slime: # previously slime, changed in 1.20.5
+			name: slime @-
+			pattern: slime
+
+		snow_shovel:
+			name: snow shovel @-
+			pattern: (snow shovel|snow(man| golem) spawn)
+		item_snowball: # previously snow_shovel, changed in 1.20.5
+			name: snow shovel @-
+			pattern: (snow shovel|snow(man| golem) spawn)
+
+		snowball:
+			name: snowball break @a
+			pattern: snowball break
+		item_snowball: # previously snowball, changed in 1.20.5
+			name: snowball break @a
+			pattern: snowball break
+
+		spell:
+			name: spell @a
+			pattern: (spell|thrown potion|lingering potion)
+		effect: # previously spell, changed in 1.20.6
+			name: effect @a
+			pattern: (spell|thrown potion) # lingering is part of entity_effect
+
+		spell_instant:
+			name: spell @a
+			pattern: instant (spell|thrown potion)
+		effect_instant: # previously spell_instant, changed in 1.20.6
+			name: instant effect @an
+			pattern: instant (spell|thrown potion)
+
+		spell_mob:
+			name: potion swirl @a
+			pattern: [%-color%] potion swirl
+		spell_mob_ambient:
+			name: transparent potion swirl @a
+			pattern: [%-color%] transparent potion swirl
+		# TODO ambient_entity_effect seems to exist, but is not supported by spigot particle enum?
+		entity_effect: # previously spell_mob/spell_mob_ambient, changed in 1.20.5
+			name: entity effect @an
+			pattern: (lingering potion|[%-color%] [transparent] potion swirl)
+
+		spell_witch:
+			name: witch spell @-
+			pattern: (witch (magic|spell)|purple spark)
+		witch: # previously spell_witch, changed in 1.20.5
+			name: witch spell @-
+			pattern: (witch (magic|spell)|purple spark)
+
+		suspended:
+			name: suspended @-
+			pattern: (suspended|underwater)
+		suspended_depth:
+			name: void fog @-
+			pattern: void fog
+		underwater: # previously suspended/suspended_depth, changed in 1.20.5
+			name: underwater @-
+			pattern: (suspended|underwater|void fog)
+
+		totem:
+			name: totem @-
+			pattern: totem
+		totem_of_undying: # previously totem, changed in 1.20.5
+			name: totem @-
+			pattern: totem
+
+		town_aura:
+			name: small smoke @-
+			pattern: (small smoke|town aura)
+		mycelium: # previously town_aura, changed in 1.20.5
+			name: small smoke @-
+			pattern: (small smoke|town aura)
+
+		villager_angry:
+			name: angry villager @a
+			pattern: (angry villager|[villager] thundercloud)
+		angry_villager: # previously villager_angry, changed in 1.20.5
+			name: angry villager @a
+			pattern: (angry villager|[villager] thundercloud)
+
+		villager_happy:
+			name: happy villager @-
+			pattern: (happy villager|green spark)
+		happy_villager: # previously villager_happy, changed in 1.20.5
+			name: happy villager @-
+			pattern: (happy villager|green spark)
+
+		water_splash:
+			name: water splash @a
+			pattern: [water] splash
+		splash: # previously water_splash, changed in 1.20.5
+			name: water splash @a
+			pattern: [water] splash
+
+		water_bubble:
+			name: water bubble @-
+			pattern: water bubble
+		bubble: # previously water_bubble, changed in 1.20.5
+			name: water bubble @-
+			pattern: water bubble
+
+		water_wake:
+			name: water wake @-
+			pattern: water wake
+		fishing:
+			name: water wake @-
+			pattern: water wake
+
+		water_drop:
+			name: water drop @-
+			pattern: water drop
+		rain: # previously water_drop, changed in 1.20.5
+			name: water drop @-
+			pattern: water drop
 
 # -- Inventory Actions --
 inventory actions:

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -1449,451 +1449,549 @@ visual effects:
 			name: hurt by explosion @-
 			pattern: (hurt|damage) by explosion
 	particle:
-		crit:
-			name: critical hit @a
-			pattern: (critical hit|crit) [spark]
-		note:
-			name: note @a
-			pattern: note [(of|with) [colo[u]r] %number%]
-		portal:
-			name: portal @a
-			pattern: [nether] portal
-		flame:
-			name: flame @-
-			pattern: (flame|fire)
-		lava:
-			name: lava pop @a
-			pattern: lava pop
-		footstep:
-			name: footstep @x
-			pattern: footsteps
+
+		angry_villager: # added in 1.20.5
+			name: angry villager @a
+			pattern: (angry villager|[villager] thundercloud)
+		villager_angry: # for versions below 1.20.5
+			name: angry villager @a
+			pattern: (angry villager|[villager] thundercloud)
+
+		ash: # added in 1.16
+			name: ash @-
+			pattern: ash
+
+		block: # added in 1.20.5
+			name: block @-
+			pattern: (%-itemtype% break[ing]|[sprinting] dust of %-itemtype%)
+		block_crack: # for versions below 1.20.5
+			name: block break @-
+			pattern: %itemtype% break[ing]
+		block_dust: # for versions below 1.20.5
+			name: block dust @-
+			pattern: [sprinting] dust of %itemtype%
+
+		block_marker: # added in 1.18 TODO barrier/light backcompat support?
+			name: block marker @a
+			pattern: %itemtype% block marker
+		barrier: # added in 1.18 TODO remove when 1.17 and below support is dropped
+			name: barrier @a
+			pattern: barrier
+		light: # added in 1.17 TODO remove when 1.17 and below support is dropped (and only existed for 1 version)
+			name: light @-
+			pattern: light
+
+		bubble: # added in 1.20.5
+			name: bubble @-
+			pattern: [water] bubble
+		water_bubble: # for versions below 1.20.5
+			name: water bubble @-
+			pattern: [water] bubble
+
+		bubble_column_up: # added in 1.13
+			name: bubble column up @-
+			pattern: (current|bubble column) up
+
+		bubble_pop: # added in 1.13
+			name: bubble pop @-
+			pattern: bubble pop
+
+		campfire_cosy_smoke: # added in 1.14
+			name: campfire cosy smoke @-
+			pattern: campfire co(s|z)y smoke
+
+		campfire_signal_smoke: # added in 1.14
+			name: campfire signal smoke @-
+			pattern: campfire signal smoke
+
+		cherry_leaves: # added in 1.20
+			name: cherry leaves @-
+			pattern: cherry leaves
+
 		cloud:
 			name: cloud @a
 			pattern: cloud
-		heart:
-			name: heart @a
-			pattern: heart
-		end_rod:
-			name: end rod @-
-			pattern: end rod
-		falling_dust:
-			name: falling dust @-
-			pattern: falling dust of [%itemtype%]
 
-		# 1.11 particles
-		spit:
-			name: spit @-
-			pattern: spit
+		composter: # added in 1.14
+			name: composter @-
+			pattern: composter [particle]
 
-		# 1.13 particles
-		squid_ink:
-			name: squid ink @-
-			pattern: squid ink
-		bubble_pop:
-			name: bubble pop @-
-			pattern: bubble pop
-		current_down:
+		crimson_spore: # added in 1.16
+			name: crimson spore @-
+			pattern: crimson spore
+
+		crit:
+			name: critical hit @a
+			pattern: (critical hit|crit) [spark]
+
+		current_down: # added in 1.13
 			name: current down @-
 			pattern: (current|bubble column) down
-		bubble_column_up:
-			name: bubble column up @-
-			pattern: (current|bubble column) up
-		nautilus:
-			name: nautilus @-
-			pattern: nautilus
-		dolphin:
+
+		damage_indicator: # added in 1.14
+			name: damage indicator @-
+			pattern: damage indicator
+
+		dolphin: # added in 1.13
 			name: dolphin @-
 			pattern: dolphin
 
-		# 1.14 particles
-		sneeze:
-			name: sneeze @-
-			pattern: sneeze
-		campfire_cosy_smoke:
-			name: campfire cosy smoke @-
-			pattern: campfire co(s|z)y smoke
-		campfire_signal_smoke:
-			name: campfire signal smoke @-
-			pattern: campfire signal smoke
-		composter:
-			name: composter @-
-			pattern: composter particle
-		flash:
-			name: flash @-
-			pattern: flash
-		falling_lava:
-			name: falling lava @-
-			pattern: falling lava
-		landing_lava:
-			name: landing lava @-
-			pattern: landing lava
-		falling_water:
-			name: falling water @-
-			pattern: falling water
-		barrier:
-			name: barrier @a
-			pattern: barrier
-		damage_indicator:
-			name: damage indicator @-
-			pattern: damage indicator
-		dragon_breath:
+		dragon_breath: # added in 1.14
 			name: dragon breath @-
-			pattern: dragon[s] breath
-		sweep_attack:
-			name: sweep attack @-
-			pattern: sweep attack
+			pattern: dragon[[']s] breath
 
-		# 1.15 particles
-		dripping_honey:
-			name: dripping honey @-
-			pattern: dripping honey
-		falling_honey:
-			name: falling honey @-
-			pattern: falling honey
-		landing_honey:
-			name: landing honey @-
-			pattern: landing honey
-		falling_nectar:
-			name: falling nectar @-
-			pattern: falling nectar
-
-		# 1.16 particles
-		ash:
-			name: ash @-
-			pattern: ash
-		crimson_spore:
-			name: crimson spore @-
-			pattern: crimson spore
-		soul_fire_flame:
-			name: soul fire flame @-
-			pattern: soul fire flame
-		warped_spore:
-			name: warped spore @-
-			pattern: warped spore
-		dripping_obsidian_tear:
-			name: dripping obsidian tear @-
-			pattern: dripping obsidian tear
-		falling_obsidian_tear:
-			name: falling obsidian tear @-
-			pattern: falling obsidian tear
-		landing_obsidian_tear:
-			name: landing obsidian tear @-
-			pattern: landing obsidian tear
-		soul:
-			name: soul @-
-			pattern: soul
-		reverse_portal:
-			name: reverse portal @-
-			pattern: reverse portal
-		white_ash:
-			name: white ash @-
-			pattern: white ash
-		# 1.17 particles
-		light:
-			name: light @-
-			pattern: light
-		#dust_color_transition:
-			#name: dust color transition @a
-			#pattern: dust colo[u]r transition [from %-color%] [to %-color%] [with size %-number%]
-		#vibration:
-			#name: vibration @a
-			#pattern: vibration
-		falling_spore_blossom:
-			name: falling spore blossom @-
-			pattern: falling spore blossom
-		spore_blossom_air:
-			name: spore blossom air @-
-			pattern: spore blossom air
-		small_flame:
-			name: small flame @-
-			pattern: small flame
-		snowflake:
-			name: snowflake @-
-			pattern: snowflake
-		dripping_dripstone_lava:
+		dripping_dripstone_lava: # added in 1.17
 			name: dripping dripstone lava @-
 			pattern: dripping dripstone lava
-		falling_dripstone_lava:
-			name: falling dripstone lava @-
-			pattern: falling dripstone lava
-		dripping_dripstone_water:
+
+		dripping_dripstone_water: # added in 1.17
 			name: dripping dripstone water @-
 			pattern: dripping dripstone water
-		falling_dripstone_water:
-			name: falling dripstone water @-
-			pattern: falling dripstone water
-		glow_squid_ink:
-			name: glow squid ink @-
-			pattern: glow squid ink
-		glow:
-			name: glow @-
-			pattern: glow
-		wax_on:
-			name: wax on @-
-			pattern: wax on
-		wax_off:
-			name: wax off @-
-			pattern: wax off
+
+		dripping_honey: # added in 1.15
+			name: dripping honey @-
+			pattern: dripping honey
+
+		dripping_lava: # added in 1.20.5
+			name: dripping lava @a
+			pattern: (dripping lava|lava drip)
+		drip_lava: # for versions below 1.20.5
+			name: lava drip @a
+			pattern: (dripping lava|lava drip)
+
+		dripping_obsidian_tear: # added in 1.16
+			name: dripping obsidian tear @-
+			pattern: dripping obsidian tear
+
+		dripping_water: # added in 1.20.5
+			name: dripping water
+			pattern: (dripping water|water drip)
+		drip_water: # for versions below 1.20.5
+			name: water drip @a
+			pattern: (dripping water|water drip)
+
+		dust: # added in 1.20.5
+			name: dust @-
+			pattern: [%-color%] [colo[u]red] dust
+		redstone: # for versions below 1.20.5
+			name: coloured dust @-
+			pattern: [%-color%] [colo[u]red] dust
+
+		dust_color_transition: # added in 1.17 TODO this was disabled?
+			name: dust color transition @a
+			pattern: dust colo[u]r transition [from %-color%] [to %-color%] [with size %-number%]
+
+		dust_pillar: # added in 1.20.5 (for 1.21)
+			name: dust pillar @a
+			pattern: dust pillar # TODO has BlockData DataType
+
+		dust_plume: # added in 1.20.3
+			name: dust plume @a
+			pattern: dust plume
+
+		effect: # added in 1.20.5
+			name: effect @an
+			pattern: (effect|spell|thrown potion) # lingering is part of entity_effect
+		spell: # for versions below 1.20.5
+			name: spell @a
+			pattern: (effect|spell|thrown potion|lingering potion)
+
+		egg_crack:
+			name: egg crack @an
+			pattern: egg crack
+
+		elder_guardian: # added in 1.20.5
+			name: elder guardian @-
+			pattern: (elder guardian|mob appearance|guardian ghost)
+		mob_appearance: # for versions below 1.20.5
+			name: mob appearance @-
+			pattern: (elder guardian|mob appearance|guardian ghost)
+
 		electric_spark:
 			name: electric spark @-
 			pattern: electric spark
-		scrape:
-			name: scrape @-
-			pattern: scrape
 
-		# 1.19 particles
-		sonic_boom:
-			name: sonic boom @-
-			pattern: sonic boom
-		sculk_soul:
-			name: sculk soul @-
-			pattern: sculk soul
-		sculk_charge:
-			name: sculk charge @-
-			pattern: sculk charge
-		sculk_charge_pop:
-			name: sculk charge pop @-
-			pattern: sculk charge pop
-		shriek:
-			name: shriek @-
-			pattern: shriek
-
-		# 1.19.4 particles
-		dripping_cherry_leaves:
-			name: dripping cherry leaves @-
-			pattern: dripping cherry leaves
-		falling_cherry_leaves:
-			name: falling cherry leaves @-
-			pattern: falling cherry leaves
-		landing_cherry_leaves:
-			name: landing cherry leaves @-
-			pattern: landing cherry leaves
-		cherry_leaves: # previously dripping_cherry_leaves/falling_cherry_leaves/landing_cherry_leaves, changed in 1.20
-			name: cherry leaves @-
-			pattern: (dripping|falling|landing) cherry leaves
-
-		# 1.20.5 particle changes
-		# many particles were removed and replaced with their modern names
-
-		smoke_normal:
-			name: smoke particle @a
-			pattern: smoke particle
-		smoke: # previously smoke_normal, changed in 1.20.5
-			name: smoke particle @a
-			pattern: smoke particle
-
-		smoke_large:
-			name: large smoke @-
-			pattern: large smoke
-		large_smoke: # previous smoke_large, changed in 1.20.5
-			name: large smoke @-
-			pattern: large smoke
-
-		item_crack:
-			name: item crack @-
-			pattern: %itemtype% item (break|crack)[ing]
-		item: # previously item_crack, changed in 1.20.5
-			name: item crack @-
-			pattern: %itemtype% item (break|crack)[ing]
-
-		block_crack:
-			name: block break @-
-			pattern: %itemtype% break[ing]
-		block_dust:
-			name: block dust @-
-			pattern: [sprinting] dust of [%itemtype%]
-		block: # previously block_crack/block_dust, changed in 1.20.5
-			name: block @-
-			pattern: (%itemtype% break[ing]|[sprinting] dust of [%itemtype%])
-
-		crit_magic:
-			name: magical critical hit @a
-			pattern: (magic[al]|blue) (critical hit|crit) [spark]
-		enchanted_hit: # previously crit_magic, changed in 1.20.5
-			name: magical critical hit @a
-			pattern: (magic[al]|blue) (critical hit|crit) [spark]
-
-		drip_water:
-			name: water drip @a
-			pattern: water drip
-		dripping_water: # previously drip_water, changed in 1.20.5
-			name: water drip @a
-			pattern: water drip
-
-		drip_lava:
-			name: lava drip @a
-			pattern: lava drip
-		dripping_lava: # previously drip_lava, changed in 1.20.5
-			name: lava drip @a
-			pattern: lava drip
-
-		enchantment_table:
+		enchant: # added in 1.20.5
+			name: enchant
+			pattern: (enchant|flying (glyph|letter)|enchantment table)
+		enchantment_table: # for versions below 1.20.5
 			name: flying glyph @a
-			pattern: (flying (glyph|letter)|enchantment table)
-		enchant: # previously enchantment_table, changed in 1.20.5
-			name: flying glyph @a
-			pattern: (flying (glyph|letter)|enchantment table)
+			pattern: (enchant|flying (glyph|letter)|enchantment table)
 
-		explosion_normal:
-			name: explosion @an
-			pattern: explosion
-		poof: # previously explosion_normal, changed in 1.20.5
-			name: explosion @an
-			pattern: explosion
+		enchanted_hit: # added in 1.20.5
+			name: enchanted hit @an
+			pattern: (enchanted hit|(magic[al]|blue) (critical hit|crit) [spark])
+		crit_magic: # for versions below 1.20.5
+			name: magical critical hit @a
+			pattern: (enchanted hit|(magic[al]|blue) (critical hit|crit) [spark])
 
-		explosion_large:
-			name: large explosion @a
-			pattern: large explosion
-		explosion: # previously explosion_large, changed in 1.20.5
-			name: large explosion @a
-			pattern: large explosion
+		end_rod:
+			name: end rod @-
+			pattern: end rod
 
-		explosion_huge:
-			name: huge explosion @a
-			pattern: huge explosion
-		explosion_emitter: # previously explosion_huge, changed in 1.20.5
-			name: huge explosion @a
-			pattern: huge explosion
-
-		fireworks_spark:
-			name: firework's spark @-
-			pattern: firework['s] spark
-		firework: # previously fireworks_spark, changed in 1.20.5
-			name: firework @-
-			pattern: firework['s] spark
-
-		mob_appearance:
-			name: mob appearance @-
-			pattern: (mob appearance|guardian ghost)
-		elder_guardian: # previously mob_appearance, changed in 1.20.5
-			name: elder guardian @-
-			pattern: (mob appearance|guardian ghost)
-
-		redstone:
-			name: coloured dust @-
-			pattern: [%-color%] [colo[u]red] dust
-		dust: # previously redstone, changed in 1.20.5
-			name: coloured dust @-
-			pattern: [%-color%] [colo[u]red] dust
-
-		slime:
-			name: slime @-
-			pattern: slime
-		item_slime: # previously slime, changed in 1.20.5
-			name: slime @-
-			pattern: slime
-
-		snow_shovel:
-			name: snow shovel @-
-			pattern: (snow shovel|snow(man| golem) spawn)
-		item_snowball: # previously snow_shovel, changed in 1.20.5
-			name: snow shovel @-
-			pattern: (snow shovel|snow(man| golem) spawn)
-
-		snowball:
-			name: snowball break @a
-			pattern: snowball break
-		item_snowball: # previously snowball, changed in 1.20.5
-			name: snowball break @a
-			pattern: snowball break
-
-		spell:
-			name: spell @a
-			pattern: (spell|thrown potion|lingering potion)
-		effect: # previously spell, changed in 1.20.6
-			name: effect @a
-			pattern: (spell|thrown potion) # lingering is part of entity_effect
-
-		spell_instant:
-			name: spell @a
-			pattern: instant (spell|thrown potion)
-		effect_instant: # previously spell_instant, changed in 1.20.6
-			name: instant effect @an
-			pattern: instant (spell|thrown potion)
-
-		spell_mob:
-			name: potion swirl @a
-			pattern: [%-color%] potion swirl
-		spell_mob_ambient:
-			name: transparent potion swirl @a
-			pattern: [%-color%] transparent potion swirl
-		# TODO ambient_entity_effect seems to exist, but is not supported by spigot particle enum?
-		entity_effect: # previously spell_mob/spell_mob_ambient, changed in 1.20.5
+		entity_effect: # added in 1.20.5
 			name: entity effect @an
 			pattern: (lingering potion|[%-color%] [transparent] potion swirl)
+		# TODO ambient_entity_effect seems to exist, but is not supported by spigot particle enum?
+		spell_mob: # for versions below 1.20.5
+			name: potion swirl @a
+			pattern: [%-color%] potion swirl
+		spell_mob_ambient: # for versions below 1.20.5
+			name: transparent potion swirl @a
+			pattern: [%-color%] transparent potion swirl
 
-		spell_witch:
-			name: witch spell @-
-			pattern: (witch (magic|spell)|purple spark)
-		witch: # previously spell_witch, changed in 1.20.5
-			name: witch spell @-
-			pattern: (witch (magic|spell)|purple spark)
+		# TODO explosions are a mess (see explosion_normal, explosion_large, explosion_huge)
+		explosion: # added in 1.20.5
+			name: large explosion @a
+			pattern: large explosion
+		explosion_large: # for versions below 1.20.5
+			name: large explosion @a
+			pattern: large explosion
 
-		suspended:
-			name: suspended @-
-			pattern: (suspended|underwater)
-		suspended_depth:
-			name: void fog @-
-			pattern: void fog
-		underwater: # previously suspended/suspended_depth, changed in 1.20.5
-			name: underwater @-
-			pattern: (suspended|underwater|void fog)
+		explosion_emitter: # added in 1.20.5
+			name: explosion emitter @an
+			pattern: (explosion emitter|huge explosion)
+		explosion_huge: # for versions below 1.20.5
+			name: huge explosion @a
+			pattern: (explosion emitter|huge explosion)
 
-		totem:
-			name: totem @-
-			pattern: totem
-		totem_of_undying: # previously totem, changed in 1.20.5
-			name: totem @-
-			pattern: totem
+		falling_dripstone_lava: # added in 1.17
+			name: falling dripstone lava @-
+			pattern: falling dripstone lava
 
-		town_aura:
-			name: small smoke @-
-			pattern: (small smoke|town aura)
-		mycelium: # previously town_aura, changed in 1.20.5
-			name: small smoke @-
-			pattern: (small smoke|town aura)
+		falling_dripstone_water: # added in 1.17
+			name: falling dripstone water @-
+			pattern: falling dripstone water
 
-		villager_angry:
-			name: angry villager @a
-			pattern: (angry villager|[villager] thundercloud)
-		angry_villager: # previously villager_angry, changed in 1.20.5
-			name: angry villager @a
-			pattern: (angry villager|[villager] thundercloud)
+		falling_dust:
+			name: falling dust @-
+			pattern: falling dust of %itemtype%
 
+		falling_honey: # added in 1.15
+			name: falling honey @-
+			pattern: falling honey
+
+		falling_lava: # added in 1.14
+			name: falling lava @-
+			pattern: falling lava
+
+		falling_nectar: # added in 1.15
+			name: falling nectar @-
+			pattern: falling nectar
+
+		falling_obsidian_tear: # added in 1.16
+			name: falling obsidian tear @-
+			pattern: falling obsidian tear
+
+		falling_spore_blossom: # added in 1.17
+			name: falling spore blossom @-
+			pattern: falling spore blossom
+
+		falling_water: # added in 1.14
+			name: falling water @-
+			pattern: falling water
+
+		firework: # added in 1.20.5
+			name: firework @-
+			pattern: (firework|firework['s] spark)
+		fireworks_spark: # for versions below 1.20.5
+			name: firework's spark @-
+			pattern: (firework|firework['s] spark)
+
+		fishing: # added in 1.20.5
+			name: water wake @-
+			pattern: (fishing|water wake)
+		water_wake: # for versions below 1.20.5
+			name: water wake @-
+			pattern: (fishing|water wake)
+
+		flame:
+			name: flame @-
+			pattern: (flame|fire)
+
+		flash: # added in 1.14
+			name: flash @-
+			pattern: flash
+
+		glow: # added in 1.17
+			name: glow @-
+			pattern: glow
+
+		glow_squid_ink: # added in 1.17
+			name: glow squid ink @-
+			pattern: glow squid ink
+
+		gust: # added in 1.20.5 (for 1.21)
+			name: gust @a
+			pattern: gust
+
+		gust_emitter_large: # added in 1.20.5 (for 1.21)
+			name: large gust emitter @a
+			pattern: large gust emitter
+
+		gust_emitter_small: # added in 1.20.5 (for 1.21)
+			name: small gust emitter @a
+			pattern: small gust emitter
+
+		happy_villager: # added in 1.20.5
+			name: happy villager @-
+			pattern: (happy villager|green spark)
 		villager_happy:
 			name: happy villager @-
 			pattern: (happy villager|green spark)
-		happy_villager: # previously villager_happy, changed in 1.20.5
-			name: happy villager @-
-			pattern: (happy villager|green spark)
 
-		water_splash:
+		heart:
+			name: heart @a
+			pattern: heart
+
+		infested: # added in 1.20.5 (for 1.21)
+			name: infested @-
+			pattern: infested
+
+		instant_effect: # added in 1.20.5
+			name: instant effect @an
+			pattern: instant (effect|spell|thrown potion)
+		spell_instant: # for versions below 1.20.5
+			name: spell @a
+			pattern: instant (effect|spell|thrown potion)
+
+		item: # added in 1.20.5
+			name: item crack @-
+			pattern: %itemtype% item (break|crack)[ing]
+		item_crack: # for versions below 1.20.5
+			name: item crack @-
+			pattern: %itemtype% item (break|crack)[ing]
+
+		item_cobweb: # added in 1.20.5 (for 1.21)
+			name: cobweb @-
+			pattern: cobweb
+
+		item_slime: # added in 1.20.5
+			name: slime @-
+			pattern: slime
+		slime: # for versions below 1.20.5
+			name: slime @-
+			pattern: slime
+
+		item_snowball: # added in 1.20.5
+			name: snowball @-
+			pattern: (snowball [break]|snow shovel|snow(man| golem) spawn)
+		snowball: # for versions below 1.20.5
+			name: snowball break @-
+			pattern: snowball break
+		snow_shovel: # for versions below 1.20.5
+			name: snow shovel @-
+			pattern: (snowball|snow shovel|snow(man| golem) spawn)
+
+		landing_honey: # added in 1.15
+			name: landing honey @-
+			pattern: landing honey
+
+		landing_lava: # added in 1.14
+			name: landing lava @-
+			pattern: landing lava
+
+		landing_obsidian_tear: # added in 1.16
+			name: landing obsidian tear @-
+			pattern: landing obsidian tear
+
+		large_smoke: # added in 1.20.5
+			name: large smoke @-
+			pattern: large smoke
+		smoke_large: # for versions below 1.20.5
+			name: large smoke @-
+			pattern: large smoke
+
+		lava:
+			name: lava pop @a
+			pattern: lava pop
+
+		mycelium: # previously town_aura, changed in 1.20.5
+			name: mycelium @-
+			pattern: (mycelium|small smoke|town aura)
+		town_aura:
+			name: small smoke @-
+			pattern: (mycelium|small smoke|town aura)
+
+		nautilus: # added in 1.13
+			name: nautilus @-
+			pattern: nautilus
+
+		note:
+			name: note @a
+			pattern: note [(of|with) [colo[u]r] %number%] # TODO does not have color on new versions?
+
+		ominous_spawning: # added in 1.20.5 (for 1.21)
+			name: ominous spawning @-
+			pattern: ominous spawning
+
+		poof: # added in 1.20.5
+			name: poof @a
+			pattern: (poof|explosion)
+		explosion_normal: # for versions below 1.20.5
+			name: explosion @an
+			pattern: (poof|explosion)
+
+		portal:
+			name: portal @a
+			pattern: [nether] portal
+
+		raid_omen: # added in 1.20.5 (1.21)
+			name: raid omen @a
+			pattern: raid omen
+
+		rain: # added in 1.20.5
+			name: rain @-
+			pattern: (rain|water drop)
+		water_drop: # for versions below 1.20.5
+			name: water drop @a
+			pattern: (rain|water drop)
+
+		reverse_portal: # added in 1.16
+			name: reverse portal @-
+			pattern: reverse portal
+
+		scrape: # added in 1.17
+			name: scrape @-
+			pattern: scrape
+
+		sculk_charge: # added in 1.19 TODO has Float as DataType
+			name: sculk charge @-
+			pattern: sculk charge
+
+		sculk_charge_pop: # added in 1.19
+			name: sculk charge pop @-
+			pattern: sculk charge pop
+
+		sculk_soul: # added in 1.19
+			name: sculk soul @-
+			pattern: sculk soul
+
+		shriek: # added in 1.19 TODO has Integer as DataType
+			name: shriek @-
+			pattern: shriek
+
+		small_flame: # added in 1.17
+			name: small flame @a
+			pattern: small flame
+
+		small_gust: # added in 1.20.5 (for 1.21)
+			name: small gust @a
+			pattern: small gust
+
+		smoke: # added in 1.20.5
+			name: smoke @-
+			pattern: smoke [particle]
+		smoke_normal: # for versions below 1.20.5
+			name: smoke @-
+			pattern: smoke [particle]
+
+		sneeze: # added in 1.14
+			name: sneeze @a
+			pattern: sneeze
+
+		snowflake: # added in 1.17
+			name: snowflake @a
+			pattern: snowflake
+
+		sonic_boom: # added in 1.19
+			name: sonic boom @a
+			pattern: sonic boom
+
+		soul: # added in 1.16
+			name: soul @-
+			pattern: soul
+
+		soul_fire_flame: # added in 1.16
+			name: soul fire flame @a
+			pattern: soul fire flame
+
+		spit: # added in 1.11
+			name: spit @-
+			pattern: spit
+
+		splash: # added in 1.20.5
+			name: splash @a
+			pattern: [water] splash
+		water_splash: # for versions below 1.20.5
 			name: water splash @a
 			pattern: [water] splash
-		splash: # previously water_splash, changed in 1.20.5
-			name: water splash @a
-			pattern: [water] splash
 
-		water_bubble:
-			name: water bubble @-
-			pattern: water bubble
-		bubble: # previously water_bubble, changed in 1.20.5
-			name: water bubble @-
-			pattern: water bubble
+		spore_blossom_air: # added in 1.17
+			name: spore blossom air @-
+			pattern: spore blossom air
 
-		water_wake:
-			name: water wake @-
-			pattern: water wake
-		fishing:
-			name: water wake @-
-			pattern: water wake
+		squid_ink: # added in 1.13
+			name: squid ink @-
+			pattern: squid ink
 
-		water_drop:
-			name: water drop @-
-			pattern: water drop
-		rain: # previously water_drop, changed in 1.20.5
-			name: water drop @-
-			pattern: water drop
+		sweep_attack: # added in 1.14
+			name: sweep attack @a
+			pattern: sweep attack
+
+		totem_of_undying: # added in 1.20.5
+			name: totem of undying @a
+			pattern: totem [of undying]
+		totem: # for versions below 1.20.5
+			name: totem @a
+			pattern: totem [of undying]
+
+		trial omen: # added in 1.20.5 (for 1.21)
+			name: trial omen @a
+			pattern: trial omen
+
+		trial_spawner_detection: # added in 1.20.5 (for 1.21)
+			name: trial spawner detection @-
+			pattern: trial spawner detection
+
+		trial_spawner_detection_ominous: # added in 1.20.5 (for 1.21)
+			name: ominous trial spawner detection @-
+			pattern: ominous trial spawner detection
+
+		underwater: # added in 1.20.5
+			name: underwater @-
+			pattern: (underwater|suspended|void fog)
+		suspended: # for versions below 1.20.5
+			name: suspended @-
+			pattern: (underwater|suspended)
+		suspended_depth: # for versions below 1.20.5
+			name: void fog @-
+			pattern: void fog
+
+		vault_connection: # added in 1.20.5 (for 1.21)
+			name: vault connection @-
+			pattern: vault connection
+
+		vibration: # added in 1.17 TODO has Vibration as DataType
+			name: vibration @a
+			pattern: vibration
+
+		warped_spore: # added in 1.16
+			name: warped spore @a
+			pattern: warped spore
+
+		wax_off: # added in 1.17
+			name: wax off @-
+			pattern: wax off
+
+		wax_on: # added in 1.17
+			name: wax on @-
+			pattern: wax on
+
+		white_ash: # added in 1.16
+			name: white ash @-
+			pattern: white ash
+
+		white_smoke: # added in 1.20.3
+			name: white smoke @-
+			pattern: white smoke
+
+		witch: # added in 1.20.5
+			name: witch @a
+			pattern: (witch [magic|spell]|purple spark)
+		spell_witch: # for versions below 1.20.5
+			name: witch spell @a
+			pattern: (witch [magic|spell]|purple spark)
 
 # -- Inventory Actions --
 inventory actions:

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -1471,13 +1471,13 @@ visual effects:
 			name: block dust @-
 			pattern: [sprinting] dust of %itemtype%
 
-		block_marker: # added in 1.18 TODO barrier/light backcompat support?
+		block_marker: # added in 1.18
 			name: block marker @a
-			pattern: %itemtype% block marker
-		barrier: # added in 1.18 TODO remove when 1.17 and below support is dropped
+			pattern: (barrierbm:barrier|lightbm:light|%-blockdata% block marker)
+		barrier:
 			name: barrier @a
 			pattern: barrier
-		light: # added in 1.17 TODO remove when 1.17 and below support is dropped (and only existed for 1 version)
+		light: # added in 1.17
 			name: light @-
 			pattern: light
 

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -1756,7 +1756,7 @@ visual effects:
 			pattern: instant (effect|spell|thrown potion)
 
 		item: # added in 1.20.5
-			name: item crack @-
+			name: item @-
 			pattern: %itemtype% item (break|crack)[ing]
 		item_crack: # for versions below 1.20.5
 			name: item crack @-

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -1463,17 +1463,17 @@ visual effects:
 
 		block: # added in 1.20.5
 			name: block @-
-			pattern: (%-itemtype% break[ing]|[sprinting] dust of %-itemtype%)
+			pattern: (%-blockdata/itemtype% break[ing]|[sprinting] dust of %-blockdata/itemtype%)
 		block_crack: # for versions below 1.20.5
 			name: block break @-
-			pattern: %itemtype% break[ing]
+			pattern: %blockdata/itemtype% break[ing]
 		block_dust: # for versions below 1.20.5
 			name: block dust @-
-			pattern: [sprinting] dust of %itemtype%
+			pattern: [sprinting] dust of %blockdata/itemtype%
 
 		block_marker: # added in 1.18
 			name: block marker @a
-			pattern: (barrierbm:barrier|lightbm:light|%-blockdata% block marker)
+			pattern: (barrierbm:barrier|lightbm:light|%-blockdata/itemtype% block marker)
 		barrier:
 			name: barrier @a
 			pattern: barrier
@@ -1577,13 +1577,13 @@ visual effects:
 			name: coloured dust @-
 			pattern: [%-color%] [colo[u]red] dust
 
-		dust_color_transition: # added in 1.17 TODO this was disabled?
+		dust_color_transition: # added in 1.17
 			name: dust color transition @a
-			pattern: dust colo[u]r transition [from %-color%] [to %-color%] [with size %-number%]
+			pattern: dust colo[u]r transition [from %-color%] [to %-color%] [with size %-float%]
 
 		dust_pillar: # added in 1.20.5 (for 1.21)
 			name: dust pillar @a
-			pattern: dust pillar # TODO has BlockData DataType
+			pattern: %blockdata/itemtype% dust pillar
 
 		dust_plume: # added in 1.20.3
 			name: dust plume @a
@@ -1665,7 +1665,7 @@ visual effects:
 
 		falling_dust:
 			name: falling dust @-
-			pattern: falling dust of %itemtype%
+			pattern: falling dust of %blockdata/itemtype%
 
 		falling_honey: # added in 1.15
 			name: falling honey @-
@@ -1819,7 +1819,7 @@ visual effects:
 
 		note:
 			name: note @a
-			pattern: note [(of|with) [colo[u]r] %number%] # TODO does not have color on new versions?
+			pattern: note [(of|with) [colo[u]r] %number%]
 
 		ominous_spawning: # added in 1.20.5 (for 1.21)
 			name: ominous spawning @-
@@ -1855,9 +1855,9 @@ visual effects:
 			name: scrape @-
 			pattern: scrape
 
-		sculk_charge: # added in 1.19 TODO has Float as DataType
+		sculk_charge: # added in 1.19 TODO figure out what the DataType does and adjust pattern
 			name: sculk charge @-
-			pattern: sculk charge
+			pattern: %float% sculk charge
 
 		sculk_charge_pop: # added in 1.19
 			name: sculk charge pop @-
@@ -1867,9 +1867,9 @@ visual effects:
 			name: sculk soul @-
 			pattern: sculk soul
 
-		shriek: # added in 1.19 TODO has Integer as DataType
+		shriek: # added in 1.19 TODO figure out what the DataType does and adjust pattern
 			name: shriek @-
-			pattern: shriek
+			pattern: %integer% shriek
 
 		small_flame: # added in 1.17
 			name: small flame @a
@@ -1962,9 +1962,9 @@ visual effects:
 			name: vault connection @-
 			pattern: vault connection
 
-		vibration: # added in 1.17 TODO has Vibration as DataType
+		vibration: # added in 1.17
 			name: vibration @a
-			pattern: vibration
+			pattern: vibration [to %-entity/location% over %-timespan%]
 
 		warped_spore: # added in 1.16
 			name: warped spore @a

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -1596,9 +1596,9 @@ visual effects:
 			name: spell @a
 			pattern: (effect|spell|thrown potion|lingering potion)
 
-		egg_crack:
+		egg_crack: # added in 1.20
 			name: egg crack @an
-			pattern: egg crack
+			pattern: [sniffer] egg crack
 
 		elder_guardian: # added in 1.20.5
 			name: elder guardian @-

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -1572,10 +1572,10 @@ visual effects:
 
 		dust: # added in 1.20.5
 			name: dust @-
-			pattern: [%-color%] [colo[u]red] dust
+			pattern: [%-color%] [colo[u]red] dust [with size %-float%]
 		redstone: # for versions below 1.20.5
 			name: coloured dust @-
-			pattern: [%-color%] [colo[u]red] dust
+			pattern: [%-color%] [colo[u]red] dust [with size %-float%]
 
 		dust_color_transition: # added in 1.17
 			name: dust color transition @a
@@ -1855,9 +1855,9 @@ visual effects:
 			name: scrape @-
 			pattern: scrape
 
-		sculk_charge: # added in 1.19 TODO figure out what the DataType does and adjust pattern
+		sculk_charge: # added in 1.19
 			name: sculk charge @-
-			pattern: %float% sculk charge
+			pattern: sculk charge [with ([a] roll|[an] angle) [of] %-float%]
 
 		sculk_charge_pop: # added in 1.19
 			name: sculk charge pop @-
@@ -1867,9 +1867,9 @@ visual effects:
 			name: sculk soul @-
 			pattern: sculk soul
 
-		shriek: # added in 1.19 TODO figure out what the DataType does and adjust pattern
+		shriek: # added in 1.19
 			name: shriek @-
-			pattern: %integer% shriek
+			pattern: shriek [with [a] delay [of] %-timespan%]
 
 		small_flame: # added in 1.17
 			name: small flame @a
@@ -1964,7 +1964,8 @@ visual effects:
 
 		vibration: # added in 1.17
 			name: vibration @a
-			pattern: vibration [to %-entity/location% over %-timespan%]
+			# must be a literal, so you can't actually use this properly yet
+			pattern: vibration [to %-entity/location%] [over %-timespan%]
 
 		warped_spore: # added in 1.16
 			name: warped spore @a

--- a/src/test/skript/tests/regressions/3284-itemcrack particle.sk
+++ b/src/test/skript/tests/regressions/3284-itemcrack particle.sk
@@ -1,3 +1,3 @@
-test "item crack particles" when running below minecraft "1.20.5": # item crack does not exist on 1.20.5
+test "item crack particles":
 	set {_loc} to location of spawn of world "world"
 	play diamond sword item crack at {_loc}

--- a/src/test/skript/tests/syntaxes/effects/EffVisualEffect.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffVisualEffect.sk
@@ -14,7 +14,7 @@ test "visual effects":
 	play dolphin at {_}
 	play dripping lava at {_}
 	play dripping water at {_}
-	play white dust at {_}
+	play white dust with size 2 at {_}
 	play effect at {_}
 	play egg crack at {_}
 	play elder guardian at {_}
@@ -95,16 +95,16 @@ test "visual effects":
 		play small flame at {_}
 		play snowflake at {_}
 		play spore blossom air at {_}
-		play vibration at {_}
+		play vibration over 1 second at {_}
 		play wax off at {_}
 		play wax on at {_}
 	parse if running minecraft "1.18.2":
 		play air block marker at {_}
 	parse if running minecraft "1.19.4":
-		play 1 sculk charge at {_}
+		play sculk charge with a roll of 1 at {_}
 		play sculk charge pop at {_}
 		play sculk soul at {_}
-		play 1 shriek at {_}
+		play shriek with a delay of 0 seconds at {_}
 		play sonic boom at {_}
 	parse if running minecraft "1.20.6":
 		play cherry leaves at {_}

--- a/src/test/skript/tests/syntaxes/effects/EffVisualEffect.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffVisualEffect.sk
@@ -101,10 +101,10 @@ test "visual effects":
 	parse if running minecraft "1.18.2":
 		play air block marker at {_}
 	parse if running minecraft "1.19.4":
-		play sculk charge at {_}
+		play 1 sculk charge at {_}
 		play sculk charge pop at {_}
 		play sculk soul at {_}
-		play shriek at {_}
+		play 1 shriek at {_}
 		play sonic boom at {_}
 	parse if running minecraft "1.20.6":
 		play cherry leaves at {_}

--- a/src/test/skript/tests/syntaxes/effects/EffVisualEffect.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffVisualEffect.sk
@@ -32,7 +32,7 @@ test "visual effects":
 	play flame at {_}
 	play happy villager at {_}
 	play instant effect at {_}
-	play air item break at {_}
+	play iron sword item break at {_}
 	play slime at {_}
 	play snowball at {_}
 	play snowball break at {_}

--- a/src/test/skript/tests/syntaxes/effects/EffVisualEffect.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffVisualEffect.sk
@@ -1,0 +1,112 @@
+# we want to ensure particles parse and play on all versions
+test "visual effects":
+	set {_} to location of spawn of world "world"
+	play angry villager at {_}
+	play air breaking at {_}
+	play sprinting dust of air at {_}
+	play barrier at {_}
+	play bubble at {_}
+	play bubble column up at {_}
+	play bubble pop at {_}
+	play cloud at {_}
+	play crit at {_}
+	play current down at {_}
+	play dolphin at {_}
+	play dripping lava at {_}
+	play dripping water at {_}
+	play white dust at {_}
+	play effect at {_}
+	play egg crack at {_}
+	play elder guardian at {_}
+	play enchant at {_}
+	play enchanted hit at {_}
+	play end rod at {_}
+	play lingering potion at {_}
+	play white potion swirl at {_}
+	play white transparent potion swirl at {_}
+	play large explosion at {_}
+	play explosion emitter at {_}
+	play falling dust of air at {_}
+	play firework at {_}
+	play fishing at {_}
+	play flame at {_}
+	play happy villager at {_}
+	play instant effect at {_}
+	play air item break at {_}
+	play slime at {_}
+	play snowball at {_}
+	play snowball break at {_}
+	play large smoke at {_}
+	play lava pop at {_}
+	play mycelium at {_}
+	play nautilus at {_}
+	play note at {_}
+	play note of 5 at {_}
+	play poof at {_}
+	play portal at {_}
+	play rain at {_}
+	play smoke at {_}
+	play spit at {_}
+	play splash at {_}
+	play squid ink at {_}
+	play totem of undying at {_}
+	play suspended at {_}
+	play void fog at {_}
+	play witch at {_}
+	parse if running minecraft "1.14.4":
+		play campfire cosy smoke at {_}
+		play campfire signal smoke at {_}
+		play composter at {_}
+		play damage indicator at {_}
+		play dragon's breath at {_}
+		play falling lava at {_}
+		play falling water at {_}
+		play flash at {_}
+		play landing lava at {_}
+		play sneeze at {_}
+		play sweep attack at {_}
+	parse if running minecraft "1.15.2":
+		play dripping honey at {_}
+		play falling honey at {_}
+		play falling nectar at {_}
+		play landing honey at {_}
+	parse if running minecraft "1.16.5":
+		play ash at {_}
+		play crimson spore at {_}
+		play dripping obsidian tear at {_}
+		play falling obsidian tear at {_}
+		play landing obsidian tear at {_}
+		play reverse portal at {_}
+		play soul at {_}
+		play soul fire flame at {_}
+		play warped spore at {_}
+		play white ash at {_}
+	parse if running minecraft "1.17.1":
+		play light at {_}
+		play dripping dripstone lava at {_}
+		play dripping dripstone water at {_}
+		play dust color transition from white to white with size 1 at {_}
+		play falling dripstone lava at {_}
+		play falling dripstone water at {_}
+		play falling spore blossom at {_}
+		play glow at {_}
+		play glow squid ink at {_}
+		play scrape at {_}
+		play small flame at {_}
+		play snowflake at {_}
+		play spore blossom air at {_}
+		play vibration at {_}
+		play wax off at {_}
+		play wax on at {_}
+	parse if running minecraft "1.18.2":
+		play air block marker at {_}
+	parse if running minecraft "1.19.4":
+		play sculk charge at {_}
+		play sculk charge pop at {_}
+		play sculk soul at {_}
+		play shriek at {_}
+		play sonic boom at {_}
+	parse if running minecraft "1.20.6":
+		play cherry leaves at {_}
+		play dust plume at {_}
+		play white smoke at {_}

--- a/src/test/skript/tests/syntaxes/effects/EffVisualEffect.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffVisualEffect.sk
@@ -16,7 +16,6 @@ test "visual effects":
 	play dripping water at {_}
 	play white dust with size 2 at {_}
 	play effect at {_}
-	play egg crack at {_}
 	play elder guardian at {_}
 	play enchant at {_}
 	play enchanted hit at {_}
@@ -109,4 +108,5 @@ test "visual effects":
 	parse if running minecraft "1.20.6":
 		play cherry leaves at {_}
 		play dust plume at {_}
+		play egg crack at {_}
 		play white smoke at {_}


### PR DESCRIPTION
### Description

This PR intends to fix particle compatibility between versions and fix some other issues that have arisen, especially after the 1.20.5 update (where the Particle enum saw major changes). For this, I have remade the particle definitions in the default language file. They are organized based on the Spigot Particle enum as of 1.20.6, with duplicate definitions for particles that had name changes present.

I have also gone ahead and rewritten the Data Suppliers for Particles with extra data. To ensure all particle are representable, I have made some tweaks to the way data is passed to the suppliers. For visual effects with patterns containing multiple expressions, they receive an array of values (may contain null).

This PR is not aiming to make any major changes to the Visual Effect system.

While the test suite (hopefully) passes, in-game testing still needs to be performed.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:**
- https://github.com/SkriptLang/Skript/issues/6635
