### PR TITLE
Fix BlockIgniteEvent 

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -423,7 +423,7 @@ public final class BukkitEventValues {
 			@Override
 			@Nullable
 			public Block get(final BlockIgniteEvent e) {
-				return e.getIgnitingBlock();
+				return e.getBlock();
 			}
 		}, 0);
 		// BlockDispenseEvent


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

(edited)
`event-block` in event `BlockIgniteEvent` (`on ignite`) should return `getBlock()` instead of `getIgnitingBlock()`

issue occurred on:
- skript: 2.9.2
- engine:  paper-1.21.1-122

---
**Target Minecraft Versions:** any
**Requirements:** none 
**Related Issues:** none