### PR TITLE
Fix ExprBookAuthors performance Java 17

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprBookAuthor.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBookAuthor.java
@@ -42,7 +42,7 @@ public class ExprBookAuthor extends SimplePropertyExpression<ItemType, String> {
 	}
 
 	@Override
-	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, Object @Nullable [] delta, ChangeMode mode) {
 		String author = delta == null ? null : (String) delta[0];
 		for (ItemType item : getExpr().getArray(event)) {
 			if (item.getItemMeta() instanceof BookMeta bookMeta) {

--- a/src/main/java/ch/njol/skript/expressions/ExprBookAuthor.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBookAuthor.java
@@ -38,7 +38,7 @@ public class ExprBookAuthor extends SimplePropertyExpression<ItemType, String> {
 		return switch (mode) {
 			case SET, RESET, DELETE -> CollectionUtils.array(String.class);
 			default -> null;
-		}
+		};
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprBookAuthor.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBookAuthor.java
@@ -35,16 +35,9 @@ public class ExprBookAuthor extends SimplePropertyExpression<ItemType, String> {
 	@Nullable
 	@Override
 	public Class<?>[] acceptChange(ChangeMode mode) {
-		switch (mode) {
-			case DELETE:
-			case RESET:
-			case SET:
-				return CollectionUtils.array(String.class);
-			case ADD:
-			case REMOVE:
-			case REMOVE_ALL:
-			default:
-				return null;
+		return switch (mode) {
+			case SET, RESET, DELETE -> CollectionUtils.array(String.class);
+			default -> null;
 		}
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprBookAuthor.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBookAuthor.java
@@ -32,9 +32,8 @@ public class ExprBookAuthor extends SimplePropertyExpression<ItemType, String> {
 		return item.getItemMeta() instanceof BookMeta bookMeta ? bookMeta.getAuthor() : null;
 	}
 
-	@Nullable
 	@Override
-	public Class<?>[] acceptChange(ChangeMode mode) {
+	public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
 		return switch (mode) {
 			case SET, RESET, DELETE -> CollectionUtils.array(String.class);
 			default -> null;

--- a/src/main/java/ch/njol/skript/expressions/ExprBookAuthor.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBookAuthor.java
@@ -1,21 +1,3 @@
-/**
- *   This file is part of Skript.
- *
- *  Skript is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  Skript is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Copyright Peter Güttinger, SkriptLang team and contributors
- */
 package ch.njol.skript.expressions;
 
 import ch.njol.skript.aliases.ItemType;
@@ -29,63 +11,62 @@ import ch.njol.util.coll.CollectionUtils;
 
 import org.bukkit.event.Event;
 import org.bukkit.inventory.meta.BookMeta;
-import org.bukkit.inventory.meta.ItemMeta;
-import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 @Name("Book Author")
 @Description("The author of a book.")
-@Examples({"on book sign:",
-			"\tmessage \"Book Title: %author of event-item%\""})
+@Examples({
+	"on book sign:",
+		"\tmessage \"Book Title: %author of event-item%\""
+})
 @Since("2.2-dev31")
 public class ExprBookAuthor extends SimplePropertyExpression<ItemType, String> {
-	
+
 	static {
 		register(ExprBookAuthor.class, String.class, "[book] (author|writer|publisher)", "itemtypes");
 	}
-	
+
 	@Nullable
 	@Override
 	public String convert(ItemType item) {
-		ItemMeta meta = item.getItemMeta();
-		
-		if (meta instanceof BookMeta)
-			return ((BookMeta) meta).getAuthor();
-		
-		return null;
+		return item.getItemMeta() instanceof BookMeta bookMeta ? bookMeta.getAuthor() : null;
 	}
-	
+
 	@Nullable
 	@Override
 	public Class<?>[] acceptChange(ChangeMode mode) {
-		if (mode == ChangeMode.SET || mode == ChangeMode.RESET || mode == ChangeMode.DELETE)
-			return CollectionUtils.array(String.class);
-		return null;
+		switch (mode) {
+			case DELETE:
+			case RESET:
+			case SET:
+				return CollectionUtils.array(String.class);
+			case ADD:
+			case REMOVE:
+			case REMOVE_ALL:
+			default:
+				return null;
+		}
 	}
-	
-	@SuppressWarnings("null")
+
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		String author = delta == null ? null : (String) delta[0];
-		
-		for (ItemType item : getExpr().getArray(e)) {
-			ItemMeta meta = item.getItemMeta();
-			
-			if (meta instanceof BookMeta) {
-				((BookMeta) meta).setAuthor(author);
-				item.setItemMeta(meta);
+		for (ItemType item : getExpr().getArray(event)) {
+			if (item.getItemMeta() instanceof BookMeta bookMeta) {
+				bookMeta.setAuthor(author);
+				item.setItemMeta(bookMeta);
 			}
 		}
 	}
-	
+
 	@Override
 	public Class<? extends String> getReturnType() {
 		return String.class;
 	}
-	
+
 	@Override
 	protected String getPropertyName() {
 		return "book author";
 	}
-	
-}
 
+}


### PR DESCRIPTION
### Description
During a profiler, I noticed book author expression was a hotspot class during Skript tests at (3.60ms 72.4%) after adapting the class to Java 17 pattern matching, it has been reduced to (1.31ms 44.8%)

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
