### PR TITLE
Add Reload Event for SkriptConfig

### DIFF
--- a/src/main/java/org/skriptlang/skript/util/event/EventRegistry.java
+++ b/src/main/java/org/skriptlang/skript/util/event/EventRegistry.java
@@ -3,8 +3,8 @@ package org.skriptlang.skript.util.event;
 import com.google.common.collect.ImmutableSet;
 import org.jetbrains.annotations.Unmodifiable;
 
-import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * An EventRegistry is a generic container for events.
@@ -13,7 +13,7 @@ import java.util.Set;
  */
 public class EventRegistry<E extends Event> {
 
-	private final Set<E> events = new HashSet<>();
+	private final Set<E> events = ConcurrentHashMap.newKeySet();
 
 	/**
 	 * Registers the provided event with this register.


### PR DESCRIPTION
### Description
This PR adds event support to SkriptConfig using the new event registry API. I added one event for when the config is reloaded, though it would be trivial to add other events should the need arise. I also made some minor changes to the EventRegistry implementation for thread-safety.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
