### PR TITLE
Remove command senders from load/start/stop events

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -1100,32 +1100,6 @@ public final class BukkitEventValues {
 			}
 		}, 0);
 
-		// === ServerEvents ===
-		// Script load/unload event
-		EventValues.registerEventValue(ScriptEvent.class, CommandSender.class, new Getter<CommandSender, ScriptEvent>() {
-			@Nullable
-			@Override
-			public CommandSender get(ScriptEvent e) {
-				return Bukkit.getConsoleSender();
-			}
-		}, 0);
-		// Server load event
-		EventValues.registerEventValue(SkriptStartEvent.class, CommandSender.class, new Getter<CommandSender, SkriptStartEvent>() {
-			@Nullable
-			@Override
-			public CommandSender get(SkriptStartEvent e) {
-				return Bukkit.getConsoleSender();
-			}
-		}, 0);
-		// Server stop event
-		EventValues.registerEventValue(SkriptStopEvent.class, CommandSender.class, new Getter<CommandSender, SkriptStopEvent>() {
-			@Nullable
-			@Override
-			public CommandSender get(SkriptStopEvent e) {
-				return Bukkit.getConsoleSender();
-			}
-		}, 0);
-
 		// === InventoryEvents ===
 		// InventoryClickEvent
 		EventValues.registerEventValue(InventoryClickEvent.class, Player.class, new Getter<Player, InventoryClickEvent>() {


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Removes the console command sender from load/unload/start/stop events to prevent things like `event-player` and `cow` from being valid syntax in those events.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
