### PR TITLE
Make Parser#canParse abstract

### DIFF
--- a/src/main/java/ch/njol/skript/bukkitutil/EnchantmentUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/EnchantmentUtils.java
@@ -121,6 +121,12 @@ public class EnchantmentUtils {
 	public static ClassInfo<Enchantment> createClassInfo() {
 		return new ClassInfo<>(Enchantment.class, "enchantment")
 			.parser(new Parser<>() {
+
+				@Override
+				public boolean canParse(ParseContext context) {
+					return true;
+				}
+
 				@Override
 				@Nullable
 				public Enchantment parse(final String s, final ParseContext context) {

--- a/src/main/java/ch/njol/skript/classes/EnumClassInfo.java
+++ b/src/main/java/ch/njol/skript/classes/EnumClassInfo.java
@@ -54,6 +54,12 @@ public class EnumClassInfo<T extends Enum<T>> extends ClassInfo<T> {
 			.serializer(new EnumSerializer<>(c))
 			.defaultExpression(defaultExpression)
 			.parser(new Parser<T>() {
+
+				@Override
+				public boolean canParse(ParseContext context) {
+					return true;
+				}
+
 				@Override
 				@Nullable
 				public T parse(String s, ParseContext context) {

--- a/src/main/java/ch/njol/skript/classes/Parser.java
+++ b/src/main/java/ch/njol/skript/classes/Parser.java
@@ -36,9 +36,7 @@ public abstract class Parser<T> {
 	/**
 	 * @return Whether {@link #parse(String, ParseContext)} can actually return something other that null for the given context
 	 */
-	public boolean canParse(final ParseContext context) {
-		return false;
-	}
+	public abstract boolean canParse(final ParseContext context);
 	
 	/**
 	 * Returns a string representation of the given object to be used in messages.

--- a/src/main/java/ch/njol/skript/classes/Parser.java
+++ b/src/main/java/ch/njol/skript/classes/Parser.java
@@ -18,12 +18,10 @@
  */
 package ch.njol.skript.classes;
 
-import org.jetbrains.annotations.Nullable;
-
 import ch.njol.skript.lang.ParseContext;
-import ch.njol.skript.lang.parser.ParserInstance;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.util.StringMode;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A parser used to parse data from a string or turn data into a string.
@@ -57,7 +55,7 @@ public abstract class Parser<T> {
 	 * @return Whether {@link #parse(String, ParseContext)} can actually return something other that null for the given context
 	 */
 	public boolean canParse(final ParseContext context) {
-		return true;
+		return false;
 	}
 	
 	/**

--- a/src/main/java/ch/njol/skript/classes/Parser.java
+++ b/src/main/java/ch/njol/skript/classes/Parser.java
@@ -1,21 +1,3 @@
-/**
- *   This file is part of Skript.
- *
- *  Skript is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  Skript is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Copyright Peter Güttinger, SkriptLang team and contributors
- */
 package ch.njol.skript.classes;
 
 import ch.njol.skript.lang.ParseContext;

--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -18,18 +18,32 @@
  */
 package ch.njol.skript.classes.data;
 
-import java.io.StreamCorruptedException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map.Entry;
-import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
+import ch.njol.skript.Skript;
+import ch.njol.skript.SkriptConfig;
+import ch.njol.skript.aliases.Aliases;
+import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.bukkitutil.BukkitUtils;
+import ch.njol.skript.bukkitutil.EnchantmentUtils;
+import ch.njol.skript.bukkitutil.ItemUtils;
+import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.classes.ConfigurationSerializer;
+import ch.njol.skript.classes.EnumClassInfo;
+import ch.njol.skript.classes.Parser;
+import ch.njol.skript.classes.Serializer;
+import ch.njol.skript.classes.registry.RegistryClassInfo;
+import ch.njol.skript.entity.EntityData;
+import ch.njol.skript.expressions.ExprDamageCause;
+import ch.njol.skript.expressions.base.EventValueExpression;
+import ch.njol.skript.lang.ParseContext;
+import ch.njol.skript.lang.util.SimpleLiteral;
+import ch.njol.skript.localization.Language;
+import ch.njol.skript.registrations.Classes;
+import ch.njol.skript.util.BlockUtils;
+import ch.njol.skript.util.PotionEffectUtils;
+import ch.njol.skript.util.StringMode;
+import ch.njol.util.StringUtils;
+import ch.njol.yggdrasil.Fields;
+import io.papermc.paper.world.MoonPhase;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Difficulty;
@@ -79,33 +93,18 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.CachedServerIcon;
 import org.bukkit.util.Vector;
-
-import ch.njol.skript.Skript;
-import ch.njol.skript.SkriptConfig;
-import ch.njol.skript.aliases.Aliases;
-import ch.njol.skript.aliases.ItemType;
-import ch.njol.skript.bukkitutil.EnchantmentUtils;
-import ch.njol.skript.bukkitutil.ItemUtils;
-import ch.njol.skript.classes.ClassInfo;
-import ch.njol.skript.classes.ConfigurationSerializer;
-import ch.njol.skript.classes.EnumClassInfo;
-import ch.njol.skript.classes.Parser;
-import ch.njol.skript.classes.Serializer;
-import ch.njol.skript.classes.registry.RegistryClassInfo;
-import ch.njol.skript.entity.EntityData;
-import ch.njol.skript.expressions.ExprDamageCause;
-import ch.njol.skript.expressions.base.EventValueExpression;
-import ch.njol.skript.lang.ParseContext;
-import ch.njol.skript.lang.util.SimpleLiteral;
-import ch.njol.skript.localization.Language;
-import ch.njol.skript.registrations.Classes;
-import ch.njol.skript.util.BlockUtils;
-import ch.njol.skript.util.PotionEffectUtils;
-import ch.njol.skript.util.StringMode;
-import ch.njol.util.StringUtils;
-import ch.njol.yggdrasil.Fields;
-import io.papermc.paper.world.MoonPhase;
 import org.jetbrains.annotations.Nullable;
+
+import java.io.StreamCorruptedException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map.Entry;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * @author Peter Güttinger
@@ -306,12 +305,18 @@ public class BukkitClasses {
 				.after("itemtype")
 				.since("2.5")
 				.parser(new Parser<BlockData>() {
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Nullable
 					@Override
 					public BlockData parse(String input, ParseContext context) {
 						return BlockUtils.createBlockData(input);
 					}
-	
+
 					@Override
 					public String toString(BlockData o, int flags) {
 						return o.getAsString().replace(",", ";");
@@ -536,7 +541,12 @@ public class BukkitClasses {
 				.parser(new Parser<World>() {
 					@SuppressWarnings("null")
 					private final Pattern parsePattern = Pattern.compile("(?:(?:the )?world )?\"(.+)\"", Pattern.CASE_INSENSITIVE);
-					
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Override
 					@Nullable
 					public World parse(final String s, final ParseContext context) {
@@ -936,6 +946,12 @@ public class BukkitClasses {
 					.map(ItemStack::new)
 					.iterator())
 				.parser(new Parser<ItemStack>() {
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Override
 					@Nullable
 					public ItemStack parse(final String s, final ParseContext context) {
@@ -1075,6 +1091,12 @@ public class BukkitClasses {
 				.since("")
 				.supplier(PotionEffectType.values())
 				.parser(new Parser<PotionEffectType>() {
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Override
 					@Nullable
 					public PotionEffectType parse(final String s, final ParseContext context) {
@@ -1434,6 +1456,12 @@ public class BukkitClasses {
 			.requiredPlugins("Minecraft 1.13 or newer")
 			.supplier(GameRule.values())
 			.parser(new Parser<GameRule>() {
+
+				@Override
+				public boolean canParse(ParseContext context) {
+					return true;
+				}
+
 				@Override
 				@Nullable
 				public GameRule parse(final String input, final ParseContext context) {

--- a/src/main/java/ch/njol/skript/classes/data/JavaClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/JavaClasses.java
@@ -62,6 +62,12 @@ public class JavaClasses {
 				// is registered after all other number classes
 				.defaultExpression(new SimpleLiteral<>(1, true))
 				.parser(new Parser<Number>() {
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Override
 					@Nullable
 					public Number parse(String s, ParseContext context) {
@@ -132,6 +138,12 @@ public class JavaClasses {
 				.before("integer", "short", "byte")
 				.defaultExpression(new SimpleLiteral<>((long) 1, true))
 				.parser(new Parser<Long>() {
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Override
 					@Nullable
 					public Long parse(String s, ParseContext context) {
@@ -189,6 +201,12 @@ public class JavaClasses {
 				.name(ClassInfo.NO_DOC)
 				.defaultExpression(new SimpleLiteral<>(1, true))
 				.parser(new Parser<Integer>() {
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Override
 					@Nullable
 					public Integer parse(String s, ParseContext context) {
@@ -248,6 +266,12 @@ public class JavaClasses {
 				.after("long")
 				.before("float", "integer", "short", "byte")
 				.parser(new Parser<Double>() {
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Override
 					@Nullable
 					public Double parse(String s, ParseContext context) {
@@ -308,6 +332,12 @@ public class JavaClasses {
 				.name(ClassInfo.NO_DOC)
 				.defaultExpression(new SimpleLiteral<>(1f, true))
 				.parser(new Parser<Float>() {
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Override
 					@Nullable
 					public Float parse(String s, ParseContext context) {
@@ -375,7 +405,12 @@ public class JavaClasses {
 				.parser(new Parser<Boolean>() {
 					private final RegexMessage truePattern = new RegexMessage("boolean.true.pattern");
 					private final RegexMessage falsePattern = new RegexMessage("boolean.false.pattern");
-					
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Override
 					@Nullable
 					public Boolean parse(String s, ParseContext context) {
@@ -434,6 +469,12 @@ public class JavaClasses {
 				.name(ClassInfo.NO_DOC)
 				.defaultExpression(new SimpleLiteral<>((short) 1, true))
 				.parser(new Parser<Short>() {
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Override
 					@Nullable
 					public Short parse(String s, ParseContext context) {
@@ -491,6 +532,12 @@ public class JavaClasses {
 				.name(ClassInfo.NO_DOC)
 				.defaultExpression(new SimpleLiteral<>((byte) 1, true))
 				.parser(new Parser<Byte>() {
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Override
 					@Nullable
 					public Byte parse(String s, ParseContext context) {
@@ -502,12 +549,12 @@ public class JavaClasses {
 							return null;
 						}
 					}
-					
+
 					@Override
 					public String toString(Byte b, int flags) {
 						return "" + b;
 					}
-					
+
 					@Override
 					public String toVariableNameString(Byte b) {
 						return "" + b;

--- a/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
@@ -18,16 +18,6 @@
  */
 package ch.njol.skript.classes.data;
 
-import java.io.StreamCorruptedException;
-import java.util.Iterator;
-import java.util.Locale;
-import java.util.regex.Pattern;
-
-import org.bukkit.Material;
-import org.bukkit.enchantments.Enchantment;
-import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.Nullable;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.Aliases;
 import ch.njol.skript.aliases.ItemData;
@@ -64,8 +54,16 @@ import ch.njol.skript.util.slot.Slot;
 import ch.njol.skript.util.visual.VisualEffect;
 import ch.njol.skript.util.visual.VisualEffects;
 import ch.njol.yggdrasil.Fields;
+import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Nullable;
 
+import java.io.StreamCorruptedException;
 import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.regex.Pattern;
 
 /**
  * @author Peter Güttinger
@@ -91,6 +89,12 @@ public class SkriptClasses {
 				.after("entitydata", "entitytype", "itemtype")
 				.supplier(() -> (Iterator) Classes.getClassInfos().iterator())
 				.parser(new Parser<ClassInfo>() {
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Override
 					@Nullable
 					public ClassInfo parse(final String s, final ParseContext context) {
@@ -166,6 +170,12 @@ public class SkriptClasses {
 				.since("1.0")
 				.defaultExpression(new SimpleLiteral<>(WeatherType.CLEAR, true))
 				.parser(new Parser<WeatherType>() {
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Override
 					@Nullable
 					public WeatherType parse(final String s, final ParseContext context) {
@@ -206,6 +216,12 @@ public class SkriptClasses {
 					.map(ItemType::new)
 					.iterator())
 				.parser(new Parser<ItemType>() {
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Override
 					@Nullable
 					public ItemType parse(final String s, final ParseContext context) {
@@ -261,6 +277,12 @@ public class SkriptClasses {
 				.since("1.0")
 				.defaultExpression(new EventValueExpression<>(Time.class))
 				.parser(new Parser<Time>() {
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Override
 					@Nullable
 					public Time parse(final String s, final ParseContext context) {
@@ -294,6 +316,12 @@ public class SkriptClasses {
 						"	halt for 12.7 irl minutes, 12 hours and 120.5 seconds")
 				.since("1.0, 2.6.1 (weeks, months, years)")
 				.parser(new Parser<Timespan>() {
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Override
 					@Nullable
 					public Timespan parse(final String s, final ParseContext context) {
@@ -329,6 +357,12 @@ public class SkriptClasses {
 				.before("timespan") // otherwise "day" gets parsed as '1 day'
 				.defaultExpression(new SimpleLiteral<>(new Timeperiod(0, 23999), true))
 				.parser(new Parser<Timeperiod>() {
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Override
 					@Nullable
 					public Timeperiod parse(final String s, final ParseContext context) {
@@ -542,6 +576,12 @@ public class SkriptClasses {
 				.since("")
 				.supplier(SkriptColor.values())
 				.parser(new Parser<Color>() {
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Override
 					@Nullable
 					public Color parse(String input, ParseContext context) {
@@ -572,6 +612,12 @@ public class SkriptClasses {
 				.since("")
 				.defaultExpression(new SimpleLiteral<>(StructureType.TREE, true))
 				.parser(new Parser<StructureType>() {
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Override
 					@Nullable
 					public StructureType parse(final String s, final ParseContext context) {
@@ -598,6 +644,12 @@ public class SkriptClasses {
 						"helmet is enchanted with waterbreathing")
 				.since("1.4.6")
 				.parser(new Parser<EnchantmentType>() {
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Override
 					@Nullable
 					public EnchantmentType parse(final String s, final ParseContext context) {
@@ -626,7 +678,12 @@ public class SkriptClasses {
 				.since("2.0")
 				.parser(new Parser<Experience>() {
 					private final RegexMessage pattern = new RegexMessage("types.experience.pattern", Pattern.CASE_INSENSITIVE);
-					
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Override
 					@Nullable
 					public Experience parse(String s, final ParseContext context) {
@@ -663,6 +720,12 @@ public class SkriptClasses {
 				.user("(visual|particle) effects?")
 				.after("itemtype")
 				.parser(new Parser<VisualEffect>() {
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Override
 					@Nullable
 					public VisualEffect parse(String s, ParseContext context) {

--- a/src/main/java/ch/njol/skript/classes/registry/RegistryParser.java
+++ b/src/main/java/ch/njol/skript/classes/registry/RegistryParser.java
@@ -106,6 +106,11 @@ public class RegistryParser<R extends Keyed> extends Parser<R> {
 		}
 	}
 
+	@Override
+	public boolean canParse(ParseContext context) {
+		return true;
+	}
+
 	/**
 	 * This method attempts to match the string input against one of the string representations of the registry.
 	 *

--- a/src/main/java/ch/njol/skript/entity/EntityData.java
+++ b/src/main/java/ch/njol/skript/entity/EntityData.java
@@ -18,29 +18,6 @@
  */
 package ch.njol.skript.entity;
 
-import java.io.NotSerializableException;
-import java.io.StreamCorruptedException;
-import java.lang.reflect.Array;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.function.Consumer;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
-import org.bukkit.Bukkit;
-import org.bukkit.Chunk;
-import org.bukkit.Location;
-import org.bukkit.RegionAccessor;
-import org.bukkit.World;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Player;
-import org.jetbrains.annotations.Nullable;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptAPIException;
 import ch.njol.skript.bukkitutil.EntityUtils;
@@ -67,6 +44,28 @@ import ch.njol.util.coll.CollectionUtils;
 import ch.njol.util.coll.iterator.SingleItemIterator;
 import ch.njol.yggdrasil.Fields;
 import ch.njol.yggdrasil.YggdrasilSerializable.YggdrasilExtendedSerializable;
+import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
+import org.bukkit.Location;
+import org.bukkit.RegionAccessor;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.NotSerializableException;
+import java.io.StreamCorruptedException;
+import java.lang.reflect.Array;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @SuppressWarnings("rawtypes")
 public abstract class EntityData<E extends Entity> implements SyntaxElement, YggdrasilExtendedSerializable {// TODO extended horse support, zombie villagers // REMIND unit
@@ -190,17 +189,23 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 				.before("entitytype")
 				.supplier(ALL_ENTITY_DATAS::iterator)
 				.parser(new Parser<EntityData>() {
+
 					@Override
-					public String toString(final EntityData d, final int flags) {
-						return d.toString(flags);
+					public boolean canParse(ParseContext context) {
+						return true;
 					}
-					
+
 					@Override
 					@Nullable
 					public EntityData parse(final String s, final ParseContext context) {
 						return EntityData.parse(s);
 					}
-					
+
+					@Override
+					public String toString(final EntityData d, final int flags) {
+						return d.toString(flags);
+					}
+
 					@Override
 					public String toVariableNameString(final EntityData o) {
 						return "entitydata:" + o.toString();

--- a/src/main/java/ch/njol/skript/entity/EntityType.java
+++ b/src/main/java/ch/njol/skript/entity/EntityType.java
@@ -45,6 +45,12 @@ public class EntityType implements Cloneable, YggdrasilSerializable {
 				.since("1.3")
 				.defaultExpression(new SimpleLiteral<>(new EntityType(Entity.class, 1), true))
 				.parser(new Parser<EntityType>() {
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Override
 					@Nullable
 					public EntityType parse(final String s, final ParseContext context) {

--- a/src/main/java/ch/njol/skript/hooks/economy/classes/Money.java
+++ b/src/main/java/ch/njol/skript/hooks/economy/classes/Money.java
@@ -54,6 +54,12 @@ public class Money {
 				.before("itemtype", "itemstack")
 				.requiredPlugins("Vault", "an economy plugin that supports Vault")
 				.parser(new Parser<Money>() {
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Override
 					@Nullable
 					public Money parse(final String s, final ParseContext context) {

--- a/src/main/java/ch/njol/skript/hooks/regions/classes/Region.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/classes/Region.java
@@ -55,6 +55,12 @@ public abstract class Region implements YggdrasilExtendedSerializable {
 				.user("regions?")
 				.requiredPlugins("Supported regions plugin")
 				.parser(new Parser<Region>() {
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return true;
+					}
+
 					@Override
 					@Nullable
 					public Region parse(String s, final ParseContext context) {

--- a/src/main/java/ch/njol/skript/registrations/Classes.java
+++ b/src/main/java/ch/njol/skript/registrations/Classes.java
@@ -18,6 +18,39 @@
  */
 package ch.njol.skript.registrations;
 
+import ch.njol.skript.Skript;
+import ch.njol.skript.SkriptAPIException;
+import ch.njol.skript.SkriptConfig;
+import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.classes.Parser;
+import ch.njol.skript.classes.Serializer;
+import ch.njol.skript.command.Commands;
+import ch.njol.skript.entity.EntityData;
+import ch.njol.skript.lang.DefaultExpression;
+import ch.njol.skript.lang.ParseContext;
+import ch.njol.skript.localization.Language;
+import ch.njol.skript.log.ParseLogHandler;
+import ch.njol.skript.log.SkriptLogger;
+import ch.njol.skript.util.StringMode;
+import ch.njol.skript.util.Utils;
+import ch.njol.skript.variables.SQLStorage;
+import ch.njol.skript.variables.SerializedVariable;
+import ch.njol.skript.variables.Variables;
+import ch.njol.util.Kleenean;
+import ch.njol.util.StringUtils;
+import ch.njol.yggdrasil.Tag;
+import ch.njol.yggdrasil.Yggdrasil;
+import ch.njol.yggdrasil.YggdrasilInputStream;
+import ch.njol.yggdrasil.YggdrasilOutputStream;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Chunk;
+import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.lang.converter.Converter;
+import org.skriptlang.skript.lang.converter.ConverterInfo;
+import org.skriptlang.skript.lang.converter.Converters;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -36,40 +69,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
-
-import ch.njol.skript.command.Commands;
-import ch.njol.skript.entity.EntityData;
-import ch.njol.skript.util.Utils;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.Chunk;
-import org.jetbrains.annotations.Nullable;
-
-import ch.njol.skript.Skript;
-import ch.njol.skript.SkriptAPIException;
-import ch.njol.skript.SkriptConfig;
-import ch.njol.skript.classes.ClassInfo;
-import ch.njol.skript.classes.Parser;
-import ch.njol.skript.classes.Serializer;
-import ch.njol.skript.lang.DefaultExpression;
-import ch.njol.skript.lang.ParseContext;
-import ch.njol.skript.localization.Language;
-import ch.njol.skript.log.ParseLogHandler;
-import ch.njol.skript.log.SkriptLogger;
-import ch.njol.skript.util.StringMode;
-import ch.njol.skript.variables.SQLStorage;
-import ch.njol.skript.variables.SerializedVariable;
-import ch.njol.skript.variables.Variables;
-import ch.njol.util.Kleenean;
-import ch.njol.util.StringUtils;
-import ch.njol.yggdrasil.Tag;
-import ch.njol.yggdrasil.Yggdrasil;
-import ch.njol.yggdrasil.YggdrasilInputStream;
-import ch.njol.yggdrasil.YggdrasilOutputStream;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.skriptlang.skript.lang.converter.Converter;
-import org.skriptlang.skript.lang.converter.ConverterInfo;
-import org.skriptlang.skript.lang.converter.Converters;
 
 /**
  * @author Peter Güttinger
@@ -590,6 +589,12 @@ public abstract class Classes {
 	
 	private static <F, T> Parser<T> createConvertedParser(final Parser<?> parser, final Converter<F, T> converter) {
 		return new Parser<T>() {
+
+			@Override
+			public boolean canParse(ParseContext context) {
+				return parser.canParse(context);
+			}
+
 			@SuppressWarnings("unchecked")
 			@Override
 			@Nullable


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
PR is a draft to act more as a proposal and wanting feedback on it first before making ready to review. I'm aware of the implications behind this being merge for addons.

This PR aims to complete one of my older issues, the intended design changed a bit, due to breaking everything implemented without defining canParse and as a means to better handle this in the future.

Before Sovde ask if there is any benefit to changing this, my response is yes, not only was it impossible to omit the usage of `.parse()` (or the canParse part) due to it previously returning true by default and spamming the server with UnsupportedOperationExceptionm but is also a core part of the parser class and should be handled as one.

This is a breaking change for addons that did the same thing as skript and rely on the default implementation of true, however the change itself is very light and most addons could easily add the method without breaking anything else, if someone has a better implementation that doesn't break old addons that were abandoned or discontinued I'm willing to hear ideas. Although I would prefer to, not see a repeat of `Timespan#fromTicks_i()`

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #5971 <!-- Links to related issues -->
