### PR TITLE
ExprVillagerLevel -  add experience

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprVillagerLevel.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVillagerLevel.java
@@ -7,6 +7,9 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
 import ch.njol.util.Math2;
 import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.entity.LivingEntity;
@@ -14,17 +17,21 @@ import org.bukkit.entity.Villager;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 
-@Name("Villager Level")
+@Name("Villager Level/Experience")
 @Description({
-	"Represents the level of a villager.",
+	"Represents the level/experience of a villager.",
+	"The level will determine which trades are available to players.",
+	"Experience works along with the leveling system, determining which level the villager will move to.",
 	"Level must be between 1 and 5, with 1 being the default level.",
-	"Do note when a villager's level is 1, they may lose their profession."})
+	"Do note when a villager's level is 1, they may lose their profession.",
+	"Experience must be greater than or equal to 0."})
 @Examples({
 	"set {_level} to villager level of {_villager}",
 	"set villager level of last spawned villager to 2",
 	"add 1 to villager level of target entity",
 	"remove 1 from villager level of event-entity",
-	"reset villager level of event-entity"
+	"reset villager level of event-entity",
+	"set villager experience of last spawned entity to 100"
 })
 @Since("INSERT VERSION")
 public class ExprVillagerLevel extends SimplePropertyExpression<LivingEntity, Number> {
@@ -32,13 +39,21 @@ public class ExprVillagerLevel extends SimplePropertyExpression<LivingEntity, Nu
 	private static final boolean HAS_INCREASE_METHOD = Skript.methodExists(Villager.class, "increaseLevel", int.class);
 
 	static {
-		register(ExprVillagerLevel.class, Number.class, "villager level", "livingentities");
+		register(ExprVillagerLevel.class, Number.class, "villager (level|:experience)", "livingentities");
+	}
+
+	private boolean experience;
+
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		this.experience = parseResult.hasTag("experience");
+		return super.init(expressions, matchedPattern, isDelayed, parseResult);
 	}
 
 	@Override
 	public @Nullable Number convert(LivingEntity from) {
 		if (from instanceof Villager villager)
-			return villager.getVillagerLevel();
+			return experience ? villager.getVillagerExperience() : villager.getVillagerLevel();
 		return null;
 	}
 
@@ -59,16 +74,20 @@ public class ExprVillagerLevel extends SimplePropertyExpression<LivingEntity, Nu
 		for (LivingEntity livingEntity : getExpr().getArray(event)) {
 			if (!(livingEntity instanceof Villager villager)) continue;
 
-			int previousLevel = villager.getVillagerLevel();
+			int minLevel = experience ? 0 : 1;
+			int maxLevel = experience ? Integer.MAX_VALUE : 5;
+			int previousLevel = experience ? villager.getVillagerExperience() : villager.getVillagerLevel();
 			int newLevel = switch (mode) {
 				case SET -> changeValue;
 				case ADD -> previousLevel + changeValue;
 				case REMOVE -> previousLevel - changeValue;
-				default -> 1;
+				default -> minLevel;
 			};
-			newLevel = Math2.fit(1, newLevel,  5);
-			if (newLevel > previousLevel && HAS_INCREASE_METHOD) {
-				int increase = Math2.fit(1, newLevel - previousLevel,  5);
+			newLevel = Math2.fit(minLevel, newLevel,  maxLevel);
+			if (experience)
+				villager.setVillagerExperience(newLevel);
+			else if (newLevel > previousLevel && HAS_INCREASE_METHOD) {
+				int increase = Math2.fit(minLevel, newLevel - previousLevel,  maxLevel);
 				// According to the docs for this method:
 				// Increases the level of this villager.
 				// The villager will also unlock new recipes unlike the raw 'setVillagerLevel' method
@@ -81,7 +100,7 @@ public class ExprVillagerLevel extends SimplePropertyExpression<LivingEntity, Nu
 
 	@Override
 	protected String getPropertyName() {
-		return "villager level";
+		return "villager " + (experience ? "experience" : "level");
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprVillagerLevel.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVillagerLevel.java
@@ -23,8 +23,9 @@ import org.jetbrains.annotations.Nullable;
 	"The level will determine which trades are available to players.",
 	"Experience works along with the leveling system, determining which level the villager will move to.",
 	"Level must be between 1 and 5, with 1 being the default level.",
-	"Do note when a villager's level is 1, they may lose their profession.",
-	"Experience must be greater than or equal to 0."})
+	"When a villager's level is 1, they may lose their profession.",
+	"Experience must be greater than or equal to 0."
+})
 @Examples({
 	"set {_level} to villager level of {_villager}",
 	"set villager level of last spawned villager to 2",

--- a/src/main/java/ch/njol/skript/expressions/ExprVillagerLevel.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVillagerLevel.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.Nullable;
 	"When a villager's level is 1, they may lose their profession if they don't have a workstation.",
 	"Experience works along with the leveling system, determining which level the villager will move to.",
 	"Experience must be greater than or equal to 0.",
-	"Learn more about villager levels on <a href='https://minecraft.wiki/w/Villager#Trading'>Minecraft Wiki</a>"
+	"Learn more about villager levels on <a href='https://minecraft.wiki/w/Trading#Level'>Minecraft Wiki</a>"
 })
 @Examples({
 	"set {_level} to villager level of {_villager}",

--- a/src/main/java/ch/njol/skript/expressions/ExprVillagerLevel.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVillagerLevel.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.Nullable;
 	"When a villager's level is 1, they may lose their profession if they don't have a workstation.",
 	"Experience works along with the leveling system, determining which level the villager will move to.",
 	"Experience must be greater than or equal to 0.",
-	"Learn more about villager levels on <a href='https://minecraft.wiki/w/Villager#Trading'>Minecraft Wiki</a>",
+	"Learn more about villager levels on <a href='https://minecraft.wiki/w/Villager#Trading'>Minecraft Wiki</a>"
 })
 @Examples({
 	"set {_level} to villager level of {_villager}",

--- a/src/test/skript/tests/syntaxes/expressions/ExprVillagerLevel.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprVillagerLevel.sk
@@ -2,6 +2,7 @@ test "villager level expression":
 	spawn a villager at event-location:
 		set {_e} to entity
 
+	# Level
 	assert villager level of {_e} = 1 with "Villager should start out with a level of 1"
 	set villager level of {_e} to 2
 	assert villager level of {_e} = 2 with "Villager level should now be 2"
@@ -13,6 +14,14 @@ test "villager level expression":
 	assert villager level of {_e} = 3 with "Villager level should be 3 now"
 	reset villager level of {_e}
 	assert villager level of {_e} = 1 with "Villager level should reset back to 1"
+
+	# Experience
+	set villager experience of {_e} to 0
+	assert villager experience of {_e} = 0 with "Villager experience should be 0"
+	set villager experience of {_e} to 100
+	assert villager experience of {_e} = 100 with "Villager experience should be 100"
+	reset villager experience of {_e}
+	assert villager experience of {_e} = 0 with "Villager experience should have been reset to 0"
 
 	# Thank you for your service
 	delete entity within {_e}

--- a/src/test/skript/tests/syntaxes/expressions/ExprVillagerLevel.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprVillagerLevel.sk
@@ -19,7 +19,13 @@ test "villager level expression":
 	set villager experience of {_e} to 0
 	assert villager experience of {_e} = 0 with "Villager experience should be 0"
 	set villager experience of {_e} to 100
-	assert villager experience of {_e} = 100 with "Villager experience should be 100"
+	assert villager experience of {_e} = 100 with "Villager experience should be 100 after setting"
+	remove 1000 from villager experience of {_e}
+	assert villager experience of {_e} = 0 with "Villager experience should be 0 after removing"
+	add 100 to villager experience of {_e}
+	assert villager experience of {_e} = 100 with "Villager experience should be 100 after adding"
+	remove 20 from villager experience of {_e}
+	assert villager experience of {_e} = 80 with "Villager experience should be 80 after removing"
 	reset villager experience of {_e}
 	assert villager experience of {_e} = 0 with "Villager experience should have been reset to 0"
 


### PR DESCRIPTION
### Description
This PR aims to add villager experience to the villager level expression.
I forgot to do this when I did the Villager PR

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
