### PR TITLE
RegistryClassInfo - fix comparator (Failing Tests)

### DIFF
--- a/src/main/java/ch/njol/skript/classes/registry/RegistryClassInfo.java
+++ b/src/main/java/ch/njol/skript/classes/registry/RegistryClassInfo.java
@@ -66,7 +66,7 @@ public class RegistryClassInfo<R extends Keyed> extends ClassInfo<R> {
 			.parser(registryParser);
 
 		if (registerComparator)
-			Comparators.registerComparator(registryClass, registryClass, (o1, o2) -> Relation.get(o1.getKey() == o2.getKey()));
+			Comparators.registerComparator(registryClass, registryClass, (o1, o2) -> Relation.get(o1.getKey().equals(o2.getKey())));
 	}
 
 }


### PR DESCRIPTION
### Description
This PR aims to fix the comparator in RegistryClassInfo.
Paper recently did a change that broke `NamespacedKey == NamespacedKey`, luckily `.equals` works.
Due to this recent change, tests have all been failing.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
