### PR TITLE
Update Pair

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/AliasesParser.java
+++ b/src/main/java/ch/njol/skript/aliases/AliasesParser.java
@@ -27,6 +27,7 @@ import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.localization.ArgsMessage;
 import ch.njol.skript.localization.Message;
 import ch.njol.skript.localization.Noun;
+import ch.njol.util.NonNullPair;
 import ch.njol.util.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.util.NotNullPair;
@@ -691,11 +692,11 @@ public class AliasesParser {
 				assert id != null;
 				try {
 					// Create singular and plural forms of the alias
-					NotNullPair<String, Integer> plain = Noun.stripGender(name, name); // Name without gender and its gender token
-					NotNullPair<String, String> forms = getAliasPlural(plain.first()); // Singular and plural forms
-					
+					NonNullPair<String, Integer> plain = Noun.stripGender(name, name); // Name without gender and its gender token
+					NotNullPair<String, String> forms = getAliasPlural(plain.getFirst()); // Singular and plural forms
+
 					// Add alias to provider
-					provider.addAlias(new AliasesProvider.AliasName(forms.first(), forms.second(), plain.second()),
+					provider.addAlias(new AliasesProvider.AliasName(forms.first(), forms.second(), plain.getSecond()),
 							id, merged.getTags(), merged.getBlockStates());
 				} catch (InvalidMinecraftIdException e) { // Spit out a more useful error message
 					Skript.error(m_invalid_minecraft_id.toString(e.getId()));

--- a/src/main/java/ch/njol/skript/aliases/AliasesParser.java
+++ b/src/main/java/ch/njol/skript/aliases/AliasesParser.java
@@ -18,17 +18,6 @@
  */
 package ch.njol.skript.aliases;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.function.Function;
-
-import org.jetbrains.annotations.Nullable;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.AliasesProvider.Variation;
 import ch.njol.skript.aliases.AliasesProvider.VariationGroup;
@@ -38,8 +27,12 @@ import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.localization.ArgsMessage;
 import ch.njol.skript.localization.Message;
 import ch.njol.skript.localization.Noun;
-import ch.njol.util.NonNullPair;
 import ch.njol.util.StringUtils;
+import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.util.NotNullPair;
+
+import java.util.*;
+import java.util.function.Function;
 
 /**
  * Parses aliases.
@@ -635,12 +628,12 @@ public class AliasesParser {
 	 * @param name Name to get forms from.
 	 * @return Singular form, plural form.
 	 */
-	protected NonNullPair<String, String> getAliasPlural(String name) {
+	protected NotNullPair<String, String> getAliasPlural(String name) {
 		int marker = name.indexOf('¦');
 		if (marker == -1) { // No singular/plural forms
 			String trimmed = name.trim();
 			assert trimmed != null;
-			return new NonNullPair<>(trimmed, trimmed);
+			return new NotNullPair<>(trimmed, trimmed);
 		}
 		int pluralEnd = -1;
 		for (int i = marker; i < name.length(); i++) {
@@ -662,7 +655,7 @@ public class AliasesParser {
 			plural = plural.trim();
 			assert singular != null;
 			assert plural != null;
-			return new NonNullPair<>(singular, plural);
+			return new NotNullPair<>(singular, plural);
 		}
 		
 		// Need to stitch both singular and plural together
@@ -674,7 +667,7 @@ public class AliasesParser {
 		plural = plural.trim();
 		assert singular != null;
 		assert plural != null;
-		return new NonNullPair<>(singular, plural);
+		return new NotNullPair<>(singular, plural);
 	}
 	
 	protected void loadSingleAlias(Map<String, Variation> variations, String item) {
@@ -698,11 +691,11 @@ public class AliasesParser {
 				assert id != null;
 				try {
 					// Create singular and plural forms of the alias
-					NonNullPair<String, Integer> plain = Noun.stripGender(name, name); // Name without gender and its gender token
-					NonNullPair<String, String> forms = getAliasPlural(plain.getFirst()); // Singular and plural forms
+					NotNullPair<String, Integer> plain = Noun.stripGender(name, name); // Name without gender and its gender token
+					NotNullPair<String, String> forms = getAliasPlural(plain.first()); // Singular and plural forms
 					
 					// Add alias to provider
-					provider.addAlias(new AliasesProvider.AliasName(forms.getFirst(), forms.getSecond(), plain.getSecond()),
+					provider.addAlias(new AliasesProvider.AliasName(forms.first(), forms.second(), plain.second()),
 							id, merged.getTags(), merged.getBlockStates());
 				} catch (InvalidMinecraftIdException e) { // Spit out a more useful error message
 					Skript.error(m_invalid_minecraft_id.toString(e.getId()));

--- a/src/main/java/ch/njol/skript/expressions/ExprIndices.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprIndices.java
@@ -30,12 +30,11 @@ import ch.njol.skript.lang.Variable;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.skript.util.LiteralUtils;
 import ch.njol.util.Kleenean;
-import ch.njol.util.Pair;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.util.Pair;
 
 import java.util.Map;
-import java.util.Map.Entry;
 
 @Name("Indices of List")
 @Description({
@@ -108,8 +107,8 @@ public class ExprIndices extends SimpleExpression<String> {
 						? ((Map<?,?>) entry.getValue()).get(null)
 						: entry.getValue()
 				))
-				.sorted((a, b) -> ExprSortedList.compare(a.getValue(), b.getValue()) * direction)
-				.map(Pair::getKey)
+				.sorted((a, b) -> ExprSortedList.compare(a.second(), b.second()) * direction)
+				.map(Pair::first)
 				.toArray(String[]::new);
 		}
 

--- a/src/main/java/ch/njol/skript/test/platform/PlatformMain.java
+++ b/src/main/java/ch/njol/skript/test/platform/PlatformMain.java
@@ -19,28 +19,19 @@
 package ch.njol.skript.test.platform;
 
 import ch.njol.skript.test.utils.TestResults;
-import ch.njol.util.NonNullPair;
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import org.apache.commons.lang.StringUtils;
+import org.skriptlang.skript.util.NotNullPair;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -92,7 +83,7 @@ public class PlatformMain {
 				envs.stream().map(Environment::getName).collect(Collectors.toList())));
 		
 		Set<String> allTests = new HashSet<>();
-		Map<String, List<NonNullPair<Environment, String>>> failures = new HashMap<>();
+		Map<String, List<NotNullPair<Environment, String>>> failures = new HashMap<>();
 		
 		boolean docsFailed = false;
 		// Run tests and collect the results
@@ -120,7 +111,7 @@ public class PlatformMain {
 				String error = fail.getValue();
 				assert error != null;
 				failures.computeIfAbsent(fail.getKey(), (k) -> new ArrayList<>())
-						.add(new NonNullPair<>(env, error));
+						.add(new NotNullPair<>(env, error));
 			}
 		}
 
@@ -151,10 +142,10 @@ public class PlatformMain {
 		if (!failNames.isEmpty()) { // More space for failed tests, they're important
 			output.append("\nFailed:");
 			for (String failed : failNames) {
-				List<NonNullPair<Environment, String>> errors = failures.get(failed);
+				List<NotNullPair<Environment, String>> errors = failures.get(failed);
 				output.append("\n  " + failed + " (on " + errors.size() + " environment" + (errors.size() == 1 ? "" : "s") + ")");
-				for (NonNullPair<Environment, String> error : errors) {
-					output.append("\n    " + error.getSecond() + " (on " + error.getFirst().getName() + ")");
+				for (NotNullPair<Environment, String> error : errors) {
+					output.append("\n    " + error.second() + " (on " + error.first().getName() + ")");
 				}
 			}
 			output.append(String.format("%n%n%s", StringUtils.repeat("-", 60)));

--- a/src/main/java/ch/njol/skript/util/Timespan.java
+++ b/src/main/java/ch/njol/skript/util/Timespan.java
@@ -5,11 +5,11 @@ import ch.njol.skript.lang.ParseContext;
 import ch.njol.skript.localization.GeneralWords;
 import ch.njol.skript.localization.Language;
 import ch.njol.skript.localization.Noun;
-import ch.njol.util.NonNullPair;
 import ch.njol.util.coll.CollectionUtils;
 import ch.njol.yggdrasil.YggdrasilSerializable;
 import com.google.common.base.Preconditions;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.util.NotNullPair;
 
 import java.time.Duration;
 import java.time.temporal.*;
@@ -29,14 +29,14 @@ public class Timespan implements YggdrasilSerializable, Comparable<Timespan>, Te
 	private static final Pattern TIMESPAN_SPLIT_PATTERN = Pattern.compile("[:.]");
 	private static final Pattern SHORT_FORM_PATTERN = Pattern.compile("^(\\d+(?:\\.\\d+)?)([a-zA-Z]+)$");
 
-	private static final List<NonNullPair<Noun, Long>> SIMPLE_VALUES = Arrays.asList(
-		new NonNullPair<>(TimePeriod.YEAR.name, TimePeriod.YEAR.time),
-		new NonNullPair<>(TimePeriod.MONTH.name, TimePeriod.MONTH.time),
-		new NonNullPair<>(TimePeriod.WEEK.name, TimePeriod.WEEK.time),
-		new NonNullPair<>(TimePeriod.DAY.name, TimePeriod.DAY.time),
-		new NonNullPair<>(TimePeriod.HOUR.name, TimePeriod.HOUR.time),
-		new NonNullPair<>(TimePeriod.MINUTE.name, TimePeriod.MINUTE.time),
-		new NonNullPair<>(TimePeriod.SECOND.name, TimePeriod.SECOND.time)
+	private static final List<NotNullPair<Noun, Long>> SIMPLE_VALUES = Arrays.asList(
+		new NotNullPair<>(TimePeriod.YEAR.name, TimePeriod.YEAR.time),
+		new NotNullPair<>(TimePeriod.MONTH.name, TimePeriod.MONTH.time),
+		new NotNullPair<>(TimePeriod.WEEK.name, TimePeriod.WEEK.time),
+		new NotNullPair<>(TimePeriod.DAY.name, TimePeriod.DAY.time),
+		new NotNullPair<>(TimePeriod.HOUR.name, TimePeriod.HOUR.time),
+		new NotNullPair<>(TimePeriod.MINUTE.name, TimePeriod.MINUTE.time),
+		new NotNullPair<>(TimePeriod.SECOND.name, TimePeriod.SECOND.time)
 	);
 
 	private static final Map<String, Long> PARSE_VALUES = new HashMap<>();
@@ -154,11 +154,11 @@ public class Timespan implements YggdrasilSerializable, Comparable<Timespan>, Te
 
 	public static String toString(long millis, int flags) {
 		for (int i = 0; i < SIMPLE_VALUES.size() - 1; i++) {
-			NonNullPair<Noun, Long> pair = SIMPLE_VALUES.get(i);
-			long second1 = pair.getSecond();
+			NotNullPair<Noun, Long> pair = SIMPLE_VALUES.get(i);
+			long second1 = pair.second();
 			if (millis >= second1) {
 				long remainder = millis % second1;
-				double second = 1. * remainder / SIMPLE_VALUES.get(i + 1).getSecond();
+				double second = 1. * remainder / SIMPLE_VALUES.get(i + 1).second();
 				if (!"0".equals(Skript.toString(second))) { // bad style but who cares...
 					return toString(Math.floor(1. * millis / second1), pair, flags) + " " + GeneralWords.and + " " + toString(remainder, flags);
 				} else {
@@ -166,11 +166,11 @@ public class Timespan implements YggdrasilSerializable, Comparable<Timespan>, Te
 				}
 			}
 		}
-		return toString(1. * millis / SIMPLE_VALUES.get(SIMPLE_VALUES.size() - 1).getSecond(), SIMPLE_VALUES.get(SIMPLE_VALUES.size() - 1), flags);
+		return toString(1. * millis / SIMPLE_VALUES.get(SIMPLE_VALUES.size() - 1).second(), SIMPLE_VALUES.get(SIMPLE_VALUES.size() - 1), flags);
 	}
 
-	private static String toString(double amount, NonNullPair<Noun, Long> pair, int flags) {
-		return pair.getFirst().withAmount(amount, flags);
+	private static String toString(double amount, NotNullPair<Noun, Long> pair, int flags) {
+		return pair.first().withAmount(amount, flags);
 	}
 
 	private final long millis;

--- a/src/main/java/ch/njol/skript/variables/Variables.java
+++ b/src/main/java/ch/njol/skript/variables/Variables.java
@@ -31,8 +31,6 @@ import ch.njol.skript.log.SkriptLogger;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.variables.SerializedVariable.Value;
 import ch.njol.util.Kleenean;
-import ch.njol.util.NonNullPair;
-import ch.njol.util.Pair;
 import ch.njol.util.StringUtils;
 import ch.njol.util.SynchronizedReference;
 import ch.njol.util.coll.iterator.EmptyIterator;
@@ -47,21 +45,13 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnmodifiableView;
 import org.skriptlang.skript.lang.converter.Converters;
+import org.skriptlang.skript.util.NotNullPair;
+import org.skriptlang.skript.util.Pair;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.NoSuchElementException;
-import java.util.Optional;
-import java.util.Queue;
-import java.util.TreeMap;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -204,7 +194,7 @@ public class Variables {
 				} catch (InterruptedException ignored) {}
 
 				synchronized (TEMP_VARIABLES) {
-					Map<String, NonNullPair<Object, VariablesStorage>> tvs = TEMP_VARIABLES.get();
+					Map<String, NotNullPair<Object, VariablesStorage>> tvs = TEMP_VARIABLES.get();
 					if (tvs != null)
 						Skript.info("Loaded " + tvs.size() + " variables so far...");
 					else
@@ -260,7 +250,7 @@ public class Variables {
 					// Get the amount of variables currently loaded
 					int totalVariablesLoaded;
 					synchronized (TEMP_VARIABLES) {
-						Map<String, NonNullPair<Object, VariablesStorage>> tvs = TEMP_VARIABLES.get();
+						Map<String, NotNullPair<Object, VariablesStorage>> tvs = TEMP_VARIABLES.get();
 						assert tvs != null;
 						totalVariablesLoaded = tvs.size();
 					}
@@ -278,7 +268,7 @@ public class Variables {
 					// Get the amount of variables loaded by this variables storage object
 					int newVariablesLoaded;
 					synchronized (TEMP_VARIABLES) {
-						Map<String, NonNullPair<Object, VariablesStorage>> tvs = TEMP_VARIABLES.get();
+						Map<String, NotNullPair<Object, VariablesStorage>> tvs = TEMP_VARIABLES.get();
 						assert tvs != null;
 						newVariablesLoaded = tvs.size() - totalVariablesLoaded;
 					}
@@ -706,7 +696,7 @@ public class Variables {
 	 * <p>
 	 * Access must be synchronised.
 	 */
-	private static final SynchronizedReference<Map<String, NonNullPair<Object, VariablesStorage>>> TEMP_VARIABLES =
+	private static final SynchronizedReference<Map<String, NotNullPair<Object, VariablesStorage>>> TEMP_VARIABLES =
 			new SynchronizedReference<>(new HashMap<>());
 
 	/**
@@ -747,13 +737,13 @@ public class Variables {
 			return false;
 
 		synchronized (TEMP_VARIABLES) {
-			Map<String, NonNullPair<Object, VariablesStorage>> tvs = TEMP_VARIABLES.get();
+			Map<String, NotNullPair<Object, VariablesStorage>> tvs = TEMP_VARIABLES.get();
 			if (tvs != null) {
-				NonNullPair<Object, VariablesStorage> existingVariable = tvs.get(name);
+				NotNullPair<Object, VariablesStorage> existingVariable = tvs.get(name);
 
 				// Check for conflicts with other storages
 				conflict: if (existingVariable != null) {
-					VariablesStorage existingVariableStorage = existingVariable.getSecond();
+					VariablesStorage existingVariableStorage = existingVariable.second();
 
 					if (existingVariableStorage == source) {
 						// No conflict if from the same storage
@@ -779,7 +769,7 @@ public class Variables {
 				}
 
 				// Add to the loaded variables
-				tvs.put(name, new NonNullPair<>(value, source));
+				tvs.put(name, new NotNullPair<>(value, source));
 
 				return false;
 			}
@@ -835,7 +825,7 @@ public class Variables {
 		Skript.debug("Databases loaded, setting variables...");
 
 		synchronized (TEMP_VARIABLES) {
-			Map<String, NonNullPair<Object, VariablesStorage>> tvs = TEMP_VARIABLES.get();
+			Map<String, NotNullPair<Object, VariablesStorage>> tvs = TEMP_VARIABLES.get();
 			TEMP_VARIABLES.set(null);
 			assert tvs != null;
 
@@ -843,8 +833,8 @@ public class Variables {
 			try {
 				// Calculate the amount of variables that don't have a storage
 				int unstoredVariables = 0;
-				for (Entry<String, NonNullPair<Object, VariablesStorage>> tv : tvs.entrySet()) {
-					if (!variableLoaded(tv.getKey(), tv.getValue().getFirst(), tv.getValue().getSecond()))
+				for (Entry<String, NotNullPair<Object, VariablesStorage>> tv : tvs.entrySet()) {
+					if (!variableLoaded(tv.getKey(), tv.getValue().first(), tv.getValue().second()))
 						unstoredVariables++;
 				}
 

--- a/src/main/java/ch/njol/util/NonNullPair.java
+++ b/src/main/java/ch/njol/util/NonNullPair.java
@@ -19,8 +19,9 @@
 package ch.njol.util;
 
 /**
- * @author Peter Güttinger
+ * @deprecated use {@link org.skriptlang.skript.util.NotNullPair} instead
  */
+@Deprecated
 public class NonNullPair<T1, T2> extends Pair<T1, T2> {
 	private static final long serialVersionUID = 820250942098905541L;
 	

--- a/src/main/java/ch/njol/util/Pair.java
+++ b/src/main/java/ch/njol/util/Pair.java
@@ -25,8 +25,9 @@ import java.util.Objects;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * @author Peter Güttinger
+ * @deprecated use {@link org.skriptlang.skript.util.Pair} instead
  */
+@Deprecated
 public class Pair<T1, T2> implements Entry<T1, T2>, Cloneable, Serializable {
 	private static final long serialVersionUID = 8296563685697678334L;
 	

--- a/src/main/java/ch/njol/util/coll/CollectionUtils.java
+++ b/src/main/java/ch/njol/util/coll/CollectionUtils.java
@@ -18,9 +18,7 @@
  */
 package ch.njol.util.coll;
 
-import ch.njol.util.Pair;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.UnknownNullability;
 
 import java.lang.reflect.Array;
 import java.util.*;
@@ -216,7 +214,10 @@ public abstract class CollectionUtils {
 		if (map == null)
 			return null;
 		if (map.containsKey(key))
-			return new Pair<>(key, map.get(key));
+			return map.entrySet().stream()
+				.filter(e -> Objects.equals(e.getKey(), key))
+				.findFirst()
+				.orElse(null);
 		return null;
 	}
 	

--- a/src/main/java/org/skriptlang/skript/lang/arithmetic/Arithmetics.java
+++ b/src/main/java/org/skriptlang/skript/lang/arithmetic/Arithmetics.java
@@ -20,18 +20,11 @@ package org.skriptlang.skript.lang.arithmetic;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptAPIException;
-import ch.njol.util.Pair;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnmodifiableView;
+import org.skriptlang.skript.util.Pair;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Collection;
-import java.util.Set;
-import java.util.HashSet;
+import java.util.*;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 

--- a/src/main/java/org/skriptlang/skript/lang/comparator/Comparators.java
+++ b/src/main/java/org/skriptlang/skript/lang/comparator/Comparators.java
@@ -21,18 +21,14 @@ package org.skriptlang.skript.lang.comparator;
 import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptAPIException;
 import ch.njol.skript.util.Utils;
-import ch.njol.util.Pair;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 import org.skriptlang.skript.lang.converter.Converter;
 import org.skriptlang.skript.lang.converter.ConverterInfo;
 import org.skriptlang.skript.lang.converter.Converters;
+import org.skriptlang.skript.util.Pair;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Comparators are used to provide Skript with specific instructions for comparing two objects.

--- a/src/main/java/org/skriptlang/skript/lang/converter/Converters.java
+++ b/src/main/java/org/skriptlang/skript/lang/converter/Converters.java
@@ -20,17 +20,12 @@ package org.skriptlang.skript.lang.converter;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptAPIException;
-import ch.njol.util.Pair;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
+import org.skriptlang.skript.util.Pair;
 
 import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Converters are used to provide Skript with specific instructions for converting an object to a different type.

--- a/src/main/java/org/skriptlang/skript/util/NotNullPair.java
+++ b/src/main/java/org/skriptlang/skript/util/NotNullPair.java
@@ -3,8 +3,6 @@ package org.skriptlang.skript.util;
 import com.google.common.base.Preconditions;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.Serializable;
-
 /**
  * Represents a read-only pair of two values, which may not be null.
  * Throws a {@link NullPointerException} if the first or second value is null.

--- a/src/main/java/org/skriptlang/skript/util/NotNullPair.java
+++ b/src/main/java/org/skriptlang/skript/util/NotNullPair.java
@@ -1,0 +1,30 @@
+package org.skriptlang.skript.util;
+
+import com.google.common.base.Preconditions;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.Serializable;
+
+/**
+ * Represents a read-only pair of two values, which may not be null.
+ * Throws a {@link NullPointerException} if the first or second value is null.
+ *
+ * @param first The first value.
+ * @param second The second value.
+ * @param <A> The type of the first value.
+ * @param <B> The type of the second value.
+ */
+public record NotNullPair<A, B>(
+	@NotNull A first,
+	@NotNull B second
+) {
+
+	/**
+	 * @throws NullPointerException If the first or second value is null.
+	 */
+	public NotNullPair {
+		Preconditions.checkNotNull(first, "first passed value is null");
+		Preconditions.checkNotNull(second, "second passed value is null");
+	}
+
+}

--- a/src/main/java/org/skriptlang/skript/util/NotNullTriple.java
+++ b/src/main/java/org/skriptlang/skript/util/NotNullTriple.java
@@ -1,0 +1,32 @@
+package org.skriptlang.skript.util;
+
+import com.google.common.base.Preconditions;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Represents a read-only pair of three values, which may not be null.
+ * Throws a {@link NullPointerException} if the first, second or third value is null.
+ *
+ * @param first The first value.
+ * @param second The second value.
+ * @param third The third value.
+ * @param <A> The type of the first value.
+ * @param <B> The type of the second value.
+ * @param <C> The type of the third value.
+ */
+public record NotNullTriple<A, B, C>(
+	@NotNull A first,
+	@NotNull B second,
+	@NotNull C third
+) {
+
+	/**
+	 * @throws NullPointerException If the first, second or third value is null.
+	 */
+	public NotNullTriple {
+		Preconditions.checkNotNull(first, "first passed value is null");
+		Preconditions.checkNotNull(second, "second passed value is null");
+		Preconditions.checkNotNull(third, "third passed value is null");
+	}
+
+}

--- a/src/main/java/org/skriptlang/skript/util/Pair.java
+++ b/src/main/java/org/skriptlang/skript/util/Pair.java
@@ -1,0 +1,18 @@
+package org.skriptlang.skript.util;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Represents a read-only pair of two values, which may be null.
+ *
+ * @param first The first value.
+ * @param second The second value.
+ * @param <A> The type of the first value.
+ * @param <B> The type of the second value.
+ */
+public record Pair<A, B>(
+	@Nullable A first,
+	@Nullable B second
+) {
+
+}

--- a/src/main/java/org/skriptlang/skript/util/Triple.java
+++ b/src/main/java/org/skriptlang/skript/util/Triple.java
@@ -1,0 +1,21 @@
+package org.skriptlang.skript.util;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Represents a read-only pair of three values, which may be null.
+ *
+ * @param first The first value.
+ * @param second The second value.
+ * @param third The third value.
+ * @param <A> The type of the first value.
+ * @param <B> The type of the second value.
+ * @param <C> The type of the third value.
+ */
+public record Triple<A, B, C>(
+	@Nullable A first,
+	@Nullable B second,
+	@Nullable C third
+) {
+
+}


### PR DESCRIPTION
### Description
Updates the Pair utility and replaces all internal usages of the old versions.

**Changes**
- Added `org.skriptlang.skript.util.Pair`
  - Replaces `ch.njol.util.Pair`
  - Made Pair a record
- Added `org.skriptlang.skript.util.Pair`
  - Replaces `ch.njol.util.NonNullPair` to use the same name as the `@NotNull` annotation 
  - Made NotNullPair a record
  - Made NotNullPair throw on initialization when one of the values is null 
- Added `org.skriptlang.skript.util.Triple`
  - 3-tuple for values, similar to Pair
- Added `org.skriptlang.skript.util.NotNullTriple`
  - 3-tuple for values, similar to NotNullPair 
- Deprecates `ch.njol.util.Pair`, `ch.njol.util.NonNullPair`
---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
