### PR TITLE
ExprStringCase - include expression in toString

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprStringCase.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprStringCase.java
@@ -153,22 +153,28 @@ public class ExprStringCase extends SimpleExpression<String> {
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
+		String mode = "";
 		switch (type) {
 			case 0: // Basic Case Change 
-				return (casemode == 1) ? "uppercase" : "lowercase";
+				mode = (casemode == 1) ? "uppercase" : "lowercase";
+				break;
 			case 1: // Proper Case 
-				return ((casemode == 3) ? "strict" : "lenient") + " proper case";
+				mode = ((casemode == 3) ? "strict" : "lenient") + " proper case";
+				break;
 			case 2: // Camel Case 
-				return ((casemode == 3) ? "strict" : "lenient") + " camel case";
+				mode = ((casemode == 3) ? "strict" : "lenient") + " camel case";
+				break;
 			case 3: // Pascal Case 
-				return ((casemode == 3) ? "strict" : "lenient") + " pascal case";
+				mode = ((casemode == 3) ? "strict" : "lenient") + " pascal case";
+				break;
 			case 4: // Snake Case 
-				return ((casemode == 0) ? "" : ((casemode == 1)) ? "upper " : "lower ") + "snake case";
+				mode = ((casemode == 0) ? "" : ((casemode == 1)) ? "upper " : "lower ") + "snake case";
+				break;
 			case 5: // Kebab Case 
-				return ((casemode == 0) ? "" : ((casemode == 1)) ? "upper " : "lower ") + "kebab case";
+				mode = ((casemode == 0) ? "" : ((casemode == 1)) ? "upper " : "lower ") + "kebab case";
 		}
-		return ""; // Shouldn't reach here anyways 
+		return mode + " " + expr.toString(event, debug);
 	}
 	
 	@SuppressWarnings("null")


### PR DESCRIPTION
### Description
I noticed in a previous error in the issues (which was forwarded to SkBee) that the toString for the case expression doesn't include the actual string used, exhibit A:
` Current item: add nbt from "{Trim:{material:"minecraft:%lowercase%",pattern:"minecraft:%lowercase%"}}"`
As we can see here, it just says `%lowercase%`
So this PR aims to fix that, by actually sending the expression

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
