### PR TITLE
Fix Particle Definition Conflicts

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
@@ -661,6 +661,7 @@ public class SkriptClasses {
 				.usage(VisualEffects.getAllNames())
 				.since("2.1")
 				.user("(visual|particle) effects?")
+				.after("itemtype")
 				.parser(new Parser<VisualEffect>() {
 					@Override
 					@Nullable

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -1989,10 +1989,10 @@ visual effects:
 
 		witch: # added in 1.20.5
 			name: witch @a
-			pattern: (witch [magic|spell|particle]|purple spark)
+			pattern: (witch (magic|spell|particle)|purple spark)
 		spell_witch: # for versions below 1.20.5
 			name: witch spell @a
-			pattern: (witch [magic|spell|particle]|purple spark)
+			pattern: (witch (magic|spell|particle)|purple spark)
 
 # -- Inventory Actions --
 inventory actions:

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -1693,10 +1693,10 @@ visual effects:
 
 		firework: # added in 1.20.5
 			name: firework @-
-			pattern: (firework [particle]|firework['s] spark)
+			pattern: (firework particle|firework['s] spark)
 		fireworks_spark: # for versions below 1.20.5
 			name: firework's spark @-
-			pattern: (firework [particle]|firework['s] spark)
+			pattern: (firework particle|firework['s] spark)
 
 		fishing: # added in 1.20.5
 			name: water wake @-

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -1473,13 +1473,13 @@ visual effects:
 
 		block_marker: # added in 1.18
 			name: block marker @a
-			pattern: (barrierbm:barrier|lightbm:light|%-blockdata/itemtype% block marker)
+			pattern: (barrierbm:barrier [particle]|lightbm:light [particle]|%-blockdata/itemtype% block marker)
 		barrier:
 			name: barrier @a
-			pattern: barrier
+			pattern: barrier [particle]
 		light: # added in 1.17
 			name: light @-
-			pattern: light
+			pattern: light [particle]
 
 		bubble: # added in 1.20.5
 			name: bubble @-
@@ -1534,7 +1534,7 @@ visual effects:
 
 		dolphin: # added in 1.13
 			name: dolphin @-
-			pattern: dolphin
+			pattern: dolphin [particle]
 
 		dragon_breath: # added in 1.14
 			name: dragon breath @-
@@ -1602,10 +1602,10 @@ visual effects:
 
 		elder_guardian: # added in 1.20.5
 			name: elder guardian @-
-			pattern: (elder guardian|mob appearance|guardian ghost)
+			pattern: (elder guardian particle|mob appearance|guardian ghost)
 		mob_appearance: # for versions below 1.20.5
 			name: mob appearance @-
-			pattern: (elder guardian|mob appearance|guardian ghost)
+			pattern: (elder guardian particle|mob appearance|guardian ghost)
 
 		electric_spark:
 			name: electric spark @-
@@ -1627,7 +1627,7 @@ visual effects:
 
 		end_rod:
 			name: end rod @-
-			pattern: end rod
+			pattern: end rod [particle]
 
 		entity_effect: # added in 1.20.5
 			name: entity effect @an
@@ -1693,10 +1693,10 @@ visual effects:
 
 		firework: # added in 1.20.5
 			name: firework @-
-			pattern: (firework|firework['s] spark)
+			pattern: (firework [particle]|firework['s] spark)
 		fireworks_spark: # for versions below 1.20.5
 			name: firework's spark @-
-			pattern: (firework|firework['s] spark)
+			pattern: (firework [particle]|firework['s] spark)
 
 		fishing: # added in 1.20.5
 			name: water wake @-
@@ -1764,24 +1764,24 @@ visual effects:
 
 		item_cobweb: # added in 1.20.5 (for 1.21)
 			name: cobweb @-
-			pattern: cobweb
+			pattern: cobweb [item|particle]
 
 		item_slime: # added in 1.20.5
 			name: slime @-
-			pattern: slime
+			pattern: slime [item|particle]
 		slime: # for versions below 1.20.5
 			name: slime @-
-			pattern: slime
+			pattern: slime [item|particle]
 
 		item_snowball: # added in 1.20.5
 			name: snowball @-
-			pattern: (snowball [break]|snow shovel|snow(man| golem) spawn)
+			pattern: (snowball [item|break|particle]|snow shovel|snow(man| golem) spawn)
 		snowball: # for versions below 1.20.5
 			name: snowball break @-
 			pattern: snowball break
 		snow_shovel: # for versions below 1.20.5
 			name: snow shovel @-
-			pattern: (snowball|snow shovel|snow(man| golem) spawn)
+			pattern: (snowball [item|particle]|snow shovel|snow(man| golem) spawn)
 
 		landing_honey: # added in 1.15
 			name: landing honey @-
@@ -1808,7 +1808,7 @@ visual effects:
 
 		mycelium: # previously town_aura, changed in 1.20.5
 			name: mycelium @-
-			pattern: (mycelium|small smoke|town aura)
+			pattern: (mycelium [particle]|small smoke|town aura)
 		town_aura:
 			name: small smoke @-
 			pattern: (mycelium|small smoke|town aura)
@@ -1931,10 +1931,10 @@ visual effects:
 
 		totem_of_undying: # added in 1.20.5
 			name: totem of undying @a
-			pattern: totem [of undying]
+			pattern: totem [of undying] [particle]
 		totem: # for versions below 1.20.5
 			name: totem @a
-			pattern: totem [of undying]
+			pattern: totem [of undying] [particle]
 
 		trial omen: # added in 1.20.5 (for 1.21)
 			name: trial omen @a
@@ -1989,10 +1989,10 @@ visual effects:
 
 		witch: # added in 1.20.5
 			name: witch @a
-			pattern: (witch [magic|spell]|purple spark)
+			pattern: (witch [magic|spell|particle]|purple spark)
 		spell_witch: # for versions below 1.20.5
 			name: witch spell @a
-			pattern: (witch [magic|spell]|purple spark)
+			pattern: (witch [magic|spell|particle]|purple spark)
 
 # -- Inventory Actions --
 inventory actions:

--- a/src/test/skript/tests/regressions/pull-6760-particle itemtype conflicts.sk
+++ b/src/test/skript/tests/regressions/pull-6760-particle itemtype conflicts.sk
@@ -1,0 +1,6 @@
+test "particle itemtype conflicts":
+
+	# itemtype parsing should take priority over visual effects
+	assert totem of undying is an itemtype with "totem of undying is not an itemtype"
+	assert composter is an itemtype with "composter is not an itemtype"
+	assert mycelium is an itemtype with "mycelium is not an itemtype"

--- a/src/test/skript/tests/regressions/pull-6760-particle itemtype conflicts.sk
+++ b/src/test/skript/tests/regressions/pull-6760-particle itemtype conflicts.sk
@@ -2,5 +2,4 @@ test "particle itemtype conflicts":
 
 	# itemtype parsing should take priority over visual effects
 	assert totem of undying is an itemtype with "totem of undying is not an itemtype"
-	assert composter is an itemtype with "composter is not an itemtype"
 	assert mycelium is an itemtype with "mycelium is not an itemtype"

--- a/src/test/skript/tests/syntaxes/effects/EffVisualEffect.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffVisualEffect.sk
@@ -16,7 +16,7 @@ test "visual effects":
 	play dripping water at {_}
 	play white dust with size 2 at {_}
 	play effect at {_}
-	play elder guardian at {_}
+	play elder guardian particle at {_}
 	play enchant at {_}
 	play enchanted hit at {_}
 	play end rod at {_}

--- a/src/test/skript/tests/syntaxes/effects/EffVisualEffect.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffVisualEffect.sk
@@ -26,7 +26,7 @@ test "visual effects":
 	play large explosion at {_}
 	play explosion emitter at {_}
 	play falling dust of air at {_}
-	play firework at {_}
+	play firework spark at {_}
 	play fishing at {_}
 	play flame at {_}
 	play happy villager at {_}

--- a/src/test/skript/tests/syntaxes/effects/EffVisualEffect.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffVisualEffect.sk
@@ -51,7 +51,7 @@ test "visual effects":
 	play totem of undying at {_}
 	play suspended at {_}
 	play void fog at {_}
-	play witch at {_}
+	play witch particle at {_}
 	parse if running minecraft "1.14.4":
 		play campfire cosy smoke at {_}
 		play campfire signal smoke at {_}


### PR DESCRIPTION
### Description
This PR aims to fix some particle-itemtype conflicts that were introduced in https://github.com/SkriptLang/Skript/pull/6716

For example, some inputs such as `totem of undying` would parse as a visual effect rather than an itemtype. This caused errors with variables as visual effect serialization is broken. To combat this, I've made it so that visual effects are parsed *after* item types. Additionally, I've added some additional optional keywords to the affected particle definitions.

We might also prefer a more aggressive route of requiring the usage of keywords like `particle`. I wanted to avoid this if possible. We may choose to pursue this if the parse-order changes reveal any unexpected issues.

There is one breaking change that affects the `elder guardian` option that was added in 2.8.5. It now requires `particle`. I attempted to force visual effect parsing after entity types/data, but that caused unexpected test failures.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #6774 <!-- Links to related issues -->
