### PR TITLE
Disable EffGlowingText item tests temporarily

### DIFF
--- a/src/test/skript/tests/syntaxes/effects/EffGlowingText.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffGlowingText.sk
@@ -11,11 +11,11 @@ test "glowing sign blocks" when running minecraft "1.17.1":
 
 ###
 # TODO: re-enable once Paper fixes ItemMeta or we find a fix ourselves.
-test "glowing sign items" when running minecraft "1.17.1":
-	set {_sign} to sign
-	assert {_sign} doesn't have glowing text with "Sign had glowing text erroneously (1)"
-	make {_sign} have glowing text
-	assert {_sign} has glowing text with "Sign had normal text erroneously"
-	make {_sign} have normal text
-	assert {_sign} doesn't have glowing text with "Sign had glowing text erroneously (2)"
+#test "glowing sign items" when running minecraft "1.17.1":
+#	set {_sign} to sign
+#	assert {_sign} doesn't have glowing text with "Sign had glowing text erroneously (1)"
+#	make {_sign} have glowing text
+#	assert {_sign} has glowing text with "Sign had normal text erroneously"
+#	make {_sign} have normal text
+#	assert {_sign} doesn't have glowing text with "Sign had glowing text erroneously (2)"
 ###

--- a/src/test/skript/tests/syntaxes/effects/EffGlowingText.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffGlowingText.sk
@@ -9,6 +9,8 @@ test "glowing sign blocks" when running minecraft "1.17.1":
 	assert block at {_loc} doesn't have glowing text with "Sign had glowing text erroneously (2)"
 	set block at {_loc} to {_original block}
 
+###
+# TODO: re-enable once Paper fixes ItemMeta or we find a fix ourselves.
 test "glowing sign items" when running minecraft "1.17.1":
 	set {_sign} to sign
 	assert {_sign} doesn't have glowing text with "Sign had glowing text erroneously (1)"
@@ -16,3 +18,4 @@ test "glowing sign items" when running minecraft "1.17.1":
 	assert {_sign} has glowing text with "Sign had normal text erroneously"
 	make {_sign} have normal text
 	assert {_sign} doesn't have glowing text with "Sign had glowing text erroneously (2)"
+###


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Paper changes to ItemMeta mean that EffGlowingText isn't properly applying to ItemTypes. This disables those test for the meantime while wither Paper fixes this issue or we find our own solution.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
