### PR TITLE
Fix bugs with Timespan#getAs

### DIFF
--- a/src/main/java/ch/njol/skript/util/Timespan.java
+++ b/src/main/java/ch/njol/skript/util/Timespan.java
@@ -18,18 +18,6 @@
  */
 package ch.njol.skript.util;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.Locale;
-
-import org.eclipse.jdt.annotation.Nullable;
-import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.ApiStatus.ScheduledForRemoval;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.localization.GeneralWords;
 import ch.njol.skript.localization.Language;
@@ -38,6 +26,17 @@ import ch.njol.skript.localization.Noun;
 import ch.njol.util.NonNullPair;
 import ch.njol.util.coll.CollectionUtils;
 import ch.njol.yggdrasil.YggdrasilSerializable;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.ApiStatus.ScheduledForRemoval;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class Timespan implements YggdrasilSerializable, Comparable<Timespan> { // REMIND unit
 
@@ -257,7 +256,7 @@ public class Timespan implements YggdrasilSerializable, Comparable<Timespan> { /
 	 * @return the amount of TimePeriod this timespan represents.
 	 */
 	public long getAs(TimePeriod timePeriod) {
-		return Math.round(millis * timePeriod.getTime());
+		return millis / timePeriod.getTime();
 	}
 
 	/**

--- a/src/main/java/ch/njol/skript/util/Timespan.java
+++ b/src/main/java/ch/njol/skript/util/Timespan.java
@@ -210,7 +210,7 @@ public class Timespan implements YggdrasilSerializable, Comparable<Timespan> { /
 	/**
 	 * Builds a Timespan from the given long parameter.
 	 *
-	 * @deprecated Use {@link Timespan#Timespan(TimePeriod, long)}
+	 * @deprecated Use {@link #Timespan(TimePeriod, long)}
 	 * 
 	 * @param ticks The amount of Minecraft ticks to convert to a timespan.
 	 * @return Timespan based on the provided long.

--- a/src/test/skript/tests/regressions/6908-timespan too big.sk
+++ b/src/test/skript/tests/regressions/6908-timespan too big.sk
@@ -2,5 +2,5 @@ test "large timespans truncated to ints":
 	set {_now} to now
 	set {_a} to unix timestamp of {_now} * 1 seconds
 	set {_b} to unix timestamp of 10 minutes from {_now} * 1 second
-	assert {_a} - {_b} is 10 minutes with "large timespan was truncated"
+	assert {_b} - {_a} is 10 minutes with "large timespan was truncated"
 

--- a/src/test/skript/tests/regressions/6908-timespan too big.sk
+++ b/src/test/skript/tests/regressions/6908-timespan too big.sk
@@ -1,0 +1,6 @@
+test "large timespans truncated to ints":
+	set {_now} to now
+	set {_a} to unix timestamp of {_now} * 1 seconds
+	set {_b} to unix timestamp of 10 minutes from {_now} * 1 second
+	assert {_a} - {_b} is 10 minutes with "large timespan was truncated"
+


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Remove rounding from getAs (it should truncate anyway) to avoid limiting as int max value. Fix bug where millis was multiplied instead of divided.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #6908 <!-- Links to related issues -->
