### PR TITLE
SkriptCommand - don't double send reload messages

### DIFF
--- a/src/main/java/ch/njol/skript/SkriptCommand.java
+++ b/src/main/java/ch/njol/skript/SkriptCommand.java
@@ -105,7 +105,7 @@ public class SkriptCommand implements CommandExecutor {
 
 		// Log reloading message
 		String text = Language.format(CONFIG_NODE + ".reload." + "player reload", sender.getName(), what);
-		logHandler.log(new LogEntry(Level.INFO, Utils.replaceEnglishChatStyles(text)));
+		logHandler.log(new LogEntry(Level.INFO, Utils.replaceEnglishChatStyles(text)), sender);
 	}
 
 
@@ -124,7 +124,6 @@ public class SkriptCommand implements CommandExecutor {
 			message = StringUtils.fixCapitalization(PluralizingArgsMessage.format(m_reload_error.toString(what, logHandler.numErrors(), timeTaken)));
 			logHandler.log(new LogEntry(Level.SEVERE, Utils.replaceEnglishChatStyles(message)));
 		}
-		Skript.info(sender, message);
 	}
 
 	private static void info(CommandSender sender, String what, Object... args) {
@@ -143,10 +142,11 @@ public class SkriptCommand implements CommandExecutor {
 			return true;
 
 		Set<CommandSender> recipients = new HashSet<>();
+		recipients.add(sender);
 
 		if (args[0].equalsIgnoreCase("reload")) {
 			recipients.addAll(Bukkit.getOnlinePlayers().stream()
-				.filter(player -> player != sender && player.hasPermission("skript.reloadnotify"))
+				.filter(player -> player.hasPermission("skript.reloadnotify"))
 				.collect(Collectors.toSet()));
 		}
 

--- a/src/main/java/ch/njol/skript/SkriptCommand.java
+++ b/src/main/java/ch/njol/skript/SkriptCommand.java
@@ -124,6 +124,7 @@ public class SkriptCommand implements CommandExecutor {
 			message = StringUtils.fixCapitalization(PluralizingArgsMessage.format(m_reload_error.toString(what, logHandler.numErrors(), timeTaken)));
 			logHandler.log(new LogEntry(Level.SEVERE, Utils.replaceEnglishChatStyles(message)));
 		}
+		Skript.info(sender, message);
 	}
 
 	private static void info(CommandSender sender, String what, Object... args) {
@@ -142,11 +143,10 @@ public class SkriptCommand implements CommandExecutor {
 			return true;
 
 		Set<CommandSender> recipients = new HashSet<>();
-		recipients.add(sender);
 
 		if (args[0].equalsIgnoreCase("reload")) {
 			recipients.addAll(Bukkit.getOnlinePlayers().stream()
-				.filter(player -> player.hasPermission("skript.reloadnotify"))
+				.filter(player -> player != sender && player.hasPermission("skript.reloadnotify"))
 				.collect(Collectors.toSet()));
 		}
 

--- a/src/main/java/ch/njol/skript/log/RedirectingLogHandler.java
+++ b/src/main/java/ch/njol/skript/log/RedirectingLogHandler.java
@@ -46,8 +46,14 @@ public class RedirectingLogHandler extends LogHandler {
 
 	@Override
 	public LogResult log(LogEntry entry) {
+		return log(entry, null);
+	}
+
+	public LogResult log(LogEntry entry, @Nullable CommandSender ignore) {
 		String formattedMessage = prefix + entry.toFormattedString();
 		for (CommandSender recipient : recipients) {
+			if (recipient == ignore)
+				continue;
 			SkriptLogger.sendFormatted(recipient, formattedMessage);
 		}
 		if (entry.level == Level.SEVERE) {


### PR DESCRIPTION
### Description
This PR aims to fix an issue with double sending reload messages.

### BEFORE:
Reload in console:
<img width="425" alt="Screenshot 2024-12-21 at 3 33 25 PM" src="https://github.com/user-attachments/assets/c49a561b-22d2-4996-86d6-159c6dd05cb9" />

Reload in game:
<img width="462" alt="Screenshot 2024-12-21 at 3 33 45 PM" src="https://github.com/user-attachments/assets/9281e469-3cb8-467f-979c-7917efb3e46c" />

### AFTER:
Reload in console:
<img width="460" alt="Screenshot 2024-12-21 at 7 37 23 PM" src="https://github.com/user-attachments/assets/e3d8cbd2-5c43-4a7f-8c8f-6aaf63ba8c8b" />

Reload in game:
<img width="485" alt="Screenshot 2024-12-21 at 7 37 44 PM" src="https://github.com/user-attachments/assets/052c3081-c738-4780-b321-391858c90e58" />



---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
