### PR TITLE
Add missing tree types to prevent EvtGrow causing errors.

### DIFF
--- a/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
@@ -314,7 +314,7 @@ public class ItemUtils {
 			TREE_TO_SAPLING_MAP.put(TreeType.CHERRY, Material.CHERRY_SAPLING);
 
 		// mega pine (2x2 spruce tree with minimal leaves at top)
-		if (Skript.isRunningMinecraft(1, 20,5))
+		if (Skript.isRunningMinecraft(1, 20, 5))
 			TREE_TO_SAPLING_MAP.put(TreeType.MEGA_PINE, Material.SPRUCE_SAPLING);
 
 		// pale oak

--- a/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
@@ -312,6 +312,16 @@ public class ItemUtils {
 		// cherry
 		if (Skript.isRunningMinecraft(1, 19, 4))
 			TREE_TO_SAPLING_MAP.put(TreeType.CHERRY, Material.CHERRY_SAPLING);
+
+		// mega pine (2x2 spruce tree with minimal leaves at top)
+		if (Skript.isRunningMinecraft(1, 20,5))
+			TREE_TO_SAPLING_MAP.put(TreeType.MEGA_PINE, Material.SPRUCE_SAPLING);
+
+		// pale oak
+		if (Skript.isRunningMinecraft(1, 21, 3)) {
+			TREE_TO_SAPLING_MAP.put(TreeType.PALE_OAK, Material.PALE_OAK_SAPLING);
+			TREE_TO_SAPLING_MAP.put(TreeType.PALE_OAK_CREAKING, Material.PALE_OAK_SAPLING);
+		}
 	}
 
 	public static Material getTreeSapling(TreeType treeType) {

--- a/src/test/java/org/skriptlang/skript/test/tests/regression/MissingTreeSaplingMapEntriesTest.java
+++ b/src/test/java/org/skriptlang/skript/test/tests/regression/MissingTreeSaplingMapEntriesTest.java
@@ -1,0 +1,17 @@
+package org.skriptlang.skript.test.tests.regression;
+
+import ch.njol.skript.bukkitutil.ItemUtils;
+import org.bukkit.TreeType;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MissingTreeSaplingMapEntriesTest {
+
+	@Test
+	public void test() {
+		for (TreeType type : TreeType.values()) {
+			Assert.assertNotNull("Tree type " + type + " has no mapped sapling in ItemUtils#getTreeSapling().", ItemUtils.getTreeSapling(type));
+		}
+	}
+
+}


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Also adds a test to catch this in the future.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
