### PR TITLE
Fix ExprName InventoryView IncompatibleClassChangeError

### DIFF
--- a/src/main/java/ch/njol/skript/bukkitutil/InventoryUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/InventoryUtils.java
@@ -1,0 +1,111 @@
+package ch.njol.skript.bukkitutil;
+
+import ch.njol.skript.Skript;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryView;
+import org.eclipse.jdt.annotation.Nullable;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+/**
+ * Utilities for inventories.
+ * In newer versions (1.21+), InventoryView is an interface instead of an abstract class
+ * Directing calling InventoryView#getTitle on 1.20.6 and below results in an IncompatibleClassChangeError
+ *  as an interface, not an abstract class, is expected.
+ */
+public class InventoryUtils {
+
+	private static final @Nullable MethodHandle GET_TITLE;
+	private static final @Nullable MethodHandle GET_INVENTORY;
+	private static final @Nullable MethodHandle CONVERT_SLOT;
+	private static final @Nullable MethodHandle GET_TOP_INVENTORY;
+	private static final @Nullable MethodHandle GET_BOTTOM_INVENTORY;
+
+	static {
+		MethodHandle getTitle = null;
+		MethodHandle getInventory = null;
+		MethodHandle convertSlot = null;
+		MethodHandle getTopInventory = null;
+		MethodHandle getBottomInventory = null;
+		if (!InventoryView.class.isInterface()) { // initialize legacy support as it's likely an abstract class
+			try {
+				MethodHandles.Lookup lookup = MethodHandles.lookup();
+				getTitle = lookup.findVirtual(InventoryView.class, "getTitle", MethodType.methodType(String.class));
+				getInventory = lookup.findVirtual(InventoryView.class, "getInventory", MethodType.methodType(Inventory.class, int.class));
+				convertSlot = lookup.findVirtual(InventoryView.class, "convertSlot", MethodType.methodType(int.class, int.class));
+				getTopInventory = lookup.findVirtual(InventoryView.class, "getTopInventory", MethodType.methodType(Inventory.class));
+				getBottomInventory = lookup.findVirtual(InventoryView.class, "getBottomInventory", MethodType.methodType(Inventory.class));
+			} catch (NoSuchMethodException | IllegalAccessException e) {
+				Skript.exception(e, "Failed to load old inventory view support.");
+			}
+		}
+		GET_TITLE = getTitle;
+		GET_INVENTORY = getInventory;
+		CONVERT_SLOT = convertSlot;
+		GET_TOP_INVENTORY = getTopInventory;
+		GET_BOTTOM_INVENTORY = getBottomInventory;
+	}
+
+	/**
+	 * @see InventoryView#getTitle()
+	 */
+	public static @Nullable String getTitle(InventoryView inventoryView) {
+		if (GET_TITLE == null)
+			return inventoryView.getTitle();
+		try {
+			GET_TITLE.invoke(inventoryView);
+		} catch (Throwable ignored) { }
+		return null;
+	}
+
+	/**
+	 * @see InventoryView#getInventory(int)
+	 */
+	public static @Nullable Inventory getInventory(InventoryView inventoryView, int rawSlot) {
+		if (GET_INVENTORY == null)
+			return inventoryView.getInventory(rawSlot);
+		try {
+			GET_INVENTORY.invoke(inventoryView, rawSlot);
+		} catch (Throwable ignored) { }
+		return null;
+	}
+
+	/**
+	 * @see InventoryView#convertSlot(int)
+	 */
+	public static @Nullable Integer convertSlot(InventoryView inventoryView, int rawSlot) {
+		if (CONVERT_SLOT == null)
+			return inventoryView.convertSlot(rawSlot);
+		try {
+			CONVERT_SLOT.invoke(inventoryView, rawSlot);
+		} catch (Throwable ignored) { }
+		return null;
+	}
+
+	/**
+	 * @see InventoryView#getTopInventory()
+	 */
+	public static @Nullable Inventory getTopInventory(InventoryView inventoryView) {
+		if (GET_TOP_INVENTORY == null)
+			return inventoryView.getTopInventory();
+		try {
+			GET_TOP_INVENTORY.invoke(inventoryView);
+		} catch (Throwable ignored) { }
+		return null;
+	}
+
+	/**
+	 * @see InventoryView#getBottomInventory()
+	 */
+	public static @Nullable Inventory getBottomInventory(InventoryView inventoryView) {
+		if (GET_BOTTOM_INVENTORY == null)
+			return inventoryView.getTopInventory();
+		try {
+			GET_BOTTOM_INVENTORY.invoke(inventoryView);
+		} catch (Throwable ignored) { }
+		return null;
+	}
+
+}

--- a/src/main/java/ch/njol/skript/bukkitutil/InventoryUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/InventoryUtils.java
@@ -55,7 +55,7 @@ public class InventoryUtils {
 		if (GET_TITLE == null)
 			return inventoryView.getTitle();
 		try {
-			GET_TITLE.invoke(inventoryView);
+			return (String) GET_TITLE.invoke(inventoryView);
 		} catch (Throwable ignored) { }
 		return null;
 	}
@@ -67,7 +67,7 @@ public class InventoryUtils {
 		if (GET_INVENTORY == null)
 			return inventoryView.getInventory(rawSlot);
 		try {
-			GET_INVENTORY.invoke(inventoryView, rawSlot);
+			return (Inventory) GET_INVENTORY.invoke(inventoryView, rawSlot);
 		} catch (Throwable ignored) { }
 		return null;
 	}
@@ -79,7 +79,7 @@ public class InventoryUtils {
 		if (CONVERT_SLOT == null)
 			return inventoryView.convertSlot(rawSlot);
 		try {
-			CONVERT_SLOT.invoke(inventoryView, rawSlot);
+			return (Integer) CONVERT_SLOT.invoke(inventoryView, rawSlot);
 		} catch (Throwable ignored) { }
 		return null;
 	}
@@ -91,7 +91,7 @@ public class InventoryUtils {
 		if (GET_TOP_INVENTORY == null)
 			return inventoryView.getTopInventory();
 		try {
-			GET_TOP_INVENTORY.invoke(inventoryView);
+			return (Inventory) GET_TOP_INVENTORY.invoke(inventoryView);
 		} catch (Throwable ignored) { }
 		return null;
 	}
@@ -103,7 +103,7 @@ public class InventoryUtils {
 		if (GET_BOTTOM_INVENTORY == null)
 			return inventoryView.getTopInventory();
 		try {
-			GET_BOTTOM_INVENTORY.invoke(inventoryView);
+			return (Inventory) GET_BOTTOM_INVENTORY.invoke(inventoryView);
 		} catch (Throwable ignored) { }
 		return null;
 	}

--- a/src/main/java/ch/njol/skript/bukkitutil/InventoryUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/InventoryUtils.java
@@ -101,7 +101,7 @@ public class InventoryUtils {
 	 */
 	public static @Nullable Inventory getBottomInventory(InventoryView inventoryView) {
 		if (GET_BOTTOM_INVENTORY == null)
-			return inventoryView.getTopInventory();
+			return inventoryView.getBottomInventory();
 		try {
 			return (Inventory) GET_BOTTOM_INVENTORY.invoke(inventoryView);
 		} catch (Throwable ignored) { }

--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.Aliases;
 import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.bukkitutil.InventoryUtils;
 import ch.njol.skript.command.CommandEvent;
 import ch.njol.skript.events.bukkit.ScriptEvent;
 import ch.njol.skript.events.bukkit.SkriptStartEvent;
@@ -1252,15 +1253,15 @@ public final class BukkitEventValues {
 				List<Slot> slots = new ArrayList<>(event.getRawSlots().size());
 				InventoryView view = event.getView();
 				for (Integer rawSlot : event.getRawSlots()) {
-					Inventory inventory = view.getInventory(rawSlot);
-					int slot = view.convertSlot(rawSlot);
-					if (inventory == null)
+					Inventory inventory = InventoryUtils.getInventory(view, rawSlot);
+					Integer slot = InventoryUtils.convertSlot(view, rawSlot);
+					if (inventory == null || slot == null)
 						continue;
 					// Not all indices point to inventory slots. Equipment, for example
 					if (inventory instanceof PlayerInventory && slot >= 36) {
 						slots.add(new ch.njol.skript.util.slot.EquipmentSlot(((PlayerInventory) view.getBottomInventory()).getHolder(), slot));
 					} else {
-						slots.add(new InventorySlot(inventory, view.convertSlot(rawSlot)));
+						slots.add(new InventorySlot(inventory, slot));
 					}
 				}
 				return slots.toArray(new Slot[0]);
@@ -1280,7 +1281,9 @@ public final class BukkitEventValues {
 				Set<Inventory> inventories = new HashSet<>();
 				InventoryView view = event.getView();
 				for (Integer rawSlot : event.getRawSlots()) {
-					inventories.add(view.getInventory(rawSlot));
+					Inventory inventory = InventoryUtils.getInventory(view, rawSlot);
+					if (inventory != null)
+						inventories.add(inventory);
 				}
 				return inventories.toArray(new Inventory[0]);
 			}

--- a/src/main/java/ch/njol/skript/expressions/ExprOpenedInventory.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprOpenedInventory.java
@@ -18,9 +18,11 @@
  */
 package ch.njol.skript.expressions;
 
+import ch.njol.skript.bukkitutil.InventoryUtils;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryView;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
@@ -61,10 +63,12 @@ public class ExprOpenedInventory extends PropertyExpression<Player, Inventory> {
 	@Override
 	protected Inventory[] get(Event event, Player[] source) {
 		return get(source, new Getter<Inventory, Player>() {
-			@SuppressWarnings("null")
 			@Override
-			public Inventory get(final Player player) {
-				return player.getOpenInventory() != null ? player.getOpenInventory().getTopInventory() : null;
+			public @Nullable Inventory get(final Player player) {
+				InventoryView openInventory = player.getOpenInventory();
+				if (openInventory == null)
+					return null;
+				return InventoryUtils.getTopInventory(openInventory);
 			}
 		});
 	}


### PR DESCRIPTION
### Description

This fixes an issue where `name of <inventory>` does not work on versions older than 1.21. This is caused by InventoryView now being an interface on 1.21 rather than an abstract class.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:**
- https://github.com/SkriptLang/Skript/issues/6872
- https://github.com/SkriptLang/Skript/issues/6879
