### PR TITLE
ItemType Random Safety Improvements

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/ItemType.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemType.java
@@ -612,13 +612,25 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 				.collect(Collectors.toList());
 		if (datas.isEmpty())
 			return null;
-		int numItems = datas.size();
-		int index = random.nextInt(numItems);
-		ItemStack is = datas.get(index).getStack();
+		ItemStack is = datas.get(random.nextInt(datas.size())).getStack();
 		assert is != null; // verified above
 		is = is.clone();
 		is.setAmount(getAmount());
 		return is;
+	}
+
+	/**
+	 * @return One random ItemStack or Material that this ItemType represents.
+	 * A Material may only be returned for ItemStacks containing a Material where {@link Material#isItem()} is false.
+	 */
+	public Object getRandomStackOrMaterial() {
+		ItemData randomData = types.get(random.nextInt(types.size()));
+		ItemStack stack = randomData.getStack();
+		if (stack == null)
+			return randomData.getType();
+		stack = stack.clone();
+		stack.setAmount(getAmount());
+		return stack;
 	}
 
 	/**
@@ -1396,8 +1408,11 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 		globalMeta = null;
 	}
 
+	/**
+	 * @return A random Material this ItemType represents.
+	 */
 	public Material getMaterial() {
-		ItemData data = types.get(0);
+		ItemData data = types.get(random.nextInt(types.size()));
 		if (data == null)
 			throw new IllegalStateException("material not found");
 		return data.getType();

--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -949,7 +949,10 @@ public class BukkitClasses {
 						}
 						
 						final ItemStack i = t.getRandom();
-						assert i != null;
+						if (i == null) {
+							Skript.error("'" + s + "' cannot represent an item");
+							return null;
+						}
 						return i;
 					}
 					

--- a/src/main/java/ch/njol/skript/conditions/CondIsPreferredTool.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsPreferredTool.java
@@ -80,13 +80,14 @@ public class CondIsPreferredTool extends Condition {
 	public boolean check(Event event) {
 		return blocks.check(event, block ->
 			items.check(event, item -> {
-				if (block instanceof Block) {
-					return ((Block) block).isPreferredTool(item.getRandom());
-				} else if (block instanceof BlockData) {
-					return ((BlockData) block).isPreferredTool(item.getRandom());
-				} else {
-					return false;
+				ItemStack stack = item.getRandom();
+				if (stack != null) {
+					if (block instanceof Block)
+						return ((Block) block).isPreferredTool(stack);
+					if (block instanceof BlockData)
+						return ((BlockData) block).isPreferredTool(stack);
 				}
+				return false;
 			}), isNegated());
 	}
 

--- a/src/main/java/ch/njol/skript/effects/EffOpenBook.java
+++ b/src/main/java/ch/njol/skript/effects/EffOpenBook.java
@@ -68,7 +68,7 @@ public class EffOpenBook extends Effect {
 		ItemType itemType = book.getSingle(e);
 		if (itemType != null) {
 			ItemStack itemStack = itemType.getRandom();
-			if (itemStack.getType() == Material.WRITTEN_BOOK) {
+			if (itemStack != null && itemStack.getType() == Material.WRITTEN_BOOK) {
 				for (Player player : players.getArray(e)) {
 					player.openBook(itemStack);
 				}

--- a/src/main/java/ch/njol/skript/effects/EffReplace.java
+++ b/src/main/java/ch/njol/skript/effects/EffReplace.java
@@ -129,9 +129,10 @@ public class EffReplace extends Effect {
 
 						if (new ItemType(itemStack).isSimilar(needle)) {
 							ItemStack newItemStack = ((ItemType) replacement).getRandom();
-							newItemStack.setAmount(itemStack.getAmount());
-
-							inv.setItem(slot, newItemStack);
+							if (newItemStack != null) {
+								newItemStack.setAmount(itemStack.getAmount());
+								inv.setItem(slot, newItemStack);
+							}
 						}
 					}
 		}

--- a/src/main/java/ch/njol/skript/entity/BoatChestData.java
+++ b/src/main/java/ch/njol/skript/entity/BoatChestData.java
@@ -110,8 +110,7 @@ public class BoatChestData extends EntityData<ChestBoat> {
 	public boolean isOfItemType(ItemType itemType) {
 		int ordinal = -1;
 
-		ItemStack stack = itemType.getRandom();
-		Material type = stack.getType();
+		Material type = itemType.getMaterial();
 		if (type == Material.OAK_CHEST_BOAT)
 			ordinal = 0;
 		else if (type == Material.SPRUCE_CHEST_BOAT)

--- a/src/main/java/ch/njol/skript/entity/BoatData.java
+++ b/src/main/java/ch/njol/skript/entity/BoatData.java
@@ -112,9 +112,8 @@ public class BoatData extends EntityData<Boat> {
 	
 	public boolean isOfItemType(ItemType i){
 		int ordinal = -1;
-		
-		ItemStack stack = i.getRandom();
-		Material type = stack.getType();
+
+		Material type = i.getMaterial();
 		if (type == Material.OAK_BOAT)
 			ordinal = 0;
 		else if (type == Material.SPRUCE_BOAT)

--- a/src/main/java/ch/njol/skript/entity/DroppedItemData.java
+++ b/src/main/java/ch/njol/skript/entity/DroppedItemData.java
@@ -64,8 +64,15 @@ public class DroppedItemData extends EntityData<Item> {
 	
 	@Override
 	protected boolean init(Literal<?>[] expressions, int matchedPattern, ParseResult parseResult) {
-		if (expressions.length > 0 && expressions[0] != null)
+		if (expressions.length > 0 && expressions[0] != null) {
 			types = (ItemType[]) expressions[0].getAll();
+			for (ItemType type : types) {
+				if (!type.getMaterial().isItem()) {
+					Skript.error("'" + type + "' cannot represent a dropped item");
+					return false;
+				}
+			}
+		}
 		return true;
 	}
 	
@@ -97,6 +104,7 @@ public class DroppedItemData extends EntityData<Item> {
 		final ItemType t = CollectionUtils.getRandom(types);
 		assert t != null;
 		ItemStack stack = t.getItem().getRandom();
+		assert stack != null; // should be true by init checks
 		entity.setItemStack(stack);
 	}
 	
@@ -159,6 +167,7 @@ public class DroppedItemData extends EntityData<Item> {
 		final ItemType itemType = CollectionUtils.getRandom(types);
 		assert itemType != null;
 		ItemStack stack = itemType.getItem().getRandom();
+		assert stack != null; // should be true by init checks
 
 		Item item;
 		if (consumer == null) {

--- a/src/main/java/ch/njol/skript/expressions/ExprMaxStack.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprMaxStack.java
@@ -24,6 +24,8 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
 
 /**
  * @author joeuguce99
@@ -40,8 +42,11 @@ public class ExprMaxStack extends SimplePropertyExpression<ItemType, Long> {
 	
 	@SuppressWarnings("null")
 	@Override
-	public Long convert(final ItemType i) {
-		return (long) i.getRandom().getMaxStackSize();
+	public Long convert(ItemType itemType) {
+		Object random = itemType.getRandomStackOrMaterial();
+		if (random instanceof Material)
+			return (long) ((Material) random).getMaxStackSize();
+		return (long) ((ItemStack) random).getMaxStackSize();
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprPlain.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPlain.java
@@ -32,6 +32,7 @@ import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 
 import org.bukkit.event.Event;
+import org.bukkit.inventory.ItemStack;
 import org.eclipse.jdt.annotation.Nullable;
 
 @Name("Plain Item")
@@ -61,7 +62,7 @@ public class ExprPlain extends SimpleExpression<ItemType> {
 		ItemType itemType = item.getSingle(e);
 		if (itemType == null)
 			return new ItemType[0];
-		ItemData data = new ItemData(itemType.getRandom().getType());
+		ItemData data = new ItemData(itemType.getMaterial());
 		data.setPlain(true);
 		ItemType plain = new ItemType(data);
 		return new ItemType[]{plain};

--- a/src/main/java/ch/njol/skript/util/visual/VisualEffects.java
+++ b/src/main/java/ch/njol/skript/util/visual/VisualEffects.java
@@ -151,8 +151,11 @@ public class VisualEffects {
 				}
 				if (raw == null)
 					return Bukkit.createBlockData(Material.AIR);
-				if (raw instanceof ItemType)
-					return Bukkit.createBlockData(((ItemType) raw).getRandom().getType());
+				if (raw instanceof ItemType) {
+					ItemType type = (ItemType) raw;
+					ItemStack random = type.getRandom();
+					return Bukkit.createBlockData(random != null ? random.getType() : type.getMaterial());
+				}
 				return raw;
 			};
 			registerDataSupplier("Particle.BLOCK", blockDataSupplier);

--- a/src/test/java/org/skriptlang/skript/test/tests/regression/ExprPlainAliasTest.java
+++ b/src/test/java/org/skriptlang/skript/test/tests/regression/ExprPlainAliasTest.java
@@ -52,7 +52,7 @@ public class ExprPlainAliasTest extends SkriptJUnitTest {
 		ContextlessEvent event = ContextlessEvent.get();
 		Variables.setVariable("item", itemType, event, true);
 
-		EasyMock.expect(itemType.getRandom()).andReturn(new ItemStack(Material.STONE)).atLeastOnce();
+		EasyMock.expect(itemType.getMaterial()).andReturn(Material.STONE).atLeastOnce();
 		EasyMock.replay(itemType);
 		TriggerItem.walk(getPlainRandomItemEffect, event);
 		EasyMock.verify(itemType);


### PR DESCRIPTION
### Description
This PR aims to fix usages of ItemType#getRandom that did not properly check whether it is null (as is possible due to 1.21 changes).

I've updated `ItemType#getMaterial` to instead return a random Material rather than the material of the first ItemData. Some places do not need a random ItemStack, just a random Material (which can never be null).

Additionally, I've added a new method, `getRandomStackOrMaterial` (terrible I know, suggestions welcome) which grabs a random ItemData from the ItemType, and returns its ItemStack or Material (if it does not have stack). This is for cases where either an ItemStack or a Material is valid (e.g. max stack size). We may also choose to not return values for these materials, even though they exist. Thoughts welcome 🙂 

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:**
- https://github.com/SkriptLang/Skript/issues/6883
