### PR TITLE
allow entity emitters to be null, since 1.17 and below don't support them.

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffPlaySound.java
+++ b/src/main/java/ch/njol/skript/effects/EffPlaySound.java
@@ -75,6 +75,7 @@ public class EffPlaySound extends Effect {
 	private static final boolean ADVENTURE_API = Skript.classExists("net.kyori.adventure.sound.Sound$Builder");
 	private static final boolean PLAYER_ENTITY_EMITTER = Skript.methodExists(Player.class, "playSound", Entity.class, Sound.class, SoundCategory.class, float.class, float.class);
 	private static final boolean WORLD_ENTITY_EMITTER = Skript.methodExists(World.class, "playSound", Entity.class, String.class, SoundCategory.class, float.class, float.class);
+	private static final boolean KEY_FROM_STRING = Skript.methodExists(NamespacedKey.class, "fromString", new Class[]{String.class}, NamespacedKey.class);
 	public static final Pattern KEY_PATTERN = Pattern.compile("([a-z0-9._-]+:)?[a-z0-9/._-]+");
 
 	static {
@@ -244,7 +245,8 @@ public class EffPlaySound extends Effect {
 					if (!KEY_PATTERN.matcher(sound).matches())
 						continue;
 					try {
-						key = NamespacedKey.fromString(sound);
+						if (KEY_FROM_STRING)
+							key = NamespacedKey.fromString(sound);
 					} catch (IllegalArgumentException argument) {
 						// The user input invalid characters
 					}

--- a/src/main/java/ch/njol/skript/effects/EffPlaySound.java
+++ b/src/main/java/ch/njol/skript/effects/EffPlaySound.java
@@ -74,7 +74,7 @@ public class EffPlaySound extends Effect {
 
 	private static final boolean ADVENTURE_API = Skript.classExists("net.kyori.adventure.sound.Sound$Builder");
 	private static final boolean PLAYER_ENTITY_EMITTER = Skript.methodExists(Player.class, "playSound", Entity.class, Sound.class, SoundCategory.class, float.class, float.class);
-	private static final boolean WORLD_ENTITY_EMITTER = Skript.methodExists(World.class, "playSound", Entity.class, Sound.class, SoundCategory.class, float.class, float.class);
+	private static final boolean WORLD_ENTITY_EMITTER = Skript.methodExists(World.class, "playSound", Entity.class, String.class, SoundCategory.class, float.class, float.class);
 	public static final Pattern KEY_PATTERN = Pattern.compile("([a-z0-9._-]+:)?[a-z0-9/._-]+");
 
 	static {

--- a/src/main/java/ch/njol/skript/effects/EffPlaySound.java
+++ b/src/main/java/ch/njol/skript/effects/EffPlaySound.java
@@ -73,7 +73,8 @@ import java.util.regex.Pattern;
 public class EffPlaySound extends Effect {
 
 	private static final boolean ADVENTURE_API = Skript.classExists("net.kyori.adventure.sound.Sound$Builder");
-	private static final boolean ENTITY_EMITTER = Skript.methodExists(Player.class, "playSound", Entity.class, Sound.class, SoundCategory.class, float.class, float.class);
+	private static final boolean PLAYER_ENTITY_EMITTER = Skript.methodExists(Player.class, "playSound", Entity.class, Sound.class, SoundCategory.class, float.class, float.class);
+	private static final boolean WORLD_ENTITY_EMITTER = Skript.methodExists(World.class, "playSound", Entity.class, Sound.class, SoundCategory.class, float.class, float.class);
 	public static final Pattern KEY_PATTERN = Pattern.compile("([a-z0-9._-]+:)?[a-z0-9/._-]+");
 
 	static {
@@ -81,7 +82,7 @@ public class EffPlaySound extends Effect {
 		if (ADVENTURE_API)
 			additional = "[[with] seed %-number%] ";
 		String emitterTypes = "locations";
-		if (ENTITY_EMITTER)
+		if (PLAYER_ENTITY_EMITTER)
 			emitterTypes += "/entities";
 		Skript.registerEffect(EffPlaySound.class,
 				"play sound[s] %strings% " + additional + "[(in|from) %-soundcategory%] " +
@@ -152,19 +153,19 @@ public class EffPlaySound extends Effect {
 		if (players != null) {
 			if (emitters == null) {
 				for (Player player : players.getArray(event)) {
-					play(ENTITY_EMITTER ? Player::playSound : null, Player::playSound, ADVENTURE_API ? Player::playSound : null, ADVENTURE_API ? Player::playSound : null,
+					play(PLAYER_ENTITY_EMITTER ? Player::playSound : null, Player::playSound, ADVENTURE_API ? Player::playSound : null, ADVENTURE_API ? Player::playSound : null,
 							player,	player.getLocation(), sounds.getArray(event), category, volume, pitch, seed);
 				}
 			} else {
 				for (Player player : players.getArray(event)) {
 					for (Object emitter : emitters.getArray(event)) {
-						if (emitter instanceof Entity && ENTITY_EMITTER) {
+						if (emitter instanceof Entity && PLAYER_ENTITY_EMITTER) {
 							Entity entity = (Entity) emitter;
 							play(Player::playSound, Player::playSound, ADVENTURE_API ? Player::playSound : null, ADVENTURE_API ? Player::playSound : null,
 									player,	entity, sounds.getArray(event), category, volume, pitch, seed);
 						} else if (emitter instanceof Location) {
 							Location location = (Location) emitter;
-							play(ENTITY_EMITTER ? Player::playSound : null, Player::playSound, ADVENTURE_API ? Player::playSound : null, ADVENTURE_API ? Player::playSound : null,
+							play(PLAYER_ENTITY_EMITTER ? Player::playSound : null, Player::playSound, ADVENTURE_API ? Player::playSound : null, ADVENTURE_API ? Player::playSound : null,
 									player, location, sounds.getArray(event), category, volume, pitch, seed);
 						}
 					}
@@ -172,13 +173,13 @@ public class EffPlaySound extends Effect {
 			}
 		} else if (emitters != null) {
 			for (Object emitter : emitters.getArray(event)) {
-				if (emitter instanceof Entity && ENTITY_EMITTER) {
+				if (emitter instanceof Entity && WORLD_ENTITY_EMITTER) {
 					Entity entity = (Entity) emitter;
 					play(World::playSound, World::playSound, ADVENTURE_API ? World::playSound : null, ADVENTURE_API ? World::playSound : null,
 							entity.getWorld(), entity, sounds.getArray(event), category, volume, pitch, seed);
 				} else if (emitter instanceof Location) {
 					Location location = (Location) emitter;
-					play(ENTITY_EMITTER ? World::playSound : null, World::playSound, ADVENTURE_API ? World::playSound : null, ADVENTURE_API ? World::playSound : null,
+					play(WORLD_ENTITY_EMITTER ? World::playSound : null, World::playSound, ADVENTURE_API ? World::playSound : null, ADVENTURE_API ? World::playSound : null,
 							location.getWorld(), location, sounds.getArray(event), category, volume, pitch, seed);
 				}
 			}

--- a/src/main/java/ch/njol/skript/effects/EffPlaySound.java
+++ b/src/main/java/ch/njol/skript/effects/EffPlaySound.java
@@ -248,7 +248,7 @@ public class EffPlaySound extends Effect {
 					try {
 						String namespace = keyMatcher.group(1);
 						String keyValue = keyMatcher.group(2);
-						if (namespace.isEmpty()) {
+						if (namespace == null) {
 							key = NamespacedKey.minecraft(keyValue);
 						} else {
 							namespace = namespace.substring(0, namespace.length() - 1);

--- a/src/main/java/ch/njol/skript/effects/EffPlaySound.java
+++ b/src/main/java/ch/njol/skript/effects/EffPlaySound.java
@@ -44,6 +44,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
 import java.util.OptionalLong;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @Name("Play Sound")
@@ -75,8 +76,7 @@ public class EffPlaySound extends Effect {
 	private static final boolean ADVENTURE_API = Skript.classExists("net.kyori.adventure.sound.Sound$Builder");
 	private static final boolean PLAYER_ENTITY_EMITTER = Skript.methodExists(Player.class, "playSound", Entity.class, Sound.class, SoundCategory.class, float.class, float.class);
 	private static final boolean WORLD_ENTITY_EMITTER = Skript.methodExists(World.class, "playSound", Entity.class, String.class, SoundCategory.class, float.class, float.class);
-	private static final boolean KEY_FROM_STRING = Skript.methodExists(NamespacedKey.class, "fromString", new Class[]{String.class}, NamespacedKey.class);
-	public static final Pattern KEY_PATTERN = Pattern.compile("([a-z0-9._-]+:)?[a-z0-9/._-]+");
+	public static final Pattern KEY_PATTERN = Pattern.compile("([a-z0-9._-]+:)?([a-z0-9/._-]+)");
 
 	static {
 		String additional = "";
@@ -242,11 +242,13 @@ public class EffPlaySound extends Effect {
 					key = enumSound.getKey();
 				} catch (IllegalArgumentException alternative) {
 					sound = sound.toLowerCase(Locale.ENGLISH);
-					if (!KEY_PATTERN.matcher(sound).matches())
+					Matcher keyMatcher = KEY_PATTERN.matcher(sound);
+					if (!keyMatcher.matches())
 						continue;
 					try {
-						if (KEY_FROM_STRING)
-							key = NamespacedKey.fromString(sound);
+						String namespace = keyMatcher.group(1).substring(0, keyMatcher.group(1).length() - 1);
+						String keyValue = keyMatcher.group(2);
+						key = new NamespacedKey(namespace, keyValue);
 					} catch (IllegalArgumentException argument) {
 						// The user input invalid characters
 					}

--- a/src/main/java/ch/njol/skript/effects/EffPlaySound.java
+++ b/src/main/java/ch/njol/skript/effects/EffPlaySound.java
@@ -246,9 +246,14 @@ public class EffPlaySound extends Effect {
 					if (!keyMatcher.matches())
 						continue;
 					try {
-						String namespace = keyMatcher.group(1).substring(0, keyMatcher.group(1).length() - 1);
+						String namespace = keyMatcher.group(1);
 						String keyValue = keyMatcher.group(2);
-						key = new NamespacedKey(namespace, keyValue);
+						if (namespace.isEmpty()) {
+							key = NamespacedKey.minecraft(keyValue);
+						} else {
+							namespace = namespace.substring(0, namespace.length() - 1);
+							key = new NamespacedKey(namespace, keyValue);
+						}
 					} catch (IllegalArgumentException argument) {
 						// The user input invalid characters
 					}

--- a/src/test/skript/tests/regressions/6907-playsound entity method doesn't exist.sk
+++ b/src/test/skript/tests/regressions/6907-playsound entity method doesn't exist.sk
@@ -1,0 +1,3 @@
+test "1.17 playsound exception":
+	# would throw exception on <1.17
+	play sound "entity.experience_orb.pickup" with volume 1 at spawn of world "world"


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Not the nicest fix, but couldn't think of much else. I'm not a fan of how all this functional interface stuff is set up.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #6907 <!-- Links to related issues -->
