### PR TITLE
Attempt to fix ExprVehicle NoClassDef

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprVehicle.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVehicle.java
@@ -68,7 +68,8 @@ public class ExprVehicle extends SimplePropertyExpression<Entity, Entity> {
 		register(ExprVehicle.class, Entity.class, "vehicle[s]", "entities");
 
 		// legacy support
-		boolean hasOldMountEvents = Skript.classExists("org.spigotmc.event.entity.EntityMountEvent");
+		boolean hasOldMountEvents = !HAS_NEW_MOUNT_EVENTS &&
+				Skript.classExists("org.spigotmc.event.entity.EntityMountEvent");
 		Class<?> oldMountEventClass = null;
 		MethodHandle oldGetMountHandle = null;
 		Class<?> oldDismountEventClass = null;


### PR DESCRIPTION
### Description
This PR attempts to fix a NoClassDef error that occurs with ExprVehicle on newer versions of Paper. While I couldn't reproduce the issue, it appears to come from the `classExists` check. This just ensures that check is not performed in "new" support is already true/initialized.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:**
- https://github.com/SkriptLang/Skript/issues/6882
