### PR TITLE
Mod Material support, for Hybrid Server

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/Aliases.java
+++ b/src/main/java/ch/njol/skript/aliases/Aliases.java
@@ -403,7 +403,10 @@ public abstract class Aliases {
 		for (Material material : Material.values()) {
 			if (!material.isLegacy() && !provider.hasAliasForMaterial(material)) {
 				NamespacedKey key = material.getKey();
-				String name = key.getKey().replace("_", " ");
+				String name = (key.getNamespace().equals(NamespacedKey.MINECRAFT) ? key.getKey() : key.toString())
+								  .replace("_", " ");
+				// mod:an_item → mod:an item
+				// minecraft:dirt → dirt
 				parser.loadAlias(name + "¦s", key.toString());
 				Skript.debug(ChatColor.YELLOW + "Creating temporary alias for: " + key);
 			}

--- a/src/main/java/ch/njol/skript/bukkitutil/BukkitUnsafe.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/BukkitUnsafe.java
@@ -70,7 +70,10 @@ public class BukkitUnsafe {
 
 	@Nullable
 	public static Material getMaterialFromMinecraftId(String id) {
-		return Material.matchMaterial(id);
+		return Material.matchMaterial(id.toLowerCase().startsWith("minecraft:")
+										  ? id
+										  : id.replace(":", "_")  //For Hybrid Server
+		);
 	}
 
 	public static void modifyItemStack(ItemStack stack, String arguments) {


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
As title, support for items which added by mods
#7121 
①
```
on enchant:
    if event-item is cataclysm:the incinerator:
        send "success" to player
```
![b258fdd942e5bf2210428d7b21cdb3d9](https://github.com/user-attachments/assets/a771c20b-c277-4c10-a4de-be3fd0bd753e)


②
```
on right click:
    send "%type of tool of player%" to player
```
![63134e0a5c43b268706222ad750c48d0](https://github.com/user-attachments/assets/7c03efb8-761b-48aa-b196-c6cbc3866a78)


The pattern just like: `mod:an_item_name_with_line` (parsed to alias)→ `mod:an item name with line`
And vanilla aliases are not changed. `minecraft:dirt` → `dirt`
---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
