### PR TITLE
allow pufferfish as entitydata

### DIFF
--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -1061,7 +1061,7 @@ entities:
 		pattern: salmon(|1¦s)
 	puffer fish:
 		name: puffer fish¦es
-		pattern: puffer fish(|1¦es)
+		pattern: puffer[ ]fish(|1¦es)
 	tropical fish:
 		name: tropical fish¦es
 		pattern: tropical fish(|1¦es)


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

allows `pufferfish` as entitydata instead of just `puffer fish`

related: https://github.com/SkriptLang/skript-aliases/pull/116

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
