### PR TITLE
Fix EffContinue

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffContinue.java
+++ b/src/main/java/ch/njol/skript/effects/EffContinue.java
@@ -73,10 +73,6 @@ public class EffContinue extends Effect {
 
 	@Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		level = matchedPattern == 0 ? 1 : Integer.parseInt(parseResult.regexes.get(0).group());
-		if (level < 1)
-			return false;
-
 		ParserInstance parser = getParser();
 		int loops = parser.getCurrentSections(LoopSection.class).size();
 		if (loops == 0) {
@@ -84,8 +80,12 @@ public class EffContinue extends Effect {
 			return false;
 		}
 
-		// Section.getSections counts from the innermost section, so we need to invert the level 
-		int levels = level == -1 ? 1 : loops - level + 1;
+		level = matchedPattern == 0 ? loops : Integer.parseInt(parseResult.regexes.get(0).group());
+		if (level < 1)
+			return false;
+
+		// ParserInstance#getSections counts from the innermost section, so we need to invert the level 
+		int levels = loops - level + 1;
 		if (levels <= 0) {
 			Skript.error("Can't continue the " + StringUtils.fancyOrderNumber(level) + " loop as there " +
 				(loops == 1 ? "is only 1 loop" : "are only " + loops + " loops") + " present");

--- a/src/test/skript/tests/syntaxes/effects/EffContinue.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffContinue.sk
@@ -19,3 +19,10 @@ test "continue effect":
 			assert loop-value-2 is not 15 with "leveled continue failed #2"
 			continue 1st loop if loop-value-1 is 10
 		assert loop-value is not 10 with "leveled continue failed #3"
+
+	set {_ran} to false
+	loop 10 times:
+		loop 10 times:
+			continue
+		set {_ran} to true
+	assert {_ran} is true with "continue in nested loop continued outermost loop"


### PR DESCRIPTION
### Description
This PR fixes a bug with `EffContinue` in 2.10 beta where `continue` (without specifying a loop) would continue the outermost loop rather than the innermost.

```applescript
loop x:
    loop y:
        # ...
        continue # Would continue 'loop x'
    # ... Doesn't run
```

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
