### PR TITLE
Fix dependency incompatibility caused by Paper.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,9 +37,12 @@ dependencies {
 	implementation group: 'org.joml', name: 'joml', version: '1.10.5'
 
 	// Plugin hook libraries
-	implementation group: 'com.sk89q.worldguard', name: 'worldguard-legacy', version: '7.0.0-SNAPSHOT'
+	implementation group: 'com.sk89q.worldguard', name: 'worldguard-legacy', version: '7.0.0-SNAPSHOT', {
+		exclude group: 'org.bukkit', module: 'bukkit'
+	}
 	implementation group: 'net.milkbowl.vault', name: 'Vault', version: '1.7.3', {
 		exclude group: 'org.bstats', module: 'bstats-bukkit'
+		exclude group: 'org.bukkit', module: 'bukkit'
 	}
 
 	implementation fileTree(dir: 'lib', include: '*.jar')

--- a/src/main/java/ch/njol/skript/util/PotionEffectUtils.java
+++ b/src/main/java/ch/njol/skript/util/PotionEffectUtils.java
@@ -29,7 +29,6 @@ import org.bukkit.entity.ThrownPotion;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.inventory.meta.SuspiciousStewMeta;
-import org.bukkit.potion.Potion;
 import org.bukkit.potion.PotionData;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -127,18 +126,7 @@ public abstract class PotionEffectUtils {
 	public static String[] getNames() {
 		return names;
 	}
-	
-	public static short guessData(final ThrownPotion p) {
-		if (p.getEffects().size() == 1) {
-			final PotionEffect e = p.getEffects().iterator().next();
-			PotionType type = PotionType.getByEffect(e.getType());
-			assert type != null;
-			final Potion d = new Potion(type).splash();
-			return d.toDamageValue();
-		}
-		return 0;
-	}
-	
+
 	/**
 	 * Checks if given string represents a known potion type and returns that type.
 	 * Unused currently, will be used soon (TM).


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Suddenly, some transitive dependencies decided they would become incompatible this morning.

I excluded them from WorldEdit and Vault. This also made a potion class disappear, since it isn't present in 1.21 anymore, so I had to remove that too. I don't think anything used it, since it was deprecated in 2013, more than 11 years ago.

This should fix the build & test issues that appeared today.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
