### PR TITLE
Adds Armour as an alias to armor stand

### DIFF
--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -923,7 +923,7 @@ entities:
 		pattern: fish[ ]hook(|1¦s)
 	armor stand:
 		name: armor stand¦s
-		pattern: armor stand(|1¦s)
+		pattern: armo[u]r stand(|1¦s)
 	endermite:
 		name: endermite¦s
 		pattern: endermite(|1¦s)

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -922,8 +922,8 @@ entities:
 		name: fish hook¦s
 		pattern: fish[ ]hook(|1¦s)
 	armor stand:
-		name: armo[u]r stand¦s
-		pattern: armo[u]r stand(|1¦s)
+		name: armor stand¦s
+		pattern: armor stand(|1¦s)
 	endermite:
 		name: endermite¦s
 		pattern: endermite(|1¦s)

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -922,7 +922,7 @@ entities:
 		name: fish hook¦s
 		pattern: fish[ ]hook(|1¦s)
 	armor stand:
-		name: armor stand¦s
+		name: armo[u]r stand¦s
 		pattern: armo[u]r stand(|1¦s)
 	endermite:
 		name: endermite¦s


### PR DESCRIPTION
### Description
This simply adds the ability to use Armour as an alias to Armor for Armor Stands

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
