### PR TITLE
Add support for spawning dropped items

### DIFF
--- a/src/main/java/ch/njol/skript/entity/DroppedItemData.java
+++ b/src/main/java/ch/njol/skript/entity/DroppedItemData.java
@@ -24,14 +24,10 @@ import java.util.Arrays;
 import java.util.function.Consumer;
 
 import ch.njol.skript.Skript;
-import ch.njol.skript.lang.Condition;
 import org.bukkit.Location;
-import org.bukkit.RegionAccessor;
 import org.bukkit.World;
 import org.bukkit.entity.Item;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.util.Vector;
-import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.lang.Literal;
@@ -41,6 +37,7 @@ import ch.njol.skript.localization.Language;
 import ch.njol.skript.localization.Noun;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.util.coll.CollectionUtils;
+import org.jetbrains.annotations.Nullable;
 
 public class DroppedItemData extends EntityData<Item> {
 
@@ -152,11 +149,10 @@ public class DroppedItemData extends EntityData<Item> {
 
 	@Override
 	public boolean canSpawn(@Nullable World world) {
-		return (HAS_JAVA_CONSUMER_DROP || HAS_BUKKIT_CONSUMER_DROP) && types != null && types.length > 0 && world != null;
+		return types != null && types.length > 0 && world != null;
 	}
 
 	@Override
-	@SuppressWarnings({"deprecation"})
 	public @Nullable Item spawn(Location location, @Nullable Consumer<Item> consumer) {
 		World world = location.getWorld();
 		if (!canSpawn(world))
@@ -175,6 +171,7 @@ public class DroppedItemData extends EntityData<Item> {
 		} else if (HAS_BUKKIT_CONSUMER_DROP) {
 			try {
 				assert BUKKIT_CONSUMER_DROP != null;
+				// noinspection deprecation
 				item = (Item) BUKKIT_CONSUMER_DROP.invoke(world, location, stack, (org.bukkit.util.Consumer<Item>) consumer::accept);
 			} catch (InvocationTargetException | IllegalAccessException e) {
 				if (Skript.testing())
@@ -182,10 +179,9 @@ public class DroppedItemData extends EntityData<Item> {
 				return null;
 			}
 		} else {
-			return null;
+			item = world.dropItem(location, stack);
+			consumer.accept(item);
 		}
-		item.teleport(location);
-		item.setVelocity(new Vector(0, 0, 0));
 		return item;
 	}
 

--- a/src/main/java/ch/njol/skript/entity/DroppedItemData.java
+++ b/src/main/java/ch/njol/skript/entity/DroppedItemData.java
@@ -156,9 +156,9 @@ public class DroppedItemData extends EntityData<Item> {
 			return null;
 		assert types != null && types.length > 0;
 
-		final ItemType t = CollectionUtils.getRandom(types);
-		assert t != null;
-		ItemStack stack = t.getItem().getRandom();
+		final ItemType itemType = CollectionUtils.getRandom(types);
+		assert itemType != null;
+		ItemStack stack = itemType.getItem().getRandom();
 
 		Item item;
 		if (consumer == null) {

--- a/src/main/java/ch/njol/skript/entity/DroppedItemData.java
+++ b/src/main/java/ch/njol/skript/entity/DroppedItemData.java
@@ -42,17 +42,14 @@ import org.jetbrains.annotations.Nullable;
 public class DroppedItemData extends EntityData<Item> {
 
 	private static final boolean HAS_JAVA_CONSUMER_DROP = Skript.methodExists(World.class, "dropItem", Location.class, ItemStack.class, Consumer.class);
-	private static final boolean HAS_BUKKIT_CONSUMER_DROP = Skript.methodExists(World.class, "dropItem", Location.class, ItemStack.class, org.bukkit.util.Consumer.class);
 	private static @Nullable Method BUKKIT_CONSUMER_DROP;
 
 	static {
 		EntityData.register(DroppedItemData.class, "dropped item", Item.class, "dropped item");
 
 		try {
-			if (HAS_BUKKIT_CONSUMER_DROP) {
-				BUKKIT_CONSUMER_DROP = World.class.getDeclaredMethod("dropItem", Location.class, ItemStack.class, org.bukkit.util.Consumer.class);
-			}
-		} catch (NoSuchMethodException | SecurityException ignored) { /* We already checked if the method exists */ }
+			BUKKIT_CONSUMER_DROP = World.class.getDeclaredMethod("dropItem", Location.class, ItemStack.class, org.bukkit.util.Consumer.class);
+		} catch (NoSuchMethodException | SecurityException ignored) {}
 	}
 	
 	private final static Adjective m_adjective = new Adjective("entities.dropped item.adjective");
@@ -168,9 +165,8 @@ public class DroppedItemData extends EntityData<Item> {
 			item = world.dropItem(location, stack);
 		} else if (HAS_JAVA_CONSUMER_DROP) {
 			item = world.dropItem(location, stack, consumer);
-		} else if (HAS_BUKKIT_CONSUMER_DROP) {
+		} else if (BUKKIT_CONSUMER_DROP != null) {
 			try {
-				assert BUKKIT_CONSUMER_DROP != null;
 				// noinspection deprecation
 				item = (Item) BUKKIT_CONSUMER_DROP.invoke(world, location, stack, (org.bukkit.util.Consumer<Item>) consumer::accept);
 			} catch (InvocationTargetException | IllegalAccessException e) {

--- a/src/main/java/ch/njol/skript/sections/EffSecSpawn.java
+++ b/src/main/java/ch/njol/skript/sections/EffSecSpawn.java
@@ -62,7 +62,6 @@ import ch.njol.util.Kleenean;
 		"\tset name of the zombie to \"\""
 })
 @Since("1.0, 2.6.1 (with section), INSERT_VERSION (dropped items)")
-@RequiredPlugins("Minecraft 1.17.1+ (dropped items)")
 public class EffSecSpawn extends EffectSection {
 
 	public static class SpawnEvent extends Event {

--- a/src/main/java/ch/njol/skript/sections/EffSecSpawn.java
+++ b/src/main/java/ch/njol/skript/sections/EffSecSpawn.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
+import ch.njol.skript.doc.RequiredPlugins;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
@@ -58,9 +59,10 @@ import ch.njol.util.Kleenean;
 	"spawn 3 creepers at the targeted block",
 	"spawn a ghast 5 meters above the player",
 	"spawn a zombie at the player:",
-	"\tset name of the zombie to \"\""
+		"\tset name of the zombie to \"\""
 })
-@Since("1.0, 2.6.1 (with section)")
+@Since("1.0, 2.6.1 (with section), INSERT_VERSION (dropped items)")
+@RequiredPlugins("Minecraft 1.17.1+ (dropped items)")
 public class EffSecSpawn extends EffectSection {
 
 	public static class SpawnEvent extends Event {

--- a/src/main/java/ch/njol/skript/sections/EffSecSpawn.java
+++ b/src/main/java/ch/njol/skript/sections/EffSecSpawn.java
@@ -61,7 +61,7 @@ import ch.njol.util.Kleenean;
 	"spawn a zombie at the player:",
 		"\tset name of the zombie to \"\""
 })
-@Since("1.0, 2.6.1 (with section), INSERT_VERSION (dropped items)")
+@Since("1.0, 2.6.1 (with section), INSERT VERSION (dropped items)")
 public class EffSecSpawn extends EffectSection {
 
 	public static class SpawnEvent extends Event {

--- a/src/test/skript/tests/regressions/pull-6746-spawn-dropped-item.sk
+++ b/src/test/skript/tests/regressions/pull-6746-spawn-dropped-item.sk
@@ -4,7 +4,6 @@ test "spawn dropped item":
 	assert {_e} is set with "failed to spawn dropped stone"
 	delete entity within {_e}
 
-
 	spawn dropped item at spawn of world "world":
 		set {_e2} to entity
 	assert {_e2} is not set with "spawned `dropped item` despite undefined item type"

--- a/src/test/skript/tests/regressions/pull-6746-spawn-dropped-item.sk
+++ b/src/test/skript/tests/regressions/pull-6746-spawn-dropped-item.sk
@@ -1,8 +1,7 @@
 test "spawn dropped item":
 	spawn dropped stone at spawn of world "world":
 		set {_e} to entity
-	if running minecraft "1.17.1":
-		assert {_e} is set with "failed to spawn dropped stone"
+	assert {_e} is set with "failed to spawn dropped stone"
 	delete entity within {_e}
 
 

--- a/src/test/skript/tests/regressions/pull-6746-spawn-dropped-item.sk
+++ b/src/test/skript/tests/regressions/pull-6746-spawn-dropped-item.sk
@@ -1,0 +1,11 @@
+test "spawn dropped item":
+	spawn dropped stone at spawn of world "world":
+		set {_e} to entity
+	if running minecraft "1.17.1":
+		assert {_e} is set with "failed to spawn dropped stone"
+	delete entity within {_e}
+
+
+	spawn dropped item at spawn of world "world":
+		set {_e2} to entity
+	assert {_e2} is not set with "spawned `dropped item` despite undefined item type"


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Allows DroppedItemData to be spawned via the World#dropItem method.

I'm kind of shaky on how the EntityData system works, so please correct me if I misunderstood parts!

This is marked as a bug fix since you could `spawn dropped stone` and it would do nothing, despite the fact that logically it should work, since you can drop stone just fine.

---
**Target Minecraft Versions:** 1.17+ <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #6745  <!-- Links to related issues -->
