### PR TITLE
Fixes 5804-is-burning regression test

### DIFF
--- a/src/test/skript/tests/regressions/5804-is-burning.sk
+++ b/src/test/skript/tests/regressions/5804-is-burning.sk
@@ -8,7 +8,7 @@ test "burning":
 	assert "burning" parsed as damage cause is burning with "burning damage cause compare"
 
 	ignite {_pig}
-	assert entity within {_pig} is burning with "is burning failed"
-	assert {_pig} is burning with "is burning failed ##2"
+	assert entity within {_pig} is burning with "entity within is burning failed"
+	assert {_pig} is burning with "is burning failed"
 
 	delete entity within {_pig}

--- a/src/test/skript/tests/regressions/5804-is-burning.sk
+++ b/src/test/skript/tests/regressions/5804-is-burning.sk
@@ -1,9 +1,14 @@
+# This test is to see if the `is burning` condition works properly.
+# Before, something like `if {x} is burning` would try to compare {x} to the burning damage cause
+# instead of whether or not the entity was burning.
 test "burning":
-	spawn a pig at event-location
-	set {_pig} to the last spawned pig
+	spawn a pig at event-location:
+		set {_pig} to entity
+
 	assert "burning" parsed as damage cause is burning with "burning damage cause compare"
-	set burning time of {_pig} to 9000 ticks
-	wait a tick
+
+	ignite {_pig}
 	assert entity within {_pig} is burning with "is burning failed"
 	assert {_pig} is burning with "is burning failed ##2"
-	clear entity within {_pig}
+
+	delete entity within {_pig}


### PR DESCRIPTION
### Description
This PR fixes Skript tests failing, due to a wait being used to allow the pig's fire ticks to update. Waits aren't allowed in tests, so now just uses the ignite effect.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
