### PR TITLE
gradle.properties - update testEnv

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ groupid=ch.njol
 name=skript
 version=2.9.5
 jarName=Skript.jar
-testEnv=java21/paper-1.21.3
+testEnv=java21/paper-1.21.4
 testEnvJavaVersion=21


### PR DESCRIPTION
### Description
This PR aims to update the testEnv property in gradle.properties.
this property is used to decide which server to default of the "dev test" server

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
