### PR TITLE
Fix ItemData#equals check

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/ItemData.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemData.java
@@ -278,7 +278,7 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 			return false;
 		
 		ItemData other = (ItemData) obj;
-		if (isAlias) { // This is alias, other item might not be
+		if (isAlias()) { // This is alias, other item might not be
 			return other.matchAlias(this).isAtLeast(MatchQuality.SAME_ITEM);
 		} else { // This is not alias, but other might be
 			return matchAlias(other).isAtLeast(MatchQuality.SAME_ITEM);

--- a/src/test/skript/tests/syntaxes/effects/EffEquip.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffEquip.sk
@@ -1,0 +1,12 @@
+test "equip effect":
+	spawn a zombie at spawn of "world":
+		set {_entity} to event-entity
+
+	equip {_entity} with a diamond chestplate
+	assert chestplate of {_entity} is a diamond chestplate with "entity was not wearing a diamond chestplate"
+	set chestplate of {_entity} to air
+
+	equip {_entity} with a diamond chestplate named "Test"
+	assert chestplate of {_entity} is a diamond chestplate named "Test" with "entity was not wearing a named diamond chestplate"
+
+	delete the entity within {_entity}


### PR DESCRIPTION
### Description
This PR aims to fix an issue where ItemData#equals did not use the proper method of determining whether an ItemData represented an alias (e.g. a default item). This fixes an issue introduced by https://github.com/SkriptLang/Skript/pull/6834 where code like `equip the player with a diamond chestplate named "Test"` did not place the armor in the correct slot.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
