### PR TITLE
RegistrySerializer - fix serialization issues

### DIFF
--- a/src/test/skript/tests/misc/registry.sk
+++ b/src/test/skript/tests/misc/registry.sk
@@ -1,0 +1,10 @@
+test "registry" when minecraft version is "1.14":
+
+	# Test namespaced keys
+	assert curse of vanishing = minecraft:vanishing_curse with "'curse of vanishing' enchant should match namespace key"
+
+	# Test serialization
+	set {test::enchantment} to minecraft:sharpness
+	assert {test::enchantment} = sharpness with "variable should have been set to sharpness enchantment"
+
+


### PR DESCRIPTION
### Description
This PR aims to fix some serialization issues with the RegistrySerializer:

1) It apparently did not like using a primitive String, now using object instead.
2) Threw massive errors when it couldn't load an invalid object from registry
(one example was removing a data pack, that held a custom enchantment which was saved to a var)

Added some tests as well. 

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #6862
