### PR TITLE
ItemUtils - fix error when setting damage lower than 0

### DIFF
--- a/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
@@ -105,7 +105,7 @@ public class ItemUtils {
 	public static void setDamage(ItemStack itemStack, int damage) {
 		ItemMeta meta = itemStack.getItemMeta();
 		if (meta instanceof Damageable) {
-			((Damageable) meta).setDamage(damage);
+			((Damageable) meta).setDamage(Math.max(0, damage));
 			itemStack.setItemMeta(meta);
 		}
 	}

--- a/src/test/skript/tests/syntaxes/expressions/ExprDurability.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprDurability.sk
@@ -13,6 +13,16 @@ test "durability":
 	assert damage of {_i} is {_max} with "max item damage failed"
 	assert durability of {_i} is 0 with "zero item durability failed"
 
+	# Test out of bound values
+	set durability of {_i} to 500
+	assert damage of {_i} is 0 with "damage of item should be 0 when setting durability higher than max"
+	assert durability of {_i} is {_max} with "durability of item should be max when setting higher than max"
+
+	set damage of {_i} to -1
+	assert damage of {_i} is 0 with "damage of item should be 0 when setting damage less than 0"
+	assert durability of {_i} is {_max} with "durability of item should be max when setting damage below 0"
+
+
 test "durability - custom" when running minecraft "1.20.5":
 	set {_i} to 1 of iron sword
 	set max durability of {_i} to 1000

--- a/src/test/skript/tests/syntaxes/expressions/ExprDurability.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprDurability.sk
@@ -22,7 +22,6 @@ test "durability":
 	assert damage of {_i} is 0 with "damage of item should be 0 when setting damage less than 0"
 	assert durability of {_i} is {_max} with "durability of item should be max when setting damage below 0"
 
-
 test "durability - custom" when running minecraft "1.20.5":
 	set {_i} to 1 of iron sword
 	set max durability of {_i} to 1000


### PR DESCRIPTION
### Description
This PR aims to fix an error when setting damage of an item to less than 0

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #6869 
