### PR TITLE
Fixes an error with SimplifiedChinese language file

### DIFF
--- a/src/main/resources/lang/simplifiedchinese.lang
+++ b/src/main/resources/lang/simplifiedchinese.lang
@@ -15,7 +15,7 @@ skript:
 	invalid reload: Skript只能通过Bukkit的“/reload”或Skript的“/skript reload”命令来重新加载。
 	no scripts: 没有发现任何脚本，也许你应该写一些 ;)
 	no errors: 所有脚本都已加载，没有错误。
-	scripts loaded: 已加载 %s 个脚本，总共包含 %s 个结构。 (耗时 %s）
+	scripts loaded: 已加载%s个脚本，总共包含%s个结构。 (耗时%s）
 	finished loading: 已完成加载。
 
 # -- Skript command --

--- a/src/main/resources/lang/simplifiedchinese.lang
+++ b/src/main/resources/lang/simplifiedchinese.lang
@@ -15,7 +15,7 @@ skript:
 	invalid reload: Skript只能通过Bukkit的“/reload”或Skript的“/skript reload”命令来重新加载。
 	no scripts: 没有发现任何脚本，也许你应该写一些 ;)
 	no errors: 所有脚本都已加载，没有错误。
-	scripts loaded: 已加载%s个脚本，包括%s个结构和%s个命令（%s内）
+	scripts loaded: 已加载 %s 个脚本 总共包含 %s 个结构 (耗时 %s)。
 	finished loading: 已完成加载。
 
 # -- Skript command --

--- a/src/main/resources/lang/simplifiedchinese.lang
+++ b/src/main/resources/lang/simplifiedchinese.lang
@@ -15,7 +15,7 @@ skript:
 	invalid reload: Skript只能通过Bukkit的“/reload”或Skript的“/skript reload”命令来重新加载。
 	no scripts: 没有发现任何脚本，也许你应该写一些 ;)
 	no errors: 所有脚本都已加载，没有错误。
-	scripts loaded: 已加载 %s 个脚本 总共包含 %s 个结构 (耗时 %s)。
+	scripts loaded: 已加载 %s 个脚本，总共包含 %s 个结构。 (耗时 %s）
 	finished loading: 已完成加载。
 
 # -- Skript command --


### PR DESCRIPTION
### Description
Previously, this would throw a severe error on load because of an extraneous %s format specifier. This is caused by the message seemingly referencing commands when that is no longer done. (According to pickle)

Credit: Msyial & NotSoDelayed (for the fixed translation)

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #6928 