### PR TITLE
Optional Default Comparator

### DIFF
--- a/src/main/java/ch/njol/skript/classes/EnumClassInfo.java
+++ b/src/main/java/ch/njol/skript/classes/EnumClassInfo.java
@@ -25,7 +25,17 @@ public class EnumClassInfo<T extends Enum<T>> extends ClassInfo<T> {
 	 * @param languageNode The language node of the type
 	 */
 	public EnumClassInfo(Class<T> enumClass, String codeName, String languageNode) {
-		this(enumClass, codeName, languageNode, new EventValueExpression<>(enumClass));
+		this(enumClass, codeName, languageNode, new EventValueExpression<>(enumClass), true);
+	}
+
+	/**
+	 * @param enumClass The class
+	 * @param codeName The name used in patterns
+	 * @param languageNode The language node of the type
+	 * @param registerComparator Allow a default comparator to be made
+	 */
+	public EnumClassInfo(Class<T> enumClass, String codeName, String languageNode, boolean registerComparator) {
+		this(enumClass, codeName, languageNode, new EventValueExpression<>(enumClass), registerComparator);
 	}
 
 	/**
@@ -35,6 +45,17 @@ public class EnumClassInfo<T extends Enum<T>> extends ClassInfo<T> {
 	 * @param defaultExpression The default expression of the type
 	 */
 	public EnumClassInfo(Class<T> enumClass, String codeName, String languageNode, DefaultExpression<T> defaultExpression) {
+		this(enumClass, codeName, languageNode, defaultExpression, true);
+	}
+
+	/**
+	 * @param enumClass The class
+	 * @param codeName The name used in patterns
+	 * @param languageNode The language node of the type
+	 * @param defaultExpression The default expression of the type
+	 * @param registerComparator Allow a default comparator to be made
+	 */
+	public EnumClassInfo(Class<T> enumClass, String codeName, String languageNode, DefaultExpression<T> defaultExpression, boolean registerComparator) {
 		super(enumClass, codeName);
 		EnumUtils<T> enumUtils = new EnumUtils<>(enumClass, languageNode);
 		usage(enumUtils.getAllNames())
@@ -57,8 +78,8 @@ public class EnumClassInfo<T extends Enum<T>> extends ClassInfo<T> {
 					return enumUtils.toString(constant, StringMode.VARIABLE_NAME);
 				}
 			});
-
-		Comparators.registerComparator(enumClass, enumClass, (o1, o2) -> Relation.get(o1.ordinal() - o2.ordinal()));
+		if (registerComparator)
+			Comparators.registerComparator(enumClass, enumClass, (o1, o2) -> Relation.get(o1.ordinal() - o2.ordinal()));
 	}
 
 }

--- a/src/main/java/ch/njol/skript/classes/EnumClassInfo.java
+++ b/src/main/java/ch/njol/skript/classes/EnumClassInfo.java
@@ -32,7 +32,7 @@ public class EnumClassInfo<T extends Enum<T>> extends ClassInfo<T> {
 	 * @param enumClass The class
 	 * @param codeName The name used in patterns
 	 * @param languageNode The language node of the type
-	 * @param registerComparator Allow a default comparator to be made
+	 * @param registerComparator Whether a default comparator should be registered for this enum's classinfo
 	 */
 	public EnumClassInfo(Class<T> enumClass, String codeName, String languageNode, boolean registerComparator) {
 		this(enumClass, codeName, languageNode, new EventValueExpression<>(enumClass), registerComparator);
@@ -53,7 +53,7 @@ public class EnumClassInfo<T extends Enum<T>> extends ClassInfo<T> {
 	 * @param codeName The name used in patterns
 	 * @param languageNode The language node of the type
 	 * @param defaultExpression The default expression of the type
-	 * @param registerComparator Allow a default comparator to be made
+	 * @param registerComparator Whether a default comparator should be registered for this enum's classinfo
 	 */
 	public EnumClassInfo(Class<T> enumClass, String codeName, String languageNode, DefaultExpression<T> defaultExpression, boolean registerComparator) {
 		super(enumClass, codeName);

--- a/src/main/java/ch/njol/skript/classes/registry/RegistryClassInfo.java
+++ b/src/main/java/ch/njol/skript/classes/registry/RegistryClassInfo.java
@@ -34,7 +34,7 @@ public class RegistryClassInfo<R extends Keyed> extends ClassInfo<R> {
 	 * @param registerComparator Whether a default comparator should be registered for this registry's classinfo
 	 */
 	public RegistryClassInfo(Class<R> registryClass, Registry<R> registry, String codeName, String languageNode, boolean registerComparator) {
-		this(registryClass, registry, codeName, languageNode, new EventValueExpression<>(registryClass), false);
+		this(registryClass, registry, codeName, languageNode, new EventValueExpression<>(registryClass), registerComparator);
 	}
 
 	/**

--- a/src/main/java/ch/njol/skript/classes/registry/RegistryClassInfo.java
+++ b/src/main/java/ch/njol/skript/classes/registry/RegistryClassInfo.java
@@ -16,15 +16,47 @@ import org.skriptlang.skript.lang.comparator.Relation;
  */
 public class RegistryClassInfo<R extends Keyed> extends ClassInfo<R> {
 
+	/**
+	 * @param registryClass The registry class
+	 * @param registry The registry
+	 * @param codeName The name used in patterns
+	 * @param languageNode The language node of the type
+	 */
 	public RegistryClassInfo(Class<R> registryClass, Registry<R> registry, String codeName, String languageNode) {
-		this(registryClass, registry, codeName, languageNode, new EventValueExpression<>(registryClass));
+		this(registryClass, registry, codeName, languageNode, new EventValueExpression<>(registryClass), true);
 	}
 
 	/**
+	 * @param registryClass The registry class
 	 * @param registry The registry
 	 * @param codeName The name used in patterns
+	 * @param languageNode The language node of the type
+	 * @param registerComparator Whether a default comparator should be registered for this registry's classinfo
+	 */
+	public RegistryClassInfo(Class<R> registryClass, Registry<R> registry, String codeName, String languageNode, boolean registerComparator) {
+		this(registryClass, registry, codeName, languageNode, new EventValueExpression<>(registryClass), false);
+	}
+
+	/**
+	 * @param registryClass The registry class
+	 * @param registry The registry
+	 * @param codeName The name used in patterns
+	 * @param languageNode The language node of the type
+	 * @param defaultExpression The default expression of the type
 	 */
 	public RegistryClassInfo(Class<R> registryClass, Registry<R> registry, String codeName, String languageNode, DefaultExpression<R> defaultExpression) {
+		this(registryClass, registry, codeName, languageNode,  defaultExpression, true);
+	}
+
+	/**
+	 * @param registryClass The registry class
+	 * @param registry The registry
+	 * @param codeName The name used in patterns
+	 * @param languageNode The language node of the type
+	 * @param defaultExpression The default expression of the type
+	 * @param registerComparator Whether a default comparator should be registered for this registry's classinfo
+	 */
+	public RegistryClassInfo(Class<R> registryClass, Registry<R> registry, String codeName, String languageNode, DefaultExpression<R> defaultExpression, boolean registerComparator) {
 		super(registryClass, codeName);
 		RegistryParser<R> registryParser = new RegistryParser<>(registry, languageNode);
 		usage(registryParser.getAllNames())
@@ -33,7 +65,8 @@ public class RegistryClassInfo<R extends Keyed> extends ClassInfo<R> {
 			.defaultExpression(defaultExpression)
 			.parser(registryParser);
 
-		Comparators.registerComparator(registryClass, registryClass, (o1, o2) -> Relation.get(o1.getKey() == o2.getKey()));
+		if (registerComparator)
+			Comparators.registerComparator(registryClass, registryClass, (o1, o2) -> Relation.get(o1.getKey() == o2.getKey()));
 	}
 
 }


### PR DESCRIPTION
### Description
This PR aims to add the option of registering a default comparator when creating a new EnumClassInfo and RegistryClassInfo

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
