### PR TITLE
Temporary fix for plural endings error.

### DIFF
--- a/src/main/java/ch/njol/skript/util/Utils.java
+++ b/src/main/java/ch/njol/skript/util/Utils.java
@@ -70,9 +70,6 @@ public abstract class Utils {
 	protected final static Deque<WordEnding> plurals = new LinkedList<>();
 
 	static {
-		plurals.add(new WordEnding("ive", "ives")); // objective fix
-		plurals.add(new WordEnding("fe", "ves"));// most -f words' plurals can end in -fs as well as -ves
-
 		plurals.add(new WordEnding("axe", "axes"));
 		plurals.add(new WordEnding("x", "xes"));
 
@@ -84,6 +81,11 @@ public abstract class Utils {
 		plurals.add(new WordEnding("kie", "kies"));
 		plurals.add(new WordEnding("zombie", "zombies"));
 		plurals.add(new WordEnding("y", "ies"));
+
+		plurals.add(new WordEnding("wife", "wives")); // we have to do the -ife -> ives first
+		plurals.add(new WordEnding("life", "lives"));
+		plurals.add(new WordEnding("ive", "ives"));
+		plurals.add(new WordEnding("fe", "ves"));// most -f words' plurals can end in -fs as well as -ves
 
 		plurals.add(new WordEnding("h", "hes"));
 

--- a/src/main/java/ch/njol/skript/util/Utils.java
+++ b/src/main/java/ch/njol/skript/util/Utils.java
@@ -283,7 +283,7 @@ public abstract class Utils {
 	 * @return Pair of singular string + boolean whether it was plural
 	 */
 	@SuppressWarnings("null")
-	public static NonNullPair<String, Boolean> getEnglishPlural(final String word) {
+	public static NonNullPair<String, Boolean> getEnglishPlural(String word) {
 		assert word != null;
 		if (word.isEmpty())
 			return new NonNullPair<>("", Boolean.FALSE);
@@ -302,9 +302,9 @@ public abstract class Utils {
 	 * @param word
 	 * @return The english plural of the given word
 	 */
-	public static String toEnglishPlural(final String word) {
+	public static String toEnglishPlural(String word) {
 		assert word != null && word.length() != 0;
-		for (final WordEnding ending : plurals) {
+		for (WordEnding ending : plurals) {
 			if (word.endsWith(ending.singular()))
 				return word.substring(0, word.length() - ending.singular().length()) + ending.plural();
 		}

--- a/src/main/java/ch/njol/skript/util/Utils.java
+++ b/src/main/java/ch/njol/skript/util/Utils.java
@@ -94,6 +94,7 @@ public abstract class Utils {
 		plurals.add(new WordEnding("man", "men"));
 
 		plurals.add(new WordEnding("ui", "uis")); // gui fix
+		plurals.add(new WordEnding("api", "apis")); // api fix
 		plurals.add(new WordEnding("us", "i"));
 
 		plurals.add(new WordEnding("hoe", "hoes"));

--- a/src/main/java/ch/njol/skript/util/Utils.java
+++ b/src/main/java/ch/njol/skript/util/Utils.java
@@ -282,7 +282,6 @@ public abstract class Utils {
 	 * @param word trimmed string
 	 * @return Pair of singular string + boolean whether it was plural
 	 */
-	@SuppressWarnings("null")
 	public static NonNullPair<String, Boolean> getEnglishPlural(String word) {
 		assert word != null;
 		if (word.isEmpty())

--- a/src/main/java/ch/njol/skript/util/Utils.java
+++ b/src/main/java/ch/njol/skript/util/Utils.java
@@ -84,7 +84,9 @@ public abstract class Utils {
 
 		plurals.add(new WordEnding("wife", "wives")); // we have to do the -ife -> ives first
 		plurals.add(new WordEnding("life", "lives"));
+		plurals.add(new WordEnding("knife", "knives"));
 		plurals.add(new WordEnding("ive", "ives"));
+		plurals.add(new WordEnding("elf", "elves")); // self shelf elf
 		plurals.add(new WordEnding("fe", "ves"));// most -f words' plurals can end in -fs as well as -ves
 
 		plurals.add(new WordEnding("h", "hes"));
@@ -822,6 +824,19 @@ public abstract class Utils {
 
 		public String plural() {
 			return plural;
+		}
+
+		@Override
+		public boolean equals(Object object) {
+			if (this == object) return true;
+			if (!(object instanceof WordEnding)) return false;
+			WordEnding ending = (WordEnding) object;
+			return Objects.equals(singular, ending.singular) && Objects.equals(plural, ending.plural);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(singular, plural);
 		}
 
 	}

--- a/src/main/java/ch/njol/skript/util/Utils.java
+++ b/src/main/java/ch/njol/skript/util/Utils.java
@@ -241,6 +241,7 @@ public abstract class Utils {
 
 	private final static String[][] plurals = {
 
+			{"ive", "ives"}, // objective fix
 			{"fe", "ves"},// most -f words' plurals can end in -fs as well as -ves
 
 			{"axe", "axes"},
@@ -259,7 +260,7 @@ public abstract class Utils {
 
 			{"man", "men"},
 
-		    {"ui", "uis"},
+		    {"ui", "uis"}, // gui fix
 			{"us", "i"},
 
 			{"hoe", "hoes"},

--- a/src/main/java/ch/njol/skript/util/Utils.java
+++ b/src/main/java/ch/njol/skript/util/Utils.java
@@ -66,15 +66,15 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Utility class.
- * 
+ *
  * @author Peter Güttinger
  */
 public abstract class Utils {
-	
+
 	private Utils() {}
-	
+
 	public final static Random random = new Random();
-	
+
 	public static String join(final Object[] objects) {
 		assert objects != null;
 		final StringBuilder b = new StringBuilder();
@@ -85,7 +85,7 @@ public abstract class Utils {
 		}
 		return "" + b.toString();
 	}
-	
+
 	public static String join(final Iterable<?> objects) {
 		assert objects != null;
 		final StringBuilder b = new StringBuilder();
@@ -99,12 +99,12 @@ public abstract class Utils {
 		}
 		return "" + b.toString();
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	public static <T> boolean isEither(@Nullable T compared, @Nullable T... types) {
 		return CollectionUtils.contains(types, compared);
 	}
-	
+
 	public static Pair<String, Integer> getAmount(String s) {
 		if (s.matches("\\d+ of .+")) {
 			return new Pair<>(s.split(" ", 3)[2], Utils.parseInt("" + s.split(" ", 2)[0]));
@@ -115,7 +115,7 @@ public abstract class Utils {
 		}
 		return new Pair<>(s, Integer.valueOf(-1));
 	}
-	
+
 //	public final static class AmountResponse {
 //		public final String s;
 //		public final int amount;
@@ -163,7 +163,7 @@ public abstract class Utils {
 
 	/**
 	 * Loads classes of the plugin by package. Useful for registering many syntax elements like Skript does it.
-	 * 
+	 *
 	 * @param basePackage The base package to add to all sub packages, e.g. <tt>"ch.njol.skript"</tt>.
 	 * @param subPackages Which subpackages of the base package should be loaded, e.g. <tt>"expressions", "conditions", "effects"</tt>. Subpackages of these packages will be loaded
 	 *            as well. Use an empty array to load all subpackages of the base package.
@@ -216,7 +216,7 @@ public abstract class Utils {
 
 	/**
 	 * The first invocation of this method uses reflection to invoke the protected method {@link JavaPlugin#getFile()} to get the plugin's jar file.
-	 * 
+	 *
 	 * @return The jar file of the plugin.
 	 */
 	@Nullable
@@ -240,12 +240,12 @@ public abstract class Utils {
 	}
 
 	private final static String[][] plurals = {
-			
+
 			{"fe", "ves"},// most -f words' plurals can end in -fs as well as -ves
-			
+
 			{"axe", "axes"},
 			{"x", "xes"},
-			
+
 			{"ay", "ays"},
 			{"ey", "eys"},
 			{"iy", "iys"},
@@ -254,28 +254,29 @@ public abstract class Utils {
 			{"kie", "kies"},
 			{"zombie", "zombies"},
 			{"y", "ies"},
-			
+
 			{"h", "hes"},
-			
+
 			{"man", "men"},
-			
+
+		    {"ui", "uis"},
 			{"us", "i"},
-			
+
 			{"hoe", "hoes"},
 			{"toe", "toes"},
 			{"o", "oes"},
-			
+
 			{"alias", "aliases"},
 			{"gas", "gases"},
-			
+
 			{"child", "children"},
-			
+
 			{"sheep", "sheep"},
-			
+
 			// general ending
 			{"", "s"},
 	};
-	
+
 	/**
 	 * @param s trimmed string
 	 * @return Pair of singular string + boolean whether it was plural
@@ -293,10 +294,10 @@ public abstract class Utils {
 		}
 		return new NonNullPair<>(s, Boolean.FALSE);
 	}
-	
+
 	/**
 	 * Gets the english plural of a word.
-	 * 
+	 *
 	 * @param s
 	 * @return The english plural of the given word
 	 */
@@ -309,10 +310,10 @@ public abstract class Utils {
 		assert false;
 		return s + "s";
 	}
-	
+
 	/**
 	 * Gets the plural of a word (or not if p is false)
-	 * 
+	 *
 	 * @param s
 	 * @param p
 	 * @return The english plural of the given word, or the word itself if p is false.
@@ -322,10 +323,10 @@ public abstract class Utils {
 			return toEnglishPlural(s);
 		return s;
 	}
-	
+
 	/**
 	 * Adds 'a' or 'an' to the given string, depending on the first character of the string.
-	 * 
+	 *
 	 * @param s The string to add the article to
 	 * @return The given string with an appended a/an and a space at the beginning
 	 * @see #A(String)
@@ -334,10 +335,10 @@ public abstract class Utils {
 	public static String a(final String s) {
 		return a(s, false);
 	}
-	
+
 	/**
 	 * Adds 'A' or 'An' to the given string, depending on the first character of the string.
-	 * 
+	 *
 	 * @param s The string to add the article to
 	 * @return The given string with an appended A/An and a space at the beginning
 	 * @see #a(String)
@@ -346,10 +347,10 @@ public abstract class Utils {
 	public static String A(final String s) {
 		return a(s, true);
 	}
-	
+
 	/**
 	 * Adds 'a' or 'an' to the given string, depending on the first character of the string.
-	 * 
+	 *
 	 * @param s The string to add the article to
 	 * @param capA Whether to use a capital a or not
 	 * @return The given string with an appended a/an (or A/An if capA is true) and a space at the beginning
@@ -367,14 +368,14 @@ public abstract class Utils {
 			return "a " + s;
 		}
 	}
-	
+
 	/**
 	 * Gets the collision height of solid or partially-solid blocks at the center of the block.
 	 * This is mostly for use in the {@link EffTeleport teleport effect}.
 	 * <p>
 	 * This version operates on numeric ids, thus only working on
 	 * Minecraft 1.12 or older.
-	 * 
+	 *
 	 * @param type
 	 * @return The block's height at the center
 	 */
@@ -530,14 +531,14 @@ public abstract class Utils {
 
 		return completableFuture;
 	}
-	
+
 	final static ChatColor[] styles = {ChatColor.BOLD, ChatColor.ITALIC, ChatColor.STRIKETHROUGH, ChatColor.UNDERLINE, ChatColor.MAGIC, ChatColor.RESET};
 	final static Map<String, String> chat = new HashMap<>();
 	final static Map<String, String> englishChat = new HashMap<>();
-	
+
 	public final static boolean HEX_SUPPORTED = Skript.isRunningMinecraft(1, 16);
 	public final static boolean COPY_SUPPORTED = Skript.isRunningMinecraft(1, 15);
-	
+
 	static {
 		Language.addListener(new LanguageChangeListener() {
 			@Override
@@ -554,21 +555,21 @@ public abstract class Utils {
 			}
 		});
 	}
-	
+
 	@Nullable
 	public static String getChatStyle(final String s) {
 		SkriptColor color = SkriptColor.fromName(s);
-		
+
 		if (color != null)
 			return color.getFormattedChat();
 		return chat.get(s);
 	}
-	
+
 	private final static Pattern stylePattern = Pattern.compile("<([^<>]+)>");
-	
+
 	/**
 	 * Replaces &lt;chat styles&gt; in the message
-	 * 
+	 *
 	 * @param message
 	 * @return message with localised chat styles converted to Minecraft's format
 	 */
@@ -602,11 +603,11 @@ public abstract class Utils {
 		m = ChatColor.translateAlternateColorCodes('&', "" + m);
 		return "" + m;
 	}
-	
+
 	/**
 	 * Replaces english &lt;chat styles&gt; in the message. This is used for messages in the language file as the language of colour codes is not well defined while the language is
 	 * changing, and for some hardcoded messages.
-	 * 
+	 *
 	 * @param message
 	 * @return message with english chat styles converted to Minecraft's format
 	 */
@@ -653,7 +654,7 @@ public abstract class Utils {
 	public static ChatColor parseHexColor(String hex) {
 		if (!HEX_SUPPORTED || !HEX_PATTERN.matcher(hex).matches()) // Proper hex code validation
 			return null;
-		
+
 		hex = hex.replace("#", "");
 		try {
 			return ChatColor.of('#' + hex.substring(0, 6));
@@ -661,10 +662,10 @@ public abstract class Utils {
 			return null;
 		}
 	}
-	
+
 	/**
 	 * Gets a random value between <tt>start</tt> (inclusive) and <tt>end</tt> (exclusive)
-	 * 
+	 *
 	 * @param start
 	 * @param end
 	 * @return <tt>start + random.nextInt(end - start)</tt>
@@ -733,12 +734,12 @@ public abstract class Utils {
 		// See #1747 to learn how it broke returning items from functions
 		return (Class<Found>) (chosen == Cloneable.class ? bestGuess : chosen == Object.class ? bestGuess : chosen);
 	}
-	
+
 	/**
 	 * Parses a number that was validated to be an integer but might still result in a {@link NumberFormatException} when parsed with {@link Integer#parseInt(String)} due to
 	 * overflow.
 	 * This method will return {@link Integer#MIN_VALUE} or {@link Integer#MAX_VALUE} respectively if that happens.
-	 * 
+	 *
 	 * @param s
 	 * @return The parsed integer, {@link Integer#MIN_VALUE} or {@link Integer#MAX_VALUE} respectively
 	 */
@@ -750,12 +751,12 @@ public abstract class Utils {
 			return s.startsWith("-") ? Integer.MIN_VALUE : Integer.MAX_VALUE;
 		}
 	}
-	
+
 	/**
 	 * Parses a number that was validated to be an integer but might still result in a {@link NumberFormatException} when parsed with {@link Long#parseLong(String)} due to
 	 * overflow.
 	 * This method will return {@link Long#MIN_VALUE} or {@link Long#MAX_VALUE} respectively if that happens.
-	 * 
+	 *
 	 * @param s
 	 * @return The parsed long, {@link Long#MIN_VALUE} or {@link Long#MAX_VALUE} respectively
 	 */
@@ -767,7 +768,7 @@ public abstract class Utils {
 			return s.startsWith("-") ? Long.MIN_VALUE : Long.MAX_VALUE;
 		}
 	}
-	
+
 	/**
 	 * Gets class for name. Throws RuntimeException instead of checked one.
 	 * Use this only when absolutely necessary.
@@ -783,7 +784,7 @@ public abstract class Utils {
 			throw new RuntimeException("Class not found!");
 		}
 	}
-	
+
 	/**
 	 * Finds the index of the last in a {@link List} that matches the given {@link Checker}.
 	 *
@@ -807,5 +808,5 @@ public abstract class Utils {
 		}
 		return true;
 	}
-	
+
 }

--- a/src/test/java/org/skriptlang/skript/test/tests/localization/UtilsPlurals.java
+++ b/src/test/java/org/skriptlang/skript/test/tests/localization/UtilsPlurals.java
@@ -51,9 +51,11 @@ public class UtilsPlurals {
 				{"kidney", "kidneys"},
 				{"anatomy", "anatomies"},
 				{"axe", "axes"},
-				{"elf", "elfs"},
 				{"knife", "knives"},
-				{"shelf", "shelfs"},
+				{"elf", "elves"},
+				{"shelf", "shelves"},
+				{"self", "selves"},
+				{"gui", "guis"},
 		};
 		for (String[] s : strings) {
 			assertEquals(s[1], Utils.toEnglishPlural(s[0]));


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Some plural word endings are incorrectly detected, e.g. `-us` -> `-i` picks up "gui" as being a plural of (the well known word) "guus", and `-fe` -> `-ves` picks up "objectives" as being a plural of "objectife".

This PR patches these two cases _for now_ (by adding an alternative first) and I've moved to a queue and a helper class rather than a fixed-size array to make the follow-up API a little easier: you should be able to add stuff to the beginning or end of the queue without trouble.

I'd like to follow up with a proper system for doing this a little more effectively, and the ability for addons to fix any of their own problematic cases by registering plural overrides.
That's probably out of scope for a patch version so it will likely be a 2.10 feature, maybe using some registrations stuff?

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** fixes #6981, fixes #5879 <!-- Links to related issues -->
