### PR TITLE
Improve "Arrow Attached Block" example

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprAttachedBlock.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAttachedBlock.java
@@ -32,7 +32,7 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("Arrow Attached Block")
 @Description("Returns the attached block of an arrow.")
-@Examples("set hit block of last shot arrow to diamond block")
+@Examples("broadcast hit block of last shot arrow")
 @Since("2.8.0")
 public class ExprAttachedBlock extends SimplePropertyExpression<Projectile, Block> {
 


### PR DESCRIPTION
### Description
Improves the Arrow Attached Block example using a getter instead of a setter. The current example is unclear at first sight and is worse than a getter.
(ignore the branch name I thought it was unintentional since the expression didn't have changers)

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
