### PR TITLE
Properly name PotionEffectType in lang

### DIFF
--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -2317,7 +2317,7 @@ types:
 	itemstack: item stack¦s @an
 	itementity: dropped item¦s @a # same as entities.dropped item.name
 	biome: biome¦s @a
-	potioneffecttype: potion¦s @a
+	potioneffecttype: potion effect type¦s @a
 	potioneffect: potion effect¦s @a
 	enchantment: enchantment¦s @an
 	damagecause: damage cause¦s @a


### PR DESCRIPTION
### Description
This PR aims to properly name the PotionEffectType in lang.

A few years back I did a change in the class info, from potion -> potion effect type
I think I forgot to do the lang.

This rename is more precise to the actual name of the class.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
