### PR TITLE
Fix current section update issues

### DIFF
--- a/src/main/java/ch/njol/skript/lang/Section.java
+++ b/src/main/java/ch/njol/skript/lang/Section.java
@@ -27,6 +27,7 @@ import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Supplier;
@@ -81,12 +82,17 @@ public abstract class Section extends TriggerSection implements SyntaxElement {
 	 * (although the loaded code may change it), the calling code must deal with this.
 	 */
 	protected void loadCode(SectionNode sectionNode) {
-		List<TriggerSection> currentSections = getParser().getCurrentSections();
-		currentSections.add(this);
+		ParserInstance parser = getParser();
+		List<TriggerSection> currentSections = parser.getCurrentSections();
+
+		List<TriggerSection> newSections = new ArrayList<>(currentSections);
+		newSections.add(this);
+		parser.setCurrentSections(newSections);
+
 		try {
 			setTriggerItems(ScriptLoader.loadItems(sectionNode));
 		} finally {
-			currentSections.remove(currentSections.size() - 1);
+			parser.setCurrentSections(currentSections);
 		}
 	}
 

--- a/src/main/java/ch/njol/skript/lang/Section.java
+++ b/src/main/java/ch/njol/skript/lang/Section.java
@@ -83,16 +83,16 @@ public abstract class Section extends TriggerSection implements SyntaxElement {
 	 */
 	protected void loadCode(SectionNode sectionNode) {
 		ParserInstance parser = getParser();
-		List<TriggerSection> currentSections = parser.getCurrentSections();
+		List<TriggerSection> previousSections = parser.getCurrentSections();
 
-		List<TriggerSection> newSections = new ArrayList<>(currentSections);
-		newSections.add(this);
-		parser.setCurrentSections(newSections);
+		List<TriggerSection> sections = new ArrayList<>(previousSections);
+		sections.add(this);
+		parser.setCurrentSections(sections);
 
 		try {
 			setTriggerItems(ScriptLoader.loadItems(sectionNode));
 		} finally {
-			parser.setCurrentSections(currentSections);
+			parser.setCurrentSections(previousSections);
 		}
 	}
 

--- a/src/main/java/ch/njol/skript/lang/TriggerSection.java
+++ b/src/main/java/ch/njol/skript/lang/TriggerSection.java
@@ -44,16 +44,16 @@ public abstract class TriggerSection extends TriggerItem {
 
 	protected TriggerSection(SectionNode node) {
 		ParserInstance parser = ParserInstance.get();
-		List<TriggerSection> currentSections = parser.getCurrentSections();
+		List<TriggerSection> previousSections = parser.getCurrentSections();
 
-		List<TriggerSection> newSections = new ArrayList<>(currentSections);
-		newSections.add(this);
-		parser.setCurrentSections(newSections);
+		List<TriggerSection> sections = new ArrayList<>(previousSections);
+		sections.add(this);
+		parser.setCurrentSections(sections);
 
 		try {
 			setTriggerItems(ScriptLoader.loadItems(node));
 		} finally {
-			parser.setCurrentSections(currentSections);
+			parser.setCurrentSections(previousSections);
 		}
 	}
 

--- a/src/main/java/ch/njol/skript/lang/TriggerSection.java
+++ b/src/main/java/ch/njol/skript/lang/TriggerSection.java
@@ -24,6 +24,7 @@ import ch.njol.skript.lang.parser.ParserInstance;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -42,12 +43,17 @@ public abstract class TriggerSection extends TriggerItem {
 	}
 
 	protected TriggerSection(SectionNode node) {
-		List<TriggerSection> currentSections = ParserInstance.get().getCurrentSections();
-		currentSections.add(this);
+		ParserInstance parser = ParserInstance.get();
+		List<TriggerSection> currentSections = parser.getCurrentSections();
+
+		List<TriggerSection> newSections = new ArrayList<>(currentSections);
+		newSections.add(this);
+		parser.setCurrentSections(newSections);
+
 		try {
 			setTriggerItems(ScriptLoader.loadItems(node));
 		} finally {
-			currentSections.remove(currentSections.size() - 1);
+			parser.setCurrentSections(currentSections);
 		}
 	}
 

--- a/src/test/skript/tests/regressions/6843-current section reference issue.sk
+++ b/src/test/skript/tests/regressions/6843-current section reference issue.sk
@@ -6,4 +6,4 @@ test "outdated current section references":
 		loop {_list::*}:
 			set {_var} to loop-value
 			set {_var} to loop-value-1
-	assert last parse logs is not set with "loop-value and loop-value-1 should've worked: %last parse logs%"
+	assert last parse logs is not set with "loop-value and loop-value-1 should've worked"

--- a/src/test/skript/tests/regressions/6843-current section reference issue.sk
+++ b/src/test/skript/tests/regressions/6843-current section reference issue.sk
@@ -1,0 +1,9 @@
+test "outdated current section references":
+	parse:
+		loop {_list::*}:
+			spawn a sheep at {_loc}:
+				set {_e} to event-entity
+		loop {_list::*}:
+			set {_var} to loop-value
+			set {_var} to loop-value-1
+	assert last parse logs is not set with "loop-value and loop-value-1 should've worked: %last parse logs%"


### PR DESCRIPTION
### Description

This PR fixes an important issue where, when loading a new section, Skript may fail to remove the newly-loaded section from the current sections list. This is caused by the methods holding onto an unsafe. This issue was exposed by https://github.com/SkriptLang/Skript/pull/6699 which makes changes to the list being referenced. However, even before this PR, this was unsafe as the method `ParserInstance#setCurrentSections` exists (meaning any addons changing the list reference could introduce issues).

I have resolved this issue by creating and setting a copy of the current sections list, and then setting it back to the original list when it is time to exit.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:*
- #6843 
