### PR TITLE
Fix default variables concurrency issues

### DIFF
--- a/src/main/java/ch/njol/skript/structures/StructVariables.java
+++ b/src/main/java/ch/njol/skript/structures/StructVariables.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import com.google.common.collect.Queues;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
@@ -85,7 +86,16 @@ public class StructVariables extends Structure {
 
 	public static class DefaultVariables implements ScriptData {
 
-		private final Deque<Map<String, Class<?>[]>> hints = new ArrayDeque<>();
+		/*
+		 * Performance/Risk Notice:
+		 * In the event that an element is pushed to the deque on one thread, causing it to grow, a second thread
+		 *  waiting to access the dequeue may not see the correct deque or pointers (the backing array is not volatile),
+		 *  causing issues such as a loss of data or attempting to write beyond the array's capacity.
+		 * It is unlikely for the array to ever grow from its default capacity (16), as this would require extreme
+		 *  nesting of variables (e.g. {a::%{b::%{c::<and so on>}%}%} (given the current usage of enter/exit scope)
+		 * While thread-safe deque implementations are available, this setup has been chosen for performance.
+		 */
+		private final Deque<Map<String, Class<?>[]>> hints = Queues.synchronizedDeque(new ArrayDeque<>());
 		private final List<NonNullPair<String, Object>> variables;
 		private boolean loaded;
 
@@ -99,23 +109,18 @@ public class StructVariables extends Structure {
 			if (CollectionUtils.containsAll(hints, Object.class)) // Ignore useless type hint.
 				return;
 			// This important empty check ensures that the variable type hint came from a defined DefaultVariable.
-			synchronized (this.hints) {
-				if (this.hints.isEmpty())
-					return;
-				this.hints.getFirst().put(variable, hints);
-			}
+			Map<String, Class<?>[]> map = this.hints.peekFirst();
+			if (map == null)
+				return;
+			map.put(variable, hints);
 		}
 
 		public void enterScope() {
-			synchronized (hints) {
-				hints.push(new HashMap<>());
-			}
+			hints.push(new HashMap<>());
 		}
 
 		public void exitScope() {
-			synchronized (hints) {
-				hints.pop();
-			}
+			hints.pop();
 		}
 
 		/**
@@ -125,9 +130,8 @@ public class StructVariables extends Structure {
 		 * @param variable The variable string of a variable.
 		 * @return type hints of a variable if found otherwise null.
 		 */
-		@Nullable
-		public Class<?>[] get(String variable) {
-			synchronized (hints) {
+		public Class<?> @Nullable [] get(String variable) {
+			synchronized (hints) { // must manually synchronize for iterators
 				for (Map<String, Class<?>[]> map : hints) {
 					Class<?>[] hints = map.get(variable);
 					if (hints != null && hints.length > 0)

--- a/src/main/java/ch/njol/skript/structures/StructVariables.java
+++ b/src/main/java/ch/njol/skript/structures/StructVariables.java
@@ -99,17 +99,23 @@ public class StructVariables extends Structure {
 			if (CollectionUtils.containsAll(hints, Object.class)) // Ignore useless type hint.
 				return;
 			// This important empty check ensures that the variable type hint came from a defined DefaultVariable.
-			if (this.hints.isEmpty())
-				return;
-			this.hints.getFirst().put(variable, hints);
+			synchronized (this.hints) {
+				if (this.hints.isEmpty())
+					return;
+				this.hints.getFirst().put(variable, hints);
+			}
 		}
 
 		public void enterScope() {
-			hints.push(new HashMap<>());
+			synchronized (hints) {
+				hints.push(new HashMap<>());
+			}
 		}
 
 		public void exitScope() {
-			hints.pop();
+			synchronized (hints) {
+				hints.pop();
+			}
 		}
 
 		/**
@@ -121,10 +127,12 @@ public class StructVariables extends Structure {
 		 */
 		@Nullable
 		public Class<?>[] get(String variable) {
-			for (Map<String, Class<?>[]> map : hints) {
-				Class<?>[] hints = map.get(variable);
-				if (hints != null && hints.length > 0)
-					return hints;
+			synchronized (hints) {
+				for (Map<String, Class<?>[]> map : hints) {
+					Class<?>[] hints = map.get(variable);
+					if (hints != null && hints.length > 0)
+						return hints;
+				}
 			}
 			return null;
 		}


### PR DESCRIPTION
### Description
This PR fixes to aim rare concurrency issues that can occur with default variables. Specifically, this may occur when two (or more) parts of a script operating on different threads (e.g. a script has an async event) try to work with default variables at the same time. What occurs is that not all `push` calls are successful (e.g. one overrides another), leading to the `pop` calls causing NoSuchElementExceptions.

I have chosen to use synchronization blocks over implementations such as [ConcurrentLinkedQueue](https://docs.oracle.com/en%2Fjava%2Fjavase%2F11%2Fdocs%2Fapi%2F%2F/java.base/java/util/concurrent/ConcurrentLinkedQueue.html). I found performance of the synchronization blocks to be better, and this is not a common occurrence that would lead to threads waiting for access.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** Reported through Discord
