### PR TITLE
Boss bars 2 (segmented boogaloo)

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -30,6 +30,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import ch.njol.skript.bukkitutil.BukkitUtils;
+import ch.njol.skript.classes.*;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Difficulty;
@@ -49,6 +50,9 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.DoubleChest;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.boss.BarFlag;
+import org.bukkit.boss.BarStyle;
+import org.bukkit.boss.BossBar;
 import org.bukkit.command.CommandSender;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.enchantments.EnchantmentOffer;
@@ -86,11 +90,6 @@ import ch.njol.skript.aliases.Aliases;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.bukkitutil.EnchantmentUtils;
 import ch.njol.skript.bukkitutil.ItemUtils;
-import ch.njol.skript.classes.ClassInfo;
-import ch.njol.skript.classes.ConfigurationSerializer;
-import ch.njol.skript.classes.EnumClassInfo;
-import ch.njol.skript.classes.Parser;
-import ch.njol.skript.classes.Serializer;
 import ch.njol.skript.classes.registry.RegistryClassInfo;
 import ch.njol.skript.entity.EntityData;
 import ch.njol.skript.expressions.ExprDamageCause;
@@ -155,12 +154,12 @@ public class BukkitClasses {
 						}
 						return null;
 					}
-					
+
 					@Override
 					public boolean canParse(final ParseContext context) {
 						return context == ParseContext.COMMAND || context == ParseContext.PARSE;
 					}
-					
+
 					@Override
 					public String toVariableNameString(final Entity e) {
 						return "entity:" + e.getUniqueId().toString().toLowerCase(Locale.ENGLISH);
@@ -172,7 +171,7 @@ public class BukkitClasses {
 					}
 				})
 				.changer(DefaultChangers.entityChanger));
-		
+
 		Classes.registerClass(new ClassInfo<>(LivingEntity.class, "livingentity")
 				.user("living ?entit(y|ies)")
 				.name("Living Entity")
@@ -184,7 +183,7 @@ public class BukkitClasses {
 				.since("1.0")
 				.defaultExpression(new EventValueExpression<>(LivingEntity.class))
 				.changer(DefaultChangers.entityChanger));
-		
+
 		Classes.registerClass(new ClassInfo<>(Projectile.class, "projectile")
 				.user("projectiles?")
 				.name("Projectile")
@@ -195,7 +194,7 @@ public class BukkitClasses {
 				.since("1.0")
 				.defaultExpression(new EventValueExpression<>(Projectile.class))
 				.changer(DefaultChangers.nonLivingEntityChanger));
-		
+
 		Classes.registerClass(new ClassInfo<>(Block.class, "block")
 				.user("blocks?")
 				.name("Block")
@@ -211,17 +210,17 @@ public class BukkitClasses {
 					public Block parse(final String s, final ParseContext context) {
 						return null;
 					}
-					
+
 					@Override
 					public boolean canParse(final ParseContext context) {
 						return false;
 					}
-					
+
 					@Override
 					public String toString(final Block b, final int flags) {
 						return BlockUtils.blockToString(b, flags);
 					}
-					
+
 					@Override
 					public String toVariableNameString(final Block b) {
 						return b.getWorld().getName() + ":" + b.getX() + "," + b.getY() + "," + b.getZ();
@@ -243,12 +242,12 @@ public class BukkitClasses {
 						f.putPrimitive("z", b.getZ());
 						return f;
 					}
-					
+
 					@Override
 					public void deserialize(final Block o, final Fields f) {
 						assert false;
 					}
-					
+
 					@Override
 					protected Block deserialize(final Fields fields) throws StreamCorruptedException {
 						final World w = fields.getObject("world", World.class);
@@ -257,17 +256,17 @@ public class BukkitClasses {
 							throw new StreamCorruptedException();
 						return w.getBlockAt(x, y, z);
 					}
-					
+
 					@Override
 					public boolean mustSyncDeserialization() {
 						return true;
 					}
-					
+
 					@Override
 					public boolean canBeInstantiated() {
 						return false;
 					}
-					
+
 					// return b.getWorld().getName() + ":" + b.getX() + "," + b.getY() + "," + b.getZ();
 					@Override
 					@Nullable
@@ -311,12 +310,12 @@ public class BukkitClasses {
 					public BlockData parse(String input, ParseContext context) {
 						return BlockUtils.createBlockData(input);
 					}
-	
+
 					@Override
 					public String toString(BlockData o, int flags) {
 						return o.getAsString().replace(",", ";");
 					}
-	
+
 					@Override
 					public String toVariableNameString(BlockData o) {
 						return "blockdata:" + o.getAsString();
@@ -329,12 +328,12 @@ public class BukkitClasses {
 						f.putObject("blockdata", o.getAsString());
 						return f;
 					}
-	
+
 					@Override
 					public void deserialize(BlockData o, Fields f) {
 						assert false;
 					}
-	
+
 					@Override
 					protected BlockData deserialize(Fields f) throws StreamCorruptedException {
 						String data = f.getObject("blockdata", String.class);
@@ -345,12 +344,12 @@ public class BukkitClasses {
 							throw new StreamCorruptedException("Invalid block data: " + data);
 						}
 					}
-	
+
 					@Override
 					public boolean mustSyncDeserialization() {
 						return true;
 					}
-	
+
 					@Override
 					protected boolean canBeInstantiated() {
 						return false;
@@ -372,18 +371,18 @@ public class BukkitClasses {
 					public Location parse(final String s, final ParseContext context) {
 						return null;
 					}
-					
+
 					@Override
 					public boolean canParse(final ParseContext context) {
 						return false;
 					}
-					
+
 					@Override
 					public String toString(final Location l, final int flags) {
 						String worldPart = l.getWorld() == null ? "" : " in '" + l.getWorld().getName() + "'"; // Safety: getWorld is marked as Nullable by spigot
 						return "x: " + Skript.toString(l.getX()) + ", y: " + Skript.toString(l.getY()) + ", z: " + Skript.toString(l.getZ()) + ", yaw: " + Skript.toString(l.getYaw()) + ", pitch: " + Skript.toString(l.getPitch()) + worldPart;
 					}
-					
+
 					@Override
 					public String toVariableNameString(final Location l) {
 						return l.getWorld().getName() + ":" + l.getX() + "," + l.getY() + "," + l.getZ();
@@ -411,29 +410,29 @@ public class BukkitClasses {
 						fields.putPrimitive("pitch", location.getPitch());
 						return fields;
 					}
-					
+
 					@Override
 					public void deserialize(final Location o, final Fields f) {
 						assert false;
 					}
-					
+
 					@Override
 					public Location deserialize(final Fields f) throws StreamCorruptedException {
 						return new Location(f.getObject("world", World.class),
 								f.getPrimitive("x", double.class), f.getPrimitive("y", double.class), f.getPrimitive("z", double.class),
 								f.getPrimitive("yaw", float.class), f.getPrimitive("pitch", float.class));
 					}
-					
+
 					@Override
 					public boolean canBeInstantiated() {
 						return false; // no nullary constructor - also, saving the location manually prevents errors should Location ever be changed
 					}
-					
+
 					@Override
 					public boolean mustSyncDeserialization() {
 						return true;
 					}
-					
+
 					// return l.getWorld().getName() + ":" + l.getX() + "," + l.getY() + "," + l.getZ() + "|" + l.getYaw() + "/" + l.getPitch();
 					@Override
 					@Nullable
@@ -455,7 +454,7 @@ public class BukkitClasses {
 					}
 				})
 				.cloner(Location::clone));
-		
+
 		Classes.registerClass(new ClassInfo<>(Vector.class, "vector")
 				.user("vectors?")
 				.name("Vector")
@@ -470,17 +469,17 @@ public class BukkitClasses {
 					public Vector parse(final String s, final ParseContext context) {
 						return null;
 					}
-					
+
 					@Override
 					public boolean canParse(final ParseContext context) {
 						return false;
 					}
-					
+
 					@Override
 					public String toString(final Vector vec, final int flags) {
 						return "x: " + Skript.toString(vec.getX()) + ", y: " + Skript.toString(vec.getY()) + ", z: " + Skript.toString(vec.getZ());
 					}
-					
+
 					@Override
 					public String toVariableNameString(final Vector vec) {
 						return "vector:" + vec.getX() + "," + vec.getY() + "," + vec.getZ();
@@ -500,29 +499,29 @@ public class BukkitClasses {
 						f.putPrimitive("z", o.getZ());
 						return f;
 					}
-					
+
 					@Override
 					public void deserialize(Vector o, Fields f) {
 						assert false;
 					}
-					
+
 					@Override
 					public Vector deserialize(final Fields f) throws StreamCorruptedException {
 						return new Vector(f.getPrimitive("x", double.class), f.getPrimitive("y", double.class), f.getPrimitive("z", double.class));
 					}
-					
+
 					@Override
 					public boolean mustSyncDeserialization() {
 						return false;
 					}
-					
+
 					@Override
 					protected boolean canBeInstantiated() {
 						return false;
 					}
 				})
 				.cloner(Vector::clone));
-		
+
 		Classes.registerClass(new ClassInfo<>(World.class, "world")
 				.user("worlds?")
 				.name("World")
@@ -536,7 +535,7 @@ public class BukkitClasses {
 				.parser(new Parser<World>() {
 					@SuppressWarnings("null")
 					private final Pattern parsePattern = Pattern.compile("(?:(?:the )?world )?\"(.+)\"", Pattern.CASE_INSENSITIVE);
-					
+
 					@Override
 					@Nullable
 					public World parse(final String s, final ParseContext context) {
@@ -548,12 +547,12 @@ public class BukkitClasses {
 							return Bukkit.getWorld(m.group(1));
 						return null;
 					}
-					
+
 					@Override
 					public String toString(final World w, final int flags) {
 						return "" + w.getName();
 					}
-					
+
 					@Override
 					public String toVariableNameString(final World w) {
 						return "" + w.getName();
@@ -565,17 +564,17 @@ public class BukkitClasses {
 						f.putObject("name", w.getName());
 						return f;
 					}
-					
+
 					@Override
 					public void deserialize(final World o, final Fields f) {
 						assert false;
 					}
-					
+
 					@Override
 					public boolean canBeInstantiated() {
 						return false;
 					}
-					
+
 					@Override
 					protected World deserialize(final Fields fields) throws StreamCorruptedException {
 						final String name = fields.getObject("name", String.class);
@@ -585,20 +584,20 @@ public class BukkitClasses {
 							throw new StreamCorruptedException("Missing world " + name);
 						return w;
 					}
-					
+
 					// return w.getName();
 					@Override
 					@Nullable
 					public World deserialize(final String s) {
 						return Bukkit.getWorld(s);
 					}
-					
+
 					@Override
 					public boolean mustSyncDeserialization() {
 						return true;
 					}
 				}));
-		
+
 		Classes.registerClass(new ClassInfo<>(Inventory.class, "inventory")
 				.user("inventor(y|ies)")
 				.name("Inventory")
@@ -617,28 +616,28 @@ public class BukkitClasses {
 					public Inventory parse(final String s, final ParseContext context) {
 						return null;
 					}
-					
+
 					@Override
 					public boolean canParse(final ParseContext context) {
 						return false;
 					}
-					
+
 					@Override
 					public String toString(final Inventory i, final int flags) {
 						return "inventory of " + Classes.toString(i.getHolder());
 					}
-					
+
 					@Override
 					public String getDebugMessage(final Inventory i) {
 						return "inventory of " + Classes.getDebugMessage(i.getHolder());
 					}
-					
+
 					@Override
 					public String toVariableNameString(final Inventory i) {
 						return "inventory of " + Classes.toString(i.getHolder(), StringMode.VARIABLE_NAME);
 					}
 				}).changer(DefaultChangers.inventoryChanger));
-		
+
 		Classes.registerClass(new EnumClassInfo<>(InventoryAction.class, "inventoryaction", "inventory actions")
 				.user("inventory ?actions?")
 				.name("Inventory Action")
@@ -653,7 +652,7 @@ public class BukkitClasses {
 						"assuming that default keybindings are used in client side.")
 				.examples("")
 				.since("2.2-dev16b, 2.2-dev35 (renamed to click type)"));
-		
+
 		Classes.registerClass(new EnumClassInfo<>(InventoryType.class, "inventorytype", "inventory types")
 				.user("inventory ?types?")
 				.name("Inventory Type")
@@ -709,17 +708,17 @@ public class BukkitClasses {
 						assert false;
 						return null;
 					}
-					
+
 					@Override
 					public boolean canParse(final ParseContext context) {
 						return context == ParseContext.COMMAND || context == ParseContext.PARSE;
 					}
-					
+
 					@Override
 					public String toString(final Player p, final int flags) {
 						return "" + p.getName();
 					}
-					
+
 					@Override
 					public String toVariableNameString(final Player p) {
 						if (SkriptConfig.usePlayerUUIDsInVariableNames.value())
@@ -764,17 +763,17 @@ public class BukkitClasses {
 						assert false;
 						return null;
 					}
-					
+
 					@Override
 					public boolean canParse(ParseContext context) {
 						return context == ParseContext.COMMAND || context == ParseContext.PARSE;
 					}
-					
+
 					@Override
 					public String toString(OfflinePlayer p, int flags) {
 						return p.getName() == null ? p.getUniqueId().toString() : p.getName();
 					}
-					
+
 					@Override
 					public String toVariableNameString(OfflinePlayer p) {
 						if (SkriptConfig.usePlayerUUIDsInVariableNames.value() || p.getName() == null)
@@ -796,17 +795,17 @@ public class BukkitClasses {
 						f.putObject("uuid", p.getUniqueId());
 						return f;
 					}
-					
+
 					@Override
 					public void deserialize(final OfflinePlayer o, final Fields f) {
 						assert false;
 					}
-					
+
 					@Override
 					public boolean canBeInstantiated() {
 						return false;
 					}
-					
+
 					@SuppressWarnings("deprecation")
 					@Override
 					protected OfflinePlayer deserialize(final Fields fields) throws StreamCorruptedException {
@@ -822,7 +821,7 @@ public class BukkitClasses {
 							return Bukkit.getOfflinePlayer(name);
 						}
 					}
-					
+
 					// return p.getName();
 					@SuppressWarnings("deprecation")
 					@Override
@@ -830,13 +829,13 @@ public class BukkitClasses {
 					public OfflinePlayer deserialize(final String s) {
 						return Bukkit.getOfflinePlayer(s);
 					}
-					
+
 					@Override
 					public boolean mustSyncDeserialization() {
 						return true;
 					}
 				}));
-		
+
 		Classes.registerClass(new ClassInfo<>(CommandSender.class, "commandsender")
 				.user("((commands?)? ?)?(sender|executor)s?")
 				.name("Command Sender")
@@ -862,23 +861,23 @@ public class BukkitClasses {
 					public CommandSender parse(final String s, final ParseContext context) {
 						return null;
 					}
-					
+
 					@Override
 					public boolean canParse(final ParseContext context) {
 						return false;
 					}
-					
+
 					@Override
 					public String toString(final CommandSender s, final int flags) {
 						return "" + s.getName();
 					}
-					
+
 					@Override
 					public String toVariableNameString(final CommandSender s) {
 						return "" + s.getName();
 					}
 				}));
-		
+
 		Classes.registerClass(new ClassInfo<>(InventoryHolder.class, "inventoryholder")
 				.name(ClassInfo.NO_DOC)
 				.defaultExpression(new EventValueExpression<>(InventoryHolder.class))
@@ -888,7 +887,7 @@ public class BukkitClasses {
 					public boolean canParse(ParseContext context) {
 						return false;
 					}
-					
+
 					@Override
 					public String toString(InventoryHolder holder, int flags) {
 						if (holder instanceof BlockState) {
@@ -903,7 +902,7 @@ public class BukkitClasses {
 							return Classes.toString(holder);
 						}
 					}
-					
+
 					@Override
 					public String toVariableNameString(InventoryHolder holder) {
 						return toString(holder, 0);
@@ -916,7 +915,7 @@ public class BukkitClasses {
 				.examples("player's gamemode is survival",
 						"set the player argument's game mode to creative")
 				.since("1.0"));
-		
+
 		Classes.registerClass(new ClassInfo<>(ItemStack.class, "itemstack")
 				.user("items?")
 				.name("Item")
@@ -947,7 +946,7 @@ public class BukkitClasses {
 							Skript.error("'" + s + "' represents multiple materials");
 							return null;
 						}
-						
+
 						final ItemStack i = t.getRandom();
 						if (i == null) {
 							Skript.error("'" + s + "' cannot represent an item");
@@ -955,19 +954,19 @@ public class BukkitClasses {
 						}
 						return i;
 					}
-					
+
 					@Override
 					public String toString(final ItemStack i, final int flags) {
 						return ItemType.toString(i, flags);
 					}
-					
+
 					@Override
 					public String toVariableNameString(final ItemStack i) {
 						final StringBuilder b = new StringBuilder("item:");
 						b.append(i.getType().name());
 						b.append(":" + ItemUtils.getDamage(i));
 						b.append("*" + i.getAmount());
-						
+
 						for (Entry<Enchantment, Integer> entry : i.getEnchantments().entrySet())
 							b.append("#" + EnchantmentUtils.getKey(entry.getKey()))
 									.append(":" + entry.getValue());
@@ -977,7 +976,7 @@ public class BukkitClasses {
 				})
 				.cloner(ItemStack::clone)
 				.serializer(new ConfigurationSerializer<>()));
-		
+
 		Classes.registerClass(new ClassInfo<>(Item.class, "itementity")
 				.name(ClassInfo.NO_DOC)
 				.since("2.0")
@@ -997,7 +996,7 @@ public class BukkitClasses {
 				.examples("biome at the player is desert")
 				.since("1.4.4")
 				.after("damagecause"));
-		
+
 		Classes.registerClass(new ClassInfo<>(PotionEffect.class, "potioneffect")
 			.user("potion ?effects?")
 			.name("Potion Effect")
@@ -1005,17 +1004,17 @@ public class BukkitClasses {
 			.usage("speed of tier 1 for 10 seconds")
 			.since("2.5.2")
 			.parser(new Parser<PotionEffect>() {
-				
+
 				@Override
 				public boolean canParse(ParseContext context) {
 					return false;
 				}
-				
+
 				@Override
 				public String toString(PotionEffect potionEffect, int flags) {
 					return PotionEffectUtils.toString(potionEffect);
 				}
-				
+
 				@Override
 				public String toVariableNameString(PotionEffect o) {
 					return "potion_effect:" + o.getType().getName();
@@ -1033,12 +1032,12 @@ public class BukkitClasses {
 					fields.putPrimitive("ambient", o.isAmbient());
 					return fields;
 				}
-				
+
 				@Override
 				public void deserialize(PotionEffect o, Fields f) {
 					assert false;
 				}
-				
+
 				@Override
 				protected PotionEffect deserialize(Fields fields) throws StreamCorruptedException {
 					String typeName = fields.getObject("type", String.class);
@@ -1052,18 +1051,18 @@ public class BukkitClasses {
 					boolean ambient = fields.getPrimitive("ambient", boolean.class);
 					return new PotionEffect(type, duration, amplifier, ambient, particles);
 				}
-				
+
 				@Override
 				public boolean mustSyncDeserialization() {
 					return false;
 				}
-				
+
 				@Override
 				protected boolean canBeInstantiated() {
 					return false;
 				}
 			}));
-		
+
 		Classes.registerClass(new ClassInfo<>(PotionEffectType.class, "potioneffecttype")
 				.user("potion( ?effect)? ?types?") // "type" had to be made non-optional to prevent clashing with potion effects
 				.name("Potion Effect Type")
@@ -1098,17 +1097,17 @@ public class BukkitClasses {
 						f.putObject("name", o.getName());
 						return f;
 					}
-					
+
 					@Override
 					public boolean canBeInstantiated() {
 						return false;
 					}
-					
+
 					@Override
 					public void deserialize(final PotionEffectType o, final Fields f) {
 						assert false;
 					}
-					
+
 					@Override
 					protected PotionEffectType deserialize(final Fields fields) throws StreamCorruptedException {
 						final String name = fields.getObject("name", String.class);
@@ -1118,20 +1117,20 @@ public class BukkitClasses {
 							throw new StreamCorruptedException("Invalid PotionEffectType " + name);
 						return t;
 					}
-					
+
 					// return o.getName();
 					@Override
 					@Nullable
 					public PotionEffectType deserialize(final String s) {
 						return PotionEffectType.getByName(s);
 					}
-					
+
 					@Override
 					public boolean mustSyncDeserialization() {
 						return false;
 					}
 				}));
-		
+
 		// REMIND make my own damage cause class (that e.g. stores the attacker entity, the projectile, or the attacking block)
 		Classes.registerClass(new EnumClassInfo<>(DamageCause.class, "damagecause", "damage causes", new ExprDamageCause())
 				.user("damage ?causes?")
@@ -1142,7 +1141,7 @@ public class BukkitClasses {
 				.examples("")
 				.since("2.0")
 				.after("itemtype", "itemstack", "entitydata", "entitytype"));
-		
+
 		Classes.registerClass(new ClassInfo<>(Chunk.class, "chunk")
 				.user("chunks?")
 				.name("Chunk")
@@ -1156,17 +1155,17 @@ public class BukkitClasses {
 					public Chunk parse(final String s, final ParseContext context) {
 						return null;
 					}
-					
+
 					@Override
 					public boolean canParse(final ParseContext context) {
 						return false;
 					}
-					
+
 					@Override
 					public String toString(final Chunk c, final int flags) {
 						return "chunk (" + c.getX() + "," + c.getZ() + ") of " + c.getWorld().getName();
 					}
-					
+
 					@Override
 					public String toVariableNameString(final Chunk c) {
 						return c.getWorld().getName() + ":" + c.getX() + "," + c.getZ();
@@ -1181,17 +1180,17 @@ public class BukkitClasses {
 						f.putPrimitive("z", c.getZ());
 						return f;
 					}
-					
+
 					@Override
 					public void deserialize(final Chunk o, final Fields f) {
 						assert false;
 					}
-					
+
 					@Override
 					public boolean canBeInstantiated() {
 						return false;
 					}
-					
+
 					@Override
 					protected Chunk deserialize(final Fields fields) throws StreamCorruptedException {
 						final World w = fields.getObject("world", World.class);
@@ -1200,7 +1199,7 @@ public class BukkitClasses {
 							throw new StreamCorruptedException();
 						return w.getChunkAt(x, z);
 					}
-					
+
 					// return c.getWorld().getName() + ":" + c.getX() + "," + c.getZ();
 					@Override
 					@Nullable
@@ -1219,7 +1218,7 @@ public class BukkitClasses {
 							return null;
 						}
 					}
-					
+
 					@Override
 					public boolean mustSyncDeserialization() {
 						return true;
@@ -1242,7 +1241,7 @@ public class BukkitClasses {
 				.examples("")
 				.since("1.4.6")
 				.before("enchantmenttype"));
-		
+
 		Material[] allMaterials = Material.values();
 		Classes.registerClass(new ClassInfo<>(Material.class, "material")
 				.name(ClassInfo.NO_DOC)
@@ -1254,49 +1253,49 @@ public class BukkitClasses {
 						f.putObject("i", o.ordinal());
 						return f;
 					}
-					
+
 					@Override
 					public void deserialize(Material o, Fields f) {
 						assert false;
 					}
-					
+
 					@Override
 					public Material deserialize(Fields f) throws StreamCorruptedException {
 						Material mat = allMaterials[(int) f.getPrimitive("i")];
 						assert mat != null; // Hope server owner didn't mod too much...
 						return mat;
 					}
-					
+
 					@Override
 					public boolean mustSyncDeserialization() {
 						return false;
 					}
-					
+
 					@Override
 					protected boolean canBeInstantiated() {
 						return false; // It is an enum, come on
 					}
 				}));
-		
+
 		Classes.registerClass(new ClassInfo<>(Metadatable.class, "metadataholder")
 				.user("metadata ?holders?")
 				.name("Metadata Holder")
 				.description("Something that can hold metadata (e.g. an entity or block)")
 				.examples("set metadata value \"super cool\" of player to true")
 				.since("2.2-dev36"));
-		
+
 		Classes.registerClass(new EnumClassInfo<>(TeleportCause.class, "teleportcause", "teleport causes")
 				.user("teleport ?(cause|reason|type)s?")
 				.name("Teleport Cause")
 				.description("The teleport cause in a <a href='events.html#teleport'>teleport</a> event.")
 				.since("2.2-dev35"));
-		
+
 		Classes.registerClass(new EnumClassInfo<>(SpawnReason.class, "spawnreason", "spawn reasons")
 				.user("spawn(ing)? ?reasons?")
 				.name("Spawn Reason")
 				.description("The spawn reason in a <a href='events.html#spawn'>spawn</a> event.")
 				.since("2.3"));
-		
+
 		if (Skript.classExists("com.destroystokyo.paper.event.server.PaperServerListPingEvent")) {
 			Classes.registerClass(new ClassInfo<>(CachedServerIcon.class, "cachedservericon")
 					.user("server ?icons?")
@@ -1310,31 +1309,31 @@ public class BukkitClasses {
 						public CachedServerIcon parse(final String s, final ParseContext context) {
 							return null;
 						}
-						
+
 						@Override
 						public boolean canParse(final ParseContext context) {
 							return false;
 						}
-						
+
 						@Override
 						public String toString(final CachedServerIcon o, int flags) {
 							return "server icon";
 						}
-						
+
 						@Override
 						public String toVariableNameString(final CachedServerIcon o) {
 							return "server icon";
 						}
 					}));
 		}
-		
+
 		Classes.registerClass(new EnumClassInfo<>(FireworkEffect.Type.class, "fireworktype", "firework types")
 				.user("firework ?types?")
 				.name("Firework Type")
 				.description("The type of a <a href='#fireworkeffect'>fireworkeffect</a>.")
 				.since("2.4")
 				.documentationId("FireworkType"));
-		
+
 		Classes.registerClass(new ClassInfo<>(FireworkEffect.class, "fireworkeffect")
 				.user("firework ?effects?")
 				.name("Firework Effect")
@@ -1355,23 +1354,23 @@ public class BukkitClasses {
 					public FireworkEffect parse(String input, ParseContext context) {
 						return null;
 					}
-					
+
 					@Override
 					public boolean canParse(ParseContext context) {
 						return false;
 					}
-					
+
 					@Override
 					public String toString(FireworkEffect effect, int flags) {
 						return "Firework effect " + effect.toString();
 					}
-					
+
 					@Override
 					public String toVariableNameString(FireworkEffect effect) {
 						return "firework effect " + effect.toString();
 					}
 				}));
-		
+
 		Classes.registerClass(new EnumClassInfo<>(Difficulty.class, "difficulty", "difficulties")
 				.user("difficult(y|ies)")
 				.name("Difficulty")
@@ -1465,12 +1464,12 @@ public class BukkitClasses {
 					public boolean canParse(ParseContext context) {
 						return false;
 					}
-	
+
 					@Override
 					public String toString(EnchantmentOffer eo, int flags) {
 						return EnchantmentUtils.toString(eo.getEnchantment(), flags) + " " + eo.getEnchantmentLevel();
 					}
-	
+
 					@Override
 					public String toVariableNameString(EnchantmentOffer eo) {
 						return "offer:" + EnchantmentUtils.toString(eo.getEnchantment()) + "=" + eo.getEnchantmentLevel();
@@ -1526,6 +1525,70 @@ public class BukkitClasses {
 				.name("Transform Reason")
 				.description("Represents a transform reason of an <a href='events.html#entity transform'>entity transform event</a>.")
 				.since("2.8.0"));
+
+		// Boss Bars
+		Classes.registerClass(new ClassInfo<>(BossBar.class, "bossbar")
+				.user("boss bars?")
+				.name("Boss Bar")
+				.description("A boss/event bar, displayed at the top of the screen.")
+				.examples("set {bar} to a new boss bar", "add player to {bar}")
+				.since("INSERT VERSION")
+				.changer(new Changer<>() {
+					@Override
+					public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
+						return switch (mode) {
+							case ADD, REMOVE -> new Class[] {Player.class};
+							case RESET -> new Class[0];
+							default -> null;
+						};
+					}
+
+					@Override
+					public void change(BossBar[] what, Object @Nullable [] delta, ChangeMode mode) {
+						switch (mode) {
+							case RESET -> {
+								for (BossBar bar : what) {
+									bar.removeAll();
+									for (BarFlag value : BarFlag.values())
+										bar.removeFlag(value);
+								}
+							}
+							case ADD -> {
+								if (delta == null)
+									break;
+								for (BossBar bar : what) {
+									for (Object object : delta) {
+										if (object instanceof Player player)
+											bar.addPlayer(player);
+									}
+								}
+							}
+							case REMOVE -> {
+								if (delta == null)
+									break;
+								for (BossBar bar : what) {
+									for (Object object : delta) {
+										if (object instanceof Player player)
+											bar.removePlayer(player);
+									}
+								}
+							}
+						}
+					}
+				}));
+
+		Classes.registerClass(new EnumClassInfo<>(BarStyle.class, "bossbarstyle", "boss bar styles")
+				.user("boss ?bar styles?")
+				.name("Boss Bar Style")
+				.description("Represents the style of a boss bar (e.g. segmented or solid)")
+				.since("INSERT VERSION"));
+
+		Classes.registerClass(new EnumClassInfo<>(BarFlag.class, "bossbarflag", "boss bar flags")
+				.user("boss ?bar flags?")
+				.name("Boss Bar Flags")
+				.description("Represents a flag that can be added to a boss bar (e.g. darken sky or play boss music)")
+				.since("INSERT VERSION"));
+
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprBossBar.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBossBar.java
@@ -1,0 +1,141 @@
+/**
+ * This file is part of Skript.
+ * <p>
+ * Skript is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * Skript is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ * <p>
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.skript.util.Color;
+import ch.njol.util.Kleenean;
+import org.bukkit.Bukkit;
+import org.bukkit.DyeColor;
+import org.bukkit.boss.BarColor;
+import org.bukkit.boss.BarStyle;
+import org.bukkit.boss.BossBar;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Boss Bar")
+@Description("")
+@Examples({
+	"set {bar} to a new boss bar",
+	"set the name of {bar} to \"hello\"",
+	"set the color of {bar} to red",
+	"add player to {bar}",
+	"set {bar} to a new pink boss bar named \"hello\""
+})
+@Since("INSERT VERSION")
+public class ExprBossBar extends SimpleExpression<BossBar> {
+
+	static {
+		Skript.registerExpression(ExprBossBar.class, BossBar.class, ExpressionType.SIMPLE,
+			"[a] new boss bar [name:(named|with title) %-string%]",
+			"[a] new %color% boss bar [name:(named|with title) %-string%]"
+		);
+	}
+
+	private @Nullable Expression<String> name;
+	private @Nullable Expression<Color> color;
+
+	@Override
+	public boolean init(Expression<?>[] expressions, int pattern, Kleenean delayed, final ParseResult result) {
+		if (result.hasTag("name"))
+			//noinspection unchecked
+			this.name = (Expression<String>) expressions[pattern];
+		if (pattern == 1)
+			//noinspection unchecked
+			this.color = (Expression<Color>) expressions[0];
+		return true;
+	}
+
+	@Override
+	protected BossBar[] get(Event event) {
+		@NotNull BossBar bar;
+		BarColor color = BarColor.PINK;
+		color:
+		if (this.color != null) {
+			@Nullable Color provided = this.color.getSingle(event);
+			if (provided == null)
+				break color;
+			@Nullable DyeColor dye = provided.asDyeColor();
+			if (dye == null)
+				break color;
+			color = getColor(dye);
+		}
+		if (name != null)
+			bar = Bukkit.createBossBar(name.getSingle(event), color, BarStyle.SOLID);
+		else
+			bar = Bukkit.createBossBar(null, color, BarStyle.SOLID);
+		return new BossBar[] {bar};
+	}
+
+	@Override
+	public boolean isSingle() {
+		return true;
+	}
+
+	@Override
+	public Class<? extends BossBar> getReturnType() {
+		return BossBar.class;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		StringBuilder builder = new StringBuilder("a new ");
+		if (color != null)
+			builder.append(color.toString(event, debug)).append(" ");
+		builder.append("boss bar");
+		if (name != null)
+			builder.append(" named ").append(name.toString(event, debug));
+		return builder.toString();
+	}
+
+	static BarColor getColor(@Nullable DyeColor dye) {
+		if (dye == null) return BarColor.PINK; // default to pink since it's the original
+		return switch (dye) {
+			case WHITE, LIGHT_GRAY -> BarColor.WHITE;
+			case LIGHT_BLUE, BLACK, CYAN, BLUE -> BarColor.BLUE;
+			case LIME, GRAY, GREEN -> BarColor.GREEN;
+			case YELLOW -> BarColor.YELLOW;
+			case PURPLE -> BarColor.PURPLE;
+			case RED -> BarColor.RED;
+			default -> BarColor.PINK;
+		};
+	}
+
+	static DyeColor getDye(BarColor color) {
+		return switch (color) {
+			case PINK -> DyeColor.PINK;
+			case BLUE -> DyeColor.BLUE;
+			case RED -> DyeColor.RED;
+			case GREEN -> DyeColor.GREEN;
+			case YELLOW -> DyeColor.YELLOW;
+			case PURPLE -> DyeColor.PURPLE;
+			case WHITE -> DyeColor.WHITE;
+		};
+	}
+
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprBossBar.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBossBar.java
@@ -52,8 +52,8 @@ public class ExprBossBar extends SimpleExpression<BossBar> {
 
 	static {
 		Skript.registerExpression(ExprBossBar.class, BossBar.class, ExpressionType.SIMPLE,
-			"[a] new boss bar [name:(named|with title) %-string%]",
-			"[a] new %color% boss bar [name:(named|with title) %-string%]"
+			"[a] new boss bar [name:(named|titled|with title) %-string%]",
+			"[a] new %color% boss bar [name:(named|titled|with title) %-string%]"
 		);
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprBossBarFlags.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBossBarFlags.java
@@ -25,22 +25,20 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.PropertyExpression;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
 import ch.njol.util.Kleenean;
 import org.bukkit.boss.BarFlag;
 import org.bukkit.boss.BossBar;
 import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static ch.njol.skript.lang.SkriptParser.*;
 
-
 @Name("Boss Bar Flags")
-@Description("The flags of a bossbar. These flags control the behavior of the bossbar.")
-@Examples({"add darken sky to flags of player's bossbar"})
+@Description("The flags of a boss bar. These flags control the behavior of the boss bar.")
+@Examples({"add darken sky to flags of player's boss bar"})
 @Since("INSERT VERSION")
 public class ExprBossBarFlags extends PropertyExpression<BossBar, BarFlag> {
 
@@ -51,7 +49,7 @@ public class ExprBossBarFlags extends PropertyExpression<BossBar, BarFlag> {
 	@Override
 	@SuppressWarnings("unchecked")
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		setExpr((Expression<? extends BossBar>) exprs[0]);
+		this.setExpr((Expression<? extends BossBar>) exprs[0]);
 		return true;
 	}
 
@@ -67,35 +65,29 @@ public class ExprBossBarFlags extends PropertyExpression<BossBar, BarFlag> {
 
 
 	@Override
-	@Nullable
-	public Class<?>[] acceptChange(ChangeMode mode) {
-		switch (mode) {
-			case SET:
-			case ADD:
-			case REMOVE:
-			case DELETE:
-				return new Class[] {BarFlag.class};
-			default:
-				return null;
-		}
+	public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
+		return switch (mode) {
+			case SET, ADD, REMOVE, DELETE -> new Class[] {BarFlag.class};
+			default -> null;
+		};
 	}
 
 	@Override
-	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
-		for (BossBar bossBar : getExpr().getArray(event))
+	public void change(Event event, Object[] delta, ChangeMode mode) {
+		for (BossBar bar : this.getExpr().getArray(event))
 			switch (mode) {
 				case SET:
-					clearFlags(bossBar);
+					this.clearFlags(bar);
 				case ADD:
 					for (Object flag : delta)
-						bossBar.addFlag((BarFlag) flag);
+						bar.addFlag((BarFlag) flag);
 					break;
 				case REMOVE:
 					for (Object flag : delta)
-						bossBar.removeFlag((BarFlag) flag);
+						bar.removeFlag((BarFlag) flag);
 					break;
 				case DELETE:
-					clearFlags(bossBar);
+					this.clearFlags(bar);
 			}
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprBossBarFlags.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBossBarFlags.java
@@ -38,7 +38,7 @@ import static ch.njol.skript.lang.SkriptParser.*;
 
 @Name("Boss Bar Flags")
 @Description("The flags of a boss bar. These flags control the behavior of the boss bar.")
-@Examples({"add darken sky to flags of player's boss bar"})
+@Examples({"add darken sky to flags of {_bar}"})
 @Since("INSERT VERSION")
 public class ExprBossBarFlags extends PropertyExpression<BossBar, BarFlag> {
 

--- a/src/main/java/ch/njol/skript/expressions/ExprBossBarProgress.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBossBarProgress.java
@@ -26,11 +26,12 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
 import org.bukkit.boss.BossBar;
 import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Name("Boss Bar Progress")
 @Description("The progress of a boss bar (ranges from 0 to 100)")
-@Examples({"set progress of player's bossbar to 56"})
+@Examples({"set progress of player's boss bar to 56"})
 @Since("INSERT VERSION")
 public class ExprBossBarProgress extends SimplePropertyExpression<BossBar, Double> {
 
@@ -39,30 +40,30 @@ public class ExprBossBarProgress extends SimplePropertyExpression<BossBar, Doubl
 	}
 
 	@Override
-	@Nullable
-	public Double convert(BossBar bossBar) {
+	public @NotNull Double convert(BossBar bossBar) {
 		return bossBar.getProgress() * 100;
 	}
 
 	@Override
-	@Nullable
-	public Class<?>[] acceptChange(ChangeMode mode) {
-		if (mode == ChangeMode.SET || mode == ChangeMode.RESET)
-			return new Class[] {Number.class};
-		return null;
+	public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
+		return switch (mode) {
+			case SET, ADD, REMOVE -> new Class[]{Number.class};
+			case RESET -> new Class[0];
+			default -> null;
+		};
 	}
 
 	@Override
-	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
-		for (BossBar bossBar : getExpr().getArray(event)) {
-			switch (mode) {
-				case RESET:
-					bossBar.setProgress(0);
-					break;
-				case SET:
-					assert delta[0] != null;
-					bossBar.setProgress(((Number) delta[0]).doubleValue() / 100);
-			}
+	public void change(Event event, Object[] delta, ChangeMode mode) {
+		for (BossBar bar : getExpr().getArray(event)) {
+			double current = this.convert(bar).doubleValue();
+			double change = delta != null && delta.length > 0 ? ((Number) delta[0]).doubleValue() : 0;
+			bar.setProgress(Math.max(0, Math.min(1, switch (mode) {
+				case ADD -> current + change;
+				case REMOVE -> current - change;
+				case SET -> change;
+				default -> 0;
+			} / 100)));
 		}
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprBossBarProgress.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBossBarProgress.java
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("Boss Bar Progress")
 @Description("The progress of a boss bar (ranges from 0 to 100)")
-@Examples({"set progress of player's boss bar to 56"})
+@Examples({"set the progress of {_bar} to 56"})
 @Since("INSERT VERSION")
 public class ExprBossBarProgress extends SimplePropertyExpression<BossBar, Double> {
 

--- a/src/main/java/ch/njol/skript/expressions/ExprBossBarStyle.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBossBarStyle.java
@@ -27,11 +27,11 @@ import ch.njol.skript.expressions.base.SimplePropertyExpression;
 import org.bukkit.boss.BarStyle;
 import org.bukkit.boss.BossBar;
 import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 @Name("Boss Bar Style")
 @Description("The style of a boss bar. This changes how the boss bar displays on the player's screen.")
-@Examples({"set style of player's bossbar to 10 segments"})
+@Examples({"set style of player's boss bar to 10 segments"})
 @Since("INSERT VERSION")
 public class ExprBossBarStyle extends SimplePropertyExpression<BossBar, BarStyle> {
 
@@ -40,25 +40,30 @@ public class ExprBossBarStyle extends SimplePropertyExpression<BossBar, BarStyle
 	}
 
 	@Override
-	@Nullable
-	public BarStyle convert(BossBar bossBar) {
+	public @Nullable BarStyle convert(BossBar bossBar) {
 		return bossBar.getStyle();
 	}
 
 	@Override
-	@Nullable
-	public Class<?>[] acceptChange(ChangeMode mode) {
-		if (mode == ChangeMode.SET)
-			return new Class[] {BarStyle.class};
-		return null;
+	public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
+		return switch (mode) {
+			case SET -> new Class[] {BarStyle.class};
+			case RESET -> new Class[0];
+			default -> null;
+		};
 	}
 
 	@Override
 	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
-		assert delta[0] != null;
-		BarStyle style = (BarStyle) delta[0];
-		for (BossBar bossBar : getExpr().getArray(event))
-			bossBar.setStyle(style);
+		BarStyle style = BarStyle.SOLID;
+		switch (mode) {
+			case SET:
+				assert delta.length > 0 && delta[0] != null;
+				style = (BarStyle) delta[0];
+			case RESET:
+				for (BossBar bossBar : this.getExpr().getArray(event))
+					bossBar.setStyle(style);
+		}
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprBossBarStyle.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBossBarStyle.java
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("Boss Bar Style")
 @Description("The style of a boss bar. This changes how the boss bar displays on the player's screen.")
-@Examples({"set style of player's boss bar to 10 segments"})
+@Examples({"set style of {_bar} to 10 segments"})
 @Since("INSERT VERSION")
 public class ExprBossBarStyle extends SimplePropertyExpression<BossBar, BarStyle> {
 

--- a/src/main/java/ch/njol/skript/expressions/ExprBossBarTitle.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBossBarTitle.java
@@ -26,11 +26,11 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
 import org.bukkit.boss.BossBar;
 import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 @Name("Boss Bar Title")
-@Description("The title/text of a boss bar. This is the text shown above the progress bar of the bossbar.")
-@Examples({"set title of player's bossbar to \"Goodbye!\""})
+@Description("The title/text of a boss bar. This is the text shown above the progress bar of the boss bar.")
+@Examples({"set the title of {bar} to \"Goodbye!\""})
 @Since("INSERT VERSION")
 public class ExprBossBarTitle extends SimplePropertyExpression<BossBar, String> {
 
@@ -39,25 +39,30 @@ public class ExprBossBarTitle extends SimplePropertyExpression<BossBar, String> 
 	}
 
 	@Override
-	@Nullable
-	public String convert(BossBar bossBar) {
+	public @Nullable String convert(BossBar bossBar) {
 		return bossBar.getTitle();
 	}
 
 	@Override
-	@Nullable
-	public Class<?>[] acceptChange(Changer.ChangeMode mode) {
-		if (mode == Changer.ChangeMode.SET)
-			return new Class[] {String.class};
-		return null;
+	public Class<?> @Nullable [] acceptChange(Changer.ChangeMode mode) {
+		return switch (mode) {
+			case SET -> new Class[] {String.class};
+			case RESET, DELETE -> new Class[0];
+			default -> null;
+		};
 	}
 
 	@Override
 	public void change(Event event, @Nullable Object[] delta, Changer.ChangeMode mode) {
-		assert delta[0] != null;
-		String title = (String) delta[0];
-		for (BossBar bossBar : getExpr().getArray(event))
-			bossBar.setTitle(title);
+		String title = null;
+			switch (mode) {
+			case SET:
+				assert delta.length > 0 && delta[0] != null;
+				title = (String) delta[0];
+			case RESET, DELETE:
+				for (BossBar bossBar : this.getExpr().getArray(event))
+					bossBar.setTitle(title);
+		}
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprColorOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprColorOf.java
@@ -115,16 +115,7 @@ public class ExprColorOf extends PropertyExpression<Object, Color> {
 		if (FireworkEffect.class.isAssignableFrom(returnType))
 			return CollectionUtils.array(Color[].class);
 
-		if (mode != ChangeMode.SET && !getExpr().isSingle())
-			return null;
-
-		if (Entity.class.isAssignableFrom(returnType))
-			return CollectionUtils.array(Color.class);
-		else if (Block.class.isAssignableFrom(returnType))
-			return CollectionUtils.array(Color.class);
-		else if (BossBar.class.isAssignableFrom(returnType))
-			return CollectionUtils.array(Color.class);
-		if (ItemType.class.isAssignableFrom(returnType))
+		if (mode == ChangeMode.SET)
 			return CollectionUtils.array(Color.class);
 		return null;
 	}
@@ -132,13 +123,13 @@ public class ExprColorOf extends PropertyExpression<Object, Color> {
 	@SuppressWarnings("deprecated")
 	@Override
 	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
-		if (delta == null)
-			return;
-		DyeColor color = ((Color) delta[0]).asDyeColor();
 
-		for (Object o : getExpr().getArray(e)) {
-			if (o instanceof Item || o instanceof ItemType) {
-				ItemStack stack = o instanceof Item ? ((Item) o).getItemStack() : ((ItemType) o).getRandom();
+		for (Object object : this.getExpr().getArray(e)) {
+			if (object instanceof Item || object instanceof ItemType) {
+				if (delta == null || delta.length < 1)
+					continue;
+				DyeColor color = ((Color) delta[0]).asDyeColor();
+				ItemStack stack = object instanceof Item ? ((Item) object).getItemStack() : ((ItemType) object).getRandom();
 
 				if (stack == null)
 					continue;
@@ -151,10 +142,13 @@ public class ExprColorOf extends PropertyExpression<Object, Color> {
 				((Colorable) data).setColor(color);
 				stack.setData(data);
 
-				if (o instanceof Item)
-					((Item) o).setItemStack(stack);
-			} else if (o instanceof Block || o instanceof BossBar || o instanceof Colorable) {
-				Colorable colorable = getColorable(o);
+				if (object instanceof Item)
+					((Item) object).setItemStack(stack);
+			} else if (object instanceof Block || object instanceof BossBar || object instanceof Colorable) {
+				if (delta == null || delta.length < 1)
+					continue;
+				DyeColor color = ((Color) delta[0]).asDyeColor();
+				Colorable colorable = getColorable(object);
 
 				if (colorable != null) {
 					try {
@@ -166,9 +160,11 @@ public class ExprColorOf extends PropertyExpression<Object, Color> {
 							"Instead, set the block to right material, such as a blue bed."); // Let's just assume it's a bed
 					}
 				}
-			} else if (o instanceof FireworkEffect) {
-				Color[] input = (Color[]) delta;
-				FireworkEffect effect = ((FireworkEffect) o);
+			} else if (object instanceof FireworkEffect) {
+				Color[] input = delta instanceof Color[]
+					? (Color[]) delta
+					: Arrays.copyOf(delta, delta.length, Color[].class);
+				FireworkEffect effect = ((FireworkEffect) object);
 				switch (mode) {
 					case ADD:
 						for (Color c : input)

--- a/src/main/java/ch/njol/skript/expressions/ExprColorOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprColorOf.java
@@ -19,9 +19,11 @@
 package ch.njol.skript.expressions;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import ch.njol.skript.Skript;
+import org.bukkit.boss.BossBar;
 import org.bukkit.DyeColor;
 import org.bukkit.FireworkEffect;
 import org.bukkit.block.Block;
@@ -57,29 +59,29 @@ import ch.njol.util.coll.CollectionUtils;
 public class ExprColorOf extends PropertyExpression<Object, Color> {
 
 	static {
-		register(ExprColorOf.class, Color.class, "colo[u]r[s]", "blocks/itemtypes/entities/fireworkeffects");
+		register(ExprColorOf.class, Color.class, "colo[u]r[s]", "blocks/itemtypes/entities/fireworkeffects/bossbars");
 	}
-	
+
 	@SuppressWarnings("null")
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		setExpr(exprs[0]);
 		return true;
 	}
-	
+
 	@SuppressWarnings("null")
 	@Override
 	protected Color[] get(Event e, Object[] source) {
 		if (source instanceof FireworkEffect[]) {
 			List<Color> colors = new ArrayList<>();
-			
+
 			for (FireworkEffect effect : (FireworkEffect[]) source) {
 				effect.getColors().stream()
 					.map(SkriptColor::fromBukkitColor)
 					.forEach(colors::add);
 			}
-			
-			if (colors.size() == 0)
+
+			if (colors.isEmpty())
 				return null;
 			return colors.toArray(new Color[0]);
 		}
@@ -120,6 +122,8 @@ public class ExprColorOf extends PropertyExpression<Object, Color> {
 			return CollectionUtils.array(Color.class);
 		else if (Block.class.isAssignableFrom(returnType))
 			return CollectionUtils.array(Color.class);
+		else if (BossBar.class.isAssignableFrom(returnType))
+			return CollectionUtils.array(Color.class);
 		if (ItemType.class.isAssignableFrom(returnType))
 			return CollectionUtils.array(Color.class);
 		return null;
@@ -149,7 +153,7 @@ public class ExprColorOf extends PropertyExpression<Object, Color> {
 
 				if (o instanceof Item)
 					((Item) o).setItemStack(stack);
-			} else if (o instanceof Block || o instanceof Colorable) {
+			} else if (o instanceof Block || o instanceof BossBar || o instanceof Colorable) {
 				Colorable colorable = getColorable(o);
 
 				if (colorable != null) {
@@ -194,6 +198,19 @@ public class ExprColorOf extends PropertyExpression<Object, Color> {
 	@SuppressWarnings("deprecated")
 	@Nullable
 	private Colorable getColorable(Object colorable) {
+		if (colorable instanceof BossBar bar) {
+			return new Colorable() {
+				@Override
+				public DyeColor getColor() {
+					return ExprBossBar.getDye(bar.getColor());
+				}
+
+				@Override
+				public void setColor(DyeColor color) {
+					bar.setColor(ExprBossBar.getColor(color));
+				}
+			};
+		}
 		if (colorable instanceof Item || colorable instanceof ItemType) {
 			ItemStack item = colorable instanceof Item ?
 					((Item) colorable).getItemStack() : ((ItemType) colorable).getRandom();

--- a/src/main/java/ch/njol/skript/expressions/ExprName.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprName.java
@@ -29,6 +29,7 @@ import org.bukkit.Nameable;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
+import org.bukkit.boss.BossBar;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.LivingEntity;
@@ -103,6 +104,11 @@ import net.md_5.bungee.api.chat.BaseComponent;
 	"\t\t\t<li><strong>Name:</strong> The name of the world. Cannot be changed.</li>",
 	"\t\t</ul>",
 	"\t</li>",
+	"\t<li><strong>Boss Bars</strong>",
+	"\t\t<ul>",
+	"\t\t\t<li><strong>Name:</strong> The title of the boss bar.</li>",
+	"\t\t</ul>",
+	"\t</li>",
 	"</ul>"
 })
 @Examples({
@@ -125,7 +131,7 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 				Skript.methodExists(Bukkit.class, "createInventory", InventoryHolder.class, int.class, Component.class))
 			serializer = BungeeComponentSerializer.get();
 		HAS_GAMERULES = Skript.classExists("org.bukkit.GameRule");
-		register(ExprName.class, String.class, "(1¦name[s]|2¦(display|nick|chat|custom)[ ]name[s])", "offlineplayers/entities/blocks/itemtypes/inventories/slots/worlds"
+		register(ExprName.class, String.class, "(1¦name[s]|2¦(display|nick|chat|custom)[ ]name[s])", "offlineplayers/entities/blocks/bossbars/itemtypes/inventories/slots/worlds"
 			+ (HAS_GAMERULES ? "/gamerules" : ""));
 		register(ExprName.class, String.class, "(3¦(player|tab)[ ]list name[s])", "players");
 	}
@@ -167,7 +173,9 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 			return mark == 1 ? ((OfflinePlayer) object).getName() : null;
 		} else if (object instanceof Entity) {
 			return ((Entity) object).getCustomName();
-		} else if (object instanceof Block) {
+		} else if (object instanceof BossBar bar) {
+			return bar.getTitle();
+		}else if (object instanceof Block) {
 			BlockState state = ((Block) object).getState();
 			if (state instanceof Nameable)
 				return ((Nameable) state).getCustomName();
@@ -229,6 +237,8 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 					((Entity) object).setCustomNameVisible(name != null);
 				if (object instanceof LivingEntity)
 					((LivingEntity) object).setRemoveWhenFarAway(name == null);
+			} else if (object instanceof BossBar bar) {
+				bar.setTitle(name);
 			} else if (object instanceof Block) {
 				BlockState state = ((Block) object).getState();
 				if (state instanceof Nameable) {

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -2377,3 +2377,16 @@ types:
 	# Hooks
 	money: money
 	region: region¦s
+
+# -- Boss Bars --
+boss bar styles:
+	segmented_6: 6 segments
+	segmented_10: 10 segments
+	segmented_12: 12 segments
+	segmented_20: 20 segments
+	solid: solid
+
+boss bar flags:
+	create_fog: fog
+	darken_sky: darken sky
+	play_boss_music: play boss music

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -2354,6 +2354,9 @@ types:
 	quitreason: quit reason¦s @a
 	inventoryclosereason: inventory close reason¦s @an
 	transformreason: transform reason¦s @a
+	bossbar: boss bar¦s @a
+	bossbarstyle: boss bar style¦s @a
+	bossbarflag: boss bar flag¦s @a
 
 	# Skript
 	weathertype: weather type¦s @a

--- a/src/test/skript/tests/syntaxes/expressions/ExprBossBar.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprBossBar.sk
@@ -1,0 +1,18 @@
+test "boss bars":
+	set {_bar} to a new boss bar
+
+	assert the title of {_bar} is "" with "title is %title of {_bar}%"
+	set the title of {_bar} to "foo bar"
+	assert the title of {_bar} is "foo bar" with "title is %title of {_bar}%"
+
+	# colors can't be compared with colors currently so we use strings
+	assert "%the color of {_bar}%" is "pink" with "color is %color of {_bar}%"
+	set the color of {_bar} to red
+	assert "%the color of {_bar}%" is "red" with "color is %color of {_bar}%"
+
+	assert the style of {_bar} is solid with "style is %style of {_bar}%"
+	set the style of {_bar} to 12 segments
+	assert the style of {_bar} is 12 segments with "style is %style of {_bar}%"
+
+	add play boss music to the flags of {_bar}
+	assert the flags of {_bar} contains play boss music with "flags are %flags of {_bar}%"


### PR DESCRIPTION
## Description
<!--- Describe your changes here. --->
Pikachu's boss bars PR (#5246) got stale and was closed.
I've revived it with some changes: mainly getting rid of the `last boss bar` stuff and converting bars to objects rather than player/ID relations, which is much better for handling multiple bars.

Bar flags & style are merged directly from Pikachu's old PR.

There were also some serious issues in the ColorOf expression that I had to fix.

### Make bar
Syntax:
```applescript
[a] new boss bar [(named|titled|with title) %-string%]
[a] new %color% boss bar [(named|titled|with title) %-string%]
```
Examples:
```applescript
set {_bar} to a new boss bar
# pink, solid, no title

set {_bar} to a new green boss bar
# green, solid, no title

set {_bar} to a new red boss bar named "foo bar"
# red, solid, titled foo bar
```

### General usage

```applescript
set {_bar} to a new red boss bar
set the title of {_bar} to "hello :)"
add play boss music to the flags of {_bar}
add player to {_bar}
# why can I hear boss music?
```

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #5246 <!-- Links to related issues -->
