### PR TITLE
Adds basic 1.21.3 support.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 	shadow group: 'org.bstats', name: 'bstats-bukkit', version: '3.0.2'
 	shadow group: 'net.kyori', name: 'adventure-text-serializer-bungeecord', version: '4.3.2'
 
-	implementation group: 'io.papermc.paper', name: 'paper-api', version: '1.21-R0.1-SNAPSHOT'
+	implementation group: 'io.papermc.paper', name: 'paper-api', version: '1.21.3-R0.1-SNAPSHOT'
 	implementation group: 'com.google.code.findbugs', name: 'findbugs', version: '3.0.1'
 	implementation group: 'com.sk89q.worldguard', name: 'worldguard-legacy', version: '7.0.0-SNAPSHOT'
 	implementation group: 'net.milkbowl.vault', name: 'Vault', version: '1.7.3', {
@@ -240,7 +240,7 @@ def java21 = 21
 def java17 = 17
 def java11 = 11
 
-def latestEnv = 'java21/paper-1.21.0.json'
+def latestEnv = 'java21/paper-1.21.3.json'
 def latestJava = java21
 def oldestJava = java11
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ groupid=ch.njol
 name=skript
 version=2.9.3
 jarName=Skript.jar
-testEnv=java21/paper-1.21.0
+testEnv=java21/paper-1.21.3
 testEnvJavaVersion=21

--- a/src/main/java/ch/njol/skript/entity/BoatChestData.java
+++ b/src/main/java/ch/njol/skript/entity/BoatChestData.java
@@ -19,25 +19,41 @@
 package ch.njol.skript.entity;
 
 import ch.njol.skript.Skript;
-import ch.njol.skript.aliases.Aliases;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser;
 import org.bukkit.Material;
 import org.bukkit.TreeSpecies;
 import org.bukkit.entity.ChestBoat;
-import org.bukkit.inventory.ItemStack;
+import org.bukkit.entity.boat.AcaciaChestBoat;
+import org.bukkit.entity.boat.BirchChestBoat;
+import org.bukkit.entity.boat.DarkOakChestBoat;
+import org.bukkit.entity.boat.JungleChestBoat;
+import org.bukkit.entity.boat.OakChestBoat;
+import org.bukkit.entity.boat.SpruceChestBoat;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.EnumMap;
 import java.util.Random;
 
 public class BoatChestData extends EntityData<ChestBoat> {
+
+	private static final EnumMap<TreeSpecies, Class<? extends ChestBoat>> typeToClassMap = new EnumMap<>(TreeSpecies.class);
+	private static final boolean IS_RUNNING_1_21_3 = Skript.isRunningMinecraft(1, 21, 3);
 
 	static {
 		if (Skript.classExists("org.bukkit.entity.ChestBoat")) {
 			EntityData.register(BoatChestData.class, "chest boat", ChestBoat.class, 0,
 				"chest boat", "any chest boat", "oak chest boat", "spruce chest boat", "birch chest boat",
 				"jungle chest boat", "acacia chest boat", "dark oak chest boat");
+			if (IS_RUNNING_1_21_3) {
+				typeToClassMap.put(TreeSpecies.GENERIC, OakChestBoat.class);
+				typeToClassMap.put(TreeSpecies.REDWOOD, SpruceChestBoat.class);
+				typeToClassMap.put(TreeSpecies.BIRCH, BirchChestBoat.class);
+				typeToClassMap.put(TreeSpecies.JUNGLE, JungleChestBoat.class);
+				typeToClassMap.put(TreeSpecies.ACACIA, AcaciaChestBoat.class);
+				typeToClassMap.put(TreeSpecies.DARK_OAK, DarkOakChestBoat.class);
+			}
 		}
 	}
 
@@ -80,6 +96,8 @@ public class BoatChestData extends EntityData<ChestBoat> {
 
 	@Override
 	public Class<? extends ChestBoat> getType() {
+		if (IS_RUNNING_1_21_3)
+			return typeToClassMap.get(TreeSpecies.values()[matchedPattern - 2]);
 		return ChestBoat.class;
 	}
 

--- a/src/main/java/ch/njol/skript/entity/BoatData.java
+++ b/src/main/java/ch/njol/skript/entity/BoatData.java
@@ -18,30 +18,43 @@
  */
 package ch.njol.skript.entity;
 
-import java.lang.reflect.Method;
-import java.util.Random;
-
-import org.bukkit.Material;
-import org.bukkit.TreeSpecies;
-import org.bukkit.entity.Boat;
-import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.Nullable;
-
 import ch.njol.skript.Skript;
-import ch.njol.skript.aliases.Aliases;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
+import org.bukkit.Material;
+import org.bukkit.TreeSpecies;
+import org.bukkit.entity.Boat;
+import org.bukkit.entity.boat.AcaciaBoat;
+import org.bukkit.entity.boat.BirchBoat;
+import org.bukkit.entity.boat.DarkOakBoat;
+import org.bukkit.entity.boat.JungleBoat;
+import org.bukkit.entity.boat.OakBoat;
+import org.bukkit.entity.boat.SpruceBoat;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.EnumMap;
+import java.util.Random;
 
 public class BoatData extends EntityData<Boat> {
+
+	private static final EnumMap<TreeSpecies, Class<? extends Boat>> typeToClassMap = new EnumMap<>(TreeSpecies.class);
+	private static final boolean IS_RUNNING_1_21_3 = Skript.isRunningMinecraft(1, 21, 3);
+
 	static {
-		// It will only register for 1.10+,
-		// See SimpleEntityData if 1.9 or lower.
-		if (Skript.methodExists(Boat.class, "getWoodType")) { //The 'boat' is the same of 'oak boat', 'any boat' works as supertype and it can spawn random boat.
-			EntityData.register(BoatData.class, "boat", Boat.class, 0,
-					"boat", "any boat", "oak boat", "spruce boat", "birch boat", "jungle boat", "acacia boat", "dark oak boat");
+		EntityData.register(BoatData.class, "boat", Boat.class, 0,
+				"boat", "any boat", "oak boat", "spruce boat", "birch boat", "jungle boat", "acacia boat", "dark oak boat");
+		if (IS_RUNNING_1_21_3) {
+			typeToClassMap.put(TreeSpecies.GENERIC, OakBoat.class);
+			typeToClassMap.put(TreeSpecies.REDWOOD, SpruceBoat.class);
+			typeToClassMap.put(TreeSpecies.BIRCH, BirchBoat.class);
+			typeToClassMap.put(TreeSpecies.JUNGLE, JungleBoat.class);
+			typeToClassMap.put(TreeSpecies.ACACIA, AcaciaBoat.class);
+			typeToClassMap.put(TreeSpecies.DARK_OAK, DarkOakBoat.class);
 		}
 	}
+
+
 	
 	public BoatData(){
 		this(0);
@@ -83,6 +96,8 @@ public class BoatData extends EntityData<Boat> {
 
 	@Override
 	public Class<? extends Boat> getType() {
+		if (IS_RUNNING_1_21_3)
+			return typeToClassMap.get(TreeSpecies.values()[matchedPattern - 2]);
 		return Boat.class;
 	}
 
@@ -129,4 +144,5 @@ public class BoatData extends EntityData<Boat> {
 		return hashCode_i() == ordinal + 2 || (matchedPattern + ordinal == 0) || ordinal == 0;
 		
 	}
+
 }

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -2237,8 +2237,8 @@ attribute types:
 	player.sneaking_speed: player sneaking speed, sneaking speed
 	player.submerged_mining_speed: player submerged mining speed, submerged mining speed
 	player.sweeping_damage_ratio: player sweeping damage ratio, sweeping damage ratio
-	zombie.spawn_reinforcements: zombie spawn reinforcementsgeneric.armor: generic armor, armor
-	# 1.21.3 removes prefixes, adds armor and tempt range
+	zombie.spawn_reinforcements: zombie spawn reinforcements
+	# 1.21.3 removes prefixes, adds tempt range
 	armor: generic armor, armor
 	armor_toughness: generic armor toughness, armor toughness
 	attack_damage: generic attack damage, attack damage

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -274,6 +274,8 @@ biomes:
 	deep_dark: deep dark
 	# 1.19.4
 	cherry_grove: cherry grove
+	# 1.21.3
+	pale_garden: pale garden
 
 # -- Tree Types --
 tree types:
@@ -2235,7 +2237,40 @@ attribute types:
 	player.sneaking_speed: player sneaking speed, sneaking speed
 	player.submerged_mining_speed: player submerged mining speed, submerged mining speed
 	player.sweeping_damage_ratio: player sweeping damage ratio, sweeping damage ratio
-	zombie.spawn_reinforcements: zombie spawn reinforcements
+	zombie.spawn_reinforcements: zombie spawn reinforcementsgeneric.armor: generic armor, armor
+	# 1.21.3 removes prefixes, adds armor and tempt range
+	armor: generic armor, armor
+	armor_toughness: generic armor toughness, armor toughness
+	attack_damage: generic attack damage, attack damage
+	attack_knockback: generic attack knockback, attack knockback
+	attack_speed: generic attack speed, attack speed
+	burning_time: generic burning time, burning time
+	explosion_knockback_resistance: generic explosion knockback resistance, explosion knockback resistance
+	flying_speed: generic flying speed, flying speed
+	follow_range: generic follow range, follow range
+	gravity: generic gravity, gravity
+	jump_strength: generic jump strength, jump strength, horse jump strength
+	knockback_resistance: generic knockback resistance, knockback resistance
+	luck: generic luck, luck
+	max_absorption: generic max absorption, max absorption
+	max_health: generic max health, max health
+	movement_efficiency: generic movement efficiency, movement efficiency
+	movement_speed: generic movement speed, movement speed
+	oxygen_bonus: generic oxygen bonus, oxygen bonus
+	safe_fall_distance: generic safe fall distance, safe fall distance
+	fall_damage_multiplier: generic fall damage multiplier, fall damage multiplier
+	scale: generic scale, scale
+	step_height: generic step height, step height
+	tempt_range: generic tempt range, tempt range
+	water_movement_efficiency: generic water movement efficiency, water movement efficiency
+	block_break_speed: player block break speed, block break speed
+	block_interaction_range: player block interaction range, block interaction range
+	entity_interaction_range: player entity interaction range, entity interaction range
+	mining_efficiency: player mining efficiency, mining efficiency
+	sneaking_speed: player sneaking speed, sneaking speed
+	submerged_mining_speed: player submerged mining speed, submerged mining speed
+	sweeping_damage_ratio: player sweeping damage ratio, sweeping damage ratio
+	spawn_reinforcements: zombie spawn reinforcements
 
 # -- Environments --
 environments:

--- a/src/test/skript/environments/java21/paper-1.21.3.json
+++ b/src/test/skript/environments/java21/paper-1.21.3.json
@@ -1,11 +1,11 @@
 {
-	"name": "paper-1.21.0",
+	"name": "paper-1.21.3",
 	"resources": [
 		{"source": "server.properties.generic", "target": "server.properties"}
 	],
 	"paperDownloads": [
 		{
-			"version": "1.21",
+			"version": "1.21.3",
 			"target": "paperclip.jar"
 		}
 	],

--- a/src/test/skript/tests/syntaxes/effects/EffHealth.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffHealth.sk
@@ -10,14 +10,12 @@ test "health effect":
 	spawn cow at location(0, 64, 0, world "world")
 	set {_m} to last spawned cow
 	assert health of {_m} is 5 with "default cow health failed"
-	damage {_m} by 0.5
-	assert health of {_m} is 4.5 with "damage cow failed"
-	damage {_m} by 99
-	assert health of {_m} is 0 with "damage cow failed"
+	damage {_m} by 3
+	assert health of {_m} is 2 with "damage cow failed"
 	heal {_m} by 1
-	assert health of {_m} is 1 with "heal cow failed"
+	assert health of {_m} is 3 with "heal cow failed"
 	heal {_m} by 0.5
-	assert health of {_m} is 1.5 with "heal cow failed"
+	assert health of {_m} is 3.5 with "heal cow failed"
 	heal {_m} by 99
 	assert health of {_m} is 5 with "heal cow failed"
 	clear all entities


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Fixes issue with spawning boats (though boats are still buggy and will be fixed in 2.10).
Bumps tests to 1.21.3, fixes issue with cow health test.
Adds new variants to attribute types lang file, apparently all the registry fields were renamed. 1 new one was added.
Adds pale garden to biome lang entry.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
