### PR TITLE
Delay listening behavior logic until after the event implementation initializes

### DIFF
--- a/src/main/java/ch/njol/skript/events/EvtMove.java
+++ b/src/main/java/ch/njol/skript/events/EvtMove.java
@@ -132,7 +132,6 @@ public class EvtMove extends SkriptEvent {
 	}
 
 	@Override
-	@Nullable
 	@SuppressWarnings("unchecked")
 	public Class<? extends Event> [] getEventClasses() {
 		if (isPlayer) {
@@ -140,7 +139,7 @@ public class EvtMove extends SkriptEvent {
 		} else if (HAS_ENTITY_MOVE) {
 			return new Class[] {EntityMoveEvent.class};
 		}
-		return null;
+		throw new IllegalStateException("This event has not yet initialized!");
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/lang/SkriptEvent.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptEvent.java
@@ -85,8 +85,17 @@ public abstract class SkriptEvent extends Structure {
 			throw new IllegalStateException();
 		skriptEventInfo = (SkriptEventInfo<?>) syntaxElementInfo;
 
+		assert entryContainer != null; // cannot be null for non-simple structures
+		this.source = entryContainer.getSource();
+
+		// use default value for now
+		listeningBehavior = eventData.getListenerBehavior();
+
+		// initialize implementation
+		if (!init(args, matchedPattern, parseResult))
+			return false;
+
 		// evaluate whether this event supports listening to cancelled events
-		supportsListeningBehavior = false;
 		for (Class<? extends Event> eventClass : getEventClasses()) {
 			if (Cancellable.class.isAssignableFrom(eventClass)) {
 				supportsListeningBehavior = true;
@@ -94,7 +103,6 @@ public abstract class SkriptEvent extends Structure {
 			}
 		}
 
-		listeningBehavior = eventData.getListenerBehavior();
 		// if the behavior is non-null, it was set by the user
 		if (listeningBehavior != null && !isListeningBehaviorSupported()) {
 			String eventName = skriptEventInfo.name.toLowerCase(Locale.ENGLISH);
@@ -102,10 +110,7 @@ public abstract class SkriptEvent extends Structure {
 			return false;
 		}
 
-		assert entryContainer != null; // cannot be null for non-simple structures
-		this.source = entryContainer.getSource();
-
-		return init(args, matchedPattern, parseResult);
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
### Description
This PR fixes an error that could occur for events that depend on `init` to determine the values for `getEventClasses()`. This caused an error with EvtMove as listening behavior attempted to use `getEventClasses` before it was ready (that is, before EvtMove initialized). This error *only* occurred on Spigot (where entity move does not exist)

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:**
- https://github.com/SkriptLang/Skript/issues/6938
