### PR TITLE
BStats overhaul

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -1,21 +1,3 @@
-/**
- *   This file is part of Skript.
- *
- *  Skript is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  Skript is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Copyright Peter Güttinger, SkriptLang team and contributors
- */
 package ch.njol.skript;
 
 import ch.njol.skript.aliases.Aliases;

--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -59,6 +59,7 @@ import ch.njol.skript.log.SkriptLogger;
 import ch.njol.skript.log.Verbosity;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.registrations.EventValues;
+import ch.njol.skript.registrations.Feature;
 import ch.njol.skript.test.runner.EffObjectives;
 import ch.njol.skript.test.runner.SkriptJUnitTest;
 import ch.njol.skript.test.runner.SkriptTestEvent;
@@ -88,7 +89,6 @@ import ch.njol.util.coll.iterator.EnumerationIterable;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import org.bstats.bukkit.Metrics;
-import org.bstats.charts.SimplePie;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -106,18 +106,18 @@ import org.bukkit.event.server.ServerCommandEvent;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
 import org.junit.After;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
+import org.skriptlang.skript.SkriptMetrics;
 import org.skriptlang.skript.lang.comparator.Comparator;
 import org.skriptlang.skript.lang.comparator.Comparators;
 import org.skriptlang.skript.lang.converter.Converter;
 import org.skriptlang.skript.lang.converter.Converters;
 import org.skriptlang.skript.lang.entry.EntryValidator;
 import org.skriptlang.skript.lang.experiment.ExperimentRegistry;
-import ch.njol.skript.registrations.Feature;
 import org.skriptlang.skript.lang.script.Script;
 import org.skriptlang.skript.lang.structure.Structure;
 import org.skriptlang.skript.lang.structure.StructureInfo;
@@ -790,57 +790,8 @@ public final class Skript extends JavaPlugin implements Listener {
 					}, 100);
 				}
 
-				// Enable metrics and register custom charts
-				Metrics metrics = new Metrics(Skript.this, 722); // 722 is our bStats plugin ID
-				metrics.addCustomChart(new SimplePie("pluginLanguage", Language::getName));
-				metrics.addCustomChart(new SimplePie("effectCommands", () ->
-					SkriptConfig.enableEffectCommands.value().toString()
-				));
-				metrics.addCustomChart(new SimplePie("uuidsWithPlayers", () ->
-					SkriptConfig.usePlayerUUIDsInVariableNames.value().toString()
-				));
-				metrics.addCustomChart(new SimplePie("playerVariableFix", () ->
-					SkriptConfig.enablePlayerVariableFix.value().toString()
-				));
-				metrics.addCustomChart(new SimplePie("logVerbosity", () ->
-					SkriptConfig.verbosity.value().name().toLowerCase(Locale.ENGLISH).replace('_', ' ')
-				));
-				metrics.addCustomChart(new SimplePie("pluginPriority", () ->
-					SkriptConfig.defaultEventPriority.value().name().toLowerCase(Locale.ENGLISH).replace('_', ' ')
-				));
-				metrics.addCustomChart(new SimplePie("logPlayerCommands", () ->
-					String.valueOf((SkriptConfig.logEffectCommands.value() || SkriptConfig.logPlayerCommands.value()))
-				));
-				metrics.addCustomChart(new SimplePie("maxTargetDistance", () ->
-					SkriptConfig.maxTargetBlockDistance.value().toString()
-				));
-				metrics.addCustomChart(new SimplePie("softApiExceptions", () ->
-					SkriptConfig.apiSoftExceptions.value().toString()
-				));
-				metrics.addCustomChart(new SimplePie("timingsStatus", () -> {
-					if (!Skript.classExists("co.aikar.timings.Timings"))
-						return "unsupported";
-					return SkriptConfig.enableTimings.value().toString();
-				}));
-				metrics.addCustomChart(new SimplePie("parseLinks", () ->
-					ChatMessages.linkParseMode.name().toLowerCase(Locale.ENGLISH)
-				));
-				metrics.addCustomChart(new SimplePie("colorResetCodes", () ->
-					SkriptConfig.colorResetCodes.value().toString()
-				));
-				metrics.addCustomChart(new SimplePie("functionsWithNulls", () ->
-					SkriptConfig.executeFunctionsWithMissingParams.value().toString()
-				));
-				metrics.addCustomChart(new SimplePie("buildFlavor", () -> {
-					if (updater != null)
-						return updater.getCurrentRelease().flavor;
-					return "unknown";
-				}));
-				metrics.addCustomChart(new SimplePie("updateCheckerEnabled", () ->
-					SkriptConfig.checkForNewVersion.value().toString()
-				));
-				metrics.addCustomChart(new SimplePie("releaseChannel", SkriptConfig.releaseChannel::value));
-				Skript.metrics = metrics;
+				Skript.metrics = new Metrics(Skript.getInstance(), 722); // 722 is our bStats plugin ID
+				SkriptMetrics.setupMetrics(Skript.metrics);
 
 				/*
 				 * Start loading scripts

--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -111,7 +111,7 @@ import org.jetbrains.annotations.UnknownNullability;
 import org.junit.After;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
-import org.skriptlang.skript.SkriptMetrics;
+import org.skriptlang.skript.bukkit.SkriptMetrics;
 import org.skriptlang.skript.lang.comparator.Comparator;
 import org.skriptlang.skript.lang.comparator.Comparators;
 import org.skriptlang.skript.lang.converter.Converter;

--- a/src/main/java/ch/njol/skript/SkriptConfig.java
+++ b/src/main/java/ch/njol/skript/SkriptConfig.java
@@ -79,13 +79,13 @@ public class SkriptConfig {
 				}
 			});
 	
-	static final Option<Boolean> checkForNewVersion = new Option<>("check for new version", false)
+	public static final Option<Boolean> checkForNewVersion = new Option<>("check for new version", false)
 			.setter(t -> {
 				SkriptUpdater updater = Skript.getInstance().getUpdater();
 				if (updater != null)
 					updater.setEnabled(t);
 			});
-	static final Option<Timespan> updateCheckInterval = new Option<>("update check interval", new Timespan(12 * 60 * 60 * 1000))
+	public static final Option<Timespan> updateCheckInterval = new Option<>("update check interval", new Timespan(12 * 60 * 60 * 1000))
 			.setter(t -> {
 				SkriptUpdater updater = Skript.getInstance().getUpdater();
 				if (updater != null)
@@ -93,7 +93,7 @@ public class SkriptConfig {
 			});
 	static final Option<Integer> updaterDownloadTries = new Option<>("updater download tries", 7)
 			.optional(true);
-	static final Option<String> releaseChannel = new Option<>("release channel", "none")
+	public static final Option<String> releaseChannel = new Option<>("release channel", "none")
 			.setter(t -> {
 				ReleaseChannel channel;
 				switch (t) {
@@ -139,8 +139,8 @@ public class SkriptConfig {
 	public static final Option<Boolean> enablePlayerVariableFix = new Option<>("player variable fix", true);
 	
 	@SuppressWarnings("null")
-	private static final DateFormat shortDateFormat = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT);
-	private static final Option<DateFormat> dateFormat = new Option<>("date format", shortDateFormat, s -> {
+	public static final DateFormat shortDateFormat = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT);
+	public static final Option<DateFormat> dateFormat = new Option<>("date format", shortDateFormat, s -> {
 		try {
 			if (s.equalsIgnoreCase("default"))
 				return null;
@@ -158,7 +158,7 @@ public class SkriptConfig {
 		}
 	}
 	
-	static final Option<Verbosity> verbosity = new Option<>("verbosity", Verbosity.NORMAL, new EnumParser<>(Verbosity.class, "verbosity"))
+	public static final Option<Verbosity> verbosity = new Option<>("verbosity", Verbosity.NORMAL, new EnumParser<>(Verbosity.class, "verbosity"))
 			.setter(SkriptLogger::setVerbosity);
 	
 	public static final Option<EventPriority> defaultEventPriority = new Option<>("plugin priority", EventPriority.NORMAL, s -> {

--- a/src/main/java/ch/njol/skript/SkriptConfig.java
+++ b/src/main/java/ch/njol/skript/SkriptConfig.java
@@ -1,21 +1,3 @@
-/**
- *   This file is part of Skript.
- *
- *  Skript is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  Skript is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Copyright Peter Güttinger, SkriptLang team and contributors
- */
 package ch.njol.skript;
 
 import ch.njol.skript.config.Config;
@@ -43,7 +25,7 @@ import ch.njol.skript.util.chat.LinkParseMode;
 import ch.njol.skript.variables.Variables;
 import co.aikar.timings.Timings;
 import org.bukkit.event.EventPriority;
-import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/main/java/ch/njol/skript/SkriptConfig.java
+++ b/src/main/java/ch/njol/skript/SkriptConfig.java
@@ -139,7 +139,7 @@ public class SkriptConfig {
 	public static final Option<Boolean> enablePlayerVariableFix = new Option<>("player variable fix", true);
 	
 	@SuppressWarnings("null")
-	public static final DateFormat shortDateFormat = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT);
+	private static final DateFormat shortDateFormat = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT);
 	public static final Option<DateFormat> dateFormat = new Option<>("date format", shortDateFormat, s -> {
 		try {
 			if (s.equalsIgnoreCase("default"))

--- a/src/main/java/ch/njol/skript/config/Option.java
+++ b/src/main/java/ch/njol/skript/config/Option.java
@@ -1,21 +1,3 @@
-/**
- *   This file is part of Skript.
- *
- *  Skript is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  Skript is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Copyright Peter Güttinger, SkriptLang team and contributors
- */
 package ch.njol.skript.config;
 
 import ch.njol.skript.Skript;
@@ -24,7 +6,7 @@ import ch.njol.skript.classes.Parser;
 import ch.njol.skript.lang.ParseContext;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.util.Setter;
-import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.converter.Converter;
 
 import java.util.Locale;

--- a/src/main/java/ch/njol/skript/config/Option.java
+++ b/src/main/java/ch/njol/skript/config/Option.java
@@ -18,17 +18,16 @@
  */
 package ch.njol.skript.config;
 
-import java.util.Locale;
-
-import org.eclipse.jdt.annotation.Nullable;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.ClassInfo;
-import org.skriptlang.skript.lang.converter.Converter;
 import ch.njol.skript.classes.Parser;
 import ch.njol.skript.lang.ParseContext;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.util.Setter;
+import org.eclipse.jdt.annotation.Nullable;
+import org.skriptlang.skript.lang.converter.Converter;
+
+import java.util.Locale;
 
 /**
  * @author Peter Güttinger
@@ -118,6 +117,10 @@ public class Option<T> {
 	
 	public final T value() {
 		return parsedValue;
+	}
+
+	public final T defaultValue() {
+		return defaultValue;
 	}
 	
 	public final boolean isOptional() {

--- a/src/main/java/org/skriptlang/skript/SkriptMetrics.java
+++ b/src/main/java/org/skriptlang/skript/SkriptMetrics.java
@@ -1,0 +1,260 @@
+package org.skriptlang.skript;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.SkriptConfig;
+import ch.njol.skript.localization.Language;
+import ch.njol.skript.update.Updater;
+import ch.njol.skript.util.Timespan;
+import ch.njol.skript.util.Version;
+import ch.njol.skript.util.chat.ChatMessages;
+import org.bstats.bukkit.Metrics;
+import org.bstats.charts.DrilldownPie;
+import org.bstats.charts.SimplePie;
+import org.jetbrains.annotations.Nullable;
+
+import java.text.SimpleDateFormat;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * helper class to handle bstats metrics
+ */
+public class SkriptMetrics {
+
+	/**
+	 * Helper method to set up bstats charts on the supplied Metrics object
+	 * @param metrics The Metrics object to which charts will be added.
+	 */
+	public static void setupMetrics(Metrics metrics) {
+		// Enable metrics and register custom charts
+
+		// sets up the old charts to prevent data splitting due to various user version
+		setupLegacyMetrics(metrics);
+
+		// add custom version charts for easier reading:
+		metrics.addCustomChart(new DrilldownPie("drilldownPluginVersion", () -> {
+			Version version = Skript.getVersion();
+			//noinspection DuplicatedCode
+			String featureVersionString = version.getMajor() + "." + version.getMinor();
+
+			Map<String, Integer> preciseVersionEntry = new HashMap<>(1);
+			preciseVersionEntry.put(version.toString(), 1);
+
+			Map<String, Map<String, Integer>> featureVersionEntry = new HashMap<>(1);
+			featureVersionEntry.put(featureVersionString, preciseVersionEntry);
+
+			return featureVersionEntry;
+		}));
+
+		metrics.addCustomChart(new DrilldownPie("drilldownMinecraftVersion", () -> {
+			Version version = Skript.getMinecraftVersion();
+			//noinspection DuplicatedCode
+			String majorVersionString = version.getMajor() + "." + version.getMinor();
+
+			Map<String, Integer> preciseVersionEntry = new HashMap<>(1);
+			preciseVersionEntry.put(version.toString(), 1);
+
+			Map<String, Map<String, Integer>> majorVersionEntry = new HashMap<>(1);
+			majorVersionEntry.put(majorVersionString, preciseVersionEntry);
+
+			return majorVersionEntry;
+		}));
+
+		metrics.addCustomChart(new SimplePie("buildFlavor", () -> {
+			Updater updater = Skript.getInstance().getUpdater();
+			if (updater != null)
+				return updater.getCurrentRelease().flavor;
+			return "unknown";
+		}));
+
+		//
+		// config options
+		//
+
+		metrics.addCustomChart(new DrilldownPie("drilldownPluginLanguage", () -> {
+			String lang = Language.getName();
+			return isDefaultMap(lang, "english");
+		}));
+
+		metrics.addCustomChart(new DrilldownPie("drilldownUpdateChecker", () -> {
+			Map<String, Integer> charEntry = new HashMap<>(1);
+			charEntry.put(SkriptConfig.updateCheckInterval.value().toString(), 1);
+
+			Map<String, Map<String, Integer>> checkingEntry = new HashMap<>(1);
+			checkingEntry.put(SkriptConfig.checkForNewVersion.value().toString(), charEntry);
+
+			return checkingEntry;
+		}));
+		metrics.addCustomChart(new SimplePie("releaseChannel", SkriptConfig.releaseChannel::value));
+
+		// effect commands
+		metrics.addCustomChart(new DrilldownPie("drilldownEffectCommands", () -> {
+			Map<String, Integer> charEntry = new HashMap<>(1);
+			charEntry.put(SkriptConfig.effectCommandToken.value(), 1);
+
+			Map<String, Map<String, Integer>> hasEntry = new HashMap<>(1);
+			hasEntry.put(SkriptConfig.enableEffectCommands.value().toString(), charEntry);
+
+			return hasEntry;
+
+		}));
+		metrics.addCustomChart(new SimplePie("effectCommandsOps", () ->
+			SkriptConfig.allowOpsToUseEffectCommands.value().toString()
+		));
+		metrics.addCustomChart(new SimplePie("logEffectCommands", () ->
+			SkriptConfig.logEffectCommands.value().toString()
+		));
+
+		metrics.addCustomChart(new SimplePie("loadDefaultAliases", () ->
+			SkriptConfig.loadDefaultAliases.value().toString()
+		));
+
+		metrics.addCustomChart(new SimplePie("playerVariableFix", () ->
+			SkriptConfig.enablePlayerVariableFix.value().toString()
+		));
+		metrics.addCustomChart(new SimplePie("uuidsWithPlayers", () ->
+			SkriptConfig.usePlayerUUIDsInVariableNames.value().toString()
+		));
+
+		metrics.addCustomChart(new DrilldownPie("drilldownDateFormat", () -> {
+			SimpleDateFormat dateFormat = (SimpleDateFormat) SkriptConfig.dateFormat.value();
+			boolean isDefault = dateFormat.equals(SkriptConfig.shortDateFormat);
+
+			Map<String, Integer> valueEntry = new HashMap<>(1);
+			valueEntry.put(dateFormat.toPattern(),  1);
+
+			Map<String, Map<String, Integer>> isDefaultEntry = new HashMap<>(1);
+			isDefaultEntry.put(isDefault ? "default" : "other", valueEntry);
+
+			return isDefaultEntry;
+		}));
+
+		metrics.addCustomChart(new DrilldownPie("drilldownLogVerbosity", () -> {
+			String verbosity = SkriptConfig.verbosity.value().name().toLowerCase(Locale.ENGLISH).replace('_', ' ');
+			return isDefaultMap(verbosity, "normal");
+		}));
+
+		metrics.addCustomChart(new DrilldownPie("drilldownPluginPriority", () -> {
+			String priority = SkriptConfig.defaultEventPriority.value().name().toLowerCase(Locale.ENGLISH).replace('_', ' ');
+			return isDefaultMap(priority, "high");
+		}));
+		metrics.addCustomChart(new SimplePie("cancelledByDefault", () ->
+			SkriptConfig.listenCancelledByDefault.value().toString()
+		));
+
+		metrics.addCustomChart(new DrilldownPie("drilldownNumberAccuracy", () -> {
+			int numAcc = SkriptConfig.numberAccuracy.value();
+			return isDefaultMap(numAcc, 2);
+		}));
+
+		metrics.addCustomChart(new DrilldownPie("drilldownMaxTargetDistance", () -> {
+			int numAcc = SkriptConfig.maxTargetBlockDistance.value();
+			return isDefaultMap(numAcc, 100);
+		}));
+
+		metrics.addCustomChart(new SimplePie("caseSensitiveFunctions", () ->
+			SkriptConfig.caseSensitive.value().toString()
+		));
+		metrics.addCustomChart(new SimplePie("caseSensitiveVariables", () ->
+			SkriptConfig.caseInsensitiveVariables.value().toString()
+		));
+		metrics.addCustomChart(new SimplePie("caseSensitiveCommands", () ->
+			SkriptConfig.caseInsensitiveCommands.value().toString()
+		));
+
+		metrics.addCustomChart(new SimplePie("disableSaveWarnings", () ->
+			SkriptConfig.disableObjectCannotBeSavedWarnings.value().toString()
+		));
+		metrics.addCustomChart(new SimplePie("disableAndOrWarnings", () ->
+			SkriptConfig.disableMissingAndOrWarnings.value().toString()
+		));
+		metrics.addCustomChart(new SimplePie("disableStartsWithWarnings", () ->
+			SkriptConfig.disableVariableStartingWithExpressionWarnings.value().toString()
+		));
+
+		metrics.addCustomChart(new SimplePie("softApiExceptions", () ->
+			SkriptConfig.apiSoftExceptions.value().toString()
+		));
+
+		metrics.addCustomChart(new SimplePie("timingsStatus", () -> {
+			if (!Skript.classExists("co.aikar.timings.Timings"))
+				return "unsupported";
+			return SkriptConfig.enableTimings.value().toString();
+		}));
+
+		metrics.addCustomChart(new SimplePie("parseLinks", () ->
+			ChatMessages.linkParseMode.name().toLowerCase(Locale.ENGLISH)
+		));
+
+		metrics.addCustomChart(new SimplePie("colorResetCodes", () ->
+			SkriptConfig.colorResetCodes.value().toString()
+		));
+
+		metrics.addCustomChart(new SimplePie("keepLastUsage", () ->
+			SkriptConfig.keepLastUsageDates.value().toString()
+		));
+
+		metrics.addCustomChart(new DrilldownPie("drilldownParsetimeWarningThreshold", () -> {
+			Timespan timespan = SkriptConfig.longParseTimeWarningThreshold.value();
+			return isDefaultMap(timespan, new Timespan(0), "disabled");
+		}));
+	}
+
+	/**
+	 * Helper method to set up legacy charts (pre 2.9.2)
+	 * @param metrics The Metrics object to which charts will be added.
+	 */
+	private static void setupLegacyMetrics(Metrics metrics) {
+		// Enable metrics and register legacy charts
+		metrics.addCustomChart(new SimplePie("pluginLanguage", Language::getName));
+		metrics.addCustomChart(new SimplePie("updateCheckerEnabled", () ->
+			SkriptConfig.checkForNewVersion.value().toString()
+		));
+		metrics.addCustomChart(new SimplePie("logVerbosity", () ->
+			SkriptConfig.verbosity.value().name().toLowerCase(Locale.ENGLISH).replace('_', ' ')
+		));
+		metrics.addCustomChart(new SimplePie("pluginPriority", () ->
+			SkriptConfig.defaultEventPriority.value().name().toLowerCase(Locale.ENGLISH).replace('_', ' ')
+		));
+		metrics.addCustomChart(new SimplePie("effectCommands", () ->
+			SkriptConfig.enableEffectCommands.value().toString()
+		));
+		metrics.addCustomChart(new SimplePie("maxTargetDistance", () ->
+			SkriptConfig.maxTargetBlockDistance.value().toString()
+		));
+	}
+
+	/**
+	 * Provides a Map for use with a {@link DrilldownPie} chart. Meant to be used in cases where a single default option has majority share, with many or custom alternative options.
+	 * Creates a chart where the default option is presented against "other", then clicking on "other" shows the alternative options.
+	 * @param value The option the user chose.
+	 * @param default_value The default option for this chart.
+	 * @return A Map that can be returned directly to a {@link DrilldownPie}.
+	 * @param <T> The type of the option's value.
+	 */
+	private static <T> Map<String,Map<String, Integer>> isDefaultMap(@Nullable T value, T default_value) {
+		return isDefaultMap(value, default_value ,default_value.toString());
+	}
+
+	/**
+	 * Provides a Map for use with a {@link DrilldownPie} chart. Meant to be used in cases where a single default option has majority share, with many or custom alternative options.
+	 * Creates a chart where the default option is presented against "other", then clicking on "other" shows the alternative options.
+	 * @param value The option the user chose.
+	 * @param default_value The default option for this chart.
+	 * @param default_label The label to use as the default option for this chart
+	 * @return A Map that can be returned directly to a {@link DrilldownPie}.
+	 * @param <T> The type of the option's value.
+	 */
+	private static <T> Map<String,Map<String, Integer>> isDefaultMap(@Nullable T value, @Nullable T default_value, String default_label) {
+		Map<String, Integer> valueEntry = new HashMap<>(1);
+		valueEntry.put(String.valueOf(value), 1);
+
+		Map<String, Map<String, Integer>> isDefault = new HashMap<>(1);
+		isDefault.put(Objects.equals(value, default_value) ? default_label : "other", valueEntry);
+
+		return isDefault;
+	}
+
+}

--- a/src/main/java/org/skriptlang/skript/bukkit/SkriptMetrics.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/SkriptMetrics.java
@@ -7,13 +7,14 @@ import ch.njol.skript.localization.Language;
 import ch.njol.skript.update.Updater;
 import ch.njol.skript.util.Version;
 import ch.njol.skript.util.chat.ChatMessages;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.DrilldownPie;
 import org.bstats.charts.SimplePie;
 import org.jetbrains.annotations.Nullable;
 
 import java.text.SimpleDateFormat;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -36,30 +37,24 @@ public class SkriptMetrics {
 		// add custom version charts for easier reading:
 		metrics.addCustomChart(new DrilldownPie("drilldownPluginVersion", () -> {
 			Version version = Skript.getVersion();
-			//noinspection DuplicatedCode
-			String featureVersionString = version.getMajor() + "." + version.getMinor();
-
-			Map<String, Integer> preciseVersionEntry = new HashMap<>(1);
-			preciseVersionEntry.put(version.toString(), 1);
-
-			Map<String, Map<String, Integer>> featureVersionEntry = new HashMap<>(1);
-			featureVersionEntry.put(featureVersionString, preciseVersionEntry);
-
-			return featureVersionEntry;
+			Table<String, String, Integer> table = HashBasedTable.create(1,1);
+			table.put(
+				version.getMajor() + "." + version.getMinor(), // upper label
+				version.toString(), // lower label
+				1 // weight
+			);
+			return table.rowMap();
 		}));
 
 		metrics.addCustomChart(new DrilldownPie("drilldownMinecraftVersion", () -> {
 			Version version = Skript.getMinecraftVersion();
-			//noinspection DuplicatedCode
-			String majorVersionString = version.getMajor() + "." + version.getMinor();
-
-			Map<String, Integer> preciseVersionEntry = new HashMap<>(1);
-			preciseVersionEntry.put(version.toString(), 1);
-
-			Map<String, Map<String, Integer>> majorVersionEntry = new HashMap<>(1);
-			majorVersionEntry.put(majorVersionString, preciseVersionEntry);
-
-			return majorVersionEntry;
+			Table<String, String, Integer> table = HashBasedTable.create(1,1);
+			table.put(
+				version.getMajor() + "." + version.getMinor(), // upper label
+				version.toString(), // lower label
+				1 // weight
+			);
+			return table.rowMap();
 		}));
 
 		metrics.addCustomChart(new SimplePie("buildFlavor", () -> {
@@ -79,26 +74,25 @@ public class SkriptMetrics {
 		}));
 
 		metrics.addCustomChart(new DrilldownPie("drilldownUpdateChecker", () -> {
-			Map<String, Integer> charEntry = new HashMap<>(1);
-			charEntry.put(SkriptConfig.updateCheckInterval.value().toString(), 1);
-
-			Map<String, Map<String, Integer>> checkingEntry = new HashMap<>(1);
-			checkingEntry.put(SkriptConfig.checkForNewVersion.value().toString(), charEntry);
-
-			return checkingEntry;
+			Table<String, String, Integer> table = HashBasedTable.create(1,1);
+			table.put(
+				SkriptConfig.checkForNewVersion.value().toString(), // upper label
+				SkriptConfig.updateCheckInterval.value().toString(), // lower label
+				1 // weight
+			);
+			return table.rowMap();
 		}));
 		metrics.addCustomChart(new SimplePie("releaseChannel", SkriptConfig.releaseChannel::value));
 
 		// effect commands
 		metrics.addCustomChart(new DrilldownPie("drilldownEffectCommands", () -> {
-			Map<String, Integer> charEntry = new HashMap<>(1);
-			charEntry.put(SkriptConfig.effectCommandToken.value(), 1);
-
-			Map<String, Map<String, Integer>> hasEntry = new HashMap<>(1);
-			hasEntry.put(SkriptConfig.enableEffectCommands.value().toString(), charEntry);
-
-			return hasEntry;
-
+			Table<String, String, Integer> table = HashBasedTable.create(1,1);
+			table.put(
+				SkriptConfig.enableEffectCommands.value().toString(), // upper label
+				SkriptConfig.effectCommandToken.value(), // lower label
+				1 // weight
+			);
+			return table.rowMap();
 		}));
 		metrics.addCustomChart(new SimplePie("effectCommandsOps", () ->
 			SkriptConfig.allowOpsToUseEffectCommands.value().toString()
@@ -238,13 +232,13 @@ public class SkriptMetrics {
 	 * @param <T> The type of the option.
 	 */
 	private static <T> Map<String,Map<String, Integer>> isDefaultMap(@Nullable T value, @Nullable T defaultValue, String defaultLabel) {
-		Map<String, Integer> valueEntry = new HashMap<>(1);
-		valueEntry.put(String.valueOf(value), 1);
-
-		Map<String, Map<String, Integer>> isDefault = new HashMap<>(1);
-		isDefault.put(Objects.equals(value, defaultValue) ? defaultLabel : "other", valueEntry);
-
-		return isDefault;
+		Table<String, String, Integer> table = HashBasedTable.create(1,1);
+		table.put(
+			Objects.equals(value, defaultValue) ? defaultLabel : "other", // upper label
+			String.valueOf(value), // lower label
+			1 // weight
+		);
+		return table.rowMap();
 	}
 
 	/**

--- a/src/main/java/org/skriptlang/skript/bukkit/SkriptMetrics.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/SkriptMetrics.java
@@ -137,9 +137,13 @@ public class SkriptMetrics {
 			SkriptConfig.listenCancelledByDefault.value().toString()
 		));
 
-		metrics.addCustomChart(new DrilldownPie("drilldownNumberAccuracy", () -> isDefaultMap(SkriptConfig.numberAccuracy)));
+		metrics.addCustomChart(new DrilldownPie("drilldownNumberAccuracy", () ->
+			isDefaultMap(SkriptConfig.numberAccuracy)
+		));
 
-		metrics.addCustomChart(new DrilldownPie("drilldownMaxTargetDistance", () -> isDefaultMap(SkriptConfig.maxTargetBlockDistance)));
+		metrics.addCustomChart(new DrilldownPie("drilldownMaxTargetDistance", () ->
+			isDefaultMap(SkriptConfig.maxTargetBlockDistance)
+		));
 
 		metrics.addCustomChart(new SimplePie("caseSensitiveFunctions", () ->
 			SkriptConfig.caseSensitive.value().toString()
@@ -183,7 +187,9 @@ public class SkriptMetrics {
 			SkriptConfig.keepLastUsageDates.value().toString()
 		));
 
-		metrics.addCustomChart(new DrilldownPie("drilldownParsetimeWarningThreshold", () -> isDefaultMap(SkriptConfig.longParseTimeWarningThreshold, "disabled")));
+		metrics.addCustomChart(new DrilldownPie("drilldownParsetimeWarningThreshold", () ->
+			isDefaultMap(SkriptConfig.longParseTimeWarningThreshold, "disabled")
+		));
 	}
 
 	/**

--- a/src/main/java/org/skriptlang/skript/bukkit/SkriptMetrics.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/SkriptMetrics.java
@@ -1,4 +1,4 @@
-package org.skriptlang.skript;
+package org.skriptlang.skript.bukkit;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptConfig;

--- a/src/main/java/org/skriptlang/skript/bukkit/SkriptMetrics.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/SkriptMetrics.java
@@ -119,16 +119,9 @@ public class SkriptMetrics {
 		));
 
 		metrics.addCustomChart(new DrilldownPie("drilldownDateFormat", () -> {
-			SimpleDateFormat dateFormat = (SimpleDateFormat) SkriptConfig.dateFormat.value();
-			boolean isDefault = dateFormat.equals(SkriptConfig.dateFormat.defaultValue());
-
-			Map<String, Integer> valueEntry = new HashMap<>(1);
-			valueEntry.put(dateFormat.toPattern(),  1);
-
-			Map<String, Map<String, Integer>> isDefaultEntry = new HashMap<>(1);
-			isDefaultEntry.put(isDefault ? "default" : "other", valueEntry);
-
-			return isDefaultEntry;
+			String value = ((SimpleDateFormat) SkriptConfig.dateFormat.value()).toPattern();
+			String defaultValue = ((SimpleDateFormat) SkriptConfig.dateFormat.defaultValue()).toPattern();
+			return isDefaultMap(value, defaultValue, "default");
 		}));
 
 		metrics.addCustomChart(new DrilldownPie("drilldownLogVerbosity", () -> {

--- a/src/main/resources/config.sk
+++ b/src/main/resources/config.sk
@@ -91,9 +91,9 @@ load default aliases: true
 
 
 player variable fix: true
-# Whether to enable the player variable fix if a player has rejoined and was reciding inside a variable.
-# Player objects inside a variable(list or normal) are not updated to the new player object
-# A server creates whenever a player rejoins.
+# Whether to enable the player variable fix if a player has rejoined and was residing inside a variable.
+# Player objects inside a variable (list or normal) are not updated to the new player object
+# that a server creates whenever a player rejoins.
 # Basically the variable holds the old player object when a player has rejoined thus rendering the variable kinda broken.
 # This fix should work around that and whenever a invalid(old) player object is attempted to be get through a variable
 # It will check if the player is online and then get the valid(new) player object and update the variable object to that one.


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

- every exposed config option now has a pie chart
- the config options with multiple settings have a drill chart, where layer one shows the default value and "other". Clicking on other will show you a pie chart of all the options people chose.
- effects commands also got a drilldown, showing the character people use for effect commands
- there's a new mc and skript version chart that only shows major versions on the top level and can be clicked to see the details for each major version

All the legacy charts will stick around but will be relegated to the bottom of the page after a few versions pass. The new charts will only show users on 2.9.2+, so the legacy charts are still interesting to view, but by the time 2.10.x is out they shouldn't be that useful for us.

Chart changes are live at https://bstats.org/plugin/bukkit/Skript/722, with my test server as the only server running the new charts.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
