### PR TITLE
Fix compilation/runtime errors due to Bukkit enum changes

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -1412,7 +1412,8 @@ public class BukkitClasses {
 			if (BukkitUtils.registryExists("CAT_VARIANT")) {
 				catTypeClassInfo = new RegistryClassInfo<>(Cat.Type.class, Registry.CAT_VARIANT, "cattype", "cat types");
 			} else {
-				catTypeClassInfo = new EnumClassInfo<>(Cat.Type.class, "cattype", "cat types");
+				//noinspection unchecked, rawtypes - it is an enum on other versions
+				catTypeClassInfo = new EnumClassInfo<>((Class) Cat.Type.class, "cattype", "cat types");
 			}
 			Classes.registerClass(catTypeClassInfo
 					.user("cat ?(type|race)s?")

--- a/src/main/java/ch/njol/skript/entity/CatData.java
+++ b/src/main/java/ch/njol/skript/entity/CatData.java
@@ -18,6 +18,8 @@
  */
 package ch.njol.skript.entity;
 
+import ch.njol.skript.registrations.Classes;
+import com.google.common.collect.Iterators;
 import org.bukkit.entity.Cat;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -29,9 +31,14 @@ import ch.njol.util.coll.CollectionUtils;
 public class CatData extends EntityData<Cat> {
 	
 	static {
-		if (Skript.classExists("org.bukkit.entity.Cat"))
+		if (Skript.classExists("org.bukkit.entity.Cat")) {
 			EntityData.register(CatData.class, "cat", Cat.class, "cat");
+			types = Iterators.toArray(Classes.getExactClassInfo(Cat.Type.class).getSupplier().get(), Cat.Type.class);
+		}
 	}
+
+	@SuppressWarnings("NotNullFieldNotInitialized")
+	private static Cat.Type[] types;
 	
 	private Cat.@Nullable Type race = null;
 	
@@ -42,7 +49,7 @@ public class CatData extends EntityData<Cat> {
 			race = ((Literal<Cat.Type>) exprs[0]).getSingle();
 		return true;
 	}
-	
+
 	@Override
 	protected boolean init(@Nullable Class<? extends Cat> c, @Nullable Cat cat) {
 		race = (cat == null) ? Cat.Type.TABBY : cat.getCatType();
@@ -51,7 +58,7 @@ public class CatData extends EntityData<Cat> {
 	
 	@Override
 	public void set(Cat entity) {
-		Cat.Type type = race != null ? race : CollectionUtils.getRandom(Cat.Type.values());
+		Cat.Type type = race != null ? race : CollectionUtils.getRandom(types);
 		assert type != null;
 		entity.setCatType(type);
 	}
@@ -73,7 +80,8 @@ public class CatData extends EntityData<Cat> {
 	
 	@Override
 	protected int hashCode_i() {
-		return race != null ? race.hashCode() : 0;
+		//noinspection RedundantCast - cast to prevent IncompatibleClassChangeError due to Enum->Interface change
+		return race != null ? ((Object) race).hashCode() : 0;
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/entity/CatData.java
+++ b/src/main/java/ch/njol/skript/entity/CatData.java
@@ -28,6 +28,8 @@ import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.coll.CollectionUtils;
 
+import java.util.Objects;
+
 public class CatData extends EntityData<Cat> {
 	
 	static {
@@ -80,8 +82,7 @@ public class CatData extends EntityData<Cat> {
 	
 	@Override
 	protected int hashCode_i() {
-		//noinspection RedundantCast - cast to prevent IncompatibleClassChangeError due to Enum->Interface change
-		return race != null ? ((Object) race).hashCode() : 0;
+		return Objects.hashCode(race);
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/entity/FrogData.java
+++ b/src/main/java/ch/njol/skript/entity/FrogData.java
@@ -25,6 +25,8 @@ import org.bukkit.entity.Frog;
 import org.bukkit.entity.Frog.Variant;
 import org.eclipse.jdt.annotation.Nullable;
 
+import java.util.Objects;
+
 public class FrogData extends EntityData<Frog> {
 
 	static {
@@ -97,8 +99,7 @@ public class FrogData extends EntityData<Frog> {
 
 	@Override
 	protected int hashCode_i() {
-		//noinspection RedundantCast - cast to prevent IncompatibleClassChangeError due to Enum->Interface change
-		return variant != null ? ((Object) variant).hashCode() : 0;
+		return Objects.hashCode(variant);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/entity/FrogData.java
+++ b/src/main/java/ch/njol/skript/entity/FrogData.java
@@ -42,13 +42,28 @@ public class FrogData extends EntityData<Frog> {
 
 	public FrogData(@Nullable Variant variant) {
 		this.variant = variant;
-		matchedPattern = variant != null ? variant.ordinal() + 1 : 0;
+		matchedPattern = 0;
+		if (variant == Variant.TEMPERATE)
+			matchedPattern = 1;
+		if (variant == Variant.WARM)
+			matchedPattern = 2;
+		if (variant == Variant.COLD)
+			matchedPattern = 3;
 	}
 
 	@Override
 	protected boolean init(Literal<?>[] exprs, int matchedPattern, SkriptParser.ParseResult parseResult) {
-		if (matchedPattern > 0)
-			variant = Variant.values()[matchedPattern - 1];
+		switch (matchedPattern) {
+			case 1:
+				variant = Variant.TEMPERATE;
+				break;
+			case 2:
+				variant = Variant.WARM;
+				break;
+			case 3:
+				variant = Variant.COLD;
+				break;
+		}
 		return true;
 	}
 
@@ -82,7 +97,8 @@ public class FrogData extends EntityData<Frog> {
 
 	@Override
 	protected int hashCode_i() {
-		return variant != null ? variant.hashCode() : 0;
+		//noinspection RedundantCast - cast to prevent IncompatibleClassChangeError due to Enum->Interface change
+		return variant != null ? ((Object) variant).hashCode() : 0;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/entity/VillagerData.java
+++ b/src/main/java/ch/njol/skript/entity/VillagerData.java
@@ -18,6 +18,8 @@
  */
 package ch.njol.skript.entity;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -37,7 +39,7 @@ import ch.njol.util.coll.CollectionUtils;
  * @author Peter Güttinger
  */
 public class VillagerData extends EntityData<Villager> {
-	
+
 	/**
 	 * Professions can be for zombies also. These are the ones which are only
 	 * for villagers.
@@ -49,25 +51,34 @@ public class VillagerData extends EntityData<Villager> {
 		// NORMAL(-1), FARMER(0), LIBRARIAN(1), PRIEST(2), BLACKSMITH(3), BUTCHER(4), NITWIT(5);
 		
 		Variables.yggdrasil.registerSingleClass(Profession.class, "Villager.Profession");
-		
+
+		professions = new ArrayList<>();
 		if (Skript.isRunningMinecraft(1, 14)) {
 			EntityData.register(VillagerData.class, "villager", Villager.class, 0,
 					"villager", "normal", "armorer", "butcher", "cartographer",
 					"cleric", "farmer", "fisherman", "fletcher",
 					"leatherworker", "librarian", "mason", "nitwit",
 					"shepherd", "toolsmith", "weaponsmith");
-			professions = Arrays.asList(Profession.values());
+			professions = Arrays.asList(Profession.NONE, Profession.ARMORER, Profession.BUTCHER, Profession.CARTOGRAPHER,
+					Profession.CLERIC, Profession.FARMER, Profession.FISHERMAN, Profession.FLETCHER, Profession.LEATHERWORKER,
+					Profession.LIBRARIAN, Profession.MASON, Profession.NITWIT, Profession.SHEPHERD, Profession.TOOLSMITH,
+					Profession.WEAPONSMITH);
 		} else { // Post 1.10: Not all professions go for villagers
 			EntityData.register(VillagerData.class, "villager", Villager.class, 0,
 					"normal", "villager", "farmer", "librarian",
 					"priest", "blacksmith", "butcher", "nitwit");
 			// Normal is for zombie villagers, but needs to be here, since someone thought changing first element in enum was good idea :(
 
-			professions = new ArrayList<>();
-			for (Profession prof : Profession.values()) {
-				// We're better off doing stringfying the constants since these don't exist in 1.14
-				if (!prof.toString().equals("NORMAL") && !prof.toString().equals("HUSK"))
-					professions.add(prof);
+			try {
+				for (Profession prof : (Profession[]) MethodHandles.lookup().findStatic(Profession.class, "values", MethodType.methodType(Profession[].class)).invoke()) {
+					// We're better off doing stringfying the constants since these don't exist in 1.14
+					//noinspection RedundantCast - cast to prevent IncompatibleClassChangeError due to Enum->Interface change
+					String profString = ((Object) prof).toString();
+					if (!profString.equals("NORMAL") && !profString.equals("HUSK"))
+						professions.add(prof);
+				}
+			} catch (Throwable e) {
+				throw new RuntimeException("Failed to load legacy villager profession support", e);
 			}
 		}
 	}
@@ -116,7 +127,8 @@ public class VillagerData extends EntityData<Villager> {
 	
 	@Override
 	protected int hashCode_i() {
-		return profession != null ? profession.hashCode() : 0;
+		//noinspection RedundantCast - cast to prevent IncompatibleClassChangeError due to Enum->Interface change
+		return profession != null ? ((Object) profession).hashCode() : 0;
 	}
 	
 	@Override
@@ -133,7 +145,8 @@ public class VillagerData extends EntityData<Villager> {
 		if (s.isEmpty())
 			return true;
 		try {
-			profession = Profession.valueOf(s);
+			//noinspection unchecked, rawtypes - prevent IncompatibleClassChangeError due to Enum->Interface change
+			profession = (Profession) Enum.valueOf((Class) Profession.class, s);
 			return true;
 		} catch (final IllegalArgumentException e) {
 			return false;

--- a/src/main/java/ch/njol/skript/entity/VillagerData.java
+++ b/src/main/java/ch/njol/skript/entity/VillagerData.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.bukkit.entity.Villager;
 import org.bukkit.entity.Villager.Profession;
@@ -59,6 +60,9 @@ public class VillagerData extends EntityData<Villager> {
 					"cleric", "farmer", "fisherman", "fletcher",
 					"leatherworker", "librarian", "mason", "nitwit",
 					"shepherd", "toolsmith", "weaponsmith");
+			// TODO obtain from the registry in the future
+			// This is not currently done as the ordering of the professions is important
+			// There is no ordering guarantee from the registry
 			professions = Arrays.asList(Profession.NONE, Profession.ARMORER, Profession.BUTCHER, Profession.CARTOGRAPHER,
 					Profession.CLERIC, Profession.FARMER, Profession.FISHERMAN, Profession.FLETCHER, Profession.LEATHERWORKER,
 					Profession.LIBRARIAN, Profession.MASON, Profession.NITWIT, Profession.SHEPHERD, Profession.TOOLSMITH,
@@ -72,8 +76,8 @@ public class VillagerData extends EntityData<Villager> {
 			try {
 				for (Profession prof : (Profession[]) MethodHandles.lookup().findStatic(Profession.class, "values", MethodType.methodType(Profession[].class)).invoke()) {
 					// We're better off doing stringfying the constants since these don't exist in 1.14
-					//noinspection RedundantCast - cast to prevent IncompatibleClassChangeError due to Enum->Interface change
-					String profString = ((Object) prof).toString();
+					// Using String#valueOf to prevent IncompatibleClassChangeError due to Enum->Interface change
+					String profString = String.valueOf(prof);
 					if (!profString.equals("NORMAL") && !profString.equals("HUSK"))
 						professions.add(prof);
 				}
@@ -127,8 +131,7 @@ public class VillagerData extends EntityData<Villager> {
 	
 	@Override
 	protected int hashCode_i() {
-		//noinspection RedundantCast - cast to prevent IncompatibleClassChangeError due to Enum->Interface change
-		return profession != null ? ((Object) profession).hashCode() : 0;
+		return Objects.hashCode(profession);
 	}
 	
 	@Override
@@ -156,7 +159,7 @@ public class VillagerData extends EntityData<Villager> {
 	@Override
 	public boolean isSupertypeOf(final EntityData<?> e) {
 		if (e instanceof VillagerData)
-			return profession == null || ((VillagerData) e).profession == profession;
+			return profession == null || Objects.equals(((VillagerData) e).profession, profession);
 		return false;
 	}
 	

--- a/src/main/java/ch/njol/skript/entity/ZombieVillagerData.java
+++ b/src/main/java/ch/njol/skript/entity/ZombieVillagerData.java
@@ -32,6 +32,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 public class ZombieVillagerData extends EntityData<ZombieVillager> {
 
@@ -124,15 +125,13 @@ public class ZombieVillagerData extends EntityData<ZombieVillager> {
 	
 	@Override
 	protected int hashCode_i() {
-		//noinspection RedundantCast - cast to prevent IncompatibleClassChangeError due to Enum->Interface change
-		return ((Object) profession).hashCode();
+		return Objects.hashCode(profession);
 	}
 	
 	@Override
 	public boolean isSupertypeOf(final EntityData<?> e) {
 		if (e instanceof ZombieVillagerData)
-			//noinspection RedundantCast - cast to prevent IncompatibleClassChangeError due to Enum->Interface change
-			return ((Object) (((ZombieVillagerData) e).profession)).equals(profession);
+			return Objects.equals(((ZombieVillagerData) e).profession, profession);
 		return false;
 	}
 	


### PR DESCRIPTION
### Description
This PR aims to implement a more-temporary fix for the compilation and runtime errors due to Bukkit converting some classes from Enums to Interfaces. These changes should maintain the existing behavior.

I plan to implement a longer-term replacement with proper registry usage on dev/feature (where registries are available on all supported versions). Additionally, registry support is complicated by widespread matchedPattern/ordinal usage. Any solutions should not depend on any kind of entry ordering.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:**
- https://github.com/SkriptLang/Skript/issues/6924
