### PR TITLE
Fix bad EffLook example.

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffLook.java
+++ b/src/main/java/ch/njol/skript/effects/EffLook.java
@@ -40,7 +40,7 @@ import io.papermc.paper.entity.LookAnchor;
 @Name("Look At")
 @Description("Forces the mob(s) or player(s) to look at an entity, vector or location. Vanilla max head pitches range from 10 to 50.")
 @Examples({
-	"force the head of the player to look towards event-entity's feet",
+	"force the player to look towards event-entity's feet",
 	"",
 	"on entity explosion:",
 		"\tset {_player} to the nearest player",


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
The `force the head of the player to look towards event-entity's feet` example contained something not in the actual syntax. It is now `force the player to look towards event-entity's feet`.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** fixes #6967 <!-- Links to related issues -->
