### PR TITLE
EnchantmentType - fix toString showing namespacedkeys

### DIFF
--- a/src/main/java/ch/njol/skript/util/EnchantmentType.java
+++ b/src/main/java/ch/njol/skript/util/EnchantmentType.java
@@ -19,7 +19,6 @@
 package ch.njol.skript.util;
 
 import ch.njol.skript.aliases.ItemType;
-import ch.njol.skript.bukkitutil.EnchantmentUtils;
 import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.classes.Parser;
 import ch.njol.skript.lang.ParseContext;
@@ -92,7 +91,7 @@ public class EnchantmentType implements YggdrasilSerializable {
 
 	@Override
 	public String toString() {
-		return EnchantmentUtils.toString(type) + (level == -1 ? "" : " " + level);
+		return getEnchantmentParser().toString(type, 0) + (level == -1 ? "" : " " + level);
 	}
 
 	@SuppressWarnings("null")
@@ -107,27 +106,18 @@ public class EnchantmentType implements YggdrasilSerializable {
 	 */
 	@Nullable
 	public static EnchantmentType parse(final String s) {
-		if (ENCHANTMENT_PARSER == null) {
-			ClassInfo<Enchantment> classInfo = Classes.getExactClassInfo(Enchantment.class);
-			if (classInfo == null) {
-				throw new IllegalStateException("Enchantment ClassInfo not found");
-			}
-			ENCHANTMENT_PARSER = (Parser<Enchantment>) classInfo.getParser();
-			if (ENCHANTMENT_PARSER == null) {
-				throw new IllegalStateException("Enchantment parser not found");
-			}
-		}
+		Parser<Enchantment> enchantmentParser = getEnchantmentParser();
 		if (pattern.matcher(s).matches()) {
 			String name = s.substring(0, s.lastIndexOf(' '));
 			assert name != null;
-			final Enchantment ench = ENCHANTMENT_PARSER.parse(name, ParseContext.DEFAULT);
+			final Enchantment ench = enchantmentParser.parse(name, ParseContext.DEFAULT);
 			if (ench == null)
 				return null;
 			String level = s.substring(s.lastIndexOf(' ') + 1);
 			assert level != null;
 			return new EnchantmentType(ench, Utils.parseInt(level));
 		}
-		final Enchantment ench = ENCHANTMENT_PARSER.parse(s, ParseContext.DEFAULT);
+		final Enchantment ench = enchantmentParser.parse(s, ParseContext.DEFAULT);
 		if (ench == null)
 			return null;
 		return new EnchantmentType(ench, -1);
@@ -154,6 +144,21 @@ public class EnchantmentType implements YggdrasilSerializable {
 		if (level != other.level)
 			return false;
 		return type.equals(other.type);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Parser<Enchantment> getEnchantmentParser() {
+		if (ENCHANTMENT_PARSER == null) {
+			ClassInfo<Enchantment> classInfo = Classes.getExactClassInfo(Enchantment.class);
+			if (classInfo == null) {
+				throw new IllegalStateException("Enchantment ClassInfo not found");
+			}
+			ENCHANTMENT_PARSER = (Parser<Enchantment>) classInfo.getParser();
+			if (ENCHANTMENT_PARSER == null) {
+				throw new IllegalStateException("Enchantment parser not found");
+			}
+		}
+		return ENCHANTMENT_PARSER;
 	}
 
 }


### PR DESCRIPTION
### Description
This PR aims to fix an issue with how EnchantmentType#toString works.
Issue was it tried to pull names from EnchantmentUtils, but since they're not set (when using registry) it just used keys.

BEFORE PR:
<img width="502" alt="Screenshot 2024-07-05 at 4 52 06 PM" src="https://github.com/SkriptLang/Skript/assets/20008482/dc1a4c38-3f5a-44e7-a669-4b63c7373ae4">


AFTER PR:
<img width="502" alt="Screenshot 2024-07-05 at 4 50 29 PM" src="https://github.com/SkriptLang/Skript/assets/20008482/e1a3c80e-eb36-4d89-911c-7e15334a6881">


---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
