### PR TITLE
Fix PotionData NPE

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -18,9 +18,6 @@
  */
 package ch.njol.skript.classes.data;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -662,34 +659,17 @@ public final class BukkitEventValues {
 			}
 		}, EventValues.TIME_NOW);
 		EventValues.registerEventValue(AreaEffectCloudApplyEvent.class, PotionEffectType.class, new Getter<PotionEffectType, AreaEffectCloudApplyEvent>() {
-			@Nullable
-			private final MethodHandle BASE_POTION_DATA_HANDLE;
-
-			{
-				MethodHandle basePotionDataHandle = null;
-				if (Skript.methodExists(AreaEffectCloud.class, "getBasePotionData")) {
-					try {
-						basePotionDataHandle = MethodHandles.lookup().findVirtual(AreaEffectCloud.class, "getBasePotionData", MethodType.methodType(PotionData.class));
-					} catch (NoSuchMethodException | IllegalAccessException e) {
-						Skript.exception(e, "Failed to load legacy potion data support. Potions may not work as expected.");
-					}
-				}
-				BASE_POTION_DATA_HANDLE = basePotionDataHandle;
-			}
-
+			private final boolean HAS_POTION_TYPE_METHOD = Skript.methodExists(AreaEffectCloud.class, "getBasePotionType");
 			@Override
 			@Nullable
 			public PotionEffectType get(AreaEffectCloudApplyEvent e) {
-				if (BASE_POTION_DATA_HANDLE != null) {
-					try {
-						return ((PotionData) BASE_POTION_DATA_HANDLE.invoke(e.getEntity())).getType().getEffectType();
-					} catch (Throwable ex) {
-						throw Skript.exception(ex, "An error occurred while trying to invoke legacy area effect cloud potion effect support.");
-					}
-				} else {
+				// TODO needs to be reworked to support multiple values (there can be multiple potion effects)
+				if (HAS_POTION_TYPE_METHOD) {
 					PotionType base = e.getEntity().getBasePotionType();
-					if (base != null) // TODO this is deprecated... this should become a multi-value event value
+					if (base != null)
 						return base.getEffectType();
+				} else {
+					return e.getEntity().getBasePotionData().getType().getEffectType();
 				}
 				return null;
 			}

--- a/src/main/java/ch/njol/skript/util/PotionEffectUtils.java
+++ b/src/main/java/ch/njol/skript/util/PotionEffectUtils.java
@@ -18,9 +18,6 @@
  */
 package ch.njol.skript.util;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -346,7 +343,7 @@ public abstract class PotionEffectUtils {
 		itemType.setItemMeta(meta);
 	}
 
-	private static final boolean HAS_POTION_TYPE = Skript.methodExists(PotionMeta.class, "getBasePotionType");
+	private static final boolean HAS_POTION_TYPE_METHOD = Skript.methodExists(PotionMeta.class, "hasBasePotionType");
 
 	/**
 	 * Get all the PotionEffects of an ItemType
@@ -361,8 +358,9 @@ public abstract class PotionEffectUtils {
 		ItemMeta meta = itemType.getItemMeta();
 		if (meta instanceof PotionMeta) {
 			PotionMeta potionMeta = ((PotionMeta) meta);
-			effects.addAll(potionMeta.getCustomEffects());
-			if (HAS_POTION_TYPE) {
+			if (potionMeta.hasCustomEffects())
+				effects.addAll(potionMeta.getCustomEffects());
+			if (HAS_POTION_TYPE_METHOD) {
 				if (potionMeta.hasBasePotionType()) {
 					//noinspection ConstantConditions - checked via hasBasePotionType
 					effects.addAll(potionMeta.getBasePotionType().getPotionEffects());

--- a/src/test/skript/tests/regressions/6756-potion missing base type causes npe.sk
+++ b/src/test/skript/tests/regressions/6756-potion missing base type causes npe.sk
@@ -1,0 +1,3 @@
+test "potion missing base type":
+
+	assert potion effects of (plain potion of mundane) is not set with "it should not have any effects"


### PR DESCRIPTION
### Description
This PR fixes an NPE that can occur on when attempting to obtain the potion effects of a potion without a base type.

I have removed the reflection usage for a method that was originally removed when I made the 1.20.5+ support PR. The method seems to have been added back in. However, I am forcing the usage of the recommended method when it is available.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:**
- https://github.com/SkriptLang/Skript/issues/6756
