### PR TITLE
Add warning when pausing is enabled

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -489,6 +489,10 @@ public final class Skript extends JavaPlugin implements Listener {
 			classLoadError = e;
 		}
 
+		// Disable pausing
+		if (Skript.methodExists(Server.class, "allowPausing", Plugin.class, Boolean.class))
+			getServer().allowPausing(this, false);
+
 		// Config must be loaded after Java and Skript classes are parseable
 		// ... but also before platform check, because there is a config option to ignore some errors
 		SkriptConfig.load();

--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -489,9 +489,15 @@ public final class Skript extends JavaPlugin implements Listener {
 			classLoadError = e;
 		}
 
-		// Disable pausing
-		if (Skript.methodExists(Server.class, "allowPausing", Plugin.class, Boolean.class))
-			getServer().allowPausing(this, false);
+		// Warn about pausing
+		if (Skript.methodExists(Server.class, "getPauseWhenEmptyTime")) {
+			int pauseThreshold = getServer().getPauseWhenEmptyTime();
+			if (pauseThreshold > -1) {
+				Skript.warning("Server pausing is enabled!");
+				Skript.warning("Scripts may NOT execute correctly when the server is paused.");
+				Skript.warning("Set 'pause-when-empty-seconds' to -1 in server.properties to make sure you don't encounter any issues.");
+			}
+		}
 
 		// Config must be loaded after Java and Skript classes are parseable
 		// ... but also before platform check, because there is a config option to ignore some errors

--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -493,9 +493,9 @@ public final class Skript extends JavaPlugin implements Listener {
 		if (Skript.methodExists(Server.class, "getPauseWhenEmptyTime")) {
 			int pauseThreshold = getServer().getPauseWhenEmptyTime();
 			if (pauseThreshold > -1) {
-				Skript.warning("Server pausing is enabled!");
-				Skript.warning("Scripts that interact with the world or entities will not work when the server is paused and may crash your server.");
-				Skript.warning("Set 'pause-when-empty-seconds' to -1 in server.properties to make sure you don't encounter any issues.");
+				Skript.warning("Minecraft server pausing is enabled!");
+				Skript.warning("Scripts that interact with the world or entities may not work as intended when the server is paused and may crash your server.");
+				Skript.warning("Consider setting 'pause-when-empty-seconds' to -1 in server.properties to make sure you don't encounter any issues.");
 			}
 		}
 

--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -494,7 +494,7 @@ public final class Skript extends JavaPlugin implements Listener {
 			int pauseThreshold = getServer().getPauseWhenEmptyTime();
 			if (pauseThreshold > -1) {
 				Skript.warning("Server pausing is enabled!");
-				Skript.warning("Scripts may NOT execute correctly when the server is paused.");
+				Skript.warning("Scripts that interact with the world or entities will not work when the server is paused and may crash your server.");
 				Skript.warning("Set 'pause-when-empty-seconds' to -1 in server.properties to make sure you don't encounter any issues.");
 			}
 		}


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Minecraft recently added a feature where the server "pauses" when no players are online for a while, which disables world and entity ticking until a player comes back. This sounds good in theory, but can really mess with what plugins may expect when no players are online, it may also cause some saving/loading issues, which is why it's for the best to add a warning about pausing in the plugin.

Read more about what paper said about it [here](https://forums.papermc.io/threads/1-21-3.1430/)

(This also had to be directed to dev/feature because dev/patch isnt updated to 1.21.3)

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
