### PR TITLE
Add boat data check to prevent error.

### DIFF
--- a/src/main/java/ch/njol/skript/entity/BoatData.java
+++ b/src/main/java/ch/njol/skript/entity/BoatData.java
@@ -55,22 +55,22 @@ public class BoatData extends EntityData<Boat> {
 	}
 
 
-	
+
 	public BoatData(){
 		this(0);
 	}
-	
+
 	public BoatData(@Nullable TreeSpecies type){
 		this(type != null ? type.ordinal() + 2 : 1);
 	}
-	
+
 	private BoatData(int type){
 		matchedPattern = type;
 	}
-	
+
 	@Override
 	protected boolean init(Literal<?>[] exprs, int matchedPattern, ParseResult parseResult) {
-		
+
 		return true;
 	}
 
@@ -96,7 +96,7 @@ public class BoatData extends EntityData<Boat> {
 
 	@Override
 	public Class<? extends Boat> getType() {
-		if (IS_RUNNING_1_21_3)
+		if (IS_RUNNING_1_21_3 && matchedPattern > 1)
 			return typeToClassMap.get(TreeSpecies.values()[matchedPattern - 2]);
 		return Boat.class;
 	}
@@ -124,7 +124,7 @@ public class BoatData extends EntityData<Boat> {
 			return matchedPattern <= 1 || matchedPattern == ((BoatData)e).matchedPattern;
 		return false;
 	}
-	
+
 	public boolean isOfItemType(ItemType i){
 		int ordinal = -1;
 
@@ -142,7 +142,7 @@ public class BoatData extends EntityData<Boat> {
 		else if (type == Material.DARK_OAK_BOAT)
 			ordinal = TreeSpecies.DARK_OAK.ordinal();
 		return hashCode_i() == ordinal + 2 || (matchedPattern + ordinal == 0) || ordinal == 0;
-		
+
 	}
 
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Fixes a bug with boat data using `boat` or `any boat`.

Note to self: remember to merge patch into feature before release.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** fixes #7300 <!-- Links to related issues -->
