### PR TITLE
fix exponent capping at long max value

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/DefaultOperations.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultOperations.java
@@ -47,11 +47,7 @@ public class DefaultOperations {
 			return left.doubleValue() * right.doubleValue();
 		});
 		Arithmetics.registerOperation(Operator.DIVISION, Number.class, (left, right) -> left.doubleValue() / right.doubleValue());
-		Arithmetics.registerOperation(Operator.EXPONENTIATION, Number.class, (left, right) -> {
-			if (Utils.isInteger(left, right) && right.longValue() >= 0)
-				return (long) Math.pow(left.longValue(), right.longValue());
-			return Math.pow(left.doubleValue(), right.doubleValue());
-		});
+		Arithmetics.registerOperation(Operator.EXPONENTIATION, Number.class, (left, right) -> Math.pow(left.doubleValue(), right.doubleValue()));
 		Arithmetics.registerDifference(Number.class, (left, right) -> {
 			if (Utils.isInteger(left, right))
 				return Math.abs(left.longValue() - right.longValue());

--- a/src/test/skript/tests/regressions/7059-exponent overflow.sk
+++ b/src/test/skript/tests/regressions/7059-exponent overflow.sk
@@ -1,0 +1,2 @@
+test "overflow exponents":
+	assert 10 ^ 25 is 10000000000000000000000000 with "exponentiation was unexpectedly capped"


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

an optimization for long exponents was casting to a long, resulting in capped values. Good optimization for low numbers, bad for high numbers. Just removed it since it's extremely minor benefit anyway.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7059 <!-- Links to related issues -->
