### PR TITLE
Improve ReturnHandler#returnValues method

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffReturn.java
+++ b/src/main/java/ch/njol/skript/effects/EffReturn.java
@@ -19,7 +19,6 @@
 package ch.njol.skript.effects;
 
 import ch.njol.skript.Skript;
-import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -110,7 +109,7 @@ public class EffReturn extends Effect {
 	protected TriggerItem walk(Event event) {
 		debug(event, false);
 		//noinspection rawtypes,unchecked
-		((ReturnHandler) handler).returnValues(value.getArray(event));
+		((ReturnHandler) handler).returnValues(event, value);
 
 		TriggerSection parent = getParent();
 		while (parent != null && parent != handler) {

--- a/src/main/java/ch/njol/skript/lang/ReturnHandler.java
+++ b/src/main/java/ch/njol/skript/lang/ReturnHandler.java
@@ -131,8 +131,8 @@ public interface ReturnHandler<T> {
 
 	/**
 	 * Called when {@link ch.njol.skript.effects.EffReturn} is executed
-	 * @param event the event
-	 * @param value the value to return
+	 * @param event the event providing context
+	 * @param value an expression representing the value(s) to return
 	 */
 	void returnValues(Event event, Expression<? extends T> value);
 

--- a/src/main/java/ch/njol/skript/lang/ReturnHandler.java
+++ b/src/main/java/ch/njol/skript/lang/ReturnHandler.java
@@ -130,9 +130,11 @@ public interface ReturnHandler<T> {
 	}
 
 	/**
-	 * @param values the values to return
+	 * Called when {@link ch.njol.skript.effects.EffReturn} is executed
+	 * @param event the event
+	 * @param value the value to return
 	 */
-	void returnValues(T @Nullable [] values);
+	void returnValues(Event event, Expression<? extends T> value);
 
 	/**
 	 * @return whether this return handler may accept multiple return values

--- a/src/main/java/ch/njol/skript/lang/ReturnableTrigger.java
+++ b/src/main/java/ch/njol/skript/lang/ReturnableTrigger.java
@@ -18,6 +18,7 @@
  */
 package ch.njol.skript.lang;
 
+import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 import org.skriptlang.skript.lang.script.Script;
 
@@ -36,8 +37,8 @@ public class ReturnableTrigger<T> extends Trigger implements ReturnHandler<T> {
 	}
 
 	@Override
-	public void returnValues(T @Nullable [] values) {
-		handler.returnValues(values);
+	public void returnValues(Event event, Expression<? extends T> value) {
+		handler.returnValues(event, value);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/lang/function/ScriptFunction.java
+++ b/src/main/java/ch/njol/skript/lang/function/ScriptFunction.java
@@ -19,13 +19,14 @@
 package ch.njol.skript.lang.function;
 
 import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ReturnHandler;
+import org.bukkit.event.Event;
 import org.jetbrains.annotations.ApiStatus;
 import org.skriptlang.skript.lang.script.Script;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.config.SectionNode;
-import ch.njol.skript.effects.EffReturn;
 import ch.njol.skript.lang.Trigger;
 import ch.njol.skript.lang.util.SimpleEvent;
 import ch.njol.skript.variables.Variables;
@@ -80,13 +81,14 @@ public class ScriptFunction<T> extends Function<T> implements ReturnHandler<T> {
 	}
 
 	/**
-	 * Should only be called by {@link EffReturn}.
-	 * @deprecated Use {@link ScriptFunction#returnValues(Object[])}
+	 * @deprecated Use {@link ScriptFunction#returnValues(Event, Expression)}
 	 */
 	@Deprecated
 	@ApiStatus.Internal
 	public final void setReturnValue(@Nullable T[] values) {
-		returnValues(values);
+		assert !returnValueSet;
+		returnValueSet = true;
+		this.returnValues = values;
 	}
 
 	@Override
@@ -97,10 +99,10 @@ public class ScriptFunction<T> extends Function<T> implements ReturnHandler<T> {
 	}
 
 	@Override
-	public final void returnValues(T @Nullable [] values) {
+	public final void returnValues(Event event, Expression<? extends T> value) {
 		assert !returnValueSet;
 		returnValueSet = true;
-		this.returnValues = values;
+		this.returnValues = value.getArray(event);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/test/runner/SecReturnable.java
+++ b/src/main/java/ch/njol/skript/test/runner/SecReturnable.java
@@ -56,8 +56,8 @@ public class SecReturnable extends Section implements ReturnHandler<Object> {
 	}
 
 	@Override
-	public void returnValues(Object @Nullable [] values) {
-		returnedValues = values;
+	public void returnValues(Event event, Expression<?> value) {
+		returnedValues = value.getArray(event);
 	}
 
 	@Override
@@ -110,5 +110,5 @@ public class SecReturnable extends Section implements ReturnHandler<Object> {
 		}
 
 	}
-	
+
 }


### PR DESCRIPTION
### Description
This PR modifies the `ReturnHandler#returnValues` method to pass in an event and an expression object for more control on the user's end

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
