### PR TITLE
Block data stuff

### DIFF
--- a/src/main/java/ch/njol/skript/bukkitutil/BlockDataUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/BlockDataUtils.java
@@ -40,6 +40,8 @@ public class BlockDataUtils {
 	}
 
 	public static String @Nullable [] getTags(BlockData data) {
+		// should this replace "_" in the tags for a more skripty feel?
+		// and then obviously adjust logic elsewhere to replace " " back to "_"?
 		String[] tagsAndValues = getTagsAndValues(data);
 		if (tagsAndValues == null)
 			return null;

--- a/src/main/java/ch/njol/skript/bukkitutil/BlockDataUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/BlockDataUtils.java
@@ -1,0 +1,30 @@
+package ch.njol.skript.bukkitutil;
+
+import org.bukkit.block.data.BlockData;
+import org.jetbrains.annotations.Nullable;
+
+public class BlockDataUtils {
+
+	public static String @Nullable [] getTagsAndValues(BlockData data) {
+		String string = data.getAsString();
+		int start = string.indexOf("[");
+		int end = string.indexOf("]");
+
+		if (start == -1 || end == -1 || start >= end)
+			return null;
+		return string.substring(start + 1, end).split(",");
+	}
+
+	public static String @Nullable [] getTags(BlockData data) {
+		String[] tagsAndValues = getTagsAndValues(data);
+		if (tagsAndValues == null)
+			return null;
+
+		String[] tags = new String[tagsAndValues.length];
+		for (int i = 0; i < tagsAndValues.length; i++) {
+			tags[i] = tagsAndValues[i].split("=")[0];
+		}
+		return tags;
+	}
+
+}

--- a/src/main/java/ch/njol/skript/bukkitutil/BlockDataUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/BlockDataUtils.java
@@ -34,9 +34,9 @@ public class BlockDataUtils {
 		int start = string.indexOf("[");
 		int end = string.indexOf("]");
 
-		if (start == -1 || end == -1 || start >= end)
-			return null;
-		return string.substring(start + 1, end).split(",");
+		return (start == -1 || end == -1 || start >= end)
+			? null
+			: string.substring(start + 1, end).split(",");
 	}
 
 	public static String @Nullable [] getTags(BlockData data) {

--- a/src/main/java/ch/njol/skript/bukkitutil/BlockDataUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/BlockDataUtils.java
@@ -1,9 +1,33 @@
 package ch.njol.skript.bukkitutil;
 
+import org.bukkit.Material;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
 public class BlockDataUtils {
+
+	public static Material toBlock(ItemStack item) {
+		Material material = item.getType();
+		if (material.isBlock()) // already a block
+			return material;
+
+		return switch (material) {
+			case WHEAT_SEEDS -> Material.WHEAT;
+			case POTATO -> Material.POTATOES;
+			case CARROT -> Material.CARROTS;
+			case BEETROOT_SEEDS -> Material.BEETROOTS;
+			case PUMPKIN_SEEDS -> Material.PUMPKIN_STEM;
+			case MELON_SEEDS -> Material.MELON_STEM;
+			case SWEET_BERRIES -> Material.SWEET_BERRY_BUSH;
+			default -> material;
+		};
+	}
+
+	public static @Nullable Material toValidBlock(ItemStack item) {
+		Material asBlock = toBlock(item);
+		return asBlock.isBlock() ? asBlock : null;
+	}
 
 	public static String @Nullable [] getTagsAndValues(BlockData data) {
 		String string = data.getAsString();
@@ -25,6 +49,29 @@ public class BlockDataUtils {
 			tags[i] = tagsAndValues[i].split("=")[0];
 		}
 		return tags;
+	}
+
+	public static @Nullable Object getValue(BlockData data, String tag) {
+		String[] tagsAndValues = getTagsAndValues(data);
+		if (tagsAndValues == null)
+			return null;
+
+		for (String tagAndValue : tagsAndValues) {
+			String[] split = tagAndValue.split("=");
+			if (split.length == 2 && split[0].equals(tag)) {
+				String value = split[1];
+				if (value.equalsIgnoreCase("true") || value.equalsIgnoreCase("false"))
+					return Boolean.parseBoolean(value);
+
+				try {
+					return Integer.parseInt(value);
+				} catch (NumberFormatException ignored) {}
+
+				return value;
+			}
+		}
+
+		return null;
 	}
 
 }

--- a/src/main/java/ch/njol/skript/classes/data/DefaultConverters.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultConverters.java
@@ -37,6 +37,7 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.DoubleChest;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.command.BlockCommandSender;
 import org.bukkit.command.CommandSender;
 import org.bukkit.enchantments.Enchantment;
@@ -197,6 +198,9 @@ public class DefaultConverters {
 		Converters.registerConverter(EnchantmentOffer.class, EnchantmentType.class, eo -> new EnchantmentType(eo.getEnchantment(), eo.getEnchantmentLevel()));
 
 		Converters.registerConverter(String.class, World.class, Bukkit::getWorld);
+
+		// BlockData - Block
+		Converters.registerConverter(Block.class, BlockData.class, Block::getBlockData);
 
 //		// Entity - String (UUID) // Very slow, thus disabled for now
 //		Converters.registerConverter(String.class, Entity.class, new Converter<String, Entity>() {

--- a/src/main/java/ch/njol/skript/expressions/ExprBlockData.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBlockData.java
@@ -1,85 +1,100 @@
-/**
- *   This file is part of Skript.
- *
- *  Skript is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  Skript is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Copyright Peter Güttinger, SkriptLang team and contributors
- */
 package ch.njol.skript.expressions;
 
-import org.bukkit.block.Block;
-import org.bukkit.block.data.BlockData;
-import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
-
-import ch.njol.skript.Skript;
+import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.RequiredPlugins;
 import ch.njol.skript.doc.Since;
-import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.expressions.base.PropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.event.Event;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashSet;
+import java.util.Set;
 
 @Name("Block Data")
-@Description("Get the <a href='classes.html#blockdata'>block data</a> associated with a block. This data can also be used to set blocks.")
-@Examples({"set {data} to block data of target block",
+@Description({
+	"Get the <a href='classes.html#blockdata'>block data</a> associated with a block or itemtype.",
+	"This data can also be used to set blocks."
+})
+@Examples({
+	"set {data} to block data of target block",
 	"set block at player to {data}",
-	"set block data of target block to oak_stairs[facing=south;waterlogged=true]"})
+	"set block data of target block to oak_stairs[facing=south;waterlogged=true]",
+	"",
+	"set {data} to block data of player's tool",
+
+})
 @RequiredPlugins("Minecraft 1.13+")
-@Since("2.5, 2.5.2 (set)")
-public class ExprBlockData extends SimplePropertyExpression<Block, BlockData> {
+@Since("2.5, 2.5.2 (set), INSERT VERSION (itemtypes)")
+public class ExprBlockData extends PropertyExpression<Object, BlockData> {
 	
 	static {
-		if (Skript.classExists("org.bukkit.block.data.BlockData"))
-			register(ExprBlockData.class, BlockData.class, "block[ ]data", "blocks");
+		register(ExprBlockData.class, BlockData.class, "block[ ]data", "blocks/itemtypes");
 	}
-	
-	@Nullable
+
 	@Override
-	public BlockData convert(Block block) {
-		return block.getBlockData();
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		setExpr(exprs[0]);
+		return true;
 	}
-	
-	@Nullable
+
 	@Override
-	public Class<?>[] acceptChange(ChangeMode mode) {
-		if (mode == ChangeMode.SET)
-			return CollectionUtils.array(BlockData.class);
-		return null;
+	protected BlockData[] get(Event event, Object[] source) {
+		Set<BlockData> datas = new HashSet<>();
+		for (Object object : source) {
+			if (object instanceof Block block) {
+				datas.add(block.getBlockData());
+			} else if (object instanceof ItemType item && item.hasBlock()) {
+				if (item.isAll()) {
+					for (ItemStack stack : item.getAll()) {
+						Material material = stack.getType();
+						if (material.isBlock())
+							datas.add(material.createBlockData());
+					}
+				} else { // item is 'any'
+					datas.add(item.getMaterial().createBlockData());
+				}
+			}
+		}
+		return datas.toArray(BlockData[]::new);
 	}
-	
+
 	@Override
-	public void change(Event e, @Nullable Object[] delta, ChangeMode mode) {
+	public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
+		return mode == ChangeMode.SET ? CollectionUtils.array(BlockData.class) : null;
+	}
+
+	@Override
+	public void change(Event event, Object @Nullable [] delta, ChangeMode mode) {
 		if (delta == null)
 			return;
-		
-		BlockData blockData = ((BlockData) delta[0]);
-		for (Block block : getExpr().getArray(e)) {
-			block.setBlockData(blockData);
+
+		BlockData data = ((BlockData) delta[0]);
+		for (Object object : getExpr().getArray(event)) {
+			if (object instanceof Block block)
+				block.setBlockData(data);
 		}
 	}
-	
-	@Override
-	protected String getPropertyName() {
-		return "block data";
-	}
-	
+
 	@Override
 	public Class<? extends BlockData> getReturnType() {
 		return BlockData.class;
 	}
-	
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "block data of " + getExpr().toString(event, debug);
+	}
+
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprBlockDataTags.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBlockDataTags.java
@@ -1,0 +1,80 @@
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.expressions.base.PropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ExprBlockDataTags extends SimpleExpression<String> {
+
+	static {
+		PropertyExpression.register(ExprBlockDataTags.class, String.class, "[block[ ]data] tags", "blockdatas");
+	}
+
+	@SuppressWarnings("NotNullFieldNotInitialized")
+	private Expression<BlockData> datas;
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		datas = (Expression<BlockData>) exprs[0];
+		return true;
+	}
+
+	@Override
+	protected String @Nullable [] get(Event event) {
+		Set<String> tags = new HashSet<>();
+		for (BlockData data : datas.getArray(event)) {
+			String[] dataTags = getTags(data);
+			if (dataTags != null)
+				tags.addAll(Arrays.asList(dataTags));
+		}
+		return tags.toArray(String[]::new);
+	}
+
+	private static String @Nullable [] getTags(BlockData data) {
+		String[] tagsAndValues = getTagsAndValues(data);
+		if (tagsAndValues == null)
+			return null;
+
+		String[] tags = new String[tagsAndValues.length];
+		for (int i = 0; i < tagsAndValues.length; i++) {
+			tags[i] = tagsAndValues[i].split("=")[0];
+		}
+		return tags;
+	}
+
+	private static String @Nullable [] getTagsAndValues(BlockData data) {
+		String string = data.getAsString();
+		int start = string.indexOf("[");
+		int end = string.indexOf("]");
+
+		if (start == -1 || end == -1 || start >= end)
+			return null;
+		return string.substring(start + 1, end).split(",");
+	}
+
+	@Override
+	public boolean isSingle() {
+		return false;
+	}
+
+	@Override
+	public Class<? extends String> getReturnType() {
+		return String.class;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "block data tags of " + datas.toString(event, debug);
+	}
+
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprBlockDataTags.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBlockDataTags.java
@@ -10,7 +10,7 @@ import org.bukkit.block.data.BlockData;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -36,7 +36,7 @@ public class ExprBlockDataTags extends SimpleExpression<String> {
 		for (BlockData data : datas.getArray(event)) {
 			String[] dataTags = BlockDataUtils.getTags(data);
 			if (dataTags != null)
-				tags.addAll(Arrays.asList(dataTags));
+				Collections.addAll(tags, dataTags);
 		}
 		return tags.toArray(String[]::new);
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprBlockDataTags.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBlockDataTags.java
@@ -1,5 +1,6 @@
 package ch.njol.skript.expressions;
 
+import ch.njol.skript.bukkitutil.BlockDataUtils;
 import ch.njol.skript.expressions.base.PropertyExpression;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -33,33 +34,11 @@ public class ExprBlockDataTags extends SimpleExpression<String> {
 	protected String @Nullable [] get(Event event) {
 		Set<String> tags = new HashSet<>();
 		for (BlockData data : datas.getArray(event)) {
-			String[] dataTags = getTags(data);
+			String[] dataTags = BlockDataUtils.getTags(data);
 			if (dataTags != null)
 				tags.addAll(Arrays.asList(dataTags));
 		}
 		return tags.toArray(String[]::new);
-	}
-
-	private static String @Nullable [] getTags(BlockData data) {
-		String[] tagsAndValues = getTagsAndValues(data);
-		if (tagsAndValues == null)
-			return null;
-
-		String[] tags = new String[tagsAndValues.length];
-		for (int i = 0; i < tagsAndValues.length; i++) {
-			tags[i] = tagsAndValues[i].split("=")[0];
-		}
-		return tags;
-	}
-
-	private static String @Nullable [] getTagsAndValues(BlockData data) {
-		String string = data.getAsString();
-		int start = string.indexOf("[");
-		int end = string.indexOf("]");
-
-		if (start == -1 || end == -1 || start >= end)
-			return null;
-		return string.substring(start + 1, end).split(",");
 	}
 
 	@Override

--- a/src/test/skript/tests/syntaxes/expressions/ExprBlockData.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprBlockData.sk
@@ -1,14 +1,34 @@
 test "block data" when running minecraft "1.14.4":
+
+	# === SETUP ===
+
 	set {_block} to block at (spawn of world "world")
+	set {_before} to block data of block at {_block}
+
+	# === BLOCK DATA OF BLOCK ===
+
 	set block at {_block} to campfire[lit=false;waterlogged=true]
-	assert block at {_block} is an unlit campfire with "block at spawn should be an unlit campfire"
+	assert block at {_block} is an unlit campfire with "block at {_block} should have been an unlit campfire"
+	assert block at {_block} is campfire[lit=false;waterlogged=true] with "block at {_block} should have been an unlit, waterlogged campfire"
+	assert block at {_block} is campfire[waterlogged=true] with "block at {_block} should have been a waterlogged campfire"
+	assert block at {_block} is campfire[] with "block at {_block} should have been a campfire"
+	assert block at {_block} is not campfire[lit=true;waterlogged=false] with "block at {_block} should not have been a lit, unwaterlogged campfire"
 
-	assert block at {_block} is campfire[lit=false;waterlogged=true] with "block should have been an unlit, waterlogged campfire"
-	assert block at {_block} is campfire[waterlogged=true] with "block should have been a waterlogged campfire"
-	assert block at {_block} is campfire[] with "block should have been a campfire"
-	assert block at {_block} is not campfire[lit=true;waterlogged=false] with "block should not have been an unlit, waterlogged campfire"
+	# === BLOCK DATA OF ITEMS ===
 
-	set {_data} to block data of block at {_block}
-	assert "%{_data}%" contains "campfire", "lit=false" and "waterlogged=true" with "block data for campfire did not match"
+	set {_campfire} to block data of campfire
+	set {_log} to block data of oak log
+	assert {_campfire} is campfire[facing=north;lit=true;signal_fire=false;waterlogged=false] with "block data of campfire should compare properly"
+	assert {_campfire} is campfire[lit=true;waterlogged=false] with "block data of campfire should compare properly"
+	assert {_campfire} is campfire[] with "block data of campfire should compare properly"
+	assert {_log} is oak_log[axis=y] with "block data of oak log should compare properly"
+	assert {_log} is oak_log[] with "block data of oak log should compare properly"
 
-	set block at {_block} to air
+	loop all wool:
+		add loop-value to {_wools::*}
+	set {_datas::*} to block data of all wool
+	assert (size of {_wools::*}) is (size of {_datas::*}) with "getting the block data of an 'all' itemtype should return the block data of all the items"
+
+	# === CLEANUP ===
+
+	set block at {_block} to {_before}

--- a/src/test/skript/tests/syntaxes/expressions/ExprBlockData.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprBlockData.sk
@@ -5,7 +5,7 @@ test "block data" when running minecraft "1.14.4":
 	set {_block} to block at (spawn of world "world")
 	set {_before} to block data of block at {_block}
 
-	# === BLOCK DATA OF BLOCK ===
+	# === BLOCK DATA | BLOCKS ===
 
 	set block at {_block} to campfire[lit=false;waterlogged=true]
 	assert block at {_block} is an unlit campfire with "block at {_block} should have been an unlit campfire"
@@ -14,7 +14,7 @@ test "block data" when running minecraft "1.14.4":
 	assert block at {_block} is campfire[] with "block at {_block} should have been a campfire"
 	assert block at {_block} is not campfire[lit=true;waterlogged=false] with "block at {_block} should not have been a lit, unwaterlogged campfire"
 
-	# === BLOCK DATA OF ITEMS ===
+	# === BLOCK DATA | ITEMS ===
 
 	set {_campfire} to block data of campfire
 	set {_log} to block data of oak log
@@ -28,6 +28,11 @@ test "block data" when running minecraft "1.14.4":
 		add loop-value to {_wools::*}
 	set {_datas::*} to block data of all wool
 	assert (size of {_wools::*}) is (size of {_datas::*}) with "getting the block data of an 'all' itemtype should return the block data of all the items"
+
+	# === BLOCK DATA | INVALID ===
+
+	set {_text} to "asdf"
+	assert block data of {_text} and {_none} is not set with "getting the block data of an invalid object should return null"
 
 	# === CLEANUP ===
 

--- a/src/test/skript/tests/syntaxes/expressions/ExprBlockData.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprBlockData.sk
@@ -1,14 +1,14 @@
 test "block data" when running minecraft "1.14.4":
-	set {_b} to block at spawn of world "world"
-	set block at {_b} to campfire[lit=false;waterlogged=true]
-	assert block at {_b} is an unlit campfire with "block at spawn should be an unlit campfire"
+	set {_block} to block at (spawn of world "world")
+	set block at {_block} to campfire[lit=false;waterlogged=true]
+	assert block at {_block} is an unlit campfire with "block at spawn should be an unlit campfire"
 
-	assert block at {_b} = campfire[lit=false;waterlogged=true] with "block should have been an unlit, waterlogged campfire"
-	assert block at {_b} = campfire[waterlogged=true] with "block should have been a waterlogged campfire"
-	assert block at {_b} = campfire[] with "block should have been a campfire"
-	assert block at {_b} != campfire[lit=true;waterlogged=false] with "block should not have been an unlit, waterlogged campfire"
+	assert block at {_block} is campfire[lit=false;waterlogged=true] with "block should have been an unlit, waterlogged campfire"
+	assert block at {_block} is campfire[waterlogged=true] with "block should have been a waterlogged campfire"
+	assert block at {_block} is campfire[] with "block should have been a campfire"
+	assert block at {_block} is not campfire[lit=true;waterlogged=false] with "block should not have been an unlit, waterlogged campfire"
 
-	set {_data} to block data of block at {_b}
+	set {_data} to block data of block at {_block}
 	assert "%{_data}%" contains "campfire", "lit=false" and "waterlogged=true" with "block data for campfire did not match"
 
-	set block at {_b} to air
+	set block at {_block} to air

--- a/src/test/skript/tests/syntaxes/expressions/ExprBlockDataTags.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprBlockDataTags.sk
@@ -9,11 +9,14 @@ test "block data tags" when running minecraft "1.14.4":
 
 	set {_expected::campfire::*} to "facing", "waterlogged", "lit" and "signal_fire"
 	set {_expected::oak log::*} to "axis"
-	set {_expected::wheat seeds::*} to "age"
+	set {_expected::wheat::*} to "age"
 
 	loop indexes of {_expected::*}:
 		set {_i} to loop-value parsed as itemtype
+		broadcast "loop-value as item: %{_i}%"
 		set block at {_block} to {_i}
+		broadcast "i to block: %block at {_block}%"
+		broadcast "expected: %{_expected::%loop-value%::*}%"
 		assert testTags(block data of {_i}, {_expected::%loop-value%::*}) is true with "%loop-value% as itemtype had unexpected block data tags"
 		assert testTags(block at {_block}, {_expected::%loop-value%::*}) is true with "%loop-value% as block had unexpected block data tags"
 
@@ -22,7 +25,9 @@ test "block data tags" when running minecraft "1.14.4":
 	set block at {_block} to {_before}
 
 local function testTags(data: block data, tags: strings) :: boolean:
+	broadcast "%{_data}% should have tags %{_tags::*}%"
 	set {_data::*} to block data tags of {_data}
+	broadcast "%{_data}% has tags %{_data::*}%"
 	loop {_tags::*}:
 		if {_data::*} doesn't contain loop-value:
 			return false

--- a/src/test/skript/tests/syntaxes/expressions/ExprBlockDataTags.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprBlockDataTags.sk
@@ -1,0 +1,29 @@
+test "block data tags" when running minecraft "1.14.4":
+
+	# === SETUP ===
+
+	set {_block} to block at (spawn of world "world")
+	set {_before} to block data of block at {_block}
+
+	# === TESTS ===
+
+	set {_expected::campfire::*} to "facing", "waterlogged", "lit" and "signal_fire"
+	set {_expected::oak log::*} to "axis"
+	set {_expected::wheat seeds::*} to "age"
+
+	loop indexes of {_expected::*}:
+		set {_i} to loop-value parsed as itemtype
+		set block at {_block} to {_i}
+		assert testTags(block data of {_i}, {_expected::%loop-value%::*}) is true with "%loop-value% as itemtype had unexpected block data tags"
+		assert testTags(block at {_block}, {_expected::%loop-value%::*}) is true with "%loop-value% as block had unexpected block data tags"
+
+	# === CLEANUP ===
+
+	set block at {_block} to {_before}
+
+local function testTags(data: block data, tags: strings) :: boolean:
+	set {_data::*} to block data tags of {_data}
+	loop {_tags::*}:
+		if {_data::*} doesn't contain loop-value:
+			return false
+	return true


### PR DESCRIPTION
### Description
This PR adds some more basic block data support and block data tags to Skript. It introduces a block -> block data converter, which I'm happy to take feedback on.

Stuff that this PR adds:
- [ ] Getting the block data of a valid item
- [ ] Getting the block data tags of a block data
- [ ] Tests for these

Stuff that will probably also make it into this PR:
- [ ] Getting the value of a tag of a block data
- [ ] Setting the values of tags of block datas

The code in this PR was created without knowledge of SkBee's implementation. At the very end I compared the two, just to see if I had missed anything big, which I (sort of) had. SkBee uses a method, `toBlockForm`, which converts some itemstacks whose material isn't a valid block to their respective block form (e.g. wheat seeds -> wheat). I couldn't think of any other way to do this, so it was implemented with Shane's permission.
---
**Target Minecraft Versions:** 1.13+
**Requirements:** none
**Related Issues:** none
