### PR TITLE
Fix NPE caused by unregistered ClassInfo

### DIFF
--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -1181,7 +1181,15 @@ public class SkriptParser {
 				}
 				Class<?> c = types[i];
 				assert c != null;
-				message.append(Classes.getSuperClassInfo(c).getName().withIndefiniteArticle());
+				ClassInfo<?> classInfo = Classes.getSuperClassInfo(c);
+				// if there's a registered class info,
+				if (classInfo != null) {
+					// use the article,
+					message.append(classInfo.getName().withIndefiniteArticle());
+				} else {
+					// otherwise fallback to class name
+					message.append(c.getName());
+				}
 			}
 			return message.toString();
 		}


### PR DESCRIPTION
### Description
This PR fixes a null pointer caused when an unregistered ClassInfo is in an accepted changes list, and the change type is not valid. There may be other execution paths affected by this.

The proposed change will use the class' full path (or primitive name) as a fallback value in the error message if there is no ClassInfo.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
