### PR TITLE
Fix bug with target distance and clean up method

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprTarget.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTarget.java
@@ -197,31 +197,31 @@ public class ExprTarget extends PropertyExpression<LivingEntity, Entity> {
 	public static <T extends Entity> T getTarget(LivingEntity origin, @Nullable EntityData<T> type, double raysize) {
 		if (origin instanceof Mob)
 			return ((Mob) origin).getTarget() == null || type != null && !type.isInstance(((Mob) origin).getTarget()) ? null : (T) ((Mob) origin).getTarget();
-		Location location = origin.getLocation();
-		RayTraceResult result = null;
-		// TODO when DisplayData is added.
-//		if (type.getClass().equals(DisplayData.class))
-//			raysize = 1.0D;
+
 		Predicate<Entity> predicate = entity -> {
 			if (entity.equals(origin))
 				return false;
 			if (type != null && !type.isInstance(entity))
 				return false;
+			//noinspection RedundantIfStatement
 			if (entity instanceof Player && ((Player) entity).getGameMode() == GameMode.SPECTATOR)
 				return false;
 			return true;
 		};
+
+		Location eyes = origin.getEyeLocation();
+		Vector direction = origin.getLocation().getDirection();
+
+		double distance = targetBlockDistance;
 		if (!ignoreBlocks) {
-			RayTraceResult blockResult = origin.getWorld().rayTraceBlocks(origin.getEyeLocation(), location.getDirection(), targetBlockDistance);
+			RayTraceResult blockResult = origin.getWorld().rayTraceBlocks(eyes, direction, targetBlockDistance);
 			if (blockResult != null) {
 				Vector hit = blockResult.getHitPosition();
-				Location eyes = origin.getEyeLocation();
-				if (hit != null)
-					result = origin.getWorld().rayTraceEntities(eyes, location.getDirection(), eyes.toVector().distance(hit), raysize, predicate);
+				distance = eyes.toVector().distance(hit);
 			}
-		} else {
-			result = origin.getWorld().rayTraceEntities(origin.getEyeLocation(), location.getDirection(), targetBlockDistance, raysize, predicate);
 		}
+
+		RayTraceResult result = origin.getWorld().rayTraceEntities(eyes, direction, distance, raysize, predicate);
 		if (result == null)
 			return null;
 		Entity hitEntity = result.getHitEntity();


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Fixes bug described in #6722, where the target expression doesn't raycast for entities if there's no block within 100 meters.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #6722 <!-- Links to related issues -->
