### PR TITLE
Make visual effects serializable

### DIFF
--- a/src/main/java/ch/njol/skript/util/visual/VisualEffectType.java
+++ b/src/main/java/ch/njol/skript/util/visual/VisualEffectType.java
@@ -1,21 +1,3 @@
-/**
- *   This file is part of Skript.
- *
- *  Skript is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  Skript is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Copyright Peter Güttinger, SkriptLang team and contributors
- */
 package ch.njol.skript.util.visual;
 
 import ch.njol.skript.localization.Language;

--- a/src/main/java/ch/njol/skript/util/visual/VisualEffectType.java
+++ b/src/main/java/ch/njol/skript/util/visual/VisualEffectType.java
@@ -41,43 +41,40 @@ public class VisualEffectType implements YggdrasilSerializable {
 
 	static {
 		Variables.yggdrasil.registerClassResolver(new YggdrasilSerializer<VisualEffectType>() {
-			@Nullable
 			@Override
-			public Class<? extends VisualEffectType> getClass(String id) {
+			public @Nullable Class<? extends VisualEffectType> getClass(String id) {
 				return id.equals("VisualEffectType") ? VisualEffectType.class : null;
 			}
 
 			@Override
-			public Fields serialize(VisualEffectType o) {
-				Fields f = new Fields();
-				f.putObject("id", o.getId());
-				return f;
+			public Fields serialize(VisualEffectType visualEffectType) {
+				Fields fields = new Fields();
+				fields.putObject("id", visualEffectType.getId());
+				return fields;
 			}
 
-			@Nullable
 			@Override
-			public <E extends VisualEffectType> E newInstance(Class<E> c) {
+			public @Nullable <E extends VisualEffectType> E newInstance(Class<E> clazz) {
 				return null;
 			}
 
 			@Override
-			public boolean canBeInstantiated(Class<? extends VisualEffectType> c) {
+			public boolean canBeInstantiated(Class<? extends VisualEffectType> clazz) {
 				return false;
 			}
 
 			@Override
-			public void deserialize(VisualEffectType o, Fields fields) { }
+			public void deserialize(VisualEffectType visualEffectType, Fields fields) { }
 
-			@SuppressWarnings("unchecked")
 			@Override
-			public <E extends VisualEffectType> E deserialize(Class<E> c, Fields fields) throws StreamCorruptedException, NotSerializableException {
+			@SuppressWarnings("unchecked")
+			public <E extends VisualEffectType> E deserialize(Class<E> clazz, Fields fields) throws StreamCorruptedException, NotSerializableException {
 				return (E) VisualEffects.get(fields.getObject("id", String.class));
 			}
 
-			@Nullable
 			@Override
-			public String getID(Class<?> c) {
-				return c.equals(VisualEffectType.class) ? "VisualEffectType" : null;
+			public @Nullable String getID(Class<?> clazz) {
+				return clazz.equals(VisualEffectType.class) ? "VisualEffectType" : null;
 			}
 		});
 	}

--- a/src/main/java/ch/njol/skript/util/visual/VisualEffectType.java
+++ b/src/main/java/ch/njol/skript/util/visual/VisualEffectType.java
@@ -22,16 +22,65 @@ import ch.njol.skript.localization.Language;
 import ch.njol.skript.localization.Noun;
 import ch.njol.skript.log.BlockingLogHandler;
 import ch.njol.skript.log.SkriptLogger;
+import ch.njol.skript.variables.Variables;
+import ch.njol.yggdrasil.Fields;
+import ch.njol.yggdrasil.YggdrasilSerializable;
+import ch.njol.yggdrasil.YggdrasilSerializer;
 import org.bukkit.Effect;
 import org.bukkit.EntityEffect;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.NotSerializableException;
+import java.io.StreamCorruptedException;
 import java.util.Objects;
 import java.util.function.BiFunction;
 
-public class VisualEffectType {
+public class VisualEffectType implements YggdrasilSerializable {
+
+	static {
+		Variables.yggdrasil.registerClassResolver(new YggdrasilSerializer<VisualEffectType>() {
+			@Nullable
+			@Override
+			public Class<? extends VisualEffectType> getClass(String id) {
+				return id.equals("VisualEffectType") ? VisualEffectType.class : null;
+			}
+
+			@Override
+			public Fields serialize(VisualEffectType o) {
+				Fields f = new Fields();
+				f.putObject("id", o.getId());
+				return f;
+			}
+
+			@Nullable
+			@Override
+			public <E extends VisualEffectType> E newInstance(Class<E> c) {
+				return null;
+			}
+
+			@Override
+			public boolean canBeInstantiated(Class<? extends VisualEffectType> c) {
+				return false;
+			}
+
+			@Override
+			public void deserialize(VisualEffectType o, Fields fields) { }
+
+			@SuppressWarnings("ConstantConditions")
+			@Override
+			public <E extends VisualEffectType> E deserialize(Class<E> c, Fields fields) throws StreamCorruptedException, NotSerializableException {
+				return (E) VisualEffects.get(fields.getObject("id", String.class));
+			}
+
+			@Nullable
+			@Override
+			public String getID(Class<?> c) {
+				return c.equals(VisualEffectType.class) ? "VisualEffectType" : null;
+			}
+		});
+	}
 
 	private static final String LANGUAGE_NODE = "visual effects";
 

--- a/src/main/java/ch/njol/skript/util/visual/VisualEffectType.java
+++ b/src/main/java/ch/njol/skript/util/visual/VisualEffectType.java
@@ -68,7 +68,7 @@ public class VisualEffectType implements YggdrasilSerializable {
 			@Override
 			public void deserialize(VisualEffectType o, Fields fields) { }
 
-			@SuppressWarnings("ConstantConditions")
+			@SuppressWarnings("unchecked")
 			@Override
 			public <E extends VisualEffectType> E deserialize(Class<E> c, Fields fields) throws StreamCorruptedException, NotSerializableException {
 				return (E) VisualEffects.get(fields.getObject("id", String.class));

--- a/src/main/java/ch/njol/skript/util/visual/VisualEffects.java
+++ b/src/main/java/ch/njol/skript/util/visual/VisualEffects.java
@@ -1,21 +1,3 @@
-/**
- *   This file is part of Skript.
- *
- *  Skript is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  Skript is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Copyright Peter Güttinger, SkriptLang team and contributors
- */
 package ch.njol.skript.util.visual;
 
 import ch.njol.skript.Skript;

--- a/src/main/java/ch/njol/skript/util/visual/VisualEffects.java
+++ b/src/main/java/ch/njol/skript/util/visual/VisualEffects.java
@@ -76,8 +76,7 @@ public class VisualEffects {
 		return visualEffectTypes[i];
 	}
 
-	@Nullable
-	public static VisualEffectType get(String id) {
+	public static @Nullable VisualEffectType get(String id) {
 		for (VisualEffectType type : visualEffectTypes) {
 			if (id.equals(type.getId()))
 				return type;

--- a/src/main/java/ch/njol/skript/util/visual/VisualEffects.java
+++ b/src/main/java/ch/njol/skript/util/visual/VisualEffects.java
@@ -60,7 +60,6 @@ public class VisualEffects {
 	private static VisualEffectType[] visualEffectTypes;
 
 	static {
-		Variables.yggdrasil.registerSingleClass(VisualEffectType.class, "VisualEffect.NewType");
 		Variables.yggdrasil.registerSingleClass(Effect.class, "Bukkit_Effect");
 		Variables.yggdrasil.registerSingleClass(EntityEffect.class, "Bukkit_EntityEffect");
 	}
@@ -75,6 +74,15 @@ public class VisualEffects {
 
 	public static VisualEffectType get(int i) {
 		return visualEffectTypes[i];
+	}
+
+	@Nullable
+	public static VisualEffectType get(String id) {
+		for (VisualEffectType type : visualEffectTypes) {
+			if (id.equals(type.getId()))
+				return type;
+		}
+		return null;
 	}
 
 	public static String getAllNames() {


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Started by @TPGamesNL in PR #4123 (the commit has been cherry-picked and the author has been kept for credits), providing a serializer for `VisualEffectType` allows to serialize `VisualEffect` correctly. In fact, this should have been handled by `simpleClassLoaders`, where this specific class was originally registered.

However, the `Yggdrasil#getSerializer` method did not return a serializer: a `SimpleClassResolver` extends from `ClassResolver` and not from a `YggdrasilSerializer` like the others. A fix is therefore to directly register this serializer at the root of `classResolvers`.

https://github.com/SkriptLang/Skript/blob/master/src/main/java/ch/njol/yggdrasil/Yggdrasil.java

---
**Target Minecraft Versions:** any 
**Requirements:** none 
**Related Issues:** #4196
