### PR TITLE
Return isNegative() and not false, if CondIsWithin is invalid

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondIsWithin.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsWithin.java
@@ -103,7 +103,7 @@ public class CondIsWithin extends Condition {
 			Location one = loc1.getSingle(event);
 			Location two = loc2.getSingle(event);
 			if (one == null || two == null || one.getWorld() != two.getWorld())
-				return false;
+				return isNegated();
 			AABB box = new AABB(one, two);
 			return locsToCheck.check(event, box::contains, isNegated());
 		}
@@ -111,7 +111,7 @@ public class CondIsWithin extends Condition {
 		// else, within an entity/block/chunk/world
 		Object area = this.area.getSingle(event);
 		if (area == null)
-			return false;
+			return isNegated();
 
 		// Entities
 		if (area instanceof Entity) {

--- a/src/test/skript/tests/syntaxes/conditions/CondIsWithin.sk
+++ b/src/test/skript/tests/syntaxes/conditions/CondIsWithin.sk
@@ -38,6 +38,7 @@ test "within condition" when running below minecraft "1.17":
 	set {_loc2} to location(20, 20, 20, "world")
 	assert location(10, 10, 10, "world") is within {_loc1} and {_loc2} with "failed within two locs"
 	assert location(10, -10, 10, "world") is not within {_loc1} and {_loc2} with "failed within two locs"
+	assert location(0, 0, 0, "world") is not within {_none} and {_none} with "failed within two locs"
 
 	# chunks
 	set {_chunk1} to chunk at {_loc1}

--- a/src/test/skript/tests/syntaxes/conditions/CondIsWithin.sk
+++ b/src/test/skript/tests/syntaxes/conditions/CondIsWithin.sk
@@ -4,6 +4,7 @@ test "within condition" when running minecraft "1.17":
 	set {_loc2} to location(20, 20, 20, "world")
 	assert location(10, 10, 10, "world") is within {_loc1} and {_loc2} with "failed within two locs"
 	assert location(10, -10, 10, "world") is not within {_loc1} and {_loc2} with "failed within two locs"
+	assert location(0, 0, 0, "world") is not within {_none} and {_none} with "failed within two locs"
 
 	# chunks
 	set {_chunk1} to chunk at {_loc1}


### PR DESCRIPTION
### Description
This PR fixes the fact that CondIsWithin always returns false if:
- either of the two locations in `is within %location% and %location` is null, or if both are in separate worlds
- if the "container" is null in `is within %entity/chunk/world/block%`

Now, it takes into account whether the condition is negated, and returns true or false appropriately.

### What was the issue?

Say I have a guard clause like so:
```applescript
if player is not within {_loc1} and {_loc2}:
  send "&cThe region specified is invalid."
  stop
# do something
```
If the condition fails, one would assume that the player _is_ within the two locations. However, this precondition is violated if either of the two locations are not set. As the condition is doomed to _always fail_ if the locations are null (regardless of negation), the following code will still run. This PR fixes this.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
