### PR TITLE
Fix firework spawning

### DIFF
--- a/src/test/skript/tests/regressions/6762-cant spawn a firework.sk
+++ b/src/test/skript/tests/regressions/6762-cant spawn a firework.sk
@@ -1,0 +1,4 @@
+test "can't spawn a firework":
+
+	spawn a firework at spawn of world "world"
+	assert last spawned firework is set with "firework did not spawn"


### PR DESCRIPTION
### Description
This PR aims to fix fireworks not being able to be spawned. This issue was caused by https://github.com/SkriptLang/Skript/pull/6523, as Fireworks are (for whatever reason) considered not spawnable.
@sovdeeth has opened an issue with Spigot: https://hub.spigotmc.org/jira/browse/SPIGOT-7677

I've added additional API for a SimpleEntityData to specify whether it overrides the canSpawn behavior. I'm not sure if we would wish to expand it to properly check for entities blocked by experiments.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:**
- https://github.com/SkriptLang/Skript/issues/6762
