### PR TITLE
Parse-time simplifying

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/arithmetic/ExprArithmetic.java
+++ b/src/main/java/ch/njol/skript/expressions/arithmetic/ExprArithmetic.java
@@ -24,11 +24,8 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
-import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.Literal;
+import ch.njol.skript.lang.*;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.skript.lang.UnparsedLiteral;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.skript.lang.util.SimpleLiteral;
 import ch.njol.skript.registrations.Classes;
@@ -37,6 +34,7 @@ import ch.njol.skript.util.Patterns;
 import ch.njol.util.Kleenean;
 import com.google.common.collect.ImmutableSet;
 import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.arithmetic.Arithmetics;
 import org.skriptlang.skript.lang.arithmetic.OperationInfo;
@@ -55,7 +53,7 @@ import java.util.Collection;
 	"message \"You have %health of player * 2% half hearts of HP!\""})
 @Since("1.4.2")
 @SuppressWarnings("null")
-public class ExprArithmetic<L, R, T> extends SimpleExpression<T> {
+public class ExprArithmetic<L, R, T> extends SimpleExpression<T> implements Simplifiable<T> {
 
 	private static final Class<?>[] INTEGER_CLASSES = {Long.class, Integer.class, Short.class, Byte.class};
 
@@ -365,10 +363,11 @@ public class ExprArithmetic<L, R, T> extends SimpleExpression<T> {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public Expression<? extends T> simplify() {
+	public @NotNull Expression<? extends T> simplified() {
 		if (first instanceof Literal && second instanceof Literal)
+			//noinspection unchecked
 			return new SimpleLiteral<>(getArray(null), (Class<T>) getReturnType(), false);
+
 		return this;
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/base/PropertyExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/PropertyExpression.java
@@ -18,7 +18,9 @@
  */
 package ch.njol.skript.expressions.base;
 
+import ch.njol.skript.lang.Simplifiable;
 import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import ch.njol.skript.Skript;
@@ -40,7 +42,7 @@ import java.util.Arrays;
  * @see SimplePropertyExpression
  * @see #register(Class, Class, String, String)
  */
-public abstract class PropertyExpression<F, T> extends SimpleExpression<T> {
+public abstract class PropertyExpression<F, T> extends SimpleExpression<T> implements Simplifiable<T> {
 
 	/**
 	 * Registers an expression as {@link ExpressionType#PROPERTY} with the two default property patterns "property of %types%" and "%types%'[s] property"
@@ -130,8 +132,10 @@ public abstract class PropertyExpression<F, T> extends SimpleExpression<T> {
 	}
 
 	@Override
-	public Expression<? extends T> simplify() {
-		expr = expr.simplify();
+	public @NotNull Expression<? extends T> simplified() {
+		if (expr instanceof Simplifiable<?> simplifiable)
+			//noinspection unchecked
+			expr = (Expression<? extends F>) simplifiable.simplified();
 		return this;
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/base/WrapperExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/WrapperExpression.java
@@ -142,7 +142,7 @@ public abstract class WrapperExpression<T> extends SimpleExpression<T> implement
 	public @NotNull Expression<? extends T> simplified() {
 		return expr;
 	}
-	
+
 	@Override
 	@Nullable
 	public Object[] beforeChange(Expression<?> changed, @Nullable Object[] delta) {

--- a/src/main/java/ch/njol/skript/expressions/base/WrapperExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/WrapperExpression.java
@@ -20,12 +20,14 @@ package ch.njol.skript.expressions.base;
 
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.Simplifiable;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.SyntaxElement;
 import ch.njol.skript.lang.util.ConvertedExpression;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.converter.ConverterInfo;
 import org.skriptlang.skript.lang.converter.Converters;
@@ -39,7 +41,7 @@ import java.util.Iterator;
  * 
  * @author Peter Güttinger
  */
-public abstract class WrapperExpression<T> extends SimpleExpression<T> {
+public abstract class WrapperExpression<T> extends SimpleExpression<T> implements Simplifiable<T> {
 	
 	private Expression<? extends T> expr;
 	
@@ -137,7 +139,7 @@ public abstract class WrapperExpression<T> extends SimpleExpression<T> {
 	}
 	
 	@Override
-	public Expression<? extends T> simplify() {
+	public @NotNull Expression<? extends T> simplified() {
 		return expr;
 	}
 	

--- a/src/main/java/ch/njol/skript/lang/Expression.java
+++ b/src/main/java/ch/njol/skript/lang/Expression.java
@@ -286,18 +286,6 @@ public interface Expression<T> extends SyntaxElement, Debuggable {
 	Expression<?> getSource();
 
 	/**
-	 * Simplifies the expression, e.g. if it only contains literals the expression may be simplified to a literal, and wrapped expressions are unwrapped.
-	 * <p>
-	 * After this method was used the toString methods are likely not useful anymore.
-	 * <p>
-	 * This method is not yet used but will be used to improve efficiency in the future.
-	 * 
-	 * @return A reference to a simpler version of this expression. Can change this expression directly and return itself if applicable, i.e. no references to the expression before
-	 *         this method call should be kept!
-	 */
-	Expression<? extends T> simplify();
-
-	/**
 	 * Tests whether this expression supports the given mode, and if yes what type it expects the <code>delta</code> to be.
 	 * <p>
 	 * <b>Use {@link ChangerUtils#acceptsChange(Expression, ChangeMode, Class...)} to test whether an expression supports changing</b>, don't directly use this method!

--- a/src/main/java/ch/njol/skript/lang/ExpressionList.java
+++ b/src/main/java/ch/njol/skript/lang/ExpressionList.java
@@ -305,8 +305,10 @@ public class ExpressionList<T> implements Expression<T>, Simplifiable<T> {
 		boolean isSimpleList = true;
 		for (int i = 0; i < expressions.length; i++) {
 			Expression<? extends T> expression = expressions[i];
-			if (expression instanceof Simplifiable<?> simplifiable)
-				expressions[i] = ((Simplifiable<? extends T>) simplifiable).simplified();
+			if (expression instanceof Simplifiable<?> simplifiable) {
+				expression = ((Simplifiable<? extends T>) simplifiable).simplified();
+				expressions[i] = expression;
+			}
 
 			isLiteralList &= expression instanceof Literal;
 			isSimpleList &= expression.isSingle();

--- a/src/main/java/ch/njol/skript/lang/ExpressionList.java
+++ b/src/main/java/ch/njol/skript/lang/ExpressionList.java
@@ -306,7 +306,7 @@ public class ExpressionList<T> implements Expression<T>, Simplifiable<T> {
 		for (int i = 0; i < expressions.length; i++) {
 			Expression<? extends T> expression = expressions[i];
 			if (expression instanceof Simplifiable<?> simplifiable) {
-				expression = ((Simplifiable<? extends T>) simplifiable).simplified();
+				expression = (Expression<? extends T>) simplifiable.simplified();
 				expressions[i] = expression;
 			}
 

--- a/src/main/java/ch/njol/skript/lang/ExpressionList.java
+++ b/src/main/java/ch/njol/skript/lang/ExpressionList.java
@@ -31,11 +31,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.NoSuchElementException;
+import java.util.*;
 
 /**
  * A list of expressions.

--- a/src/main/java/ch/njol/skript/lang/LiteralList.java
+++ b/src/main/java/ch/njol/skript/lang/LiteralList.java
@@ -20,6 +20,7 @@ package ch.njol.skript.lang;
 
 import ch.njol.skript.lang.util.SimpleLiteral;
 import ch.njol.skript.registrations.Classes;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Array;
@@ -81,8 +82,7 @@ public class LiteralList<T> extends ExpressionList<T> implements Literal<T> {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public Expression<T> simplify() {
+	public @NotNull Expression<? extends T> simplified() {
 		boolean isSimpleList = true;
 		for (Expression<? extends T> expression : expressions)
 			isSimpleList &= expression.isSingle();

--- a/src/main/java/ch/njol/skript/lang/Simplifiable.java
+++ b/src/main/java/ch/njol/skript/lang/Simplifiable.java
@@ -1,0 +1,20 @@
+package ch.njol.skript.lang;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Represents an expression that can be simplified to a {@link Literal} at parse-time.
+ *
+ * @param <T> The type of the literal.
+ */
+@FunctionalInterface
+public interface Simplifiable<T> {
+
+    /**
+     * Simplifies the expression to a {@link Literal} at parse-time.
+     *
+     * @return the simplified expression if it can be simplified
+     */
+    @NotNull Expression<? extends T> simplified();
+
+}

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -754,6 +754,9 @@ public class SkriptParser {
 			Expression<?> parsedExpression = parseSingleExpr(true, null, exprInfo);
 			if (parsedExpression != null) {
 				log.printLog();
+
+				if (parsedExpression instanceof Simplifiable<?> simplifiable)
+					return simplifiable.simplified();
 				return parsedExpression;
 			}
 			log.clear();
@@ -784,7 +787,11 @@ public class SkriptParser {
 			if (pieces.size() == 1) { // not a list of expressions, and a single one has failed to parse above
 				if (expr.startsWith("(") && expr.endsWith(")") && next(expr, 0, context) == expr.length()) {
 					log.clear();
-					return new SkriptParser(this, "" + expr.substring(1, expr.length() - 1)).parseExpression(exprInfo);
+
+					Expression<?> expression = new SkriptParser(this, expr.substring(1, expr.length() - 1)).parseExpression(exprInfo);
+					if (expression instanceof Simplifiable<?> simplifiable)
+						return simplifiable.simplified();
+					return expression;
 				}
 				if (isObject && (flags & PARSE_LITERALS) != 0) { // single expression - can return an UnparsedLiteral now
 					log.clear();
@@ -867,11 +874,12 @@ public class SkriptParser {
 
 			if (isLiteralList) {
 				Literal<?>[] literals = parsedExpressions.toArray(new Literal[parsedExpressions.size()]);
-				return new LiteralList(literals, Classes.getSuperClassInfo(exprReturnTypes).getC(), exprReturnTypes, !and.isFalse());
+				return new LiteralList(literals, Classes.getSuperClassInfo(exprReturnTypes).getC(), exprReturnTypes, !and.isFalse())
+					.simplified();
 			} else {
 				Expression<?>[] expressions = parsedExpressions.toArray(new Expression[parsedExpressions.size()]);
-				return new ExpressionList(expressions, Classes.getSuperClassInfo(exprReturnTypes).getC(), exprReturnTypes, !and.isFalse());
-
+				return new ExpressionList(expressions, Classes.getSuperClassInfo(exprReturnTypes).getC(), exprReturnTypes, !and.isFalse())
+					.simplified();
 			}
 		}
 	}

--- a/src/main/java/ch/njol/skript/lang/UnparsedLiteral.java
+++ b/src/main/java/ch/njol/skript/lang/UnparsedLiteral.java
@@ -130,11 +130,6 @@ public class UnparsedLiteral implements Literal<Object> {
 		return true;
 	}
 
-	@Override
-	public Expression<?> simplify() {
-		return this;
-	}
-
 	private static SkriptAPIException invalidAccessException() {
 		return new SkriptAPIException("UnparsedLiterals must be converted before use");
 	}

--- a/src/main/java/ch/njol/skript/lang/Variable.java
+++ b/src/main/java/ch/njol/skript/lang/Variable.java
@@ -689,9 +689,4 @@ public class Variable<T> implements Expression<T> {
 		return source == null ? this : source;
 	}
 
-	@Override
-	public Expression<? extends T> simplify() {
-		return this;
-	}
-
 }

--- a/src/main/java/ch/njol/skript/lang/VariableString.java
+++ b/src/main/java/ch/njol/skript/lang/VariableString.java
@@ -737,9 +737,4 @@ public class VariableString implements Expression<String> {
 		return expression;
 	}
 
-	@Override
-	public Expression<String> simplify() {
-		return this;
-	}
-
 }

--- a/src/main/java/ch/njol/skript/lang/util/ConvertedExpression.java
+++ b/src/main/java/ch/njol/skript/lang/util/ConvertedExpression.java
@@ -22,12 +22,14 @@ import ch.njol.skript.classes.Changer;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.Simplifiable;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.util.Checker;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.converter.Converter;
 import org.skriptlang.skript.lang.converter.ConverterInfo;
@@ -51,7 +53,7 @@ import java.util.stream.Collectors;
  *
  * @author Peter Güttinger
  */
-public class ConvertedExpression<F, T> implements Expression<T> {
+public class ConvertedExpression<F, T> implements Expression<T>, Simplifiable<T> {
 
 	protected Expression<? extends F> source;
 	protected Class<T> to;
@@ -279,11 +281,15 @@ public class ConvertedExpression<F, T> implements Expression<T> {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public Expression<? extends T> simplify() {
-		Expression<? extends T> convertedExpression = source.simplify().getConvertedExpression(to);
+	public @NotNull Expression<? extends T> simplified() {
+		if (!(source instanceof Simplifiable<?> simplifiable))
+			return this;
+
+		//noinspection unchecked
+		Expression<? extends T> convertedExpression = simplifiable.simplified().getConvertedExpression(to);
 		if (convertedExpression != null)
 			return convertedExpression;
+
 		return this;
 	}
 

--- a/src/main/java/ch/njol/skript/lang/util/SimpleExpression.java
+++ b/src/main/java/ch/njol/skript/lang/util/SimpleExpression.java
@@ -368,11 +368,6 @@ public abstract class SimpleExpression<T> implements Expression<T> {
 	}
 
 	@Override
-	public Expression<? extends T> simplify() {
-		return this;
-	}
-
-	@Override
 	public boolean getAnd() {
 		return true;
 	}

--- a/src/main/java/ch/njol/skript/lang/util/SimpleLiteral.java
+++ b/src/main/java/ch/njol/skript/lang/util/SimpleLiteral.java
@@ -241,9 +241,4 @@ public class SimpleLiteral<T> implements Literal<T>, DefaultExpression<T> {
 		return source == null ? this : source;
 	}
 
-	@Override
-	public Expression<T> simplify() {
-		return this;
-	}
-
 }

--- a/src/main/java/ch/njol/skript/util/Direction.java
+++ b/src/main/java/ch/njol/skript/util/Direction.java
@@ -434,7 +434,7 @@ public class Direction implements YggdrasilRobustSerializable {
 		return false;
 	}
 
-	private static class LocationExpression extends SimpleExpression<Location> {
+	private static class LocationExpression extends SimpleExpression<Location> implements Simplifiable<Location> {
 		private final Expression<? extends Direction> dirs;
 		private final Expression<? extends Location> locs;
 
@@ -492,6 +492,14 @@ public class Direction implements YggdrasilRobustSerializable {
 		@Override
 		public String toString(@Nullable Event event, boolean debug) {
 			return dirs.toString(event, debug) + " " + locs.toString(event, debug);
+		}
+
+		@Override
+		public @NotNull Expression<? extends Location> simplified() {
+			if (dirs instanceof Literal<?> literal && dirs.isSingle() && Direction.ZERO.equals(literal.getSingle())) {
+				return locs;
+			}
+			return this;
 		}
 	}
 }

--- a/src/main/java/ch/njol/skript/util/Direction.java
+++ b/src/main/java/ch/njol/skript/util/Direction.java
@@ -434,7 +434,7 @@ public class Direction implements YggdrasilRobustSerializable {
 		return false;
 	}
 
-	private static class LocationExpression extends SimpleExpression<Location> implements Simplifiable<Location> {
+	private static class LocationExpression extends SimpleExpression<Location> {
 		private final Expression<? extends Direction> dirs;
 		private final Expression<? extends Location> locs;
 
@@ -443,45 +443,44 @@ public class Direction implements YggdrasilRobustSerializable {
 			this.locs = locs;
 		}
 
-		@SuppressWarnings("null")
 		@Override
-		protected Location[] get(final Event e) {
-			final Direction[] ds = dirs.getArray(e);
-			final Location[] ls = locs.getArray(e);
-			final Location[] r = ls; //ds.length == 1 ? ls : new Location[ds.length * ls.length];
-			for (int i = 0; i < ds.length; i++) {
-				for (int j = 0; j < ls.length; j++) {
-//						r[i + j * ds.length] = ds[i].getRelative(ls[j]);
-					r[j] = ds[i].getRelative(r[j]);
-				}
-			}
-			return r;
+		public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+			throw new UnsupportedOperationException();
 		}
 
 		@SuppressWarnings("null")
 		@Override
-		public Location[] getAll(final Event e) {
-			final Direction[] ds = dirs.getAll(e);
-			final Location[] ls = locs.getAll(e);
-			final Location[] r = ls; //ds.length == 1 ? ls : new Location[ds.length * ls.length];
-			for (int i = 0; i < ds.length; i++) {
-				for (int j = 0; j < ls.length; j++) {
-//						r[i + j * ds.length] = ds[i].getRelative(ls[j]);
-					r[j] = ds[i].getRelative(r[j]);
+		protected Location[] get(Event event) {
+			Direction[] directions = dirs.getArray(event);
+			Location[] locations = locs.getArray(event);
+			for (Direction direction : directions) {
+				for (int i = 0; i < locations.length; i++) {
+					locations[i] = direction.getRelative(locations[i]);
 				}
 			}
-			return r;
+			return locations;
+		}
+
+		@SuppressWarnings("null")
+		@Override
+		public Location[] getAll(Event event) {
+			Direction[] directions = dirs.getAll(event);
+			Location[] locations = locs.getAll(event);
+			for (Direction direction : directions) {
+				for (int i = 0; i < locations.length; i++) {
+					locations[i] = direction.getRelative(locations[i]);
+				}
+			}
+			return locations;
 		}
 
 		@Override
 		public boolean getAnd() {
-//				return (dirs.isSingle() || dirs.getAnd()) && (locs.isSingle() || locs.getAnd());
 			return locs.getAnd();
 		}
 
 		@Override
 		public boolean isSingle() {
-//				return dirs.isSingle() && locs.isSingle();
 			return locs.isSingle();
 		}
 
@@ -491,21 +490,8 @@ public class Direction implements YggdrasilRobustSerializable {
 		}
 
 		@Override
-		public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public String toString(final @Nullable Event e, final boolean debug) {
-			return dirs.toString(e, debug) + " " + locs.toString(e, debug);
-		}
-
-		@Override
-		public @NotNull Expression<? extends Location> simplified() {
-			if (dirs instanceof Literal && dirs.isSingle() && Direction.ZERO.equals(((Literal<?>) dirs).getSingle())) {
-				return locs;
-			}
-			return this;
+		public String toString(@Nullable Event event, boolean debug) {
+			return dirs.toString(event, debug) + " " + locs.toString(event, debug);
 		}
 	}
 }

--- a/src/test/skript/tests/misc/parse time simplifying.sk
+++ b/src/test/skript/tests/misc/parse time simplifying.sk
@@ -1,0 +1,2 @@
+test "parse time simplifying":
+	assert 10 - 3 - 2 - 1 - (1 + 3 * 4) = -9 with "chained math failed"

--- a/src/test/skript/tests/regressions/pull-5566-block iterator being 100 always.sk
+++ b/src/test/skript/tests/regressions/pull-5566-block iterator being 100 always.sk
@@ -1,5 +1,6 @@
 
 # Test not related to a made issue. Details at pull request.
 test "100 blocks fix":
+	set block at spawn of world "world" to air
 	assert blocks 5 below spawn of world "world" contains air, grass block, dirt block, dirt block, bedrock block and void air with "Failed to get correct blocks (got '%blocks 5 below spawn of world "world"%')"
 	assert size of blocks 3 below location below spawn of world "world" is 4 with "Failed to match asserted size"


### PR DESCRIPTION
### Description
- Removes `Expression#simplify` and adds new `Simplifiable` interface
- Removes simplify from classes that cannot be simplified

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
