### PR TITLE
Helper for running code with copied local variables

### DIFF
--- a/src/main/java/ch/njol/skript/sections/EffSecSpawn.java
+++ b/src/main/java/ch/njol/skript/sections/EffSecSpawn.java
@@ -136,9 +136,7 @@ public class EffSecSpawn extends EffectSection {
 	}
 
 	@Override
-	@Nullable
-	@SuppressWarnings({"unchecked", "rawtypes"})
-	protected TriggerItem walk(Event event) {
+	protected @Nullable TriggerItem walk(Event event) {
 		lastSpawned = null;
 
 		Consumer<? extends Entity> consumer;
@@ -146,13 +144,7 @@ public class EffSecSpawn extends EffectSection {
 			consumer = entity -> {
 				lastSpawned = entity;
 				SpawnEvent spawnEvent = new SpawnEvent(entity);
-				// Copy the local variables from the calling code to this section
-				Variables.setLocalVariables(spawnEvent, Variables.copyLocalVariables(event));
-				TriggerItem.walk(trigger, spawnEvent);
-				// And copy our (possibly modified) local variables back to the calling code
-				Variables.setLocalVariables(event, Variables.copyLocalVariables(spawnEvent));
-				// Clear spawnEvent's local variables as it won't be done automatically
-				Variables.removeLocals(spawnEvent);
+				Variables.withLocalVariables(event, spawnEvent, () -> TriggerItem.walk(trigger, spawnEvent));
 			};
 		} else {
 			consumer = null;
@@ -167,6 +159,7 @@ public class EffSecSpawn extends EffectSection {
 					double typeAmount = amount * type.getAmount();
 					for (int i = 0; i < typeAmount; i++) {
 						if (consumer != null) {
+							//noinspection unchecked,rawtypes
 							type.data.spawn(location, (Consumer) consumer); // lastSpawned set within Consumer
 						} else {
 							lastSpawned = type.data.spawn(location);

--- a/src/main/java/ch/njol/skript/variables/Variables.java
+++ b/src/main/java/ch/njol/skript/variables/Variables.java
@@ -413,13 +413,26 @@ public class Variables {
 	 * @param event the event to copy local variables from.
 	 * @return the copy.
 	 */
-	@Nullable
-	public static Object copyLocalVariables(Event event) {
+	public static @Nullable Object copyLocalVariables(Event event) {
 		VariablesMap from = localVariables.get(event);
 		if (from == null)
 			return null;
 
 		return from.copy();
+	}
+
+	/**
+	 * Copies local variables from provider to user, runs action, then copies variables back to provider.
+	 * Removes local variables from user after action is finished.
+	 * @param provider The originator of the local variables.
+	 * @param user The event to copy the variables to and back from.
+	 * @param action The code to run while the variables are copied.
+	 */
+	public static void withLocalVariables(Event provider, Event user, @NotNull Runnable action) {
+		Variables.setLocalVariables(user, Variables.copyLocalVariables(provider));
+		action.run();
+		Variables.setLocalVariables(provider, Variables.copyLocalVariables(user));
+		Variables.removeLocals(user);
 	}
 
 	/**


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Helper method to cut down on possible bugs when running an event with copied local variables.

Previous:
```
Variables.setLocalVariables(B, Variables.copyLocalVariables(A));
MY CODE HERE
Variables.setLocalVariables(A, Variables.copyLocalVariables(B));
Variables.removeLocals(B);
```

New:
```
Variables.withLocalVariables(A, B, () -> {
    MY CODE HERE
});
```

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
