### PR TITLE
Fix Command Syncing CME

### DIFF
--- a/src/main/java/ch/njol/skript/structures/StructCommand.java
+++ b/src/main/java/ch/njol/skript/structures/StructCommand.java
@@ -334,11 +334,13 @@ public class StructCommand extends Structure {
 	private void attemptCommandSync() {
 		if (SYNC_COMMANDS.get()) {
 			SYNC_COMMANDS.set(false);
-			if (CommandReloader.syncCommands(Bukkit.getServer())) {
-				Skript.debug("Commands synced to clients");
-			} else {
-				Skript.debug("Commands changed but not synced to clients (normal on 1.12 and older)");
-			}
+			Bukkit.getScheduler().runTask(Skript.getInstance(), () -> {
+				if (CommandReloader.syncCommands(Bukkit.getServer())) {
+					Skript.debug("Commands synced to clients");
+				} else {
+					Skript.debug("Commands changed but not synced to clients (normal on 1.12 and older)");
+				}
+			});
 		}
 	}
 

--- a/src/main/java/ch/njol/skript/structures/StructCommand.java
+++ b/src/main/java/ch/njol/skript/structures/StructCommand.java
@@ -80,6 +80,9 @@ import java.util.regex.Pattern;
 @Since("1.0")
 public class StructCommand extends Structure {
 
+	// Paper versions with the new command system need a delay before syncing commands or a CME will occur.
+	private static final boolean DELAY_COMMAND_SYNCING = Skript.classExists("io.papermc.paper.command.brigadier.Commands");
+
 	public static final Priority PRIORITY = new Priority(500);
 
 	private static final Pattern COMMAND_PATTERN = Pattern.compile("(?i)^command\\s+/?(\\S+)\\s*(\\s+(.+))?$");
@@ -315,7 +318,7 @@ public class StructCommand extends Structure {
 
 	@Override
 	public boolean postLoad() {
-		attemptCommandSync();
+		scheduleCommandSync();
 		return true;
 	}
 
@@ -328,19 +331,25 @@ public class StructCommand extends Structure {
 
 	@Override
 	public void postUnload() {
-		attemptCommandSync();
+		scheduleCommandSync();
 	}
 
-	private void attemptCommandSync() {
+	private void scheduleCommandSync() {
 		if (SYNC_COMMANDS.get()) {
 			SYNC_COMMANDS.set(false);
-			Bukkit.getScheduler().runTask(Skript.getInstance(), () -> {
-				if (CommandReloader.syncCommands(Bukkit.getServer())) {
-					Skript.debug("Commands synced to clients");
-				} else {
-					Skript.debug("Commands changed but not synced to clients (normal on 1.12 and older)");
-				}
-			});
+			if (DELAY_COMMAND_SYNCING) {
+				Bukkit.getScheduler().runTask(Skript.getInstance(), this::forceCommandSync);
+			} else {
+				forceCommandSync();
+			}
+		}
+	}
+
+	private void forceCommandSync() {
+		if (CommandReloader.syncCommands(Bukkit.getServer())) {
+			Skript.debug("Commands synced to clients");
+		} else {
+			Skript.debug("Commands changed but not synced to clients (normal on 1.12 and older)");
 		}
 	}
 


### PR DESCRIPTION
### Description
This PR aims to fix the CME that occurs when syncing commands on Paper 1.20.5+ versions due to internal command changes. This issue only seems to occur when a command is unregistered, registered, and then synced in the same tick. Adding a single tick delay seems to remove the error. I would prefer a fix that doesn't force a delay, but I could not find any other solutions.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:**
- https://github.com/SkriptLang/Skript/issues/6735
