### PR TITLE
SoundReceiver - fix error on Spigot when adventure API is implemented

### DIFF
--- a/src/main/java/ch/njol/skript/bukkitutil/sounds/SoundReceiver.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/sounds/SoundReceiver.java
@@ -19,7 +19,7 @@ import java.util.OptionalLong;
  */
 public interface SoundReceiver {
 
-	boolean ADVENTURE_API = Skript.classExists("net.kyori.adventure.sound.Sound$Builder");
+	boolean ADVENTURE_API = Skript.classExists("net.kyori.adventure.sound.Sound$Builder") && Skript.methodExists(SoundCategory.class, "soundSource");
 	boolean SPIGOT_SOUND_SEED = Skript.methodExists(Player.class, "playSound", Entity.class, Sound.class, SoundCategory.class, float.class, float.class, long.class);
 	boolean ENTITY_EMITTER_SOUND = Skript.methodExists(Player.class, "playSound", Entity.class, Sound.class, SoundCategory.class, float.class, float.class);
 	boolean ENTITY_EMITTER_STRING = Skript.methodExists(Player.class, "playSound", Entity.class, String.class, SoundCategory.class, float.class, float.class);

--- a/src/main/java/ch/njol/skript/effects/EffPlaySound.java
+++ b/src/main/java/ch/njol/skript/effects/EffPlaySound.java
@@ -67,9 +67,8 @@ public class EffPlaySound extends Effect {
 	// 		World - Location/Entity - Sound/String
 	// 1.20 - spigot adds sound seeds
 
-	private static final boolean ADVENTURE_API = Skript.classExists("net.kyori.adventure.sound.Sound$Builder");
 	private static final boolean SPIGOT_SOUND_SEED = Skript.methodExists(Player.class, "playSound", Entity.class, Sound.class, SoundCategory.class, float.class, float.class, long.class);
-	private static final boolean HAS_SEED = ADVENTURE_API || SPIGOT_SOUND_SEED;
+	private static final boolean HAS_SEED = SoundReceiver.ADVENTURE_API || SPIGOT_SOUND_SEED;
 	private static final boolean ENTITY_EMITTER_SOUND = Skript.methodExists(Player.class, "playSound", Entity.class, Sound.class, SoundCategory.class, float.class, float.class);
 	private static final boolean ENTITY_EMITTER_STRING = Skript.methodExists(Player.class, "playSound", Entity.class, String.class, SoundCategory.class, float.class, float.class);
 	private static final boolean ENTITY_EMITTER = ENTITY_EMITTER_SOUND || ENTITY_EMITTER_STRING;


### PR DESCRIPTION
### Description
This PR aims to fix an error when running Skript on Spigot when another plugin implements adventure API.
This issue was first brought to me by someone using Mohist, which I'm assuming implements adventure API but not fully.


---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7261 
