### PR TITLE
Fix missing aliases not regenerating for reloads

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/AliasesProvider.java
+++ b/src/main/java/ch/njol/skript/aliases/AliasesProvider.java
@@ -416,6 +416,7 @@ public class AliasesProvider {
 
 	public void clearAliases() {
 		aliases.clear();
+		materials.clear();
 		variations.clear();
 		aliasesMap.clear();
 	}


### PR DESCRIPTION
### Description
This PR fixes an issue where missing aliases would not regenerate when doing `/sk reload aliases` or `/sk reload all`. Specifically, the bug was caused by the materials tracker of a provider not being cleared when the provider was cleared. This seems to have been a simple mistake from the original PR.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:**
- https://github.com/SkriptLang/Skript/issues/6946
