### PR TITLE
Add unicode tag

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -209,7 +209,6 @@ public final class Skript extends JavaPlugin implements Listener {
 	/**
 	 * Check minecraft version and assign it to minecraftVersion field
 	 * This method is created to update MC version before onEnable method
-	 * To fix {@link Utils#HEX_SUPPORTED} being assigned before minecraftVersion is properly assigned
 	 */
 	public static void updateMinecraftVersion() {
 		String bukkitV = Bukkit.getBukkitVersion();

--- a/src/main/java/ch/njol/skript/util/Utils.java
+++ b/src/main/java/ch/njol/skript/util/Utils.java
@@ -1,5 +1,27 @@
 package ch.njol.skript.util;
 
+import ch.njol.skript.Skript;
+import ch.njol.skript.effects.EffTeleport;
+import ch.njol.skript.localization.Language;
+import ch.njol.skript.localization.LanguageChangeListener;
+import ch.njol.skript.registrations.Classes;
+import ch.njol.util.*;
+import ch.njol.util.coll.CollectionUtils;
+import ch.njol.util.coll.iterator.EnumerationIterable;
+import com.google.common.collect.Iterables;
+import com.google.common.io.ByteArrayDataInput;
+import com.google.common.io.ByteArrayDataOutput;
+import com.google.common.io.ByteStreams;
+import net.md_5.bungee.api.ChatColor;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.messaging.Messenger;
+import org.bukkit.plugin.messaging.PluginMessageListener;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -12,34 +34,6 @@ import java.util.jar.JarFile;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
-
-import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
-import org.bukkit.plugin.Plugin;
-import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.plugin.messaging.Messenger;
-import org.bukkit.plugin.messaging.PluginMessageListener;
-
-import com.google.common.collect.Iterables;
-import com.google.common.io.ByteArrayDataInput;
-import com.google.common.io.ByteArrayDataOutput;
-import com.google.common.io.ByteStreams;
-
-import ch.njol.skript.Skript;
-import ch.njol.skript.effects.EffTeleport;
-import ch.njol.skript.localization.Language;
-import ch.njol.skript.localization.LanguageChangeListener;
-import ch.njol.skript.registrations.Classes;
-import ch.njol.util.Callback;
-import ch.njol.util.Checker;
-import ch.njol.util.NonNullPair;
-import ch.njol.util.Pair;
-import ch.njol.util.StringUtils;
-import ch.njol.util.coll.CollectionUtils;
-import ch.njol.util.coll.iterator.EnumerationIterable;
-import net.md_5.bungee.api.ChatColor;
-import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Utility class.
@@ -518,8 +512,8 @@ public abstract class Utils {
 	final static Map<String, String> chat = new HashMap<>();
 	final static Map<String, String> englishChat = new HashMap<>();
 
-	public final static boolean HEX_SUPPORTED = Skript.isRunningMinecraft(1, 16);
-	public final static boolean COPY_SUPPORTED = Skript.isRunningMinecraft(1, 15);
+	public final static boolean HEX_SUPPORTED = true;
+	public final static boolean COPY_SUPPORTED = true;
 
 	static {
 		Language.addListener(new LanguageChangeListener() {
@@ -547,43 +541,17 @@ public abstract class Utils {
 		return chat.get(s);
 	}
 
-	private final static Pattern stylePattern = Pattern.compile("<([^<>]+)>");
-
 	/**
 	 * Replaces &lt;chat styles&gt; in the message
 	 *
 	 * @param message
 	 * @return message with localised chat styles converted to Minecraft's format
 	 */
-	public static String replaceChatStyles(final String message) {
+	public static String replaceChatStyles(String message) {
 		if (message.isEmpty())
 			return message;
-		String m = StringUtils.replaceAll(Matcher.quoteReplacement("" + message.replace("<<none>>", "")), stylePattern, new Callback<String, Matcher>() {
-			@Override
-			public String run(final Matcher m) {
-				SkriptColor color = SkriptColor.fromName("" + m.group(1));
-				if (color != null)
-					return color.getFormattedChat();
-				final String tag = m.group(1).toLowerCase(Locale.ENGLISH);
-				final String f = chat.get(tag);
-				if (f != null)
-					return f;
-				if (HEX_SUPPORTED && tag.startsWith("#")) { // Check for parsing hex colors
-					ChatColor chatColor = parseHexColor(tag);
-					if (chatColor != null)
-						return chatColor.toString();
-				}
-				return "" + m.group();
-			}
-		});
-		assert m != null;
-		// Restore user input post-sanitization
-		// Sometimes, the message has already been restored
-		if (!message.equals(m)) {
-			m = m.replace("\\$", "$").replace("\\\\", "\\");
-		}
-		m = ChatColor.translateAlternateColorCodes('&', "" + m);
-		return "" + m;
+
+		return replaceChatStyle(message.replace("<<none>>", ""));
 	}
 
 	/**
@@ -593,54 +561,81 @@ public abstract class Utils {
 	 * @param message
 	 * @return message with english chat styles converted to Minecraft's format
 	 */
-	public static String replaceEnglishChatStyles(final String message) {
+	public static String replaceEnglishChatStyles(String message) {
 		if (message.isEmpty())
 			return message;
-		String m = StringUtils.replaceAll(Matcher.quoteReplacement(message), stylePattern, new Callback<String, Matcher>() {
-			@Override
-			public String run(final Matcher m) {
-				SkriptColor color = SkriptColor.fromName("" + m.group(1));
-				if (color != null)
-					return color.getFormattedChat();
-				final String tag = m.group(1).toLowerCase(Locale.ENGLISH);
-				final String f = englishChat.get(tag);
-				if (f != null)
-					return f;
-				if (HEX_SUPPORTED && tag.startsWith("#")) { // Check for parsing hex colors
-					ChatColor chatColor = parseHexColor(tag);
-					if (chatColor != null)
-						return chatColor.toString();
-				}
-				return "" + m.group();
+
+		return replaceChatStyle(message);
+	}
+
+	private final static Pattern STYLE_PATTERN = Pattern.compile("<([^<>]+)>");
+
+	private static @NotNull String replaceChatStyle(String message) {
+		String m = StringUtils.replaceAll(Matcher.quoteReplacement(message), STYLE_PATTERN, matcher -> {
+			SkriptColor color = SkriptColor.fromName(matcher.group(1));
+			if (color != null)
+				return color.getFormattedChat();
+
+			String tag = matcher.group(1).toLowerCase(Locale.ENGLISH);
+			String f = englishChat.get(tag);
+			if (f != null)
+				return f;
+
+			if (tag.startsWith("#")) {
+				ChatColor chatColor = parseHexColor(tag);
+				if (chatColor != null)
+					return chatColor.toString();
+			} else if (tag.startsWith("u:") || tag.startsWith("unicode:")) {
+				String character = parseUnicode(tag);
+				if (character != null)
+					return character;
 			}
+			return matcher.group();
 		});
-		assert m != null;
+
 		// Restore user input post-sanitization
 		// Sometimes, the message has already been restored
 		if (!message.equals(m)) {
 			m = m.replace("\\$", "$").replace("\\\\", "\\");
 		}
-		m = ChatColor.translateAlternateColorCodes('&', "" + m);
-		return "" + m;
+
+		return ChatColor.translateAlternateColorCodes('&', m);
 	}
 
-	private static final Pattern HEX_PATTERN = Pattern.compile("(?i)#{0,2}[0-9a-f]{6}");
+	private static final Pattern UNICODE_PATTERN = Pattern.compile("(?i)u(?:nicode)?:(?<code>[0-9a-f]{4,})");
+
+	/**
+	 * Tries to extract a Unicode character from the given string.
+	 * @param string The string.
+	 * @return The Unicode character, or null if it could not be parsed.
+	 */
+	public static @Nullable String parseUnicode(String string) {
+		Matcher matcher = UNICODE_PATTERN.matcher(string);
+		if (!matcher.matches())
+			return null;
+
+		try {
+			return Character.toString(Integer.parseInt(matcher.group("code"), 16));
+		} catch (IllegalArgumentException ex) {
+			return null;
+		}
+	}
+
+	private static final Pattern HEX_PATTERN = Pattern.compile("(?i)#{0,2}(?<code>[0-9a-f]{6})");
 
 	/**
 	 * Tries to get a {@link ChatColor} from the given string.
-	 * @param hex The hex code to parse.
+	 * @param string The string code to parse.
 	 * @return The ChatColor, or null if it couldn't be parsed.
 	 */
-	@SuppressWarnings("null")
-	@Nullable
-	public static ChatColor parseHexColor(String hex) {
-		if (!HEX_SUPPORTED || !HEX_PATTERN.matcher(hex).matches()) // Proper hex code validation
+	public static ChatColor parseHexColor(String string) {
+		Matcher matcher = HEX_PATTERN.matcher(string);
+		if (!matcher.matches())
 			return null;
 
-		hex = hex.replace("#", "");
 		try {
-			return ChatColor.of('#' + hex.substring(0, 6));
-		} catch (IllegalArgumentException e) {
+			return ChatColor.of('#' + matcher.group("code"));
+		} catch (IllegalArgumentException ex) {
 			return null;
 		}
 	}

--- a/src/main/java/ch/njol/skript/util/Utils.java
+++ b/src/main/java/ch/njol/skript/util/Utils.java
@@ -512,9 +512,6 @@ public abstract class Utils {
 	final static Map<String, String> chat = new HashMap<>();
 	final static Map<String, String> englishChat = new HashMap<>();
 
-	public final static boolean HEX_SUPPORTED = true;
-	public final static boolean COPY_SUPPORTED = true;
-
 	static {
 		Language.addListener(new LanguageChangeListener() {
 			@Override
@@ -547,7 +544,7 @@ public abstract class Utils {
 	 * @param message
 	 * @return message with localised chat styles converted to Minecraft's format
 	 */
-	public static String replaceChatStyles(String message) {
+	public static @NotNull String replaceChatStyles(String message) {
 		if (message.isEmpty())
 			return message;
 
@@ -561,7 +558,7 @@ public abstract class Utils {
 	 * @param message
 	 * @return message with english chat styles converted to Minecraft's format
 	 */
-	public static String replaceEnglishChatStyles(String message) {
+	public static @NotNull String replaceEnglishChatStyles(String message) {
 		if (message.isEmpty())
 			return message;
 
@@ -628,7 +625,7 @@ public abstract class Utils {
 	 * @param string The string code to parse.
 	 * @return The ChatColor, or null if it couldn't be parsed.
 	 */
-	public static ChatColor parseHexColor(String string) {
+	public static @Nullable ChatColor parseHexColor(String string) {
 		Matcher matcher = HEX_PATTERN.matcher(string);
 		if (!matcher.matches())
 			return null;

--- a/src/main/java/ch/njol/skript/util/chat/ChatMessages.java
+++ b/src/main/java/ch/njol/skript/util/chat/ChatMessages.java
@@ -77,8 +77,6 @@ public class ChatMessages {
 				Skript.debug("Parsing message style lang files");
 				for (SkriptChatCode code : SkriptChatCode.values()) {
 					assert code != null;
-					if (code == SkriptChatCode.copy_to_clipboard && !Utils.COPY_SUPPORTED)
-						continue;
 					registerChatCode(code);
 				}
 				
@@ -213,7 +211,7 @@ public class ChatMessages {
 					}
 					name = name.toLowerCase(Locale.ENGLISH); // Tags are case-insensitive
 					
-					boolean tryHex = Utils.HEX_SUPPORTED && name.startsWith("#");
+					boolean tryHex = name.startsWith("#");
 					ChatColor chatColor = null;
 					if (tryHex) {
 						chatColor = Utils.parseHexColor(name);
@@ -261,7 +259,7 @@ public class ChatMessages {
 				
 				char color = chars[i + 1];
 				
-				boolean tryHex = Utils.HEX_SUPPORTED && color == 'x';
+				boolean tryHex = color == 'x';
 				ChatColor chatColor = null;
 				if (tryHex && i + 14 < chars.length) { // Try to parse hex "&x&1&2&3&4&5&6"
 					chatColor = Utils.parseHexColor(msg.substring(i + 2, i + 14).replace("&", "").replace("§", ""));
@@ -424,7 +422,7 @@ public class ChatMessages {
 
 				char color = chars[i + 1];
 
-				boolean tryHex = Utils.HEX_SUPPORTED && color == 'x';
+				boolean tryHex = color == 'x';
 				ChatColor chatColor = null;
 				if (tryHex && i + 14 < chars.length) { // Try to parse hex "&x&1&2&3&4&5&6"
 					chatColor = Utils.parseHexColor(msg.substring(i + 2, i + 14).replace("&", "").replace("§", ""));
@@ -582,9 +580,8 @@ public class ChatMessages {
 				builder.append(component.text);
 			}
 			String plain = builder.toString();
-			
-			if (Utils.HEX_SUPPORTED) // Strip '§x', '&x'
-				plain = HEX_COLOR_PATTERN.matcher(plain).replaceAll("");
+
+			plain = HEX_COLOR_PATTERN.matcher(plain).replaceAll("");
 			
 			result = ANY_COLOR_PATTERN.matcher(plain).replaceAll(""); // strips colors & or § (ex. &5)
 		} while (!previous.equals(result));

--- a/src/test/skript/tests/misc/unicode.sk
+++ b/src/test/skript/tests/misc/unicode.sk
@@ -1,0 +1,6 @@
+test "unicode":
+	assert "<unicode:00A7>" is "§" with "single symbol did not get replaced"
+	assert "<u:00A7>" is "§" with "single short symbol did not get replaced"
+
+	assert "a<unicode:1F41B>B" is "a🐛B" with "symbol did not get replaced"
+	assert "a<u:1F41B>B" is "a🐛B" with "short symbol did not get replaced"


### PR DESCRIPTION
### Description
Adds unicode tag, which looks like `<u:00A7>` or `<unicode:00A7>`. Also updates the coloring code.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #4355 <!-- Links to related issues -->
