### PR TITLE
Updates SyntaxStringBuilder to return itself

### DIFF
--- a/src/main/java/ch/njol/skript/lang/SyntaxStringBuilder.java
+++ b/src/main/java/ch/njol/skript/lang/SyntaxStringBuilder.java
@@ -30,31 +30,33 @@ public class SyntaxStringBuilder {
 	}
 
 	/**
-	 * Adds an object to the string.
+	 * Adds an object to the string and returns the builder.
 	 * Spaces are automatically added between the provided objects.
 	 * If the object is a {@link Debuggable} it will be formatted using
 	 * {@link Debuggable#toString(Event, boolean)}.
 	 *
 	 * @param object The object to add.
 	 */
-	public void append(@NotNull Object object) {
+	public SyntaxStringBuilder append(@NotNull Object object) {
 		Preconditions.checkNotNull(object);
 		if (object instanceof Debuggable debuggable) {
 			joiner.add(debuggable.toString(event, debug));
 		} else {
 			joiner.add(object.toString());
 		}
+		return this;
 	}
 
 	/**
-	 * Adds multiple objects to the string.
+	 * Adds multiple objects to the string and returns the builder.
 	 * Spaces are automatically added between the provided objects.
 	 * @param objects The objects to add.
 	 */
-	public void append(@NotNull Object... objects) {
+	public SyntaxStringBuilder append(@NotNull Object... objects) {
 		for (Object object : objects) {
 			append(object);
 		}
+		return this;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/lang/SyntaxStringBuilder.java
+++ b/src/main/java/ch/njol/skript/lang/SyntaxStringBuilder.java
@@ -36,6 +36,7 @@ public class SyntaxStringBuilder {
 	 * {@link Debuggable#toString(Event, boolean)}.
 	 *
 	 * @param object The object to add.
+	 * @return The builder.
 	 */
 	public SyntaxStringBuilder append(@NotNull Object object) {
 		Preconditions.checkNotNull(object);
@@ -50,7 +51,9 @@ public class SyntaxStringBuilder {
 	/**
 	 * Adds multiple objects to the string and returns the builder.
 	 * Spaces are automatically added between the provided objects.
+	 *
 	 * @param objects The objects to add.
+	 * @return The builder.
 	 */
 	public SyntaxStringBuilder append(@NotNull Object... objects) {
 		for (Object object : objects) {


### PR DESCRIPTION
### Description
Makes the SyntaxStringBuilder's append methods return itself.
Allows for stuff nicer feeling stuff like:
```java
String toString = new SyntaxStringBuilder(event, debug)
    .append(x)
    .append("and")
    .append(y)
    .toString()
```

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
