### PR TITLE
Fix StructCommand Illegal Task Scheduling

### DIFF
--- a/src/main/java/ch/njol/skript/structures/StructCommand.java
+++ b/src/main/java/ch/njol/skript/structures/StructCommand.java
@@ -338,7 +338,9 @@ public class StructCommand extends Structure {
 		if (SYNC_COMMANDS.get()) {
 			SYNC_COMMANDS.set(false);
 			if (DELAY_COMMAND_SYNCING) {
-				Bukkit.getScheduler().runTask(Skript.getInstance(), this::forceCommandSync);
+				// if the plugin is disabled, the server is likely closing and delaying will cause an error.
+				if (Bukkit.getPluginManager().isPluginEnabled(Skript.getInstance()))
+					Bukkit.getScheduler().runTask(Skript.getInstance(), this::forceCommandSync);
 			} else {
 				forceCommandSync();
 			}


### PR DESCRIPTION
### Description
Related to https://github.com/SkriptLang/Skript/pull/6763

Fixes an error that can occur from StructCommand registering a task when Skript is disabled. I noticed this error in the testing suite. I did not notice this issue in-game.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:**
- https://github.com/SkriptLang/Skript/issues/6801