### PR TITLE
Fix ExprTextOf error on Spigot

### DIFF
--- a/src/main/java/org/skriptlang/skript/bukkit/misc/expressions/ExprTextOf.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/misc/expressions/ExprTextOf.java
@@ -33,7 +33,8 @@ public class ExprTextOf extends SimplePropertyExpression<Object, String> {
 	static {
 		String types = "";
 		if (Skript.classExists("org.bukkit.entity.Display")) {
-			serializer = BungeeComponentSerializer.get();
+			if (IS_RUNNING_PAPER)
+				serializer = BungeeComponentSerializer.get();
 			types += "displays";
 		}
 		// This is because this expression is setup to support future types.


### PR DESCRIPTION
### Description
This PR aims to fix an error with ExprTextOf when run on Spigot.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7272
