### PR TITLE
Colours Are Cool 🌈

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -106,6 +106,7 @@ import org.skriptlang.skript.lang.experiment.ExperimentRegistry;
 import org.skriptlang.skript.lang.script.Script;
 import org.skriptlang.skript.lang.structure.Structure;
 import org.skriptlang.skript.lang.structure.StructureInfo;
+import org.skriptlang.skript.misc.colours.ColourModule;
 
 import java.io.File;
 import java.io.IOException;
@@ -537,6 +538,7 @@ public final class Skript extends JavaPlugin implements Listener {
 			BreedingModule.load();
 			DisplayModule.load();
 			InputModule.load();
+			ColourModule.load();
 		} catch (final Exception e) {
 			exception(e, "Could not load required .class files: " + e.getLocalizedMessage());
 			setEnabled(false);

--- a/src/main/java/ch/njol/skript/expressions/ExprARGB.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprARGB.java
@@ -28,7 +28,7 @@ import java.util.function.Function;
 public class ExprARGB extends SimplePropertyExpression<Color, Integer> {
 
 	static {
-		register(ExprARGB.class, Integer.class, "(:alpha|:red|:green|:blue) (value|component)", "colors");
+		register(ExprARGB.class, Integer.class, "(:alpha|:red|:green|:blue) (value|component|channel)", "colors");
 	}
 
 	private RGB color;

--- a/src/main/java/org/skriptlang/skript/misc/colours/ColourModule.java
+++ b/src/main/java/org/skriptlang/skript/misc/colours/ColourModule.java
@@ -1,0 +1,110 @@
+package org.skriptlang.skript.misc.colours;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.function.Functions;
+import ch.njol.skript.lang.function.Parameter;
+import ch.njol.skript.lang.function.SimpleJavaFunction;
+import ch.njol.skript.lang.util.SimpleLiteral;
+import ch.njol.skript.registrations.DefaultClasses;
+import ch.njol.skript.util.Color;
+import ch.njol.skript.util.ColorRGB;
+import ch.njol.util.coll.CollectionUtils;
+
+import java.io.IOException;
+
+public class ColourModule {
+
+	public static void load() throws IOException {
+		Skript.getAddonInstance().loadClasses("org.skriptlang.skript.misc", "colours");
+
+		Functions.registerFunction(new SimpleJavaFunction<Color>("shade", new Parameter[] {
+			new Parameter<>("colour", DefaultClasses.COLOR, true, null),
+			new Parameter<>("amount", DefaultClasses.LONG, true, new SimpleLiteral<>(1L, true)),
+			new Parameter<>("hsl", DefaultClasses.BOOLEAN, true, new SimpleLiteral<>(false, true))
+		}, DefaultClasses.COLOR, true) {
+			@Override
+			public ColorRGB[] executeSimple(Object[][] params) {
+				Color colour = (Color) params[0][0];
+				Long amount = (Long) params[1][0];
+				boolean hsl = (Boolean) params[2][0];
+				return CollectionUtils.array(hsl
+					? ColourUtils.shadeColorHSL(colour, amount.intValue())
+					: ColourUtils.shadeColor(colour, amount.intValue()));
+			}
+		}).description(
+			"Shades a given colour by a given amount. Optionally can use HSL methods to achieve this instead.",
+			"The amount should be from 0-100, with 0 doing nothing, and 100 shading it all the way to black."
+		).examples(
+			"set {_darkRed} to shade(red, 10)",
+			"set {_darkerRed} to shade(red, 20)"
+		).since("INSERT VERSION");
+
+		Functions.registerFunction(new SimpleJavaFunction<Color>("tint", new Parameter[] {
+			new Parameter<>("colour", DefaultClasses.COLOR, true, null),
+			new Parameter<>("amount", DefaultClasses.LONG, true, new SimpleLiteral<>(1L, true)),
+			new Parameter<>("hsl", DefaultClasses.BOOLEAN, true, new SimpleLiteral<>(false, true))
+		}, DefaultClasses.COLOR, true) {
+			@Override
+			public ColorRGB[] executeSimple(Object[][] params) {
+				Color colour = (Color) params[0][0];
+				Long amount = (Long) params[1][0];
+				boolean hsl = (Boolean) params[2][0];
+				return CollectionUtils.array(hsl
+					? ColourUtils.tintColorHSL(colour, amount.intValue())
+					: ColourUtils.tintColor(colour, amount.intValue()));
+			}
+		}).description(
+			"Tints a given colour by a given amount. Optionally can use HSL methods to achieve this instead.",
+			"The amount should be from 0-100, with 0 doing nothing, and 100 tinting it all the way to white."
+		).examples(
+			"set {_lightRed} to tint(red, 10)",
+			"set {_lighterRed} to tint(red, 20)"
+		).since("INSERT VERSION");
+
+		Functions.registerFunction(new SimpleJavaFunction<Color>("colourBrightness", new Parameter[] {
+			new Parameter<>("colour", DefaultClasses.COLOR, true, null),
+			new Parameter<>("amount", DefaultClasses.LONG, true, null)
+		}, DefaultClasses.COLOR, true) {
+			@Override
+			public ColorRGB[] executeSimple(Object[][] params) {
+				Color colour = (Color) params[0][0];
+				Long amount = (Long) params[1][0];
+				return CollectionUtils.array(ColourUtils.adjustBrightness(colour, amount.intValue()));
+			}
+		}).description(
+			"Adjusts the brightness of a colour by a given amount from -100 to 100."
+		).examples(
+			"set {_brighterRed} to colourBrightness(red, 10)",
+			"set {_darkerRed} to colourBrightness(red, -10)"
+		).since("INSERT VERSION");
+
+		Functions.registerFunction(new SimpleJavaFunction<Color>("grayscale", new Parameter[] {
+			new Parameter<>("colour", DefaultClasses.COLOR, true, null)
+		}, DefaultClasses.COLOR, true) {
+			@Override
+			public ColorRGB[] executeSimple(Object[][] params) {
+				Color colour = (Color) params[0][0];
+				return CollectionUtils.array(ColourUtils.toGrayscale(colour));
+			}
+		}).description(
+			"Returns a colour converted to grayscale."
+		).examples(
+			"set {_redButGrayscale} to grayscale(red)"
+		).since("INSERT VERSION");
+
+		Functions.registerFunction(new SimpleJavaFunction<Color>("sepiatone", new Parameter[] {
+			new Parameter<>("colour", DefaultClasses.COLOR, true, null)
+		}, DefaultClasses.COLOR, true) {
+			@Override
+			public ColorRGB[] executeSimple(Object[][] params) {
+				Color colour = (Color) params[0][0];
+				return CollectionUtils.array(ColourUtils.toSepia(colour));
+			}
+		}).description(
+			"Returns a colour converted to sepiatone."
+		).examples(
+			"set {_redButSepiatone} to sepiatone(red)"
+		).since("INSERT VERSION");
+	}
+
+}

--- a/src/main/java/org/skriptlang/skript/misc/colours/ColourUtils.java
+++ b/src/main/java/org/skriptlang/skript/misc/colours/ColourUtils.java
@@ -6,7 +6,7 @@ import ch.njol.skript.util.ColorRGB;
 public class ColourUtils {
 
 	public static String toHex(Color color) {
-		return String.format("<#%02X%02X%02X>", color.getRed(), color.getGreen(), color.getBlue());
+		return String.format("#%02X%02X%02X", color.getRed(), color.getGreen(), color.getBlue());
 	}
 
 	public static float[] rgbToHsl(Color color) {

--- a/src/main/java/org/skriptlang/skript/misc/colours/ColourUtils.java
+++ b/src/main/java/org/skriptlang/skript/misc/colours/ColourUtils.java
@@ -3,12 +3,27 @@ package org.skriptlang.skript.misc.colours;
 import ch.njol.skript.util.Color;
 import ch.njol.skript.util.ColorRGB;
 
+/**
+ * Utility class for colour manipulation and conversion.
+ */
 public class ColourUtils {
 
+	/**
+	 * Converts a {@link Color} to its hexadecimal representation.
+	 *
+	 * @param color the {@link Color} to convert
+	 * @return the hexadecimal string of the colour
+	 */
 	public static String toHex(Color color) {
 		return String.format("#%02X%02X%02X", color.getRed(), color.getGreen(), color.getBlue());
 	}
 
+	/**
+	 * Converts a {@link Color} to HSL (hue, saturation, lightness).
+	 *
+	 * @param color the {@link Color} to convert
+	 * @return a float array representing the HSL values
+	 */
 	public static float[] rgbToHsl(Color color) {
 		float r = color.getRed() / 255f;
 		float g = color.getGreen() / 255f;
@@ -32,6 +47,12 @@ public class ColourUtils {
 		return new float[]{ h, s, l };
 	}
 
+	/**
+	 * Converts HSL values to a {@link ColorRGB} object.
+	 *
+	 * @param hsl a float array representing HSL values
+	 * @return a {@link ColorRGB} object given the HSL values
+	 */
 	public static ColorRGB hslToRgb(float[] hsl) {
 		float h = hsl[0], s = hsl[1], l = hsl[2];
 		float r, g, b;
@@ -50,6 +71,14 @@ public class ColourUtils {
 		return ColorRGB.fromRGBA(red, green, blue, 255);
 	}
 
+	/**
+	 * Helper method to convert hue values to RGB.
+	 *
+	 * @param p intermediate value
+	 * @param q intermediate value
+	 * @param t hue offset
+	 * @return the calculated RGB value
+	 */
 	private static float hueToRgb(float p, float q, float t) {
 		if (t < 0f)
 			t += 1f;
@@ -64,6 +93,14 @@ public class ColourUtils {
 		return p;
 	}
 
+	/**
+	 * Blends two {@link Color}s based on an amount from 0 to 100.
+	 *
+	 * @param c1 the first {@link Color}
+	 * @param c2 the second {@link Color}
+	 * @param amount the percentage amount to blend the colours (0 - 100)
+	 * @return the blended colour
+	 */
 	public static Color blendColors(Color c1, Color c2, double amount) {
 		amount = Math.max(0, Math.min(100, amount));
 		amount /= 100.0;
@@ -74,6 +111,12 @@ public class ColourUtils {
 		return ColorRGB.fromRGBA(r, g, b, a);
 	}
 
+	/**
+	 * Calculates the complement of a {@link Color}.
+	 *
+	 * @param color the {@link Color} to complement
+	 * @return the complementary colour
+	 */
 	public static Color complementColor(Color color) {
 		int r = 255 - color.getRed();
 		int g = 255 - color.getGreen();
@@ -81,12 +124,25 @@ public class ColourUtils {
 		return ColorRGB.fromRGBA(r, g, b, color.getAlpha());
 	}
 
+	/**
+	 * Calculates the complement of a {@link Color} using HSL adjustments.
+	 *
+	 * @param color the {@link Color} to complement
+	 * @return the complementary colour
+	 */
 	public static Color complementColorHSL(Color color) {
 		float[] hsl = rgbToHsl(color);
 		hsl[0] = (hsl[0] + 0.5f) % 1f;
 		return hslToRgb(hsl);
 	}
 
+	/**
+	 * Shades a {@link Color} by a given amount from 1 to 100.
+	 *
+	 * @param color the {@link Color} to shade
+	 * @param amount the amount to shade the colour by (1 - 100)
+	 * @return the shaded colour
+	 */
 	public static ColorRGB shadeColor(Color color, int amount) {
 		amount = Math.max(1, Math.min(100, amount));
 		double factor = (100 - amount) / 100.0;
@@ -96,6 +152,13 @@ public class ColourUtils {
 		return ColorRGB.fromRGBA(r, g, b, color.getAlpha());
 	}
 
+	/**
+	 * Shades a {@link Color} by a given amount from 1 to 100 using HSL adjustments.
+	 *
+	 * @param color the {@link Color} to shade using HSL adjustments
+	 * @param amount the amount to shade the colour by (1 - 100)
+	 * @return the shaded colour
+	 */
 	public static ColorRGB shadeColorHSL(Color color, int amount) {
 		amount = Math.max(1, Math.min(100, amount));
 		float[] hsl = rgbToHsl(color);
@@ -103,6 +166,13 @@ public class ColourUtils {
 		return hslToRgb(hsl);
 	}
 
+	/**
+	 * Tints a {@link Color} by a given amount from 1 to 100.
+	 *
+	 * @param color the {@link Color} to tint
+	 * @param amount the amount to tint the colour by (1 - 100)
+	 * @return the tinted colour
+	 */
 	public static ColorRGB tintColor(Color color, int amount) {
 		amount = Math.max(1, Math.min(100, amount));
 		double factor = amount / 100.0;
@@ -112,6 +182,13 @@ public class ColourUtils {
 		return ColorRGB.fromRGBA(r, g, b, color.getAlpha());
 	}
 
+	/**
+	 * Tints a {@link Color} by a given amount from 1 to 100 using HSL adjustments.
+	 *
+	 * @param color the {@link Color} to tint using HSL adjustments
+	 * @param amount the amount to tint the colour by (1 - 100)
+	 * @return the tinted colour
+	 */
 	public static ColorRGB tintColorHSL(Color color, int amount) {
 		amount = Math.max(1, Math.min(100, amount));
 		float[] hsl = rgbToHsl(color);
@@ -120,6 +197,13 @@ public class ColourUtils {
 		return hslToRgb(hsl);
 	}
 
+	/**
+	 * Rotates the hue of a {@link Color} by a given degree.
+	 *
+	 * @param color the {@link Color} to rotate the hue of
+	 * @param degrees the number of degrees to rotate the hue by
+	 * @return the hue-rotated colour
+	 */
 	public static Color rotateHue(Color color, int degrees) {
 		float[] hsl = rgbToHsl(color);
 		hsl[0] = (hsl[0] + degrees / 360f) % 1f;
@@ -128,6 +212,14 @@ public class ColourUtils {
 		return hslToRgb(hsl);
 	}
 
+	/**
+	 * Adjusts the brightness of a {@link Color} by an amount from -100 to 100.
+	 * This is similar to shading and tinting, but is slightly different.
+	 *
+	 * @param color the {@link Color} to adjust the brightness of
+	 * @param amount the amount to adjust the brightness by (-100 - 100)
+	 * @return the brightness-adjusted colour
+	 */
 	public static ColorRGB adjustBrightness(Color color, int amount) {
 		amount = Math.max(-100, Math.min(100, amount));
 		float[] hsb = rgbToHsb(color);
@@ -137,6 +229,13 @@ public class ColourUtils {
 		return hsbToRgb(hsb);
 	}
 
+	/**
+	 * Converts a {@link Color} to HSB (hue, saturation, brightness).
+	 * This is different to {@link #rgbToHsl(Color)}.
+	 *
+	 * @param color the {@link Color} to convert
+	 * @return a float array representing the HSB values
+	 */
 	private static float[] rgbToHsb(Color color) {
 		float r = color.getRed() / 255f;
 		float g = color.getGreen() / 255f;
@@ -162,6 +261,13 @@ public class ColourUtils {
 		return new float[]{ h, s, v };
 	}
 
+	/**
+	 * Converts HSB values to a {@link ColorRGB} object.
+	 * This is different to {@link #hslToRgb(float[])}.
+	 *
+	 * @param hsb a float array representing HSB values
+	 * @return a {@link ColorRGB} object given the HSB values
+	 */
 	private static ColorRGB hsbToRgb(float[] hsb) {
 		float h = hsb[0], s = hsb[1], v = hsb[2];
 		float r = 0f, g = 0f, b = 0f;
@@ -190,11 +296,23 @@ public class ColourUtils {
 		return ColorRGB.fromRGBA(red, green, blue, 255);
 	}
 
+	/**
+	 * Converts a {@link Color} to its grayscale equivalent.
+	 *
+	 * @param color the {@link Color} to convert to grayscale
+	 * @return the colour's grayscale equivalent
+	 */
 	public static ColorRGB toGrayscale(Color color) {
 		int gray = (int)(0.299 * color.getRed() + 0.587 * color.getGreen() + 0.114 * color.getBlue());
 		return ColorRGB.fromRGBA(gray, gray, gray, color.getAlpha());
 	}
 
+	/**
+	 * Converts a {@link Color} to its sepiatone equivalent.
+	 *
+	 * @param color the {@link Color} to convert to sepiatone
+	 * @return the colour's sepiatone equivalent
+	 */
 	public static ColorRGB toSepia(Color color) {
 		int r = color.getRed();
 		int g = color.getGreen();
@@ -208,6 +326,13 @@ public class ColourUtils {
 		return ColorRGB.fromRGBA(tr, tg, tb, color.getAlpha());
 	}
 
+	/**
+	 * Adjusts the temperature of a {@link Color} by changing the red and blue channel values.
+	 *
+	 * @param color the {@link Color} to adjust the temperature of
+	 * @param amount the amount to adjust the temperature by (-255 - 255)
+	 * @return the temperature-adjusted colour
+	 */
 	public static ColorRGB adjustTemperature(Color color, int amount) {
 		int r = color.getRed() + amount;
 		int b = color.getBlue() - amount;

--- a/src/main/java/org/skriptlang/skript/misc/colours/ColourUtils.java
+++ b/src/main/java/org/skriptlang/skript/misc/colours/ColourUtils.java
@@ -5,6 +5,10 @@ import ch.njol.skript.util.ColorRGB;
 
 public class ColourUtils {
 
+	public static String toHex(Color color) {
+		return String.format("<#%02X%02X%02X>", color.getRed(), color.getGreen(), color.getBlue());
+	}
+
 	public static float[] rgbToHsl(Color color) {
 		float r = color.getRed() / 255f;
 		float g = color.getGreen() / 255f;
@@ -61,7 +65,8 @@ public class ColourUtils {
 	}
 
 	public static Color blendColors(Color c1, Color c2, double amount) {
-		amount = Math.max(0, Math.min(1, amount));
+		amount = Math.max(0, Math.min(100, amount));
+		amount /= 100.0;
 		int r = (int) (c1.getRed() * (1 - amount) + c2.getRed() * amount);
 		int g = (int) (c1.getGreen() * (1 - amount) + c2.getGreen() * amount);
 		int b = (int) (c1.getBlue() * (1 - amount) + c2.getBlue() * amount);

--- a/src/main/java/org/skriptlang/skript/misc/colours/ColourUtils.java
+++ b/src/main/java/org/skriptlang/skript/misc/colours/ColourUtils.java
@@ -1,0 +1,214 @@
+package org.skriptlang.skript.misc.colours;
+
+import ch.njol.skript.util.Color;
+import ch.njol.skript.util.ColorRGB;
+
+public class ColourUtils {
+
+	public static float[] rgbToHsl(Color color) {
+		float r = color.getRed() / 255f;
+		float g = color.getGreen() / 255f;
+		float b = color.getBlue() / 255f;
+		float max = Math.max(r, Math.max(g, b));
+		float min = Math.min(r, Math.min(g, b));
+		float h, s, l = (max + min) / 2f;
+		if (max == min) {
+			h = s = 0f;
+		} else {
+			float delta = max - min;
+			s = l > 0.5f ? delta / (2f - max - min) : delta / (max + min);
+			if (max == r) {
+				h = ((g - b) / delta + (g < b ? 6f : 0f)) / 6f;
+			} else if (max == g) {
+				h = ((b - r) / delta + 2f) / 6f;
+			} else {
+				h = ((r - g) / delta + 4f) / 6f;
+			}
+		}
+		return new float[]{ h, s, l };
+	}
+
+	public static ColorRGB hslToRgb(float[] hsl) {
+		float h = hsl[0], s = hsl[1], l = hsl[2];
+		float r, g, b;
+		if (s == 0f) {
+			r = g = b = l;
+		} else {
+			float q = l < 0.5f ? l * (1f + s) : l + s - l * s;
+			float p = 2f * l - q;
+			r = hueToRgb(p, q, h + 1f / 3f);
+			g = hueToRgb(p, q, h);
+			b = hueToRgb(p, q, h - 1f / 3f);
+		}
+		int red = Math.round(r * 255f);
+		int green = Math.round(g * 255f);
+		int blue = Math.round(b * 255f);
+		return ColorRGB.fromRGBA(red, green, blue, 255);
+	}
+
+	private static float hueToRgb(float p, float q, float t) {
+		if (t < 0f)
+			t += 1f;
+		if (t > 1f)
+			t -= 1f;
+		if (t < 1f / 6f)
+			return p + (q - p) * 6f * t;
+		if (t < 1f / 2f)
+			return q;
+		if (t < 2f / 3f)
+			return p + (q - p) * (2f / 3f - t) * 6f;
+		return p;
+	}
+
+	public static Color blendColors(Color c1, Color c2, double amount) {
+		amount = Math.max(0, Math.min(1, amount));
+		int r = (int) (c1.getRed() * (1 - amount) + c2.getRed() * amount);
+		int g = (int) (c1.getGreen() * (1 - amount) + c2.getGreen() * amount);
+		int b = (int) (c1.getBlue() * (1 - amount) + c2.getBlue() * amount);
+		int a = (int) (c1.getAlpha() * (1 - amount) + c2.getAlpha() * amount);
+		return ColorRGB.fromRGBA(r, g, b, a);
+	}
+
+	public static Color complementColor(Color color) {
+		int r = 255 - color.getRed();
+		int g = 255 - color.getGreen();
+		int b = 255 - color.getBlue();
+		return ColorRGB.fromRGBA(r, g, b, color.getAlpha());
+	}
+
+	public static Color complementColorHSL(Color color) {
+		float[] hsl = rgbToHsl(color);
+		hsl[0] = (hsl[0] + 0.5f) % 1f;
+		return hslToRgb(hsl);
+	}
+
+	public static ColorRGB shadeColor(Color color, int amount) {
+		amount = Math.max(1, Math.min(100, amount));
+		double factor = (100 - amount) / 100.0;
+		int r = (int) (color.getRed() * factor);
+		int g = (int) (color.getGreen() * factor);
+		int b = (int) (color.getBlue() * factor);
+		return ColorRGB.fromRGBA(r, g, b, color.getAlpha());
+	}
+
+	public static ColorRGB shadeColorHSL(Color color, int amount) {
+		amount = Math.max(1, Math.min(100, amount));
+		float[] hsl = rgbToHsl(color);
+		hsl[2] *= (100 - amount) / 100f;
+		return hslToRgb(hsl);
+	}
+
+	public static ColorRGB tintColor(Color color, int amount) {
+		amount = Math.max(1, Math.min(100, amount));
+		double factor = amount / 100.0;
+		int r = (int) (color.getRed() + (255 - color.getRed()) * factor);
+		int g = (int) (color.getGreen() + (255 - color.getGreen()) * factor);
+		int b = (int) (color.getBlue() + (255 - color.getBlue()) * factor);
+		return ColorRGB.fromRGBA(r, g, b, color.getAlpha());
+	}
+
+	public static ColorRGB tintColorHSL(Color color, int amount) {
+		amount = Math.max(1, Math.min(100, amount));
+		float[] hsl = rgbToHsl(color);
+		hsl[2] += (1f - hsl[2]) * (amount / 100f);
+		hsl[2] = Math.min(1f, hsl[2]);
+		return hslToRgb(hsl);
+	}
+
+	public static Color rotateHue(Color color, int degrees) {
+		float[] hsl = rgbToHsl(color);
+		hsl[0] = (hsl[0] + degrees / 360f) % 1f;
+		if (hsl[0] < 0f)
+			hsl[0] += 1f;
+		return hslToRgb(hsl);
+	}
+
+	public static ColorRGB adjustBrightness(Color color, int amount) {
+		amount = Math.max(-100, Math.min(100, amount));
+		float[] hsb = rgbToHsb(color);
+		float factor = amount / 100f;
+		hsb[2] = hsb[2] + hsb[2] * factor;
+		hsb[2] = Math.max(0f, Math.min(1f, hsb[2]));
+		return hsbToRgb(hsb);
+	}
+
+	private static float[] rgbToHsb(Color color) {
+		float r = color.getRed() / 255f;
+		float g = color.getGreen() / 255f;
+		float b = color.getBlue() / 255f;
+		float max = Math.max(r, Math.max(g, b));
+		float min = Math.min(r, Math.min(g, b));
+		float delta = max - min;
+		float h = 0f;
+		float s = max == 0f ? 0f : delta / max;
+		float v = max;
+		if (delta != 0f) {
+			if (max == r) {
+				h = ((g - b) / delta) % 6f;
+			} else if (max == g) {
+				h = ((b - r) / delta) + 2f;
+			} else {
+				h = ((r - g) / delta) + 4f;
+			}
+			h *= 60f;
+			if (h < 0f) h += 360f;
+		}
+		h /= 360f;
+		return new float[]{ h, s, v };
+	}
+
+	private static ColorRGB hsbToRgb(float[] hsb) {
+		float h = hsb[0], s = hsb[1], v = hsb[2];
+		float r = 0f, g = 0f, b = 0f;
+		int i = (int) (h * 6f);
+		float f = h * 6f - i;
+		float p = v * (1f - s);
+		float q = v * (1f - f * s);
+		float t = v * (1f - (1f - f) * s);
+		switch (i % 6) {
+			case 0:
+				r = v; g = t; b = p; break;
+			case 1:
+				r = q; g = v; b = p; break;
+			case 2:
+				r = p; g = v; b = t; break;
+			case 3:
+				r = p; g = q; b = v; break;
+			case 4:
+				r = t; g = p; b = v; break;
+			case 5:
+				r = v; g = p; b = q; break;
+		}
+		int red = Math.round(r * 255f);
+		int green = Math.round(g * 255f);
+		int blue = Math.round(b * 255f);
+		return ColorRGB.fromRGBA(red, green, blue, 255);
+	}
+
+	public static ColorRGB toGrayscale(Color color) {
+		int gray = (int)(0.299 * color.getRed() + 0.587 * color.getGreen() + 0.114 * color.getBlue());
+		return ColorRGB.fromRGBA(gray, gray, gray, color.getAlpha());
+	}
+
+	public static ColorRGB toSepia(Color color) {
+		int r = color.getRed();
+		int g = color.getGreen();
+		int b = color.getBlue();
+		int tr = (int) (0.393 * r + 0.769 * g + 0.189 * b);
+		int tg = (int) (0.349 * r + 0.686 * g + 0.168 * b);
+		int tb = (int) (0.272 * r + 0.534 * g + 0.131 * b);
+		tr = Math.min(255, tr);
+		tg = Math.min(255, tg);
+		tb = Math.min(255, tb);
+		return ColorRGB.fromRGBA(tr, tg, tb, color.getAlpha());
+	}
+
+	public static ColorRGB adjustTemperature(Color color, int amount) {
+		int r = color.getRed() + amount;
+		int b = color.getBlue() - amount;
+		r = Math.max(0, Math.min(255, r));
+		b = Math.max(0, Math.min(255, b));
+		return ColorRGB.fromRGBA(r, color.getGreen(), b, color.getAlpha());
+	}
+
+}

--- a/src/main/java/org/skriptlang/skript/misc/colours/ExprBlend.java
+++ b/src/main/java/org/skriptlang/skript/misc/colours/ExprBlend.java
@@ -1,6 +1,10 @@
 package org.skriptlang.skript.misc.colours;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser;
@@ -11,6 +15,20 @@ import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
+
+@Name("Blended Colours")
+@Description({
+	"Returns the result of blending colours together. Optionally takes an amount to blend the colours by, which is",
+	"a number from 0 to 100. In that range, a 50 would be an expected equal blend of each colour (the default behaviour)."
+})
+@Examples({
+	"set {_purple} to red blended with blue",
+	"set {_goldyPurple} to {_purple} blended with gold",
+	"set {_aBunch} to red blended with all colours where [input is not red]"
+})
+@Since("INSERT VERSION")
 public class ExprBlend extends SimpleExpression<Color> {
 
 	static {
@@ -33,8 +51,22 @@ public class ExprBlend extends SimpleExpression<Color> {
 
 	@Override
 	protected Color @Nullable [] get(Event event) {
+		Color[] colours = this.colours.getArray(event);
+		Color[] blendWiths = this.blendWith.getArray(event);
+		Number amount = this.amount.getSingle(event);
+		if (amount == null)
+			amount = 50;
 
-		return new Color[0];
+		List<Color> blendedColours = new ArrayList<>();
+		for (Color colour : colours) {
+			Color blended = colour;
+			for (Color blendWith : blendWiths) {
+				blended = ColourUtils.blendColors(blended, blendWith, amount.doubleValue());
+			}
+			blendedColours.add(blended);
+		}
+
+		return blendedColours.toArray(new Color[0]);
 	}
 
 	@Override
@@ -49,13 +81,14 @@ public class ExprBlend extends SimpleExpression<Color> {
 
 	@Override
 	public String toString(@Nullable Event event, boolean debug) {
-        return new SyntaxStringBuilder(event, debug)
+		return "colours blended together";
+        /* return new SyntaxStringBuilder(event, debug)
 			.append(this.colours)
 			.append("blended with")
 			.append(this.blendWith)
 			.append("by a factor of")
 			.append(this.amount)
-			.toString();
+			.toString(); */
 	}
 
 }

--- a/src/main/java/org/skriptlang/skript/misc/colours/ExprBlend.java
+++ b/src/main/java/org/skriptlang/skript/misc/colours/ExprBlend.java
@@ -7,7 +7,7 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.SyntaxStringBuilder;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.skript.util.Color;
@@ -26,6 +26,7 @@ import java.util.List;
 @Examples({
 	"set {_purple} to red blended with blue",
 	"set {_goldyPurple} to {_purple} blended with gold",
+	"set {_morePurpleThanGold} to {_purple} blended with gold by an amount of 10",
 	"set {_aBunch} to red blended with all colours where [input is not red]"
 })
 @Since("INSERT VERSION")
@@ -33,8 +34,8 @@ public class ExprBlend extends SimpleExpression<Color> {
 
 	static {
 		Skript.registerExpression(ExprBlend.class, Color.class, ExpressionType.COMBINED,
-			"%colours% (blended|mixed) with %colours% [by [[a[n] (factor|amount)] %-number%]",
-			"blend of %colours% (and|with) %colours% [by [[a[n] (factor|amount)] %-number%]");
+			"%colours% (blended|mixed) with %colours% [by [a[n] (factor|amount) of] %-number%]",
+			"blend of %colours% (and|with) %colours% [by [a[n] (factor|amount) of] %-number%]");
 	}
 
 	private Expression<Color> colours, blendWith;
@@ -42,7 +43,7 @@ public class ExprBlend extends SimpleExpression<Color> {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		this.colours = (Expression<Color>) exprs[0];
 		this.blendWith = (Expression<Color>) exprs[1];
 		this.amount	= (Expression<Number>) exprs[2];

--- a/src/main/java/org/skriptlang/skript/misc/colours/ExprBlend.java
+++ b/src/main/java/org/skriptlang/skript/misc/colours/ExprBlend.java
@@ -35,7 +35,8 @@ public class ExprBlend extends SimpleExpression<Color> {
 	static {
 		Skript.registerExpression(ExprBlend.class, Color.class, ExpressionType.COMBINED,
 			"%colors% (blended|mixed) with %colors% [by [a[n] (factor|amount) of] %-number%]",
-			"blend of %colors% (and|with) %colors% [by [a[n] (factor|amount) of] %-number%]");
+			"blend of %colors% (and|with) %colors% [by [a[n] (factor|amount) of] %-number%]",
+			"%colors% and %colors% blen(ded|t) together [by [a[n] (factor|amount) of] %-number%]");
 	}
 
 	private Expression<Color> colours, blendWith;
@@ -54,9 +55,7 @@ public class ExprBlend extends SimpleExpression<Color> {
 	protected Color @Nullable [] get(Event event) {
 		Color[] colours = this.colours.getArray(event);
 		Color[] blendWiths = this.blendWith.getArray(event);
-		Number amount = this.amount.getSingle(event);
-		if (amount == null)
-			amount = 50;
+		Number amount = this.amount == null ? 50 : this.amount.getOptionalSingle(event).orElse(50);
 
 		List<Color> blendedColours = new ArrayList<>();
 		for (Color colour : colours) {

--- a/src/main/java/org/skriptlang/skript/misc/colours/ExprBlend.java
+++ b/src/main/java/org/skriptlang/skript/misc/colours/ExprBlend.java
@@ -1,0 +1,61 @@
+package org.skriptlang.skript.misc.colours;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SyntaxStringBuilder;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.skript.util.Color;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+public class ExprBlend extends SimpleExpression<Color> {
+
+	static {
+		Skript.registerExpression(ExprBlend.class, Color.class, ExpressionType.COMBINED,
+			"%colours% (blended|mixed) with %colours% [by [[a[n] (factor|amount)] %-number%]",
+			"blend of %colours% (and|with) %colours% [by [[a[n] (factor|amount)] %-number%]");
+	}
+
+	private Expression<Color> colours, blendWith;
+	private Expression<Number> amount;
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		this.colours = (Expression<Color>) exprs[0];
+		this.blendWith = (Expression<Color>) exprs[1];
+		this.amount	= (Expression<Number>) exprs[2];
+		return true;
+	}
+
+	@Override
+	protected Color @Nullable [] get(Event event) {
+
+		return new Color[0];
+	}
+
+	@Override
+	public boolean isSingle() {
+		return this.colours.isSingle();
+	}
+
+	@Override
+	public Class<? extends Color> getReturnType() {
+		return Color.class;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+        return new SyntaxStringBuilder(event, debug)
+			.append(this.colours)
+			.append("blended with")
+			.append(this.blendWith)
+			.append("by a factor of")
+			.append(this.amount)
+			.toString();
+	}
+
+}

--- a/src/main/java/org/skriptlang/skript/misc/colours/ExprBlend.java
+++ b/src/main/java/org/skriptlang/skript/misc/colours/ExprBlend.java
@@ -34,8 +34,8 @@ public class ExprBlend extends SimpleExpression<Color> {
 
 	static {
 		Skript.registerExpression(ExprBlend.class, Color.class, ExpressionType.COMBINED,
-			"%colours% (blended|mixed) with %colours% [by [a[n] (factor|amount) of] %-number%]",
-			"blend of %colours% (and|with) %colours% [by [a[n] (factor|amount) of] %-number%]");
+			"%colors% (blended|mixed) with %colors% [by [a[n] (factor|amount) of] %-number%]",
+			"blend of %colors% (and|with) %colors% [by [a[n] (factor|amount) of] %-number%]");
 	}
 
 	private Expression<Color> colours, blendWith;

--- a/src/main/java/org/skriptlang/skript/misc/colours/ExprComplement.java
+++ b/src/main/java/org/skriptlang/skript/misc/colours/ExprComplement.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.Nullable;
 public class ExprComplement extends SimplePropertyExpression<Color, Color> {
 
 	static {
-		register(ExprComplement.class, Color.class, "[:hsl] complement[ary colo[u]r]", "colours");
+		register(ExprComplement.class, Color.class, "[:hsl] complement[ary colo[u]r]", "colors");
 	}
 
 	private boolean hsl;

--- a/src/main/java/org/skriptlang/skript/misc/colours/ExprComplement.java
+++ b/src/main/java/org/skriptlang/skript/misc/colours/ExprComplement.java
@@ -1,0 +1,28 @@
+package org.skriptlang.skript.misc.colours;
+
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.util.Color;
+import org.jetbrains.annotations.Nullable;
+
+public class ExprComplement extends SimplePropertyExpression<Color, Color> {
+
+	static {
+		register(ExprComplement.class, Color.class, "complement[ary colo[u]r]", "colours");
+	}
+
+	@Override
+	public @Nullable Color convert(Color from) {
+		return ColourUtils.complementColor(from);
+	}
+
+	@Override
+	protected String getPropertyName() {
+		return "complement";
+	}
+
+	@Override
+	public Class<? extends Color> getReturnType() {
+		return Color.class;
+	}
+
+}

--- a/src/main/java/org/skriptlang/skript/misc/colours/ExprComplement.java
+++ b/src/main/java/org/skriptlang/skript/misc/colours/ExprComplement.java
@@ -1,18 +1,43 @@
 package org.skriptlang.skript.misc.colours;
 
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.Color;
+import ch.njol.util.Kleenean;
 import org.jetbrains.annotations.Nullable;
 
+@Name("Complementary Colours")
+@Description({
+	"Returns the complementary colour of a given colour(s).",
+	"Can optionally use a HSL-based approach if need be, but this is rarely required."
+})
+@Examples({
+	"set {_bluesComplement} to complement of blue",
+	"set {_allComplements} to complementary colour of all colours"
+})
+@Since("INSERT VERSION")
 public class ExprComplement extends SimplePropertyExpression<Color, Color> {
 
 	static {
-		register(ExprComplement.class, Color.class, "complement[ary colo[u]r]", "colours");
+		register(ExprComplement.class, Color.class, "[:hsl] complement[ary colo[u]r]", "colours");
+	}
+
+	private boolean hsl;
+
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		this.hsl = parseResult.hasTag("hsl");
+		return super.init(expressions, matchedPattern, isDelayed, parseResult);
 	}
 
 	@Override
 	public @Nullable Color convert(Color from) {
-		return ColourUtils.complementColor(from);
+		return hsl ? ColourUtils.complementColorHSL(from) : ColourUtils.complementColor(from);
 	}
 
 	@Override

--- a/src/main/java/org/skriptlang/skript/misc/colours/ExprHex.java
+++ b/src/main/java/org/skriptlang/skript/misc/colours/ExprHex.java
@@ -1,0 +1,27 @@
+package org.skriptlang.skript.misc.colours;
+
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.util.Color;
+import org.jetbrains.annotations.Nullable;
+
+public class ExprHex extends SimplePropertyExpression<Color, String> {
+
+	static {
+		register(ExprHex.class, String.class, "hex [code]", "colors");
+	}
+
+	@Override
+	public @Nullable String convert(Color from) {
+		return ColourUtils.toHex(from);
+	}
+
+	@Override
+	protected String getPropertyName() {
+		return "hex code";
+	}
+
+	@Override
+	public Class<? extends String> getReturnType() {
+		return String.class;
+	}
+}

--- a/src/test/skript/tests/syntaxes/expressions/ExprColourBlend.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprColourBlend.sk
@@ -8,6 +8,4 @@ test "colour blends":
 	assert hex of {_blackAndYellow} is "#8D7A2F" with "hex of black and yellow blended together was incorrect"
 	assert hex of {_pinkAndPurple} is "#DD79AC" with "hex of pink and purple blended together by an amount of 20%% was incorrect"
 
-	assert red blended with test block is not set with "blending invalid types should return null"
-	assert "x" blended with "y" is not set with "blending invalid types should return null"
 	assert {_x} blended with {_y} is not set with "blending invalid types should return null"

--- a/src/test/skript/tests/syntaxes/expressions/ExprColourBlend.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprColourBlend.sk
@@ -1,0 +1,13 @@
+test "colour blends":
+
+	set {_redAndBlue} to red blended with blue
+	set {_blackAndYellow} to black blended with yellow
+	set {_pinkAndPurple} to pink blended with purple by an amount of 20
+
+	assert hex of {_redAndBlue} is "#763968" with "hex of red and blue blended together was incorrect"
+	assert hex of {_blackAndYellow} is "#8D7A2F" with "hex of black and yellow blended together was incorrect"
+	assert hex of {_pinkAndPurple} is "#DD79AC" with "hex of pink and purple blended together by an amount of 20%% was incorrect"
+
+	assert red blended with test block is not set with "blending invalid types should return null"
+	assert "x" blended with "y" is not set with "blending invalid types should return null"
+	assert {_x} blended with {_y} is not set with "blending invalid types should return null"

--- a/src/test/skript/tests/syntaxes/expressions/ExprColourComplement.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprColourComplement.sk
@@ -1,0 +1,23 @@
+test "colour complements":
+
+	set {_bluesComplement} to complement of blue
+	set {_bluesHslComplement} to hsl complement of blue
+	set {_bluesComplementsComplement} to complement of {_bluesComplement}
+	set {_bluesHslComplementsHslComplement} to hsl complement of {_bluesHslComplement}
+	set {_trueBlacksComplement} to complement of rgb(0, 0, 0)
+	set {_trueBlacksHslComplement} to hsl complement of rgb(0, 0, 0)
+	set {_trueWhitesComplement} to complement of rgb(255, 255, 255)
+	set {_trueWhitesHslComplement} to hsl complement of rgb(255, 255, 255)
+
+	assert hex code of {_bluesComplement} is "#C3BB55" with "complement of blue was incorrect"
+	assert hex code of {_bluesHslComplement} is "#AAA23C" with "hsl complement of blue was incorrect"
+	assert hex code of {_bluesComplementsComplement} is hex code of blue with "complement of blue's complement was incorrect"
+	assert hex code of {_bluesHslComplementsHslComplement} is hex code of blue with "hsl complement of blue's hsl complement was incorrect"
+	assert hex code of {_trueBlacksComplement} is "#FFFFFF" with "complement of true black was incorrect"
+	assert hex code of {_trueBlacksHslComplement} is "#000000" with "hsl complement of true black was incorrect"
+	assert hex code of {_trueWhitesComplement} is "#000000" with "complement of true white was incorrect"
+	assert hex code of {_trueWhitesHslComplement} is "#FFFFFF" with "hsl complement of true white was incorrect"
+
+	assert complement of test block is not set with "complement of an invalid type should return null"
+	assert complement of "x" is not set with "complement of an invalid type should return null"
+	assert complement of {_x} is not set with "complement of an invalid type should return null"

--- a/src/test/skript/tests/syntaxes/expressions/ExprColourComplement.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprColourComplement.sk
@@ -1,13 +1,13 @@
 test "colour complements":
 
-	set {_bluesComplement} to complement of blue
-	set {_bluesHslComplement} to hsl complement of blue
-	set {_bluesComplementsComplement} to complement of {_bluesComplement}
-	set {_bluesHslComplementsHslComplement} to hsl complement of {_bluesHslComplement}
-	set {_trueBlacksComplement} to complement of rgb(0, 0, 0)
-	set {_trueBlacksHslComplement} to hsl complement of rgb(0, 0, 0)
-	set {_trueWhitesComplement} to complement of rgb(255, 255, 255)
-	set {_trueWhitesHslComplement} to hsl complement of rgb(255, 255, 255)
+	set {_bluesComplement} to complementary colour of blue
+	set {_bluesHslComplement} to hsl complementary colour of blue
+	set {_bluesComplementsComplement} to complementary colour of {_bluesComplement}
+	set {_bluesHslComplementsHslComplement} to hsl complementary colour of {_bluesHslComplement}
+	set {_trueBlacksComplement} to complementary colour of rgb(0, 0, 0)
+	set {_trueBlacksHslComplement} to hsl complementary colour of rgb(0, 0, 0)
+	set {_trueWhitesComplement} to complementary colour of rgb(255, 255, 255)
+	set {_trueWhitesHslComplement} to hsl complementary colour of rgb(255, 255, 255)
 
 	assert hex code of {_bluesComplement} is "#C3BB55" with "complement of blue was incorrect"
 	assert hex code of {_bluesHslComplement} is "#AAA23C" with "hsl complement of blue was incorrect"
@@ -18,6 +18,4 @@ test "colour complements":
 	assert hex code of {_trueWhitesComplement} is "#000000" with "complement of true white was incorrect"
 	assert hex code of {_trueWhitesHslComplement} is "#FFFFFF" with "hsl complement of true white was incorrect"
 
-	assert complement of test block is not set with "complement of an invalid type should return null"
-	assert complement of "x" is not set with "complement of an invalid type should return null"
-	assert complement of {_x} is not set with "complement of an invalid type should return null"
+	assert complementary colour of {_x} is not set with "complement of an invalid type should return null"

--- a/src/test/skript/tests/syntaxes/expressions/ExprColourHex.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprColourHex.sk
@@ -1,0 +1,21 @@
+test "hex codes":
+
+	assert hex code of black is raw "#1D1D21" with "black hex code was not correct"
+	assert hex code of dark grey is raw "#474F52" with "black hex code was not correct"
+	assert hex code of grey is raw "#9D9D97" with "black hex code was not correct"
+	assert hex code of white is raw "#F9FFFE" with "black hex code was not correct"
+	assert hex code of blue is raw "#3C44AA" with "black hex code was not correct"
+	assert hex code of brown is raw "#835432" with "black hex code was not correct"
+	assert hex code of cyan is raw "#169C9C" with "black hex code was not correct"
+	assert hex code of light cyan is raw "#3AB3DA" with "black hex code was not correct"
+	assert hex code of green is raw "#5E7C16" with "black hex code was not correct"
+	assert hex code of light green is raw "#80C71F" with "black hex code was not correct"
+	assert hex code of yellow is raw "#FED83D" with "black hex code was not correct"
+	assert hex code of orange is raw "#F9801D" with "black hex code was not correct"
+	assert hex code of red is raw "#B02E26" with "black hex code was not correct"
+	assert hex code of pink is raw "#F38BAA" with "black hex code was not correct"
+	assert hex code of purple is raw "#8932B8" with "black hex code was not correct"
+	assert hex code of magenta is raw "#C74EBD" with "black hex code was not correct"
+
+	assert hex code of test block is not set with "hex code of an invalid type shouldn't return anything"
+	assert hex code of {_x} is not set with "hex code of an invalid type shouldn't return anything"

--- a/src/test/skript/tests/syntaxes/expressions/ExprColourHex.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprColourHex.sk
@@ -17,5 +17,4 @@ test "hex codes":
 	assert hex code of purple is raw "#8932B8" with "black hex code was not correct"
 	assert hex code of magenta is raw "#C74EBD" with "black hex code was not correct"
 
-	assert hex code of test block is not set with "hex code of an invalid type shouldn't return anything"
 	assert hex code of {_x} is not set with "hex code of an invalid type shouldn't return anything"

--- a/src/test/skript/tests/syntaxes/functions/colours/brightness.sk
+++ b/src/test/skript/tests/syntaxes/functions/colours/brightness.sk
@@ -1,0 +1,17 @@
+test "colour brightness":
+
+	set {_redBrightness-100} to colourBrightness(red, -100)
+	set {_redBrightness-10} to colourBrightness(red, -10)
+	set {_redBrightness10} to colourBrightness(red, 10)
+	set {_redBrightness100} to colourBrightness(red, 100)
+	set {_redBrightnessInfinity} to colourBrightness(red, infinity value)
+	set {_redBrightnessNan} to colourBrightness(red, nan value)
+
+	assert hex code of {_redBrightness-100} is "#000000" with "hex code of red brightened by -100 was incorrect"
+	assert hex code of {_redBrightness-10} is "#9E2922" with "hex code of red brightened by -10 was incorrect"
+	assert hex code of {_redBrightness10} is "#C2332A" with "hex code of red brightened by 10 was incorrect"
+	assert hex code of {_redBrightness100} is "#FF4337" with "hex code of red brightened by 100 was incorrect"
+	assert hex code of {_redBrightnessInfinity} is "#B03028" with "adjusting the brightness of a colour by infinity should clamp between -100 and 100"
+	assert hex code of {_redBrightnessNan} is "#B03028" with "adjusting the brightness of a colour by nan should clamp between -100 and 100"
+
+	assert colourBrightness({_x}) is not set with "adjusting the brightness an invalid type shouldn't return anything"

--- a/src/test/skript/tests/syntaxes/functions/colours/brightness.sk
+++ b/src/test/skript/tests/syntaxes/functions/colours/brightness.sk
@@ -11,7 +11,7 @@ test "colour brightness":
 	assert hex code of {_redBrightness-10} is "#9E2922" with "hex code of red brightened by -10 was incorrect"
 	assert hex code of {_redBrightness10} is "#C2332A" with "hex code of red brightened by 10 was incorrect"
 	assert hex code of {_redBrightness100} is "#FF4337" with "hex code of red brightened by 100 was incorrect"
-	assert hex code of {_redBrightnessInfinity} is "#B03028" with "adjusting the brightness of a colour by infinity should clamp between -100 and 100"
-	assert hex code of {_redBrightnessNan} is "#B03028" with "adjusting the brightness of a colour by nan should clamp between -100 and 100"
+	assert hex code of {_redBrightnessInfinity} is "#AE2E26" with "adjusting the brightness of a colour by infinity should clamp between -100 and 100"
+	assert hex code of {_redBrightnessNan} is "#B02E26" with "adjusting the brightness of a colour by nan should clamp between -100 and 100"
 
-	assert colourBrightness({_x}) is not set with "adjusting the brightness an invalid type shouldn't return anything"
+	assert colourBrightness({_x}, 4) is not set with "adjusting the brightness an invalid type shouldn't return anything"

--- a/src/test/skript/tests/syntaxes/functions/colours/grayscale.sk
+++ b/src/test/skript/tests/syntaxes/functions/colours/grayscale.sk
@@ -1,0 +1,11 @@
+test "colour grayscales":
+
+	set {_redGrayscale} to grayscale(red)
+	set {_redAndBlueGrayscale} to grayscale(red blended with blue)
+	set {_shadedRedGrayscale} to grayscale(shade(red, 50, true))
+
+	assert hex code of {_redGrayscale} is "#535353" with "hex code of grayscale of red was incorrect"
+	assert hex code of {_redAndBlueGrayscale} is "#505050" with "hex code of grayscale of red was incorrect"
+	assert hex code of {_shadedRedGrayscale} is "#292929" with "hex code of grayscale of red was incorrect"
+
+	assert grayscale({_x}) is not set with "getting the grayscale of an invalid type shouldn't return anything"

--- a/src/test/skript/tests/syntaxes/functions/colours/sepiatone.sk
+++ b/src/test/skript/tests/syntaxes/functions/colours/sepiatone.sk
@@ -1,0 +1,11 @@
+test "colour sepiatones":
+
+	set {_redSepiatone} to sepiatone(red)
+	set {_redAndBlueSepiatone} to sepiatone(red blended with blue)
+	set {_shadedRedSepiatone} to sepiatone(shade(red, 50, true))
+
+	assert hex code of {_redSepiatone} is "#6F634D" with "hex code of sepiatone of red was incorrect"
+	assert hex code of {_redAndBlueSepiatone} is "#6D614C" with "hex code of sepiatone of red was incorrect"
+	assert hex code of {_shadedRedSepiatone} is "#373126" with "hex code of sepiatone of red was incorrect"
+
+	assert sepiatone({_x}) is not set with "getting the sepiatone of an invalid type shouldn't return anything"

--- a/src/test/skript/tests/syntaxes/functions/colours/shade.sk
+++ b/src/test/skript/tests/syntaxes/functions/colours/shade.sk
@@ -1,0 +1,19 @@
+test "colour shades":
+
+	set {_redShade} to shade(red)
+	set {_redShade10} to shade(red, 10)
+	set {_redShade100} to shade(red, 100)
+	set {_redShadeHsl} to shade(red, 1, true)
+	set {_redShadeNegative} to shade(red, -4)
+	set {_redShadeInfinity} to shade(red, infinity value)
+	set {_redShadeNan} to shade(red, nan value)
+
+	assert hex code of {_redShade} is "#AE2D25" with "hex code of red shaded by 1 was incorrect"
+	assert hex code of {_redShade10} is "#9E2922" with "hex code of red shaded by 10 was incorrect"
+	assert hex code of {_redShade100} is "#000000" with "hex code of red shaded by 100 was incorrect"
+	assert hex code of {_redShadeHsl} is "#AE2E26" with "hex code of red shaded by 1 using hsl methods was incorrect"
+	assert hex code of {_redShadeNegative} is "#AE2D25" with "shading a colour by a negative amount should clamp between 1 and 100"
+	assert hex code of {_redShadeInfinity} is "#AE2D25" with "shading a colour by infinity should clamp between 1 and 100"
+	assert hex code of {_redShadeNan} is "#AE2D25" with "shading a colour by nan should clamp between 1 and 100"
+
+	assert shade({_x}) is not set with "shading an invalid type shouldn't return anything"

--- a/src/test/skript/tests/syntaxes/functions/colours/tint.sk
+++ b/src/test/skript/tests/syntaxes/functions/colours/tint.sk
@@ -1,0 +1,19 @@
+test "colour tints":
+
+	set {_redTint} to tint(red)
+	set {_redTint10} to tint(red, 10)
+	set {_redTint100} to tint(red, 100)
+	set {_redTintHsl} to tint(red, 1, true)
+	set {_redTintNegative} to tint(red, -4)
+	set {_redTintInfinity} to tint(red, infinity value)
+	set {_redTintNan} to tint(red, nan value)
+
+	assert hex code of {_redTint} is "#B03028" with "hex code of red tinted by 1 was incorrect"
+	assert hex code of {_redTint10} is "#B7423B" with "hex code of red tinted by 10 was incorrect"
+	assert hex code of {_redTint100} is "#FFFFFF" with "hex code of red tinted by 100 was incorrect"
+	assert hex code of {_redTintHsl} is "#B22F27" with "hex code of red tinted by 1 using hsl methods was incorrect"
+	assert hex code of {_redTintNegative} is "#B03028" with "tinting a colour by a negative amount should clamp between 1 and 100"
+	assert hex code of {_redTintInfinity} is "#B03028" with "tinting a colour by infinity should clamp between 1 and 100"
+	assert hex code of {_redTintNan} is "#B03028" with "tinting a colour by nan should clamp between 1 and 100"
+
+	assert tint({_x}) is not set with "tinting an invalid type shouldn't return anything"


### PR DESCRIPTION
### Description
This PR adds a few colour manipulation expressions and functions. There might be more to come in another PR, because there's plenty left which can still be included, but these seemed (to me) like the important-ish ones. Find below a list of new syntax:
* **Blend expression**: blends colours together
* **Complement expression**: returns the complement of a colour(s), optionally using HSL adjustments
* **`shade` function**: shades a colour by a given amount, optionally using HSL adjustments
* **`tint` function**: tints a colour by a given amount, optionally using HSL adjustments
* **`colourBrightness` function**: adjusts the brightness of a colour by a given amount. This is similar to, but not the same as, the `shade` and `tint` functions
* **`grayscale` function**: converts a colour to its grayscale equivalent
* **`sepiatone` function**: converts a colour to its sepiatone equivalent

This PR also adds `channel` as an option in ExprARGB.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
