### PR TITLE
Fix CIP implementation for Variable

### DIFF
--- a/src/main/java/ch/njol/skript/lang/Variable.java
+++ b/src/main/java/ch/njol/skript/lang/Variable.java
@@ -615,6 +615,15 @@ public class Variable<T> implements Expression<T> {
 		}
 	}
 
+	/**
+	 * {@inheritDoc}
+	 * @param getAll This has no effect for a Variable, as {@link #getArray(Event)} is the same as {@link #getAll(Event)}.
+	 */
+	@Override
+	public <R> void changeInPlace(Event event, Function<T, R> changeFunction, boolean getAll) {
+		changeInPlace(event, changeFunction);
+	}
+
 	@Override
 	public <R> void changeInPlace(Event event, Function<T, R> changeFunction) {
 		if (!list) {


### PR DESCRIPTION
### Description
This PR aims to fix the missing `changeInPlace` method implementation on Variable. For clarity, I have chosen to have both methods implemented, and the method with the unused parameter simply call the existing implementation.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
