### PR TITLE
Bandaid fix for single quotes in command args

### DIFF
--- a/src/main/java/ch/njol/skript/command/CommandUsage.java
+++ b/src/main/java/ch/njol/skript/command/CommandUsage.java
@@ -46,6 +46,10 @@ public class CommandUsage {
 	 */
 	public CommandUsage(@Nullable VariableString usage, String defaultUsage) {
 		if (usage == null) {
+			// Manually escape quotes. This is not a good solution, as it doesn't handle many other issues, like % in
+			// commands, but in lieu of re-writing the argument parser and command logic completely, I believe this is
+			// a decent stop-gap measure for using " in commands.
+			defaultUsage = defaultUsage.replaceAll("\"", "\"\"");
 			usage = VariableString.newInstance(defaultUsage);
 			assert usage != null;
 		}

--- a/src/main/java/ch/njol/skript/command/CommandUsage.java
+++ b/src/main/java/ch/njol/skript/command/CommandUsage.java
@@ -49,7 +49,7 @@ public class CommandUsage {
 			// Manually escape quotes. This is not a good solution, as it doesn't handle many other issues, like % in
 			// commands, but in lieu of re-writing the argument parser and command logic completely, I believe this is
 			// a decent stop-gap measure for using " in commands.
-			defaultUsage = defaultUsage.replaceAll("\"", "\"\"");
+			defaultUsage = VariableString.quote(defaultUsage);
 			usage = VariableString.newInstance(defaultUsage);
 			assert usage != null;
 		}

--- a/src/test/skript/tests/regressions/pull-6936-single quotes in commands.sk
+++ b/src/test/skript/tests/regressions/pull-6936-single quotes in commands.sk
@@ -1,0 +1,7 @@
+command single-quotes-in-commands ["<text="success 2">"]:
+	trigger:
+		broadcast arg
+
+test "single-quotes-in-commands":
+	execute console command "single-quotes-in-commands ""success 1"""
+	execute console command "single-quotes-in-commands"

--- a/src/test/skript/tests/regressions/pull-6936-single quotes in commands.sk
+++ b/src/test/skript/tests/regressions/pull-6936-single quotes in commands.sk
@@ -1,7 +1,10 @@
 command single-quotes-in-commands ["<text="success 2">"]:
 	trigger:
-		broadcast arg
+		set {sqic::output} to arg
 
 test "single-quotes-in-commands":
 	execute console command "single-quotes-in-commands ""success 1"""
+	assert {sqic::output} is "success 1" with "failed to parse arg in quotes"
 	execute console command "single-quotes-in-commands"
+	assert {sqic::output} is "success 2" with "failed to use default arg"
+	delete {sqic::output}


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Manually escapes single quotes in the generated command usage message to avoid errors when trying to use single quotes as command arguments. The fix is a bandaid as there are many more problems with command parsing/argument parsing that should be addressed: ``command test %now%`` being a good example. This can come in a later pr.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
