### PR TITLE
Test - Update for MC 1.19+

### DIFF
--- a/src/main/resources/config.sk
+++ b/src/main/resources/config.sk
@@ -365,3 +365,8 @@ version: @version@
 # DO NOT CHANGE THIS VALUE MANUALLY!
 # This saves for which version of Skript this configuration was written for.
 # If it does not match the version of the .jar file then the config will be updated automatically.
+
+# This is only added to help tests pass
+# Server crashes otherwise
+# Will remove before PR is merged (please remind me before merging)
+backups to keep: -1

--- a/src/main/resources/config.sk
+++ b/src/main/resources/config.sk
@@ -365,8 +365,3 @@ version: @version@
 # DO NOT CHANGE THIS VALUE MANUALLY!
 # This saves for which version of Skript this configuration was written for.
 # If it does not match the version of the .jar file then the config will be updated automatically.
-
-# This is only added to help tests pass
-# Server crashes otherwise
-# Will remove before PR is merged (please remind me before merging)
-backups to keep: -1

--- a/src/test/skript/tests/misc/boats.sk
+++ b/src/test/skript/tests/misc/boats.sk
@@ -42,7 +42,7 @@ test "chest boats":
 			set {_a chest boat} to "a chest boat" parsed as entity type
 			set {_a chest boat item} to "a chest boat" parsed as item type
 			assert {_boat} is {_a chest boat} with "%loop-value% was not a chest boat"
-			assert {_boat} is {_a chest boat item} with "%loop-value% did not match a chest boat item"
+			#assert {_boat} is {_a chest boat item} with "%loop-value% did not match a chest boat item"
 
 			clear entity within {_boat}
 			clear {_boat}

--- a/src/test/skript/tests/misc/boats.sk
+++ b/src/test/skript/tests/misc/boats.sk
@@ -42,7 +42,7 @@ test "chest boats":
 			set {_a chest boat} to "a chest boat" parsed as entity type
 			set {_a chest boat item} to "a chest boat" parsed as item type
 			assert {_boat} is {_a chest boat} with "%loop-value% was not a chest boat"
-			#assert {_boat} is {_a chest boat item} with "%loop-value% did not match a chest boat item"
+			assert {_boat} is {_a chest boat item} with "%loop-value% did not match a chest boat item"
 
 			clear entity within {_boat}
 			clear {_boat}

--- a/src/test/skript/tests/misc/displaydata.sk
+++ b/src/test/skript/tests/misc/displaydata.sk
@@ -1,4 +1,4 @@
-test "display entity data" when running minecraft "1.19":
+test "display entity data":
 	spawn a text display at spawn of world "world":
 		set {_text} to entity
 

--- a/src/test/skript/tests/misc/displays.sk
+++ b/src/test/skript/tests/misc/displays.sk
@@ -1,4 +1,4 @@
-test "spawn displays" when running minecraft "1.19.4":
+test "spawn displays":
 	spawn a text display at spawn of world "world":
 		set {_display} to event-display
 	assert billboard of display within {_display} is "fixed" parsed as billboard with "default billboard was not fixed"

--- a/src/test/skript/tests/misc/registry.sk
+++ b/src/test/skript/tests/misc/registry.sk
@@ -1,4 +1,4 @@
-test "registry" when minecraft version is "1.14":
+test "registry":
 
 	# Test namespaced keys
 	assert curse of vanishing = minecraft:vanishing_curse with "'curse of vanishing' enchant should match namespace key"

--- a/src/test/skript/tests/regressions/2535-foxdata fixes.sk
+++ b/src/test/skript/tests/regressions/2535-foxdata fixes.sk
@@ -1,4 +1,4 @@
-test "fox EntityData fixes" when running minecraft "1.15.2":
+test "fox EntityData fixes":
 	spawn red fox at location(0, 64, 0, world "world")
 	spawn 3 snow foxes at location(0, 64, 0, world "world")
 	delete all foxes

--- a/src/test/skript/tests/regressions/2537-missing mooshroom variations in 1.14+.sk
+++ b/src/test/skript/tests/regressions/2537-missing mooshroom variations in 1.14+.sk
@@ -1,4 +1,4 @@
-test "mooshroom EntityData fixes" when running minecraft "1.15.2":
+test "mooshroom EntityData fixes":
 	spawn brown mooshroom at location(0, 64, 0, world "world")
 	spawn 3 red mooshrooms at location(0, 64, 0, world "world")
 	delete all mooshrooms

--- a/src/test/skript/tests/regressions/2625-villager comparisons.sk
+++ b/src/test/skript/tests/regressions/2625-villager comparisons.sk
@@ -1,4 +1,4 @@
-test "villager comparisons" when running minecraft "1.15.2":
+test "villager comparisons":
 	spawn cleric at location(0, 64, 0, world "world")
 	assert last spawned entity is a cleric with "comparison failed"
 	delete last spawned entity

--- a/src/test/skript/tests/regressions/3253-entitydata fixes.sk
+++ b/src/test/skript/tests/regressions/3253-entitydata fixes.sk
@@ -23,7 +23,6 @@ test "entity data fixes":
 	assert last spawned entity is an adult sheep with "last spawned entity should have been an adult sheep"
 	assert last spawned entity is an adult entity with "last spawned entity should have been an adult entity"
 
-test "entity data fixes - 1.16.5" when running minecraft "1.16.5":
 	spawn a baby piglin at test-location
 	assert last spawned entity is a baby piglin with "last spawned entity should have been a baby piglin"
 	assert last spawned entity is a baby entity with "last spawned entity should have been a baby entity"

--- a/src/test/skript/tests/regressions/3303-item durability.sk
+++ b/src/test/skript/tests/regressions/3303-item durability.sk
@@ -2,11 +2,3 @@ test "item durability":
 	set {_i} to a diamond sword
 	set durability of {_i} to 500
 	assert durability of {_i} != damage value of {_i} with "Durability of item should not equal damage value"
-
-test "block data value" when running below minecraft "1.13.2":
-	set test-block to farmland
-	set {_b} to block above test-block
-	set block at {_b} to fully grown wheat plant
-	assert data value of block at {_b} = 7 with "Data value of block should have been 7"
-	set data value of block at {_b} to 1
-	assert data value of block at {_b} = 1 with "Data value of block should have been 1"

--- a/src/test/skript/tests/regressions/4769-fire-visualeffect.sk
+++ b/src/test/skript/tests/regressions/4769-fire-visualeffect.sk
@@ -2,9 +2,12 @@ test "fire visual effect comparison":
 	assert a block is a block with "failed to compare block classinfo against block classinfo"
 	assert an itemtype is an itemtype with "failed to compare itemtype classinfo against itemtype classinfo"
 	assert a diamond is an itemtype with "failed to compare itemtype 'diamond' against itemtype classinfo"
+	set {_below} to type of block below block at spawn of world "world"
 	set {_block} to type of block at spawn of world "world"
-	set block at spawn of world "world" to fire
+	set block below block at spawn of world "world" to oak planks
+	set block at spawn of world "world" to fire[]
 	assert block at spawn of world "world" is fire with "failed to compare fire (itemtype) with a block"
+	set block below block at spawn of world "world" to {_below}
 	set block at spawn of world "world" to {_block}
 	play 5 fire at spawn of world "world"
 	assert "fire" parsed as visual effect is fire with "failed to compare visual effects"

--- a/src/test/skript/tests/regressions/4773-composter-the-imposter.sk
+++ b/src/test/skript/tests/regressions/4773-composter-the-imposter.sk
@@ -1,4 +1,4 @@
-test "composter the imposter" when running minecraft "1.14.4":
+test "composter the imposter":
 	set {_block} to type of test-block
 	set test-block to composter
 	assert test-block is composter with "failed to compare composter (itemtype) with a block"

--- a/src/test/skript/tests/regressions/5491-xp orb merge overwrite.sk
+++ b/src/test/skript/tests/regressions/5491-xp orb merge overwrite.sk
@@ -1,4 +1,4 @@
-test "spawn xp orb overwriting merged value" when running minecraft "1.14.4":
+test "spawn xp orb overwriting merged value":
 	# 1.13.2 seems not to merge xp orbs in the same way, so this test is skipped
 
 	# 1.21 also does not merge orbs, so this test is disabled.

--- a/src/test/skript/tests/regressions/7140-leather horse armor unequipable.sk
+++ b/src/test/skript/tests/regressions/7140-leather horse armor unequipable.sk
@@ -1,4 +1,4 @@
-test "leather horse armor unequipable" when running minecraft "1.14":
+test "leather horse armor unequipable":
 	if minecraft version is "1.20.6":
 		stop # horse armor equipping is broken on Paper 1.20.6. see https://github.com/PaperMC/Paper/pull/11139
 

--- a/src/test/skript/tests/regressions/pull-5566-block iterator being 100 always.sk
+++ b/src/test/skript/tests/regressions/pull-5566-block iterator being 100 always.sk
@@ -1,9 +1,8 @@
 
 # Test not related to a made issue. Details at pull request.
 test "100 blocks fix":
-	set {_l} to test-location ~ vector(0, -1, 0)
+	set {_l} to test-location ~ vector(0, -1, 10)
 	set block at {_l} to air
 
-	# Failing due to finding different set of blocks
-	# assert blocks 5 below {_l} contains air, grass block, dirt block, dirt block, bedrock block and void air with "Failed to get correct blocks (got '%blocks 5 below test-location%')"
+	assert blocks 5 below {_l} contains air, grass block, dirt block, dirt block, bedrock block and void air with "Failed to get correct blocks (got '%blocks 5 below test-location%')"
 	assert size of blocks 3 below location below {_l} is 4 with "Failed to match asserted size"

--- a/src/test/skript/tests/regressions/pull-5566-block iterator being 100 always.sk
+++ b/src/test/skript/tests/regressions/pull-5566-block iterator being 100 always.sk
@@ -3,5 +3,7 @@
 test "100 blocks fix":
 	set {_l} to test-location ~ vector(0, -1, 0)
 	set block at {_l} to air
-	assert blocks 5 below {_l} contains air, grass block, dirt block, dirt block, bedrock block and void air with "Failed to get correct blocks (got '%blocks 5 below test-location%')"
+
+	# Failing due to finding different set of blocks
+	# assert blocks 5 below {_l} contains air, grass block, dirt block, dirt block, bedrock block and void air with "Failed to get correct blocks (got '%blocks 5 below test-location%')"
 	assert size of blocks 3 below location below {_l} is 4 with "Failed to match asserted size"

--- a/src/test/skript/tests/syntaxes/conditions/CondIsPreferredTool.sk
+++ b/src/test/skript/tests/syntaxes/conditions/CondIsPreferredTool.sk
@@ -1,4 +1,4 @@
-test "CondIsPreferredTool - BlockData" when running minecraft "1.19.2":
+test "CondIsPreferredTool - BlockData":
 	assert wooden pickaxe is preferred tool for minecraft:stone[] with "failed wooden pickaxe for stone blockdata"
 	assert wooden pickaxe is preferred tool for minecraft:dirt[] with "failed wooden pickaxe for dirt blockdata"
 	assert wooden pickaxe is not preferred tool for minecraft:obsidian[] with "failed wooden pickaxe for obsidian blockdata"
@@ -8,7 +8,7 @@ test "CondIsPreferredTool - BlockData" when running minecraft "1.19.2":
 	assert wooden axe is not preferred tool for minecraft:stone[] with "failed wooden axe for stone blockdata"
 	assert wooden axe is preferred tool for minecraft:dirt[] with "failed wooden axe for dirt blockdata"
 
-test "CondIsPreferredTool - Block" when running minecraft "1.16.5":
+test "CondIsPreferredTool - Block":
 	set {_block} to block at location(0,0,0, "world")
 	set {_temp} to {_block}'s type
 	set block at {_block} to grass

--- a/src/test/skript/tests/syntaxes/conditions/CondIsWithin.sk
+++ b/src/test/skript/tests/syntaxes/conditions/CondIsWithin.sk
@@ -1,4 +1,4 @@
-test "within condition" when running minecraft "1.17":
+test "within condition":
 	# two locations
 	set {_loc1} to location(0, 0, 0, "world")
 	set {_loc2} to location(20, 20, 20, "world")
@@ -22,31 +22,6 @@ test "within condition" when running minecraft "1.17":
 	set block at {_loc1} to lime carpet
 	assert {_loc1} is within block at {_loc1} with "failed within block"
 	assert ({_loc1} ~ vector(0,0.3,0)) is not within block at {_loc1} with "failed within block"
-
-	# entities
-	set {_loc} to test-location
-	spawn a pig at {_loc}
-	set {_pig} to last spawned entity
-	assert {_loc} is within {_pig} with "failed within entity"
-	assert {_loc1} is not within {_pig} with "failed within entity"
-
-	delete random entity of {_pig}
-
-test "within condition" when running below minecraft "1.17":
-	# two locations
-	set {_loc1} to location(0, 0, 0, "world")
-	set {_loc2} to location(20, 20, 20, "world")
-	assert location(10, 10, 10, "world") is within {_loc1} and {_loc2} with "failed within two locs"
-	assert location(10, -10, 10, "world") is not within {_loc1} and {_loc2} with "failed within two locs"
-	assert location(0, 0, 0, "world") is not within {_none} and {_none} with "failed within two locs"
-
-	# chunks
-	set {_chunk1} to chunk at {_loc1}
-	assert location(10, 10, 10, "world") is within {_chunk1} with "failed within chunk"
-	assert location(-10, 10, -10, "world") is not within {_chunk1} with "failed within chunk"
-
-	# worlds
-	assert location(10, 10, 10, "world") is within world("world") with "failed within world"
 
 	# entities
 	set {_loc} to test-location

--- a/src/test/skript/tests/syntaxes/effects/EffDetonate.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffDetonate.sk
@@ -4,7 +4,7 @@ test "detonate entity effect":
 	detonate last spawned entity
 	assert last spawned entity isn't valid with "creepers should instantly detonate when spawned"
 
-test "detonate explosive minecart" when running minecraft "1.19":
+test "detonate explosive minecart":
 	spawn a minecart with tnt at event-location
 	assert last spawned entity is valid with "minecarts with tnt should not detonate when they are first spawned"
 	detonate last spawned entity

--- a/src/test/skript/tests/syntaxes/effects/EffExplodeCreeper.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffExplodeCreeper.sk
@@ -1,4 +1,4 @@
-test "explode creeper effect/condition" when running minecraft "1.15.2":
+test "explode creeper effect/condition":
 	spawn a creeper at test-location
 	assert last spawned creeper is not going to explode with "creepers should not explode when they are first spawned"
 	start ignition of the last spawned creeper

--- a/src/test/skript/tests/syntaxes/effects/EffGlowingText.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffGlowingText.sk
@@ -1,4 +1,4 @@
-test "glowing sign blocks" when running minecraft "1.17.1":
+test "glowing sign blocks":
 	set {_loc} to spawn of "world"
 	set {_original block} to type of block at {_loc}
 	set block at {_loc} to sign
@@ -9,7 +9,7 @@ test "glowing sign blocks" when running minecraft "1.17.1":
 	assert block at {_loc} doesn't have glowing text with "Sign had glowing text erroneously (2)"
 	set block at {_loc} to {_original block}
 
-test "glowing sign items" when running minecraft "1.17.1":
+test "glowing sign items":
 	set {_sign} to floor sign
 	assert {_sign} doesn't have glowing text with "Sign had glowing text erroneously (1)"
 	make {_sign} have glowing text

--- a/src/test/skript/tests/syntaxes/effects/EffHandedness.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffHandedness.sk
@@ -1,4 +1,4 @@
-test "left handedness" when running minecraft "1.17.1":
+test "left handedness":
 	spawn skeleton at test-location:
 		make entity right handed
 		assert entity is not left handed with "zombie is left handed after being made right handed"

--- a/src/test/skript/tests/syntaxes/effects/EffInvisible.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffInvisible.sk
@@ -1,4 +1,4 @@
-test "entity invisibility" when running minecraft "1.16.3":
+test "entity invisibility":
 	spawn pig at test-location:
 		make entity invisible
 		assert entity is invisible with "failed to make pig invisible"

--- a/src/test/skript/tests/syntaxes/expressions/ExprBlockData.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprBlockData.sk
@@ -1,4 +1,4 @@
-test "block data" when running minecraft "1.14.4":
+test "block data":
 	set {_b} to block at test-location
 	set block at {_b} to campfire[lit=false;waterlogged=true]
 	assert block at {_b} is an unlit campfire with "block at spawn should be an unlit campfire"

--- a/src/test/skript/tests/syntaxes/expressions/ExprColorOf.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprColorOf.sk
@@ -8,7 +8,7 @@
 
 # test "color of fireworks":
 
-test "color of displays" when running minecraft "1.19.4":
+test "color of displays":
 	spawn a text display at spawn of world "world":
 		set {_e} to entity
 

--- a/src/test/skript/tests/syntaxes/expressions/ExprCustomModelData.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprCustomModelData.sk
@@ -1,4 +1,4 @@
-test "custom model data expressions/condition" when running minecraft "1.15.2":
+test "custom model data expressions/condition":
 	set {_item} to a diamond sword with custom model data 456
 	assert {_item} has custom model data with "{_item} does not have custom model data"
 	if {_item} has custom model data:

--- a/src/test/skript/tests/syntaxes/expressions/ExprDisplayBillboard.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprDisplayBillboard.sk
@@ -1,4 +1,4 @@
-test "display billboard" when running minecraft "1.19.4":
+test "display billboard":
 
 	spawn a text display at spawn of world "world":
 		set {_e} to entity

--- a/src/test/skript/tests/syntaxes/expressions/ExprDisplayBrightness.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprDisplayBrightness.sk
@@ -1,4 +1,4 @@
-test "display brightness" when running minecraft "1.19.4":
+test "display brightness":
 	spawn block display at spawn of world "world":
 		set {_e::1} to entity
 	spawn item display at spawn of world "world":

--- a/src/test/skript/tests/syntaxes/expressions/ExprDisplayGlowOverride.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprDisplayGlowOverride.sk
@@ -1,4 +1,4 @@
-test "display glow color override" when running minecraft "1.19":
+test "display glow color override":
 
 	spawn block display at spawn of world "world":
 		set {_e::1} to entity

--- a/src/test/skript/tests/syntaxes/expressions/ExprDisplayHeightWidth.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprDisplayHeightWidth.sk
@@ -1,4 +1,4 @@
-test "display height/width" when running minecraft "1.19":
+test "display height/width":
 
 	spawn block display at spawn of world "world":
 		set {_e::1} to entity

--- a/src/test/skript/tests/syntaxes/expressions/ExprDisplayInterpolation.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprDisplayInterpolation.sk
@@ -1,4 +1,4 @@
-test "display interpolation" when running minecraft "1.19.4":
+test "display interpolation":
 
 	spawn block display at spawn of world "world":
 		set {_e::1} to entity

--- a/src/test/skript/tests/syntaxes/expressions/ExprDisplayShadow.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprDisplayShadow.sk
@@ -1,4 +1,4 @@
-test "display radius/strength" when running minecraft "1.19":
+test "display radius/strength":
 
 	spawn block display at spawn of world "world":
 		set {_e::1} to entity

--- a/src/test/skript/tests/syntaxes/expressions/ExprDisplayTransformation.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprDisplayTransformation.sk
@@ -1,4 +1,4 @@
-test "display transformation rotations" when running minecraft "1.19.4":
+test "display transformation rotations":
 
 	spawn block display at spawn of world "world":
 		set {_e::1} to entity
@@ -27,7 +27,7 @@ test "display transformation rotations" when running minecraft "1.19.4":
 	delete entities within {_e::*}
 
 
-test "display transformation translation / scales" when running minecraft "1.19.4":
+test "display transformation translation / scales":
 	spawn block display at spawn of world "world":
 		set {_e::1} to entity
 	spawn item display at spawn of world "world":

--- a/src/test/skript/tests/syntaxes/expressions/ExprDisplayViewRange.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprDisplayViewRange.sk
@@ -1,4 +1,4 @@
-test "display view range" when running minecraft "1.19":
+test "display view range":
 
 	spawn block display at spawn of world "world":
 		set {_e::1} to entity

--- a/src/test/skript/tests/syntaxes/expressions/ExprExplosiveYield.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprExplosiveYield.sk
@@ -5,7 +5,7 @@ test "explosive yield":
 	assert explosive yield of last spawned tnt is 10 with "an explosive's explosive yield should be 10 if it is set to 10"
 	delete last spawned primed tnt
 
-test "creeper explosive yield" when running minecraft "1.12.2":
+test "creeper explosive yield":
 	spawn a creeper at test-location
 	assert explosive yield of last spawned creeper is 3 with "explosive yield of a creeper is 3 by default"
 	set explosive yield of last spawned creeper to 10

--- a/src/test/skript/tests/syntaxes/expressions/ExprFreezeTicks.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprFreezeTicks.sk
@@ -1,4 +1,4 @@
-test "freeze time" when running minecraft "1.18":
+test "freeze time":
 	spawn cow at test-location:
 		assert freeze time of entity is set with "freeze time get failed"
 		set freeze time of entity to 3 seconds

--- a/src/test/skript/tests/syntaxes/expressions/ExprItemDisplayTransform.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprItemDisplayTransform.sk
@@ -1,4 +1,4 @@
-test "item display transforms" when running minecraft "1.19.4":
+test "item display transforms":
 
 	spawn block display at spawn of world "world":
 		set {_bd} to entity

--- a/src/test/skript/tests/syntaxes/expressions/ExprLowestHighestSolidBlock.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprLowestHighestSolidBlock.sk
@@ -1,34 +1,4 @@
-test "lowest/highest solid block (old height)" when running below minecraft "1.18":
-
-	# highest solid block
-	set {_oldBlock::1} to block data of block at location(0.5, 255.5, 0.5, "world")
-	set {_oldBlock::2} to block data of block at location(0.5, 254.5, 0.5, "world")
-	set {_oldBlock::3} to block data of block at location(0.5, 253.5, 0.5, "world")
-	set block at location(0.5, 255.5, 0.5, "world") to air
-	set block at location(0.5, 254.5, 0.5, "world") to air
-	set block at location(0.5, 253.5, 0.5, "world") to dirt
-	set {_highest} to highest solid block at location(0.5, 64, 0.5, "world")
-	assert type of {_highest} is dirt with "highest block is not dirt (got '%type of {_highest}%')"
-	assert location of {_highest} is location(0.5, 253.5, 0.5, "world") with "highest block is not at 0.5,253.5,0.5 (got '%location of {_highest}%')"
-	set block at location(0.5, 255.5, 0.5, "world") to {_oldBlock::1}
-	set block at location(0.5, 254.5, 0.5, "world") to {_oldBlock::2}
-	set block at location(0.5, 253.5, 0.5, "world") to {_oldBlock::3}
-
-	# lowest solid block
-	set {_oldBlock::1} to block data of block at location(0.5, 0.5, 0.5, "world")
-	set {_oldBlock::2} to block data of block at location(0.5, 1.5, 0.5, "world")
-	set {_oldBlock::3} to block data of block at location(0.5, 2.5, 0.5, "world")
-	set block at location(0.5, 0.5, 0.5, "world") to air
-	set block at location(0.5, 1.5, 0.5, "world") to air
-	set block at location(0.5, 2.5, 0.5, "world") to dirt
-	set {_lowest} to lowest solid block at location(0.5, 64, 0.5, "world")
-	assert type of {_lowest} is dirt with "lowest block is not dirt (got '%type of {_lowest}%')"
-	assert location of {_lowest} is location(0.5, 2.5, 0.5, "world") with "lowest block is not at 0.5,2.5,0.5 (got '%location of {_lowest}%')"
-	set block at location(0.5, 0.5, 0.5, "world") to {_oldBlock::1}
-	set block at location(0.5, 1.5, 0.5, "world") to {_oldBlock::2}
-	set block at location(0.5, 2.5, 0.5, "world") to {_oldBlock::3}
-
-test "lowest/highest solid block (new height)" when running minecraft "1.18":
+test "lowest/highest solid block (new height)":
 
 	# highest solid block
 	set {_oldBlock::1} to block data of block at location(0.5, 319.5, 0.5, "world")

--- a/src/test/skript/tests/syntaxes/expressions/ExprLowestHighestSolidBlock.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprLowestHighestSolidBlock.sk
@@ -1,4 +1,4 @@
-test "lowest/highest solid block (new height)":
+test "lowest/highest solid block":
 
 	# highest solid block
 	set {_oldBlock::1} to block data of block at location(0.5, 319.5, 0.5, "world")

--- a/src/test/skript/tests/syntaxes/expressions/ExprMaxPlayers.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprMaxPlayers.sk
@@ -1,4 +1,4 @@
-test "max players" when running minecraft "1.16.5":
+test "max players":
 	set real max players count to 5
 	assert real max players count is 5 with "setting max players failed"
 	add 3 to real max players

--- a/src/test/skript/tests/syntaxes/expressions/ExprQuaternionAxisAngle.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprQuaternionAxisAngle.sk
@@ -1,4 +1,4 @@
-test "quaternion axis angle" when running minecraft "1.19":
+test "quaternion axis angle":
 	set {_v} to vector(1, 2, 3)
 	set {_q} to axisAngle(45, {_v})
 	assert rotation angle of {_q} is 45 with "angle of quaternion failed"

--- a/src/test/skript/tests/syntaxes/expressions/ExprTextDisplayAlignment.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprTextDisplayAlignment.sk
@@ -1,4 +1,4 @@
-test "text alignment" when running minecraft "1.19.4":
+test "text alignment":
 	
 	spawn item display at spawn of world "world":
 		set {_id} to entity

--- a/src/test/skript/tests/syntaxes/expressions/ExprTextDisplayLineWidth.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprTextDisplayLineWidth.sk
@@ -1,4 +1,4 @@
-test "line width" when running minecraft "1.19.4":
+test "line width":
 	
 	spawn item display at spawn of world "world":
 		set {_id} to entity

--- a/src/test/skript/tests/syntaxes/expressions/ExprTextDisplayOpacity.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprTextDisplayOpacity.sk
@@ -1,4 +1,4 @@
-test "text opacity" when running minecraft "1.19.4":
+test "text opacity":
 	
 	spawn item display at spawn of world "world":
 		set {_id} to entity

--- a/src/test/skript/tests/syntaxes/expressions/ExprWhitelist.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprWhitelist.sk
@@ -11,7 +11,7 @@ test "whitelist":
 	reset whitelist
 	assert whitelist is not set with "Failed to empty whitelist"
 
-test "enforce whitelist" when running minecraft "1.17":
+test "enforce whitelist":
 	enforce whitelist
 	assert server whitelist is enforced with "Failed to enforce server whitelist"
 	unenforce whitelist

--- a/src/test/skript/tests/syntaxes/expressions/ExprXYZComponent.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprXYZComponent.sk
@@ -1,14 +1,12 @@
 test "vector xyz":
-	if running minecraft "1.19.4":
-		assert the w component of vector(0, 0, 0) is not set with "w vector component return value for vector unexpectedly"
+	assert the w component of vector(0, 0, 0) is not set with "w vector component return value for vector unexpectedly"
 	assert the x component of vector(1, 0, 0) is 1 with "x vector component failed"
 	assert the y component of vector(0, 1, 0) is 1 with "y vector component failed"
 	assert the z component of vector(0, 0, 1) is 1 with "z vector component failed"
 
 	set {_v} to vector(0,0,0)
 	set x of {_v} to infinity value
-	if running minecraft "1.19.4":
-		assert the w component of {_v} is not set with "set x of vector created w component somehow"
+	assert the w component of {_v} is not set with "set x of vector created w component somehow"
 	assert the x component of {_v} is infinity value with "set x of vector failed"
 	assert the y component of {_v} is 0 with "set x of vector modified other components"
 	assert the z component of {_v} is 0 with "set x of vector modified other components"
@@ -30,7 +28,7 @@ test "vector xyz":
 	assert the x component of {_v::*} is (-1.5, -1.5, and -1.5) with "x component of multiple vectors failed"
 	assert the y component of {_v::*} is (2, 3, and 4) with "changing x component of multiple vectors changed y components too"
 
-test "quaternion wxyz" when running minecraft "1.19.4":
+test "quaternion wxyz":
 	assert the w component of quaternion(1, 0, 0, 0) is 1 with "w vector component failed"
 	assert the x component of quaternion(1, 0, 0, 0) is 0 with "x vector component failed"
 	assert the y component of quaternion(1, 0, 0, 0) is 0 with "y vector component failed"

--- a/src/test/skript/tests/syntaxes/functions/offlinePlayer.sk
+++ b/src/test/skript/tests/syntaxes/functions/offlinePlayer.sk
@@ -2,6 +2,6 @@ test "offline player function":
 	set {_lookup} to offlineplayer("Notch")
 	assert {_lookup} is set with "Failed to look up offline player"
 
-test "offline player function no lookup" when running minecraft "1.16":
+test "offline player function no lookup":
 	set {_non-lookup} to offlineplayer("Dinnerbone", false)
 	assert {_non-lookup} is not set with "Looked up offline player when told not to"

--- a/src/test/skript/tests/syntaxes/functions/quaternions.sk
+++ b/src/test/skript/tests/syntaxes/functions/quaternions.sk
@@ -1,4 +1,4 @@
-test "quaternions" when running minecraft "1.19":
+test "quaternions":
 	set {_a} to quaternion(1, 2, 3, 4)
 	assert w of {_a} is 1 with error "failed to get w component of quaternion"
 	assert x of {_a} is 2 with error "failed to get x component of quaternion"
@@ -12,7 +12,7 @@ test "quaternions" when running minecraft "1.19":
 	assert y of {_a} is -infinity value with error "failed to get y component of quaternion"
 	assert isNaN(z of {_a}) is true with error "failed to get z component of quaternion"
 
-test "axis angle" when running minecraft "1.19":
+test "axis angle":
 	set {_a} to axisAngle(100, vector(2, 3, 4))
 	assert w of {_a} is 0.642787516117096 with error "failed to get w component of axis angle"
 	assert x of {_a} is 1.5320889949798584 with error "failed to get x component of axis angle"

--- a/src/test/skript/tests/syntaxes/sections/EffSecSpawn.sk
+++ b/src/test/skript/tests/syntaxes/sections/EffSecSpawn.sk
@@ -21,7 +21,7 @@ test "spawn section":
 	assert {_before} is 10 with "value of {_before} should be 10 (got '%{_before}%')"
 	assert {_new var} is 5 with "value of {_new var} should be 5 (got '%{_new var}%')"
 
-test "spawn cats by type" when running minecraft "1.15.2":
+test "spawn cats by type":
 	delete all cats
 	set {_l} to location of spawn of world "world"
 	spawn 5 all black cats at {_l}


### PR DESCRIPTION
### Description
This PR aims to update tests by removing outdated version checks since Skript 2.10+ will be only for MC 1.19.4+

### NOTES:
- ~~`boats.sk` was failing, so I temporarily commented out the line until that can be fixed (so tests can pass)~~
Twas an Alias issue, Pickle informed me to update Aliases submodule on local and now it works.
- `4769-fire-visualeffect.sk` was failing. I think the fire block was being set mid air and wouldn't set, so I just added a block below it
- `pull-5566...sk` was failing, it was getting the wrong blocks (probably edited in another test), so I shifted the test over 10 blocks along Z

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
