### PR TITLE
Fix ExprArithmetic Set Construction

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/arithmetic/ExprArithmetic.java
+++ b/src/main/java/ch/njol/skript/expressions/arithmetic/ExprArithmetic.java
@@ -35,6 +35,7 @@ import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.util.LiteralUtils;
 import ch.njol.skript.util.Patterns;
 import ch.njol.util.Kleenean;
+import com.google.common.collect.ImmutableSet;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 import org.skriptlang.skript.lang.arithmetic.Arithmetics;
@@ -43,7 +44,6 @@ import org.skriptlang.skript.lang.arithmetic.Operator;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
-import java.util.Set;
 import java.util.List;
 import java.util.Collection;
 
@@ -258,7 +258,7 @@ public class ExprArithmetic<L, R, T> extends SimpleExpression<T> {
 				return error(firstClass, secondClass);
 			} else {
 				returnType = (Class<? extends T>) Classes.getSuperClassInfo(returnTypes).getC();
-				knownReturnTypes = Set.of(returnTypes);
+				knownReturnTypes = ImmutableSet.copyOf(returnTypes);
 			}
 		} else if (returnType == null) { // lookup
 			OperationInfo<L, R, T> operationInfo = (OperationInfo<L, R, T>) Arithmetics.lookupOperationInfo(operator, firstClass, secondClass);


### PR DESCRIPTION
### Description
This PR aims to fix two issues with ExprArithmetic introduced in https://github.com/SkriptLang/Skript/pull/6624.

Since the PR was merged into 2.8 instead of 2.9, the `Set#of` case was not safe since it requires Java 9. Additionally, `Set#of` throws an error in some cases of Vector arithmetic (multiplication) when the `returnTypes` list may contain duplicate values.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** This was reported in Discord. The fix was confirmed to be working for the affected user.
