### PR TITLE
Arithmetic Private Methods Changed to Public

### DIFF
--- a/src/main/java/org/skriptlang/skript/lang/arithmetic/Arithmetics.java
+++ b/src/main/java/org/skriptlang/skript/lang/arithmetic/Arithmetics.java
@@ -72,7 +72,7 @@ public final class Arithmetics {
 		getOperations_i(operator).add(new OperationInfo<>(leftClass, rightClass, returnType, operation));
 	}
 
-	private static boolean exactOperationExists(Operator operator, Class<?> leftClass, Class<?> rightClass) {
+	public static boolean exactOperationExists(Operator operator, Class<?> leftClass, Class<?> rightClass) {
 		for (OperationInfo<?, ?, ?> info : getOperations_i(operator)) {
 			if (info.getLeft() == leftClass && info.getRight() == rightClass)
 				return true;

--- a/src/main/java/org/skriptlang/skript/lang/arithmetic/Arithmetics.java
+++ b/src/main/java/org/skriptlang/skript/lang/arithmetic/Arithmetics.java
@@ -188,7 +188,7 @@ public final class Arithmetics {
 		differences.put(type, new DifferenceInfo<>(type, returnType, operation));
 	}
 
-	private static boolean exactDifferenceExists(Class<?> type) {
+	public static boolean exactDifferenceExists(Class<?> type) {
 		return differences.containsKey(type);
 	}
 


### PR DESCRIPTION
### Description
This PR aims to change the `exactOperationExists` method within the `Arithmetic` class allowing skript-addons to ensure an operation does or does not already exist if registered by another addon.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7206 <!-- Links to related issues -->
