### PR TITLE
Update EffExplosion.java

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffExplosion.java
+++ b/src/main/java/ch/njol/skript/effects/EffExplosion.java
@@ -48,10 +48,10 @@ public class EffExplosion extends Effect {
 
 	static {
 		Skript.registerEffect(EffExplosion.class,
-				"[(create|make)] [an] explosion (of|with) (force|strength|power) %number% [%directions% %locations%] [(1¦with fire)]",
-				"[(create|make)] [a] safe explosion (of|with) (force|strength|power) %number% [%directions% %locations%]",
-				"[(create|make)] [a] fake explosion [%directions% %locations%]",
-				"[(create|make)] [an] explosion[ ]effect [%directions% %locations%]");
+			"[(create|make)] [an] explosion (of|with) (force|strength|power) %number% [%directions% %locations%] [(1¦with fire)]",
+			"[(create|make)] [a] safe explosion (of|with) (force|strength|power) %number% [%directions% %locations%]",
+			"[(create|make)] [a] fake explosion [%directions% %locations%]",
+			"[(create|make)] [a[n]] [fake] explosion[ ]effect [%directions% %locations%]");
 	}
 
 	@Nullable


### PR DESCRIPTION
### Description
This simply allows the option to use `fake` in the explosion effect when doing `create a fake explosion effect at player`

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none 
