### PR TITLE
Fix async alias loading on 1.19.4

### DIFF
--- a/src/main/java/ch/njol/skript/entity/EntityData.java
+++ b/src/main/java/ch/njol/skript/entity/EntityData.java
@@ -279,6 +279,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	
 	@SuppressWarnings("unchecked")
 	public static <E extends Entity, T extends EntityData<E>> void register(final Class<T> dataClass, final String name, final Class<E> entityClass, final int defaultName, final String... codeNames) throws IllegalArgumentException {
+		System.out.println("registering: " + name);
 		final EntityDataInfo<T> info = new EntityDataInfo<>(dataClass, name, codeNames, defaultName, entityClass);
 		for (int i = 0; i < infos.size(); i++) {
 			if (infos.get(i).entityClass.isAssignableFrom(entityClass)) {
@@ -431,7 +432,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	@SuppressWarnings("null")
 	@Nullable
 	public static EntityData<?> parse(String s) {
-		Iterator<EntityDataInfo<EntityData<?>>> it = infos.iterator();
+		Iterator<EntityDataInfo<EntityData<?>>> it = new ArrayList<>(infos).iterator();
 		return SkriptParser.parseStatic(Noun.stripIndefiniteArticle(s), it, null);
 	}
 	
@@ -443,7 +444,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	 */
 	@Nullable
 	public static EntityData<?> parseWithoutIndefiniteArticle(String s) {
-		Iterator<EntityDataInfo<EntityData<?>>> it = infos.iterator();
+		Iterator<EntityDataInfo<EntityData<?>>> it = new ArrayList<>(infos).iterator();
 		return SkriptParser.parseStatic(s, it, null);
 	}
 

--- a/src/main/java/ch/njol/skript/entity/EntityData.java
+++ b/src/main/java/ch/njol/skript/entity/EntityData.java
@@ -279,7 +279,6 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	
 	@SuppressWarnings("unchecked")
 	public static <E extends Entity, T extends EntityData<E>> void register(final Class<T> dataClass, final String name, final Class<E> entityClass, final int defaultName, final String... codeNames) throws IllegalArgumentException {
-		System.out.println("registering: " + name);
 		final EntityDataInfo<T> info = new EntityDataInfo<>(dataClass, name, codeNames, defaultName, entityClass);
 		for (int i = 0; i < infos.size(); i++) {
 			if (infos.get(i).entityClass.isAssignableFrom(entityClass)) {


### PR DESCRIPTION
### Description
Fixes async alias loading on 1.19.4's JUnit run.

**What went wrong**
While loading the aliases, SimpleEntityData's simple entities would be registered on the alias thread. This would then be registered into EntityData by registering `simple`. After this, parsing would start on the alias thread, specifically the (simple) entity `spectral arrow`. While this was happening, the code for registering non-simple EntityDatas would run, which modified the EntityData iterator while parsing of `spectral arrow` (or sometimes `arrow`) was ongoing, causing the exception. 

**Solution**
As the alias thread seems to only start parsing simple entities when it has completed, my solution is to avoid allowing modification of the iterator while looping. So far, this has not resulted in any problems. 

Before, this error would occur on about 2/3rds of my test runs. This seems fixed now, though.

---
**Target Minecraft Versions:** 1.19.4 <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
