### PR TITLE
Fix make look at vector

### DIFF
--- a/src/main/java/ch/njol/skript/bukkitutil/PaperEntityUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/PaperEntityUtils.java
@@ -114,8 +114,8 @@ public class PaperEntityUtils {
 				Player player = (Player) entity;
 				if (target instanceof Vector) {
 					Vector vector = (Vector) target;
-					player.lookAt(player.getLocation().add(vector), LookAnchor.EYES);
-					player.lookAt(player.getLocation().add(vector), LookAnchor.FEET);
+					player.lookAt(player.getEyeLocation().add(vector), LookAnchor.EYES);
+					player.lookAt(player.getEyeLocation().add(vector), LookAnchor.FEET);
 				} else if (target instanceof Location) {
 					player.lookAt((Location) target, LookAnchor.EYES);
 					player.lookAt((Location) target, LookAnchor.FEET);
@@ -159,7 +159,7 @@ public class PaperEntityUtils {
 			switch (type) {
 				case VECTOR:
 					Vector vector = ((Vector)target);
-					mob.lookAt(mob.getLocation().add(vector), speed, maxPitch);
+					mob.lookAt(mob.getEyeLocation().add(vector), speed, maxPitch);
 					break;
 				case LOCATION:
 					mob.lookAt((Location) target, speed, maxPitch);

--- a/src/main/java/ch/njol/skript/bukkitutil/PaperEntityUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/PaperEntityUtils.java
@@ -114,8 +114,8 @@ public class PaperEntityUtils {
 				Player player = (Player) entity;
 				if (target instanceof Vector) {
 					Vector vector = (Vector) target;
-					player.lookAt(vector.getX(), vector.getY(), vector.getZ(), LookAnchor.EYES);
-					player.lookAt(vector.getX(), vector.getY(), vector.getZ(), LookAnchor.FEET);
+					player.lookAt(player.getLocation().add(vector), LookAnchor.EYES);
+					player.lookAt(player.getLocation().add(vector), LookAnchor.FEET);
 				} else if (target instanceof Location) {
 					player.lookAt((Location) target, LookAnchor.EYES);
 					player.lookAt((Location) target, LookAnchor.FEET);
@@ -159,7 +159,7 @@ public class PaperEntityUtils {
 			switch (type) {
 				case VECTOR:
 					Vector vector = ((Vector)target);
-					mob.lookAt(vector.getX(), vector.getY(), vector.getZ(), speed, maxPitch);
+					mob.lookAt(mob.getLocation().add(vector), speed, maxPitch);
 					break;
 				case LOCATION:
 					mob.lookAt((Location) target, speed, maxPitch);


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Makes the target look in the direction of the vector (by making them look at their location offset by the vector) instead of using the vector components as coordinates

Also I am not fully sure how I would add tests for this so any suggestions for that would be great

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #6723 <!-- Links to related issues -->
