### PR TITLE
Fix releaseDocs looking for wrong Skript jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,7 +188,7 @@ void createTestTask(String name, String desc, String environments, int javaVersi
 	if (junit) {
 		artifact += 'Skript-JUnit.jar'
 	} else if (releaseDocs) {
-		artifact += 'Skript-github.jar'
+		artifact += 'Skript-' + version + '.jar'
 	} else {
 		artifact += 'Skript-nightly.jar'
 	}


### PR DESCRIPTION
### Description
Automatic release documentation has not been working for some time now. This was caused by https://github.com/SkriptLang/Skript/pull/6628 not updating the releaseDocs check which expected the jar name to be 'Skript-github.jar' rather than the versioned name (e.g. 'Skript-2.8.7.jar'). Since the jar name was wrong, it could not be copied over properly for testing. I have verified that the Skript jar is properly copied over now.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
