### PR TITLE
Fix Incorrect BlockValues#isDefault

### DIFF
--- a/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
@@ -349,7 +349,7 @@ public class NewBlockCompat implements BlockCompat {
 	@Override
 	public @Nullable BlockValues getBlockValues(Material material) {
 		if (material.isBlock())
-			return new NewBlockValues(material, Bukkit.createBlockData(material), false);
+			return new NewBlockValues(material, Bukkit.createBlockData(material), true);
 		return null;
 	}
 


### PR DESCRIPTION
### Description
This PR fixes a small but major mistake I made with the ItemType changes in https://github.com/SkriptLang/Skript/pull/6798. I added a new BlockValues getter for Materials, but I accidentally marked the returned instance as NOT being default (i.e. having special block values). Of course, this is wrong because the BlockData used is freshly created. This caused many comparison issues as items without specific block values were considered as having them.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:**
- https://github.com/SkriptLang/Skript/issues/6864
