### PR TITLE
1.21 Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 	shadow group: 'org.bstats', name: 'bstats-bukkit', version: '3.0.2'
 	shadow group: 'net.kyori', name: 'adventure-text-serializer-bungeecord', version: '4.3.2'
 
-	implementation group: 'io.papermc.paper', name: 'paper-api', version: '1.20.6-R0.1-SNAPSHOT'
+	implementation group: 'io.papermc.paper', name: 'paper-api', version: '1.21-R0.1-SNAPSHOT'
 	implementation group: 'org.eclipse.jdt', name: 'org.eclipse.jdt.annotation', version: '2.2.700'
 	implementation group: 'com.google.code.findbugs', name: 'findbugs', version: '3.0.1'
 	implementation group: 'com.sk89q.worldguard', name: 'worldguard-legacy', version: '7.0.0-SNAPSHOT'
@@ -244,7 +244,7 @@ def java21 = 21
 def java17 = 17
 def java8 = 8
 
-def latestEnv = 'java21/paper-1.20.6.json'
+def latestEnv = 'java21/paper-1.21.0.json'
 def latestJava = java21
 def oldestJava = java8
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ groupid=ch.njol
 name=skript
 version=2.8.7
 jarName=Skript.jar
-testEnv=java21/paper-1.20.6
+testEnv=java21/paper-1.21.0
 testEnvJavaVersion=21

--- a/src/main/java/ch/njol/skript/aliases/AliasesProvider.java
+++ b/src/main/java/ch/njol/skript/aliases/AliasesProvider.java
@@ -304,16 +304,19 @@ public class AliasesProvider {
 			}
 			
 			// Apply (NBT) tags to item stack
-			ItemStack stack = new ItemStack(material);
+			ItemStack stack = null;
 			int itemFlags = 0;
-			if (tags != null) {
-				itemFlags = applyTags(stack, new HashMap<>(tags));
+			if (material.isItem()) {
+				stack = new ItemStack(material);
+				if (tags != null) {
+					itemFlags = applyTags(stack, new HashMap<>(tags));
+				}
 			}
 			
 			// Parse block state to block values
 			BlockValues blockValues = BlockCompat.INSTANCE.createBlockValues(material, blockStates, stack, itemFlags);
 			
-			ItemData data = new ItemData(stack, blockValues);
+			ItemData data = stack != null ? new ItemData(stack, blockValues) : new ItemData(material, blockValues);
 			data.isAlias = true;
 			data.itemFlags = itemFlags;
 			

--- a/src/main/java/ch/njol/skript/aliases/ItemData.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemData.java
@@ -37,7 +37,7 @@ import org.bukkit.inventory.ItemFactory;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.io.NotSerializableException;
@@ -92,11 +92,6 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 	public static final boolean itemDataValues = false;
 	
 	/**
-	 * ItemStack, which is used for everything but serialization.
-	 */
-	transient ItemStack stack;
-	
-	/**
 	 * Type of the item as Bukkit material. Serialized manually.
 	 */
 	transient Material type;
@@ -105,14 +100,18 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 	 * If this represents all possible items.
 	 */
 	boolean isAnything;
-	
+
+	/**
+	 * ItemStack, which is used for everything but serialization.
+	 */
+	transient @Nullable ItemStack stack;
+
 	/**
 	 * When this ItemData represents a block, this contains information to
 	 * allow comparing it against other blocks.
 	 */
-	@Nullable
-	BlockValues blockValues;
-	
+	@Nullable BlockValues blockValues;
+
 	/**
 	 * Whether this represents an item (that definitely cannot have
 	 * block states) or a block, which might have them.
@@ -140,9 +139,10 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 	
 	public ItemData(Material type, @Nullable String tags) {
 		this.type = type;
-		
-		this.stack = new ItemStack(type);
-		this.blockValues = BlockCompat.INSTANCE.getBlockValues(stack);
+
+		if (type.isItem())
+			this.stack = new ItemStack(type);
+		this.blockValues = BlockCompat.INSTANCE.getBlockValues(type);
 		if (tags != null) {
 			applyTags(tags);
 		}
@@ -150,8 +150,9 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 	
 	public ItemData(Material type, int amount) {
 		this.type = type;
-		this.stack = new ItemStack(type, Math.abs(amount));
-		this.blockValues = BlockCompat.INSTANCE.getBlockValues(stack);
+		if (type.isItem())
+			this.stack = new ItemStack(type, Math.abs(amount));
+		this.blockValues = BlockCompat.INSTANCE.getBlockValues(type);
 	}
 	
 	public ItemData(Material type) {
@@ -159,12 +160,17 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 	}
 	
 	public ItemData(ItemData data) {
-		this.stack = data.stack.clone();
+		this.stack = data.stack != null ? data.stack.clone() : null;
 		this.type = data.type;
 		this.blockValues = data.blockValues;
 		this.isAlias = data.isAlias;
 		this.plain = data.plain;
 		this.itemFlags = data.itemFlags;
+	}
+
+	public ItemData(Material material, @Nullable BlockValues values) {
+		this.type = material;
+		this.blockValues = values;
 	}
 	
 	public ItemData(ItemStack stack, @Nullable BlockValues values) {
@@ -200,7 +206,8 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 
 	public ItemData(BlockData blockData) {
 		this.type = blockData.getMaterial();
-		this.stack = new ItemStack(type);
+		if (type.isItem())
+			this.stack = new ItemStack(type);
 		this.blockValues = BlockCompat.INSTANCE.getBlockValues(blockData);
 	}
 	
@@ -227,13 +234,12 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 		if (type != item.getType())
 			return false; // Obvious mismatch
 		
-		if (itemFlags != 0) { // Either stack has tags (or durability)
+		if (stack != null && itemFlags != 0) { // Either stack has tags (or durability)
 			if (ItemUtils.getDamage(stack) != ItemUtils.getDamage(item))
 				return false; // On 1.12 and below, damage is not in meta
 			if (stack.hasItemMeta() == item.hasItemMeta()) // Compare ItemMeta as in isSimilar() of ItemStack
-				return stack.hasItemMeta() ? itemFactory.equals(stack.getItemMeta(), item.getItemMeta()) : true;
-			else
-				return false;
+				return !stack.hasItemMeta() || itemFactory.equals(stack.getItemMeta(), item.getItemMeta());
+			return false;
 		}
 		return true;
 	}
@@ -249,7 +255,7 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 	
 	public String toString(final boolean debug, final boolean plural) {
 		StringBuilder builder = new StringBuilder(Aliases.getMaterialName(this, plural));
-		ItemMeta meta = stack.getItemMeta();
+		ItemMeta meta = stack != null ? stack.getItemMeta() : null;
 		if (meta != null && meta.hasDisplayName()) {
 			builder.append(" ").append(m_named).append(" ");
 			builder.append(meta.getDisplayName());
@@ -282,7 +288,7 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 	@Override
 	public int hashCode() {
 		int hash = type.hashCode(); // Has collisions, but probably not too many of them
-		if (blockValues == null || (blockValues != null && blockValues.isDefault())) {
+		if (blockValues == null || blockValues.isDefault()) {
 			hash = hash * 37 + 1;
 		}
 		return hash;
@@ -351,7 +357,7 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 		}
 		
 		// See if we need to compare item metas (excluding durability)
-		if (quality.isAtLeast(MatchQuality.SAME_ITEM) && stack.hasItemMeta() || item.stack.hasItemMeta()) { // Item meta checks could lower this
+		if (quality.isAtLeast(MatchQuality.SAME_ITEM) && this.hasItemMeta() || item.hasItemMeta()) { // Item meta checks could lower this
 			MatchQuality metaQuality = compareItemMetas(getItemMeta(), item.getItemMeta());
 			
 			// If given item doesn't care about meta, promote to SAME_ITEM
@@ -489,8 +495,12 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 	 * It is not a copy, so please be careful.
 	 * @return Item stack.
 	 */
-	public ItemStack getStack() {
+	public @Nullable ItemStack getStack() {
 		return stack;
+	}
+
+	private boolean hasItemMeta() {
+		return stack != null && stack.hasItemMeta();
 	}
 	
 	@Override
@@ -508,7 +518,7 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 	}
 	
 	public ItemMeta getItemMeta() {
-		ItemMeta meta = stack.getItemMeta();
+		ItemMeta meta = stack != null ? stack.getItemMeta() : null;
 		if (meta == null) { // AIR has null item meta!
 			meta = itemFactory.getItemMeta(Material.STONE);
 		}
@@ -517,6 +527,8 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 	}
 	
 	public void setItemMeta(ItemMeta meta) {
+		if (stack == null)
+			return;
 		stack.setItemMeta(meta);
 		isAlias = false; // This is no longer exact alias
 		plain = false; // This is no longer a plain item
@@ -524,10 +536,14 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 	}
 	
 	public int getDurability() {
+		if (stack == null)
+			return 0; // no damage?
 		return ItemUtils.getDamage(stack);
 	}
 	
 	public void setDurability(int durability) {
+		if (stack == null)
+			return;
 		ItemUtils.setDamage(stack, durability);
 		isAlias = false; // Change happened
 		plain = false; // This is no longer a plain item
@@ -567,7 +583,7 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 	public Fields serialize() throws NotSerializableException {
 		Fields fields = new Fields(this); // ItemStack is transient, will be ignored
 		fields.putPrimitive("id", type.ordinal());
-		fields.putObject("meta", stack.getItemMeta());
+		fields.putObject("meta", stack != null ? stack.getItemMeta() : null);
 		return fields;
 	}
 
@@ -579,8 +595,10 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 		ItemMeta meta = fields.getAndRemoveObject("meta", ItemMeta.class);
 
 		// Initialize ItemStack
-		this.stack = new ItemStack(type);
-		stack.setItemMeta(meta); // Just set meta to it
+		if (meta != null && type.isItem()) {
+			this.stack = new ItemStack(type);
+			stack.setItemMeta(meta); // Just set meta to it
+		}
 
 		fields.setFields(this); // Everything but ItemStack and Material
 	}
@@ -598,17 +616,17 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 	 */
 	public ItemData aliasCopy() {
 		ItemData data = new ItemData();
-		data.stack = new ItemStack(type, 1);
-		
-		if (stack.hasItemMeta()) {
-			ItemMeta meta = stack.getItemMeta(); // Creates a copy
-			meta.setDisplayName(null); // Clear display name
-			if (!itemFactory.getItemMeta(type).equals(meta)) // there may be different tags (e.g. potions)
-				data.itemFlags |= ItemFlags.CHANGED_TAGS;
-			data.stack.setItemMeta(meta);
+		if (stack != null) {
+			data.stack = new ItemStack(type, 1);
+			if (stack.hasItemMeta()) {
+				ItemMeta meta = stack.getItemMeta(); // Creates a copy
+				meta.setDisplayName(null); // Clear display name
+				if (!itemFactory.getItemMeta(type).equals(meta)) // there may be different tags (e.g. potions)
+					data.itemFlags |= ItemFlags.CHANGED_TAGS;
+				data.stack.setItemMeta(meta);
+			}
+			ItemUtils.setDamage(data.stack, 0); // Set to undamaged
 		}
-		ItemUtils.setDamage(data.stack, 0); // Set to undamaged
-
 		data.type = type;
 		data.blockValues = blockValues;
 		data.itemForm = itemForm;
@@ -620,6 +638,8 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 	 * @param tags Tags in Mojang's JSON format.
 	 */
 	public void applyTags(String tags) {
+		if (stack == null)
+			return;
 		BukkitUnsafe.modifyItemStack(stack, tags);
 		itemFlags |= ItemFlags.CHANGED_TAGS;
 	}

--- a/src/main/java/ch/njol/skript/aliases/ItemType.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemType.java
@@ -68,6 +68,7 @@ import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.RandomAccess;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @ContainerType(ItemStack.class)
 public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>, YggdrasilExtendedSerializable {
@@ -315,7 +316,7 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 
 	public boolean isOfType(Material id) {
 		// TODO avoid object creation
-		return isOfType(new ItemData(id, null));
+		return isOfType(new ItemData(id, (String) null));
 	}
 
 	/**
@@ -343,7 +344,7 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 	 */
 	public boolean hasItem() {
 		for (ItemData d : types) {
-			if (!d.type.isBlock())
+			if (d.type.isItem())
 				return true;
 		}
 		return false;
@@ -487,9 +488,13 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 
 			@Override
 			public ItemStack next() {
-				if (!hasNext())
-					throw new NoSuchElementException();
-				ItemStack is = iter.next().getStack().clone();
+				ItemStack is = null;
+				while (is == null) {
+					if (!hasNext())
+						throw new NoSuchElementException();
+					is = iter.next().getStack();
+				}
+				is = is.clone();
 				is.setAmount(getAmount());
 				return is;
 			}
@@ -588,10 +593,17 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 	 * @see #removeFrom(ItemStack)
 	 * @see #removeFrom(List...)
 	 */
-	public ItemStack getRandom() {
-		int numItems = types.size();
+	public @Nullable ItemStack getRandom() {
+		List<ItemData> datas = types.stream()
+				.filter(data -> data.stack != null)
+				.collect(Collectors.toList());
+		if (datas.isEmpty())
+			return null;
+		int numItems = datas.size();
 		int index = random.nextInt(numItems);
-		ItemStack is = types.get(index).getStack().clone();
+		ItemStack is = datas.get(index).getStack();
+		assert is != null; // verified above
+		is = is.clone();
 		is.setAmount(getAmount());
 		return is;
 	}
@@ -869,7 +881,9 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 	 */
 	public void addTo(final List<ItemStack> list) {
 		if (!isAll()) {
-			list.add(getItem().getRandom());
+			ItemStack random = getItem().getRandom();
+			if (random != null)
+				list.add(getItem().getRandom());
 			return;
 		}
 		for (final ItemStack is : getItem().getAll())
@@ -936,7 +950,9 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 
 	public boolean addTo(final ItemStack[] buf) {
 		if (!isAll()) {
-			return addTo(getItem().getRandom(), buf);
+			ItemStack random = getItem().getRandom();
+			if (random != null)
+				return addTo(getItem().getRandom(), buf);
 		}
 		boolean ok = true;
 		for (ItemStack is : getItem().getAll()) {

--- a/src/main/java/ch/njol/skript/bukkitutil/block/BlockCompat.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/block/BlockCompat.java
@@ -66,6 +66,9 @@ public interface BlockCompat {
 	}
 
 	@Nullable
+	BlockValues getBlockValues(Material material);
+
+	@Nullable
 	BlockValues getBlockValues(BlockData blockData);
 	
 	/**

--- a/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
@@ -336,6 +336,13 @@ public class NewBlockCompat implements BlockCompat {
 		return getBlockValues(blockState.getBlockData());
 	}
 
+	@Override
+	public @Nullable BlockValues getBlockValues(Material material) {
+		if (material.isBlock())
+			return new NewBlockValues(material, Bukkit.createBlockData(material), false);
+		return null;
+	}
+
 	@Nullable
 	@Override
 	public BlockValues getBlockValues(BlockData blockData) {

--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -930,6 +930,7 @@ public class BukkitClasses {
 				.since("1.0")
 				.after("number")
 				.supplier(() -> Arrays.stream(Material.values())
+					.filter(Material::isItem)
 					.map(ItemStack::new)
 					.iterator())
 				.parser(new Parser<ItemStack>() {

--- a/src/test/skript/environments/java21/paper-1.21.0.json
+++ b/src/test/skript/environments/java21/paper-1.21.0.json
@@ -1,0 +1,17 @@
+{
+	"name": "paper-1.21.0",
+	"resources": [
+		{"source": "server.properties.generic", "target": "server.properties"}
+	],
+	"paperDownloads": [
+		{
+			"version": "1.21",
+			"target": "paperclip.jar"
+		}
+	],
+	"skriptTarget": "plugins/Skript.jar",
+	"commandLine": [
+		"-Dcom.mojang.eula.agree=true",
+		"-jar", "paperclip.jar", "--nogui"
+	]
+}

--- a/src/test/skript/tests/regressions/5491-xp orb merge overwrite.sk
+++ b/src/test/skript/tests/regressions/5491-xp orb merge overwrite.sk
@@ -1,6 +1,10 @@
 test "spawn xp orb overwriting merged value" when running minecraft "1.14.4":
 	# 1.13.2 seems not to merge xp orbs in the same way, so this test is skipped
 
+	# 1.21 also does not merge orbs, so this test is disabled.
+	# TODO: figure out how to force the orbs to merge on 1.21+
+	running below minecraft "1.21"
+
 	# sanitize
 	kill all xp orbs
 	set {_spawn} to spawn of world "world"

--- a/src/test/skript/tests/syntaxes/effects/EffGlowingText.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffGlowingText.sk
@@ -10,7 +10,7 @@ test "glowing sign blocks" when running minecraft "1.17.1":
 	set block at {_loc} to {_original block}
 
 test "glowing sign items" when running minecraft "1.17.1":
-	set {_sign} to sign
+	set {_sign} to floor sign
 	assert {_sign} doesn't have glowing text with "Sign had glowing text erroneously (1)"
 	make {_sign} have glowing text
 	assert {_sign} has glowing text with "Sign had normal text erroneously"


### PR DESCRIPTION
### Description
This PR intends to add support for Minecraft 1.21.

I have added a new testing environment for Paper 1.21. Skript compiled without issue (at the time of writing this).

However, without this PR, Skript fails to load on Paper 1.21 (and presumably any further new releases) due to ItemStack changes. ItemStacks can no longer represent block-only materials (that is, materials such that `!Material#isItem`). This is only more of a push for us to make strong changes regarding the ItemType/ItemStack/BlockData trio, but an ideal fix would likely require a significant time investment to completely rework the alias/ItemType system.

Fortunately, I have managed to get Skript loading and tests passing without *too* many changes. One significant change is that `ItemStack#getRandom` is now nullable. There is no way to avoid this. There are now likely instances of unsafe getRandom usage that need fixed (I have not taken the time to resolve this yet). Internally, it is now the case that an ItemData *may not* have an ItemStack. This item stack was likely unused in many cases as these datas represented blocks. With all of these changes, this PR needs extensive testing to determine how

---
**Target Minecraft Versions:** 1.21+, though these ItemType/ItemData changes apply to all versions (which we may want to discuss)
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:**
- https://github.com/SkriptLang/Skript/issues/6796
