### PR TITLE
Fix Improperly Typed Array in ExprXOf

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprXOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprXOf.java
@@ -36,6 +36,8 @@ import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.reflect.Array;
+
 @Name("X of Item")
 @Description("An expression to be able to use a certain amount of items where the amount can be any expression. Please note that this expression is not stable and might be replaced in the future.")
 @Examples("give level of player of pickaxes to the player")
@@ -62,7 +64,7 @@ public class ExprXOf extends PropertyExpression<Object, Object> {
 	protected Object[] get(Event e, Object[] source) {
 		Number a = amount.getSingle(e);
 		if (a == null)
-			return new Object[0];
+			return (Object[]) Array.newInstance(getReturnType(), 0);
 
 		return get(source, o -> {
 			if (o instanceof ItemStack) {

--- a/src/test/skript/tests/regressions/6817-null of x incorrect type.sk
+++ b/src/test/skript/tests/regressions/6817-null of x incorrect type.sk
@@ -1,0 +1,3 @@
+test "null of x incorrect type":
+	# would cause an exception
+	spawn {_null} of pig above {_null}


### PR DESCRIPTION
### Description
This PR simply aims to resolve the issue where ExprXOf returns an improperly typed array when the `amount` expression evaluates to null. It is _not_ a goal to rewrite or improve the expression in any other way.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:**
- https://github.com/SkriptLang/Skript/issues/6817
