### PR TITLE
EntitySnapshot ClassInfo Parser + Converter

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -6,6 +6,7 @@ import ch.njol.skript.aliases.Aliases;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.bukkitutil.BukkitUtils;
 import ch.njol.skript.bukkitutil.EnchantmentUtils;
+import ch.njol.skript.bukkitutil.EntityUtils;
 import ch.njol.skript.bukkitutil.ItemUtils;
 import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.classes.ConfigurationSerializer;
@@ -1574,12 +1575,12 @@ public class BukkitClasses {
 
 					@Override
 					public String toString(EntitySnapshot snapshot, int flags) {
-						return snapshot.getEntityType().toString().toLowerCase(Locale.ENGLISH).replace('_', ' ') + " snapshot";
+						return EntityUtils.toSkriptEntityData(snapshot.getEntityType()).toString() + " snapshot";
 					}
 
 					@Override
 					public String toVariableNameString(EntitySnapshot snapshot) {
-						return snapshot.getEntityType().toString().toLowerCase(Locale.ENGLISH).replace('_', ' ') + " snapshot";
+						return EntityUtils.toSkriptEntityData(snapshot.getEntityType()).toString() + " snapshot";
 					}
 				})
 			);

--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -1557,6 +1557,7 @@ public class BukkitClasses {
 			.since("INSERT VERSION"));
 
 		if (Skript.classExists("org.bukkit.entity.EntitySnapshot")) {
+			boolean SUPPORTS_GET_AS = Skript.methodExists(EntitySnapshot.class, "getAsString");
 			Classes.registerClass(new ClassInfo<>(EntitySnapshot.class, "entitysnapshot")
 				.user("entity ?snapshots?")
 				.name("Entity Snapshot")
@@ -1566,6 +1567,24 @@ public class BukkitClasses {
 					"Individual attributes of a snapshot cannot be modified or retrieved.")
 				.requiredPlugins("Minecraft 1.20.2+")
 				.since("INSERT VERSION")
+				.parser(new Parser<EntitySnapshot>() {
+					@Override
+					public boolean canParse(ParseContext context) {
+						return false;
+					}
+
+					@Override
+					public String toString(EntitySnapshot o, int flags) {
+						if (SUPPORTS_GET_AS)
+							return o.getAsString();
+						return o.getEntityType() + " snapshot";
+					}
+
+					@Override
+					public String toVariableNameString(EntitySnapshot o) {
+						return o.getEntityType() + " snapshot";
+					}
+				})
 			);
 		}
 

--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -1557,7 +1557,6 @@ public class BukkitClasses {
 			.since("INSERT VERSION"));
 
 		if (Skript.classExists("org.bukkit.entity.EntitySnapshot")) {
-			boolean supportsGetAs = Skript.methodExists(EntitySnapshot.class, "getAsString");
 			Classes.registerClass(new ClassInfo<>(EntitySnapshot.class, "entitysnapshot")
 				.user("entity ?snapshots?")
 				.name("Entity Snapshot")
@@ -1575,14 +1574,12 @@ public class BukkitClasses {
 
 					@Override
 					public String toString(EntitySnapshot snapshot, int flags) {
-						if (supportsGetAs)
-							return snapshot.getAsString();
 						return snapshot.getEntityType().toString().toLowerCase(Locale.ENGLISH).replace('_', ' ') + " snapshot";
 					}
 
 					@Override
 					public String toVariableNameString(EntitySnapshot snapshot) {
-						return snapshot.getEntityType() + " snapshot";
+						return snapshot.getEntityType().toString().toLowerCase(Locale.ENGLISH).replace('_', ' ') + " snapshot";
 					}
 				})
 			);

--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -1557,7 +1557,7 @@ public class BukkitClasses {
 			.since("INSERT VERSION"));
 
 		if (Skript.classExists("org.bukkit.entity.EntitySnapshot")) {
-			boolean SUPPORTS_GET_AS = Skript.methodExists(EntitySnapshot.class, "getAsString");
+			boolean supportsGetAs = Skript.methodExists(EntitySnapshot.class, "getAsString");
 			Classes.registerClass(new ClassInfo<>(EntitySnapshot.class, "entitysnapshot")
 				.user("entity ?snapshots?")
 				.name("Entity Snapshot")
@@ -1567,22 +1567,22 @@ public class BukkitClasses {
 					"Individual attributes of a snapshot cannot be modified or retrieved.")
 				.requiredPlugins("Minecraft 1.20.2+")
 				.since("INSERT VERSION")
-				.parser(new Parser<EntitySnapshot>() {
+				.parser(new Parser<>() {
 					@Override
 					public boolean canParse(ParseContext context) {
 						return false;
 					}
 
 					@Override
-					public String toString(EntitySnapshot o, int flags) {
-						if (SUPPORTS_GET_AS)
-							return o.getAsString();
-						return o.getEntityType() + " snapshot";
+					public String toString(EntitySnapshot snapshot, int flags) {
+						if (supportsGetAs)
+							return snapshot.getAsString();
+						return snapshot.getEntityType().toString().toLowerCase(Locale.ENGLISH).replace('_', ' ') + " snapshot";
 					}
 
 					@Override
-					public String toVariableNameString(EntitySnapshot o) {
-						return o.getEntityType() + " snapshot";
+					public String toVariableNameString(EntitySnapshot snapshot) {
+						return snapshot.getEntityType() + " snapshot";
 					}
 				})
 			);

--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -1580,7 +1580,7 @@ public class BukkitClasses {
 
 					@Override
 					public String toVariableNameString(EntitySnapshot snapshot) {
-						return EntityUtils.toSkriptEntityData(snapshot.getEntityType()).toString() + " snapshot";
+						return toString(snapshot, 0);
 					}
 				})
 			);

--- a/src/main/java/ch/njol/skript/classes/data/DefaultConverters.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultConverters.java
@@ -2,17 +2,14 @@ package ch.njol.skript.classes.data;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.bukkitutil.EntityUtils;
 import ch.njol.skript.command.Commands;
 import ch.njol.skript.entity.EntityData;
 import ch.njol.skript.entity.EntityType;
 import ch.njol.skript.entity.XpOrbData;
 import ch.njol.skript.lang.util.common.AnyAmount;
 import ch.njol.skript.lang.util.common.AnyNamed;
-import ch.njol.skript.util.BlockInventoryHolder;
-import ch.njol.skript.util.BlockUtils;
-import ch.njol.skript.util.Direction;
-import ch.njol.skript.util.EnchantmentType;
-import ch.njol.skript.util.Experience;
+import ch.njol.skript.util.*;
 import ch.njol.skript.util.slot.Slot;
 import org.bukkit.*;
 import org.bukkit.block.Block;
@@ -23,6 +20,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.enchantments.EnchantmentOffer;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntitySnapshot;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -266,6 +264,8 @@ public class DefaultConverters {
 		Converters.registerConverter(EnchantmentOffer.class, EnchantmentType.class, eo -> new EnchantmentType(eo.getEnchantment(), eo.getEnchantmentLevel()));
 
 		Converters.registerConverter(String.class, World.class, Bukkit::getWorld);
+
+		Converters.registerConverter(EntitySnapshot.class, EntityData.class, snapshot -> EntityUtils.toSkriptEntityData(snapshot.getEntityType()));
 
 //		// Entity - String (UUID) // Very slow, thus disabled for now
 //		Converters.registerConverter(String.class, Entity.class, new Converter<String, Entity>() {

--- a/src/main/java/ch/njol/skript/classes/data/DefaultConverters.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultConverters.java
@@ -265,7 +265,8 @@ public class DefaultConverters {
 
 		Converters.registerConverter(String.class, World.class, Bukkit::getWorld);
 
-		Converters.registerConverter(EntitySnapshot.class, EntityData.class, snapshot -> EntityUtils.toSkriptEntityData(snapshot.getEntityType()));
+		if (Skript.classExists("org.bukkit.entity.EntitySnapshot"))
+			Converters.registerConverter(EntitySnapshot.class, EntityData.class, snapshot -> EntityUtils.toSkriptEntityData(snapshot.getEntityType()));
 
 //		// Entity - String (UUID) // Very slow, thus disabled for now
 //		Converters.registerConverter(String.class, Entity.class, new Converter<String, Entity>() {

--- a/src/test/skript/tests/syntaxes/expressions/ExprEntitySnapshot.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprEntitySnapshot.sk
@@ -5,7 +5,6 @@ test "entity snapshots" when running minecraft "1.20.2":
 		set {_snapshot} to entity snapshot of entity
 		clear entity
 	assert {_snapshot} is an entity snapshot with "Get entity snapshot is not an entity snapshot"
-	broadcast "EntityType: %entity type of {_snapshot}%"
 	assert type of {_snapshot} is a pig with "Entity type of entity snapshot should be a pig"
 	spawn {_snapshot} at test-location:
 		assert the max health of entity is 20 with "Max health did not stick to the spawned entity"

--- a/src/test/skript/tests/syntaxes/expressions/ExprEntitySnapshot.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprEntitySnapshot.sk
@@ -5,6 +5,8 @@ test "entity snapshots" when running minecraft "1.20.2":
 		set {_snapshot} to entity snapshot of entity
 		clear entity
 	assert {_snapshot} is an entity snapshot with "Get entity snapshot is not an entity snapshot"
+	broadcast "EntityType: %entity type of {_snapshot}%"
+	assert type of {_snapshot} is a pig with "Entity type of entity snapshot should be a pig"
 	spawn {_snapshot} at test-location:
 		assert the max health of entity is 20 with "Max health did not stick to the spawned entity"
 		assert the health of entity is 20 with "Health did not stick to the spawned entity"


### PR DESCRIPTION
### Description
This PR aims to give EntitySnapshots a string display rather than instance as well as retrieving the entity type of snapshot

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
