### PR TITLE
Preventing NPE caused by creation of PlayerProfile from OfflinePlayer

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/ItemType.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemType.java
@@ -1,21 +1,3 @@
-/**
- *   This file is part of Skript.
- *
- *  Skript is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  Skript is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Copyright Peter Güttinger, SkriptLang team and contributors
- */
 package ch.njol.skript.aliases;
 
 import ch.njol.skript.aliases.ItemData.OldItemData;
@@ -37,10 +19,7 @@ import ch.njol.yggdrasil.FieldHandler;
 import ch.njol.yggdrasil.Fields;
 import ch.njol.yggdrasil.Fields.FieldContext;
 import ch.njol.yggdrasil.YggdrasilSerializable.YggdrasilExtendedSerializable;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.OfflinePlayer;
-import org.bukkit.Tag;
+import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Skull;
@@ -391,22 +370,31 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 	 */
 	public boolean setBlock(Block block, boolean applyPhysics) {
 		for (int i = random.nextInt(types.size()); i < types.size(); i++) {
-			ItemData d = types.get(i);
-			Material blockType = ItemUtils.asBlock(d.type);
+			ItemData data = types.get(i);
+			Material blockType = ItemUtils.asBlock(data.type);
+
 			if (blockType == null) // Ignore items which cannot be placed
 				continue;
-			if (BlockUtils.set(block, blockType, d.getBlockValues(), applyPhysics)) {
-				ItemMeta itemMeta = getItemMeta();
-				if (itemMeta instanceof SkullMeta) {
-					OfflinePlayer offlinePlayer = ((SkullMeta) itemMeta).getOwningPlayer();
-					if (offlinePlayer == null)
-						continue;
-					Skull skull = (Skull) block.getState();
+
+			if (!BlockUtils.set(block, blockType, data.getBlockValues(), applyPhysics))
+				continue;
+
+			ItemMeta itemMeta = getItemMeta();
+
+			if (itemMeta instanceof SkullMeta skullMeta) {
+				OfflinePlayer offlinePlayer = skullMeta.getOwningPlayer();
+				if (offlinePlayer == null) continue;
+				Skull skull = (Skull) block.getState();
+				if (offlinePlayer.getName() != null) {
 					skull.setOwningPlayer(offlinePlayer);
-					skull.update(false, applyPhysics);
+				} else {
+					//noinspection deprecation
+					skull.setOwnerProfile(Bukkit.createPlayerProfile(offlinePlayer.getUniqueId(), ""));
 				}
-				return true;
+				skull.update(false, applyPhysics);
 			}
+
+			return true;
 		}
 		return false;
 	}

--- a/src/main/java/ch/njol/skript/aliases/ItemType.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemType.java
@@ -19,7 +19,11 @@ import ch.njol.yggdrasil.FieldHandler;
 import ch.njol.yggdrasil.Fields;
 import ch.njol.yggdrasil.Fields.FieldContext;
 import ch.njol.yggdrasil.YggdrasilSerializable.YggdrasilExtendedSerializable;
-import org.bukkit.*;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.Tag;
+import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Skull;
@@ -383,13 +387,17 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 
 			if (itemMeta instanceof SkullMeta) {
 				OfflinePlayer offlinePlayer = ((SkullMeta) itemMeta).getOwningPlayer();
-				if (offlinePlayer == null) continue;
+				if (offlinePlayer == null)
+					continue;
 				Skull skull = (Skull) block.getState();
 				if (offlinePlayer.getName() != null) {
 					skull.setOwningPlayer(offlinePlayer);
-				} else {
+				} else if (ItemUtils.CAN_CREATE_PLAYER_PROFILE) {
 					//noinspection deprecation
 					skull.setOwnerProfile(Bukkit.createPlayerProfile(offlinePlayer.getUniqueId(), ""));
+				} else {
+					//noinspection deprecation
+					skull.setOwner("");
 				}
 				skull.update(false, applyPhysics);
 			}

--- a/src/main/java/ch/njol/skript/aliases/ItemType.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemType.java
@@ -381,8 +381,8 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 
 			ItemMeta itemMeta = getItemMeta();
 
-			if (itemMeta instanceof SkullMeta skullMeta) {
-				OfflinePlayer offlinePlayer = skullMeta.getOwningPlayer();
+			if (itemMeta instanceof SkullMeta) {
+				OfflinePlayer offlinePlayer = ((SkullMeta) itemMeta).getOwningPlayer();
 				if (offlinePlayer == null) continue;
 				Skull skull = (Skull) block.getState();
 				if (offlinePlayer.getName() != null) {

--- a/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
@@ -21,7 +21,9 @@ package ch.njol.skript.bukkitutil;
 import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.util.slot.Slot;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.Tag;
 import org.bukkit.TreeType;
 import org.bukkit.block.Block;
@@ -32,9 +34,11 @@ import org.bukkit.block.data.type.Wall;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
+import java.util.UUID;
 
 /**
  * Miscellaneous static utility methods related to items.
@@ -44,6 +48,7 @@ public class ItemUtils {
 	public static final boolean HAS_MAX_DAMAGE = Skript.methodExists(Damageable.class, "getMaxDamage");
 	// Introduced in Paper 1.21
 	public static final boolean HAS_RESET = Skript.methodExists(Damageable.class, "resetDamage");
+	public static final boolean CAN_CREATE_PLAYER_PROFILE = Skript.methodExists(Bukkit.class, "createPlayerProfile", UUID.class, String.class);
 
 	/**
 	 * Gets damage/durability of an item, or 0 if it does not have damage.
@@ -146,6 +151,30 @@ public class ItemUtils {
 			((Damageable) meta).setDamage(damage);
 			itemType.setItemMeta(meta);
 		}
+	}
+
+	/**
+	 * Sets the owner of a player head.
+	 * @param skull player head item to modify
+	 * @param player owner of the head
+	 */
+	public static void setHeadOwner(ItemType skull, OfflinePlayer player) {
+		ItemMeta meta = skull.getItemMeta();
+		if (!(meta instanceof SkullMeta))
+			return;
+
+		SkullMeta skullMeta = (SkullMeta) meta;
+
+		if (player.getName() != null) {
+			skullMeta.setOwningPlayer(player);
+		} else if (CAN_CREATE_PLAYER_PROFILE) {
+			//noinspection deprecation
+			skullMeta.setOwnerProfile(Bukkit.createPlayerProfile(player.getUniqueId(), ""));
+		} else {
+			skullMeta.setOwningPlayer(null);
+		}
+
+		skull.setItemMeta(skullMeta);
 	}
 
 	/**

--- a/src/main/java/ch/njol/skript/expressions/ExprSkull.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSkull.java
@@ -1,86 +1,55 @@
-/**
- *   This file is part of Skript.
- *
- *  Skript is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  Skript is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Copyright Peter Güttinger, SkriptLang team and contributors
- */
 package ch.njol.skript.expressions;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.jetbrains.annotations.Nullable;
 
-import ch.njol.skript.Skript;
-import ch.njol.skript.aliases.Aliases;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
-import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.util.Kleenean;
 
-/**
- * @author Peter Güttinger
- */
 @Name("Player Skull")
 @Description("Gets a skull item representing a player. Skulls for other entities are provided by the aliases.")
-@Examples({"give the victim's skull to the attacker",
-		"set the block at the entity to the entity's skull"})
+@Examples({
+	"give the victim's skull to the attacker",
+	"set the block at the entity to the entity's skull"
+})
 @Since("2.0")
-public class ExprSkull extends SimplePropertyExpression<Object, ItemType> {
-	
+public class ExprSkull extends SimplePropertyExpression<OfflinePlayer, ItemType> {
+
 	static {
 		register(ExprSkull.class, ItemType.class, "(head|skull)", "offlineplayers");
 	}
-	
-	/**
-	 * In 2017, SkullMeta finally got a method that takes OfflinePlayer.
-	 */
-	private static final boolean newSkullOwner = Skript.methodExists(SkullMeta.class, "setOwningPlayer", OfflinePlayer.class);
-	
+
 	@Override
-	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
-		return super.init(exprs, matchedPattern, isDelayed, parseResult);
-	}
-	
-	@SuppressWarnings("deprecation")
-	@Override
-	@Nullable
-	public ItemType convert(final Object o) {
+	public @Nullable ItemType convert(OfflinePlayer player) {
 		ItemType skull = new ItemType(Material.PLAYER_HEAD);
 		SkullMeta meta = (SkullMeta) skull.getItemMeta();
-		if (newSkullOwner)
-			meta.setOwningPlayer((OfflinePlayer) o);
-		else
-			meta.setOwner(((OfflinePlayer) o).getName());
+
+		if (player.getName() != null) {
+			meta.setOwningPlayer(player);
+		} else {
+			//noinspection deprecation
+			meta.setOwnerProfile(Bukkit.createPlayerProfile(player.getUniqueId(), ""));
+		}
+
 		skull.setItemMeta(meta);
 		return skull;
 	}
-	
+
 	@Override
 	public Class<? extends ItemType> getReturnType() {
 		return ItemType.class;
 	}
-	
+
 	@Override
 	protected String getPropertyName() {
 		return "skull";
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprSkull.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSkull.java
@@ -1,9 +1,8 @@
 package ch.njol.skript.expressions;
 
-import org.bukkit.Bukkit;
+import ch.njol.skript.bukkitutil.ItemUtils;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.inventory.meta.SkullMeta;
 import org.jetbrains.annotations.Nullable;
 
 import ch.njol.skript.aliases.ItemType;
@@ -29,16 +28,7 @@ public class ExprSkull extends SimplePropertyExpression<OfflinePlayer, ItemType>
 	@Override
 	public @Nullable ItemType convert(OfflinePlayer player) {
 		ItemType skull = new ItemType(Material.PLAYER_HEAD);
-		SkullMeta meta = (SkullMeta) skull.getItemMeta();
-
-		if (player.getName() != null) {
-			meta.setOwningPlayer(player);
-		} else {
-			//noinspection deprecation
-			meta.setOwnerProfile(Bukkit.createPlayerProfile(player.getUniqueId(), ""));
-		}
-
-		skull.setItemMeta(meta);
+		ItemUtils.setHeadOwner(skull, player);
 		return skull;
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprSkullOwner.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSkullOwner.java
@@ -48,9 +48,10 @@ public class ExprSkullOwner extends SimplePropertyExpression<Block, OfflinePlaye
 	public void change(Event event, Object @Nullable [] delta, ChangeMode mode) {
 		OfflinePlayer offlinePlayer = (OfflinePlayer) delta[0];
 		for (Block block : getExpr().getArray(event)) {
-			if (!(block.getState() instanceof Skull skull))
+			if (!(block.getState() instanceof Skull))
 				continue;
 
+			Skull skull = (Skull) block.getState();
 			if (offlinePlayer.getName() != null) {
 				skull.setOwningPlayer(offlinePlayer);
 			} else {

--- a/src/main/java/ch/njol/skript/expressions/ExprSkullOwner.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSkullOwner.java
@@ -1,21 +1,3 @@
-/**
- *   This file is part of Skript.
- *
- *  Skript is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  Skript is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Copyright Peter Güttinger, SkriptLang team and contributors
- */
 package ch.njol.skript.expressions;
 
 import ch.njol.skript.classes.Changer.ChangeMode;
@@ -25,6 +7,7 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
 import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
@@ -65,12 +48,16 @@ public class ExprSkullOwner extends SimplePropertyExpression<Block, OfflinePlaye
 	public void change(Event event, Object @Nullable [] delta, ChangeMode mode) {
 		OfflinePlayer offlinePlayer = (OfflinePlayer) delta[0];
 		for (Block block : getExpr().getArray(event)) {
-			BlockState state = block.getState();
-			if (state instanceof Skull) {
-				Skull skull = (Skull) state;
+			if (!(block.getState() instanceof Skull skull))
+				continue;
+
+			if (offlinePlayer.getName() != null) {
 				skull.setOwningPlayer(offlinePlayer);
-				skull.update(true, false);
+			} else {
+				//noinspection deprecation
+				skull.setOwnerProfile(Bukkit.createPlayerProfile(offlinePlayer.getUniqueId(), ""));
 			}
+			skull.update(true, false);
 		}
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprSkullOwner.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSkullOwner.java
@@ -1,5 +1,6 @@
 package ch.njol.skript.expressions;
 
+import ch.njol.skript.bukkitutil.ItemUtils;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -48,15 +49,19 @@ public class ExprSkullOwner extends SimplePropertyExpression<Block, OfflinePlaye
 	public void change(Event event, Object @Nullable [] delta, ChangeMode mode) {
 		OfflinePlayer offlinePlayer = (OfflinePlayer) delta[0];
 		for (Block block : getExpr().getArray(event)) {
-			if (!(block.getState() instanceof Skull))
+			BlockState state = block.getState();
+			if (!(state instanceof Skull))
 				continue;
 
-			Skull skull = (Skull) block.getState();
+			Skull skull = (Skull) state;
 			if (offlinePlayer.getName() != null) {
 				skull.setOwningPlayer(offlinePlayer);
-			} else {
+			} else if (ItemUtils.CAN_CREATE_PLAYER_PROFILE) {
 				//noinspection deprecation
 				skull.setOwnerProfile(Bukkit.createPlayerProfile(offlinePlayer.getUniqueId(), ""));
+			} else {
+				//noinspection deprecation
+				skull.setOwner("");
 			}
 			skull.update(true, false);
 		}


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
There's currently a bug when setting the profile of a skull using an OfflinePlayer without a username. SkullMeta#setOwningPlayer(OfflinePlayer) do not check if the username is present and still creates a new GameProfile, leading to a NPE. This PR addresses the issue by providing an alternative player profile with empty username.

Although this has been fixed in [SPIGOT-7882](https://hub.spigotmc.org/jira/browse/SPIGOT-7882) (the same way I did here), the bug persists in older versions supported by Skript.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7090 <!-- Links to related issues -->
