### PR TITLE
ExprLastDamage - fix everything

### DIFF
--- a/src/main/java/ch/njol/skript/bukkitutil/HealthUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/HealthUtils.java
@@ -26,13 +26,13 @@ import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.damage.DamageSource;
 import org.bukkit.damage.DamageType;
 import org.bukkit.entity.Damageable;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 
 public class HealthUtils {
 
@@ -112,8 +112,11 @@ public class HealthUtils {
 		return e.getFinalDamage() / 2;
 	}
 	
-	public static void setDamage(EntityDamageEvent e, double damage) {
-		e.setDamage(damage * 2);
+	public static void setDamage(EntityDamageEvent event, double damage) {
+		event.setDamage(damage * 2);
+		// Set last damage manually as Bukkit doesn't appear to do that
+		if (event.getEntity() instanceof LivingEntity)
+			((LivingEntity) event.getEntity()).setLastDamage(damage * 2);
 	}
 
 	@Nullable

--- a/src/main/java/ch/njol/skript/expressions/ExprLastDamage.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLastDamage.java
@@ -19,47 +19,34 @@
  */
 package ch.njol.skript.expressions;
 
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
-
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
-import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
-import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
 
 @Name("Last Damage")
 @Description("The last damage that was done to an entity. Note that changing it doesn't deal more/less damage.")
 @Examples({"set last damage of event-entity to 2"})
 @Since("2.5.1")
 public class ExprLastDamage extends SimplePropertyExpression<LivingEntity, Number> {
-	
+
 	static {
 		register(ExprLastDamage.class, Number.class, "last damage", "livingentities");
 	}
-	
-	@Nullable
-	private ExprDamage damageExpr;
-	
-	@Override
-	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
-		damageExpr = new ExprDamage();
-		return true;
-	}
-	
+
 	@Nullable
 	@Override
 	@SuppressWarnings("null")
 	public Number convert(LivingEntity livingEntity) {
-		return damageExpr.get(livingEntity.getLastDamageCause())[0];
+		return livingEntity.getLastDamage() / 2;
 	}
-	
+
 	@Nullable
 	@Override
 	public Class<?>[] acceptChange(ChangeMode mode) {
@@ -72,35 +59,38 @@ public class ExprLastDamage extends SimplePropertyExpression<LivingEntity, Numbe
 				return null;
 		}
 	}
-	
+
+	@SuppressWarnings("ConstantValue")
 	@Override
 	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
-		if (delta != null) {
+		if (delta != null && delta[0] instanceof Number) {
+			double damage = ((Number) delta[0]).doubleValue() * 2;
+
 			switch (mode) {
 				case SET:
 					for (LivingEntity entity : getExpr().getArray(e))
-						entity.setLastDamage((Long) delta[0]);
+						entity.setLastDamage(damage);
 					break;
 				case REMOVE:
-					delta[0] = (Long) delta[0] * -1;
+					damage = damage * -1;
 				case ADD:
 					for (LivingEntity entity : getExpr().getArray(e))
-						entity.setLastDamage((Long) delta[0] + entity.getLastDamage());
+						entity.setLastDamage(damage + entity.getLastDamage());
 					break;
 				default:
 					assert false;
 			}
 		}
 	}
-	
+
 	@Override
 	public Class<? extends Number> getReturnType() {
 		return Number.class;
 	}
-	
+
 	@Override
 	protected String getPropertyName() {
 		return "last damage";
 	}
-	
+
 }

--- a/src/test/skript/tests/syntaxes/expressions/ExprLastDamage.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprLastDamage.sk
@@ -1,0 +1,15 @@
+test "last damage":
+	set {_l} to location 0.5 above highest block at location(1,1,1)
+	spawn a sheep at {_l}
+	set {_e} to last spawned entity
+
+	assert last damage of {_e} = 0 with "last damage of newly spawned entity should be 0"
+
+	damage {_e} by 1
+	assert last damage of {_e} = 1 with "last damage of entity should be 1 after damaging it by 1"
+
+	set last damage of {_e} to 3
+	assert last damage of {_e} = 3 with "last damage of entity should be 3 after setting to 3"
+
+	# thank you for your service
+	delete entity in {_e}


### PR DESCRIPTION
### Description
This PR aims to fix the `last damage of %entity%` expression.
Someone recently stated in a help channel it threw errors.
Lo and behold it was riddled with errors.
I'm not sure how this got merged, it was horribly broken.
This fixes it, and has been tested well.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
