### PR TITLE
Fix EffReturn error message

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffReturn.java
+++ b/src/main/java/ch/njol/skript/effects/EffReturn.java
@@ -96,7 +96,8 @@ public class EffReturn extends Effect {
 		}
 
 		if (handler.isSingleReturnValue() && !convertedExpr.isSingle()) {
-			Skript.error(handler + " is defined to only return a single " + returnType + ", but this return statement can return multiple values.");
+			String typeName = Classes.getSuperClassInfo(returnType).getName().getSingular();
+			Skript.error(handler + " is defined to only return a single " + typeName + ", but this return statement can return multiple values.");
 			return false;
 		}
 		value = convertedExpr;


### PR DESCRIPTION
### Description
Previously, one of the error messages in EffReturn mistakenly used the return type's tostring method instead of getting the name of its classinfo. This PR fixes that issue

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
