### PR TITLE
Add InventoryHolder -> Location converter

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/DefaultConverters.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultConverters.java
@@ -151,6 +151,7 @@ public class DefaultConverters {
 				return (InventoryHolder) s;
 			return null;
 		}, Converter.NO_RIGHT_CHAINING | Commands.CONVERTER_NO_COMMAND_ARGUMENTS);
+
 		Converters.registerConverter(InventoryHolder.class, Block.class, holder -> {
 			if (holder instanceof BlockState)
 				return new BlockInventoryHolder((BlockState) holder);
@@ -165,7 +166,19 @@ public class DefaultConverters {
 				return (Entity) holder;
 			return null;
 		}, Converter.NO_CHAINING);
-		
+
+		// InventoryHolder - Location
+		// since the individual ones can't be trusted to chain.
+		Converters.registerConverter(InventoryHolder.class, Location.class, holder -> {
+			if (holder instanceof Entity)
+				return ((Entity) holder).getLocation();
+			if (holder instanceof Block)
+				return ((Block) holder).getLocation();
+			if (holder instanceof BlockState)
+				return BlockUtils.getLocation(((BlockState) holder).getBlock());
+			return null;
+		});
+
 		// Enchantment - EnchantmentType
 		Converters.registerConverter(Enchantment.class, EnchantmentType.class, e -> new EnchantmentType(e, -1));
 

--- a/src/test/skript/tests/regressions/6424-inventory-holder-location.sk
+++ b/src/test/skript/tests/regressions/6424-inventory-holder-location.sk
@@ -7,6 +7,10 @@ test "inventory holder location":
 	set {_inv} to inventory of {_b}
 	set {_holder} to holder of {_inv}
 
-	assert location of {_holder} is location of {_b} with "holder location differs from block location"
+	set {_a-loc} to location of {_holder}
+	set {_b-loc} to location of {_b}
 
+	# clean up first in case assert fails
 	set block at {_b} to {_prev}
+
+	assert {_a-loc} is {_b-loc} with "holder location differs from block location"

--- a/src/test/skript/tests/regressions/6424-inventory-holder-location.sk
+++ b/src/test/skript/tests/regressions/6424-inventory-holder-location.sk
@@ -1,0 +1,12 @@
+test "inventory holder location":
+	set {_b} to the block at spawn of world "world"
+	set {_prev} to type of block at {_b}
+	broadcast {_prev}
+
+	set block at {_b} to a chest
+	set {_inv} to inventory of {_b}
+	set {_holder} to holder of {_inv}
+
+	assert location of {_holder} is location of {_b} with "holder location differs from block location"
+
+	set block at {_b} to {_prev}


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Re-enables the ability to get the location of an inventory holder. This feels a little hacky, but it's the best I could do without delving into BlockStateBlock.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #6424 <!-- Links to related issues -->
