### PR TITLE
Avoid legacy materials in aliases and expritems

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/Aliases.java
+++ b/src/main/java/ch/njol/skript/aliases/Aliases.java
@@ -395,17 +395,17 @@ public abstract class Aliases {
 	}
 
 	/**
-	 * Temporarily create an alias for a material which may not have an alias yet.
+	 * Temporarily create an alias for materials which do not have aliases yet.
 	 */
 	private static void loadMissingAliases() {
 		if (!Skript.methodExists(Material.class, "getKey"))
 			return;
 		for (Material material : Material.values()) {
-			if (!provider.hasAliasForMaterial(material)) {
+			if (!material.isLegacy() && !provider.hasAliasForMaterial(material)) {
 				NamespacedKey key = material.getKey();
 				String name = key.getKey().replace("_", " ");
 				parser.loadAlias(name + "¦s", key.toString());
-				Skript.debug(ChatColor.YELLOW + "Creating temporary alias for: " + key.toString());
+				Skript.debug(ChatColor.YELLOW + "Creating temporary alias for: " + key);
 			}
 		}
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprItems.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprItems.java
@@ -1,21 +1,3 @@
-/**
- *   This file is part of Skript.
- *
- *  Skript is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  Skript is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Copyright Peter Güttinger, SkriptLang team and contributors
- */
 package ch.njol.skript.expressions;
 
 import ch.njol.skript.Skript;
@@ -34,7 +16,7 @@ import com.google.common.collect.Iterables;
 import org.bukkit.Material;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemStack;
-import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -54,7 +36,7 @@ import java.util.stream.StreamSupport;
 public class ExprItems extends SimpleExpression<ItemType> {
 
 	private static final ItemType[] ALL_BLOCKS = Arrays.stream(Material.values())
-		.filter(Material::isBlock)
+		.filter((material -> !material.isLegacy() && material.isBlock()))
 		.map(ItemType::new)
 		.toArray(ItemType[]::new);
 


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

removes legacy materials from two instances where skript iterates over all materials.
Was causing issues when running with paper's new paper.disableOldApiSupport startup flag.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
