### PR TITLE
Aliases - remove thread sleep

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/Aliases.java
+++ b/src/main/java/ch/njol/skript/aliases/Aliases.java
@@ -447,12 +447,7 @@ public abstract class Aliases {
 			Skript.warning("An item that has the id 'mod:item' can be used as 'mod's item' or 'item from mod'.");
 			Skript.warning("WARNING: Skript does not officially support any modded servers.");
 			Skript.warning("Any issues you encounter related to modded items will be your responsibility to fix.");
-			Skript.warning("The server will keep loading after 5 seconds.");
 			Skript.warning("==============================================================");
-			try {
-				Thread.sleep(5000L);
-			} catch (InterruptedException ignored) {
-			}
 		}
 	}
 


### PR DESCRIPTION
### Description
This PR aims to remove the Thread sleeping from modded aliases.
Skript loads aliases on another thread, so this sleep really doesn't have a benefit

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
