### PR TITLE
Silence unavoidable removal warnings during build & remove getters.

### DIFF
--- a/src/main/java/ch/njol/skript/SkriptConfig.java
+++ b/src/main/java/ch/njol/skript/SkriptConfig.java
@@ -219,6 +219,7 @@ public class SkriptConfig {
 
 	public static final Option<Boolean> apiSoftExceptions = new Option<>("soft api exceptions", false);
 
+	@SuppressWarnings("removal")
 	public static final Option<Boolean> enableTimings = new Option<>("enable timings", false)
 			.setter(t -> {
 				if (!Skript.classExists("co.aikar.timings.Timings")) { // Check for Timings

--- a/src/main/java/ch/njol/skript/bukkitutil/HealthUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/HealthUtils.java
@@ -32,7 +32,7 @@ public class HealthUtils {
 	private static final Attribute MAX_HEALTH;
 	static {
 		if (Skript.isRunningMinecraft(1, 21, 3)) { // In 1.21.3, Attribute became an Interface
-			MAX_HEALTH = Registry.ATTRIBUTE.get(NamespacedKey.minecraft("MAX_HEALTH"));
+			MAX_HEALTH = Registry.ATTRIBUTE.get(NamespacedKey.minecraft("max_health"));
 		} else {
 			MAX_HEALTH = (Attribute) Enum.valueOf((Class) Attribute.class, "GENERIC_MAX_HEALTH");
 		}

--- a/src/main/java/ch/njol/skript/bukkitutil/HealthUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/HealthUtils.java
@@ -4,6 +4,9 @@ import ch.njol.skript.Skript;
 import ch.njol.util.Math2;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
 import org.bukkit.attribute.Attributable;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
@@ -29,7 +32,7 @@ public class HealthUtils {
 	private static final Attribute MAX_HEALTH;
 	static {
 		if (Skript.isRunningMinecraft(1, 21, 3)) { // In 1.21.3, Attribute became an Interface
-			MAX_HEALTH = Attribute.valueOf("MAX_HEALTH");
+			MAX_HEALTH = Registry.ATTRIBUTE.get(NamespacedKey.minecraft("MAX_HEALTH"));
 		} else {
 			MAX_HEALTH = (Attribute) Enum.valueOf((Class) Attribute.class, "GENERIC_MAX_HEALTH");
 		}
@@ -133,6 +136,7 @@ public class HealthUtils {
 			((LivingEntity) event.getEntity()).setLastDamage(damage * 2);
 	}
 
+	@SuppressWarnings("removal")
 	public static void setDamageCause(Damageable damageable, DamageCause cause) {
 		if (OLD_DAMAGE_EVENT_CONSTRUCTOR != null) {
 			try {

--- a/src/main/java/ch/njol/skript/bukkitutil/SoundUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/SoundUtils.java
@@ -22,11 +22,11 @@ public final class SoundUtils {
 	 * @param soundString The enum name to use to find the sound.
 	 * @return The key of the sound.
 	 */
+	@SuppressWarnings("removal")
 	public static @Nullable NamespacedKey getKey(String soundString) {
 		soundString = soundString.toUpperCase(Locale.ENGLISH);
 		if (SOUND_IS_INTERFACE) {
 			try {
-				//noinspection deprecation,removal
 				return Sound.valueOf(soundString).getKey();
 			} catch (Exception ignored) {}
 		} else {
@@ -44,9 +44,9 @@ public final class SoundUtils {
 	 * @param sound The sound to get the key string of.
 	 * @return The key string of the {@link NamespacedKey} of the sound.
 	 */
+	@SuppressWarnings("removal")
 	public static @NotNull NamespacedKey getKey(Sound sound) {
 		if (SOUND_IS_INTERFACE) {
-			//noinspection deprecation,removal
 			return sound.getKey();
 		} else {
 			return ((Keyed) sound).getKey();

--- a/src/main/java/ch/njol/skript/classes/SerializableGetter.java
+++ b/src/main/java/ch/njol/skript/classes/SerializableGetter.java
@@ -2,8 +2,6 @@ package ch.njol.skript.classes;
 
 import ch.njol.skript.util.Getter;
 
-/**
- * @author Peter Güttinger
- */
-@Deprecated
+@Deprecated(forRemoval = true)
+@SuppressWarnings("removal")
 public abstract class SerializableGetter<R, A> extends Getter<R, A> {}

--- a/src/main/java/ch/njol/skript/command/Commands.java
+++ b/src/main/java/ch/njol/skript/command/Commands.java
@@ -82,7 +82,7 @@ public abstract class Commands {
 		return commandMap;
 	}
 
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"unchecked", "removal"})
 	private static void init() {
 		try {
 			if (Bukkit.getPluginManager() instanceof SimplePluginManager) {

--- a/src/main/java/ch/njol/skript/effects/EffHidePlayerFromServerList.java
+++ b/src/main/java/ch/njol/skript/effects/EffHidePlayerFromServerList.java
@@ -56,11 +56,12 @@ public class EffHidePlayerFromServerList extends Effect {
 	}
 
 	@Override
+	@SuppressWarnings("removal")
 	protected void execute(Event e) {
 		if (!(e instanceof ServerListPingEvent))
 			return;
 
-		Iterator<Player> it = ((ServerListPingEvent) e).iterator();		
+		Iterator<Player> it = ((ServerListPingEvent) e).iterator();
 		Iterators.removeAll(it, Arrays.asList(players.getArray(e)));
 	}
 

--- a/src/main/java/ch/njol/skript/entity/EntityData.java
+++ b/src/main/java/ch/njol/skript/entity/EntityData.java
@@ -81,17 +81,17 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 			f.putObject("codeName", o.info.codeName);
 			return f;
 		}
-		
+
 		@Override
 		public boolean canBeInstantiated() {
 			return false;
 		}
-		
+
 		@Override
 		public void deserialize(final EntityData o, final Fields f) throws StreamCorruptedException {
 			assert false;
 		}
-		
+
 		@Override
 		protected EntityData deserialize(final Fields fields) throws StreamCorruptedException, NotSerializableException {
 			final String codeName = fields.getAndRemoveObject("codeName", String.class);
@@ -111,7 +111,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 			}
 			throw new StreamCorruptedException();
 		}
-		
+
 //		return getInfo((Class<? extends EntityData<?>>) d.getClass()).codeName + ":" + d.serialize();
 		@SuppressWarnings("null")
 		@Override
@@ -135,13 +135,13 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 				return null;
 			return d;
 		}
-		
+
 		@Override
 		public boolean mustSyncDeserialization() {
 			return false;
 		}
 	};
-	
+
 	static {
 		Classes.registerClass(new ClassInfo<>(EntityData.class, "entitydata")
 				.user("entity ?types?")
@@ -159,13 +159,13 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 					public String toString(final EntityData d, final int flags) {
 						return d.toString(flags);
 					}
-					
+
 					@Override
 					@Nullable
 					public EntityData parse(final String s, final ParseContext context) {
 						return EntityData.parse(s);
 					}
-					
+
 					@Override
 					public String toVariableNameString(final EntityData o) {
 						return "entitydata:" + o.toString();
@@ -192,7 +192,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		final int defaultName;
 		final Class<? extends Entity> entityClass;
 		final Noun[] names;
-		
+
 		public EntityDataInfo(final Class<T> dataClass, final String codeName, final String[] codeNames, final int defaultName, final Class<? extends Entity> entityClass) throws IllegalArgumentException {
 			super(new String[codeNames.length], dataClass, dataClass.getName());
 			assert codeName != null && entityClass != null && codeNames.length > 0;
@@ -205,16 +205,16 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 				assert codeNames[i] != null;
 				names[i] = new Noun(LANGUAGE_NODE + "." + codeNames[i] + ".name");
 			}
-			
+
 			Language.addListener(this, LanguageListenerPriority.LATEST); // will initialise patterns, LATEST to make sure that m_age_pattern is updated before this
 		}
-		
+
 		@Override
 		public void onLanguageChange() {
 			for (int i = 0; i < codeNames.length; i++)
 				patterns[i] = Language.get(LANGUAGE_NODE + "." + codeNames[i] + ".pattern").replace("<age>", m_age_pattern.toString());
 		}
-		
+
 		@Override
 		public int hashCode() {
 			final int prime = 31;
@@ -222,7 +222,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 			result = prime * result + codeName.hashCode();
 			return result;
 		}
-		
+
 		@Override
 		public boolean equals(final @Nullable Object obj) {
 			if (this == obj)
@@ -239,13 +239,13 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 			assert entityClass == other.entityClass;
 			return true;
 		}
-		
+
 	}
-	
+
 	public static <E extends Entity, T extends EntityData<E>> void register(final Class<T> dataClass, final String name, final Class<E> entityClass, final String codeName) throws IllegalArgumentException {
 		register(dataClass, name, entityClass, 0, codeName);
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	public static <E extends Entity, T extends EntityData<E>> void register(final Class<T> dataClass, final String name, final Class<E> entityClass, final int defaultName, final String... codeNames) throws IllegalArgumentException {
 		final EntityDataInfo<T> info = new EntityDataInfo<>(dataClass, name, codeNames, defaultName, entityClass);
@@ -257,12 +257,12 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		}
 		infos.add((EntityDataInfo<EntityData<?>>) info);
 	}
-	
+
 	transient EntityDataInfo<?> info;
 	protected int matchedPattern = 0;
 	private Kleenean plural = Kleenean.UNKNOWN;
 	private Kleenean baby = Kleenean.UNKNOWN;
-	
+
 	public EntityData() {
 		for (final EntityDataInfo<?> i : infos) {
 			if (getClass() == i.getElementClass()) {
@@ -273,7 +273,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		}
 		throw new IllegalStateException();
 	}
-	
+
 	@SuppressWarnings("null")
 	@Override
 	public final boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
@@ -286,60 +286,60 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		this.baby = ageBits == 4 ? Kleenean.TRUE : ageBits == 8 ? Kleenean.FALSE : Kleenean.UNKNOWN;
 		return init(Arrays.copyOf(exprs, exprs.length, Literal[].class), matchedPattern, parseResult);
 	}
-	
+
 	protected abstract boolean init(final Literal<?>[] exprs, final int matchedPattern, final ParseResult parseResult);
-	
+
 	/**
 	 * @param c An entity's class, e.g. Player
 	 * @param e An actual entity, or null to get an entity data for an entity class
 	 * @return Whether initialisation was successful
 	 */
 	protected abstract boolean init(@Nullable Class<? extends E> c, @Nullable E e);
-	
+
 	public abstract void set(E entity);
-	
+
 	protected abstract boolean match(E entity);
-	
+
 	public abstract Class<? extends E> getType();
-	
+
 	/**
 	 * Returns the super type of this entity data, e.g. 'wolf' for 'angry wolf'.
 	 *
 	 * @return The supertype of this entity data. Must not be null.
 	 */
 	public abstract EntityData getSuperType();
-	
+
 	@Override
 	public final String toString() {
 		return toString(0);
 	}
-	
+
 	@SuppressWarnings("null")
 	protected Noun getName() {
 		return info.names[matchedPattern];
 	}
-	
+
 	@Nullable
 	protected Adjective getAgeAdjective() {
 		return baby.isTrue() ? m_baby : baby.isFalse() ? m_adult : null;
 	}
-	
+
 	@SuppressWarnings("null")
 	public String toString(final int flags) {
 		final Noun name = info.names[matchedPattern];
 		return baby.isTrue() ? m_baby.toString(name, flags) : baby.isFalse() ? m_adult.toString(name, flags) : name.toString(flags);
 	}
-	
+
 	public Kleenean isPlural() {
 		return plural;
 	}
-	
+
 	public Kleenean isBaby() {
 		return baby;
 	}
-	
+
 	protected abstract int hashCode_i();
-	
+
 	@Override
 	public final int hashCode() {
 		final int prime = 31;
@@ -351,9 +351,9 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		result = prime * result + hashCode_i();
 		return result;
 	}
-	
+
 	protected abstract boolean equals_i(EntityData<?> obj);
-	
+
 	@Override
 	public final boolean equals(final @Nullable Object obj) {
 		if (this == obj)
@@ -373,7 +373,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 			return false;
 		return equals_i(other);
 	}
-	
+
 	public static EntityDataInfo<?> getInfo(final Class<? extends EntityData<?>> c) {
 		for (final EntityDataInfo<?> i : infos) {
 			if (i.getElementClass() == c)
@@ -381,7 +381,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		}
 		throw new SkriptAPIException("Unregistered EntityData class " + c.getName());
 	}
-	
+
 	@Nullable
 	public static EntityDataInfo<?> getInfo(final String codeName) {
 		for (final EntityDataInfo<?> i : infos) {
@@ -403,7 +403,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		Iterator<EntityDataInfo<EntityData<?>>> it = new ArrayList<>(infos).iterator();
 		return SkriptParser.parseStatic(Noun.stripIndefiniteArticle(s), it, null);
 	}
-	
+
 	/**
 	 * Prints errors.
 	 *
@@ -433,7 +433,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	 * @param world World to check if entity can spawn in
 	 * @return True if entity can spawn else false
 	 */
-	@SuppressWarnings("ConstantValue")
+	@SuppressWarnings({"ConstantValue", "removal"})
 	public boolean canSpawn(@Nullable World world) {
 		if (world == null)
 			return false;
@@ -509,7 +509,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		}
 		return list.toArray((E[]) Array.newInstance(getType(), list.size()));
 	}
-	
+
 	/**
 	 * @param types
 	 * @param type
@@ -544,7 +544,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		}
 		return list.toArray((E[]) Array.newInstance(type, list.size()));
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	public static <E extends Entity> E[] getAll(final EntityData<?>[] types, final Class<E> type, Chunk[] chunks) {
 		assert types.length > 0;
@@ -561,7 +561,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		}
 		return list.toArray((E[]) Array.newInstance(type, list.size()));
 	}
-	
+
 	private static <E extends Entity> EntityData<? super E> getData(final @Nullable Class<E> c, final @Nullable E e) {
 		assert c == null ^ e == null;
 		assert c == null || c.isInterface();
@@ -584,31 +584,31 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 			return new SimpleEntityData(c);
 		}
 	}
-	
+
 	public static <E extends Entity> EntityData<? super E> fromClass(final Class<E> c) {
 		return getData(c, null);
 	}
-	
+
 	public static <E extends Entity> EntityData<? super E> fromEntity(final E e) {
 		return getData(null, e);
 	}
-	
+
 	public static String toString(final Entity e) {
 		return fromEntity(e).getSuperType().toString();
 	}
-	
+
 	public static String toString(final Class<? extends Entity> c) {
 		return fromClass(c).getSuperType().toString();
 	}
-	
+
 	public static String toString(final Entity e, final int flags) {
 		return fromEntity(e).getSuperType().toString(flags);
 	}
-	
+
 	public static String toString(final Class<? extends Entity> c, final int flags) {
 		return fromClass(c).getSuperType().toString(flags);
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	public final boolean isInstance(final @Nullable Entity e) {
 		if (e == null)
@@ -617,19 +617,19 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 			return false;
 		return getType().isInstance(e) && match((E) e);
 	}
-	
+
 	public abstract boolean isSupertypeOf(EntityData<?> e);
-	
+
 	@Override
 	public Fields serialize() throws NotSerializableException {
 		return new Fields(this);
 	}
-	
+
 	@Override
 	public void deserialize(final Fields fields) throws StreamCorruptedException, NotSerializableException {
 		fields.setFields(this);
 	}
-	
+
 	@Deprecated
 	protected boolean deserialize(final String s) {
 		return false;

--- a/src/main/java/ch/njol/skript/expressions/ExprAnvilRepairCost.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAnvilRepairCost.java
@@ -49,8 +49,8 @@ public class ExprAnvilRepairCost extends SimplePropertyExpression<Inventory, Int
 	}
 
 	@Override
-	@Nullable
-	public Integer convert(Inventory inventory) {
+	@SuppressWarnings("removal")
+	public @Nullable Integer convert(Inventory inventory) {
 		if (!(inventory instanceof AnvilInventory))
 			return null;
 
@@ -59,19 +59,15 @@ public class ExprAnvilRepairCost extends SimplePropertyExpression<Inventory, Int
 	}
 
 	@Override
-	@Nullable
-	public Class<?>[] acceptChange(ChangeMode mode) {
-		switch (mode) {
-			case ADD:
-			case REMOVE:
-			case SET:
-				return CollectionUtils.array(Number.class);
-			default:
-				return null;
-		}
+	public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
+		return switch (mode) {
+			case ADD, REMOVE, SET -> CollectionUtils.array(Number.class);
+			default -> null;
+		};
 	}
 
 	@Override
+	@SuppressWarnings("removal")
 	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		int value = ((Number) delta[0]).intValue() * (mode == ChangeMode.REMOVE ? -1 : 1);
 		for (Inventory inventory : getExpr().getArray(event)) {
@@ -97,5 +93,5 @@ public class ExprAnvilRepairCost extends SimplePropertyExpression<Inventory, Int
 	public String getPropertyName() {
 		return "anvil item" + (isMax ? " max" : "") + " repair cost";
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprAnvilText.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAnvilText.java
@@ -5,9 +5,6 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
-import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.util.Kleenean;
 import org.bukkit.inventory.AnvilInventory;
 import org.bukkit.inventory.Inventory;
 import org.jetbrains.annotations.Nullable;
@@ -28,8 +25,8 @@ public class ExprAnvilText extends SimplePropertyExpression<Inventory, String> {
 	}
 
 	@Override
-	@Nullable
-	public String convert(Inventory inv) {
+	@SuppressWarnings("removal")
+	public @Nullable String convert(Inventory inv) {
 		if (!(inv instanceof AnvilInventory))
 			return null;
 		return ((AnvilInventory) inv).getRenameText();
@@ -44,5 +41,5 @@ public class ExprAnvilText extends SimplePropertyExpression<Inventory, String> {
 	public String getPropertyName() {
 		return "anvil text input";
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprColorOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprColorOf.java
@@ -116,6 +116,7 @@ public class ExprColorOf extends PropertyExpression<Object, Color> {
 	}
 
 	@Override
+	@SuppressWarnings("removal")
 	public void change(Event event, Object @Nullable [] delta, ChangeMode mode) {
 		Color[] colors = delta != null ? (Color[]) delta : null;
 		Consumer<TextDisplay> displayChanger = getDisplayChanger(mode, colors);
@@ -148,12 +149,10 @@ public class ExprColorOf extends PropertyExpression<Object, Color> {
 				ItemStack stack = object instanceof Item ? ((Item) object).getItemStack() : ((ItemType) object).getRandom();
 				if (stack == null)
 					continue;
-				//noinspection removal
 				MaterialData data = stack.getData();
 				if (!(data instanceof Colorable colorable))
 					continue;
 				colorable.setColor(colors[0].asDyeColor());
-				//noinspection removal
 				stack.setData(data);
 				if (object instanceof Item item) {
 					item.setItemStack(stack);
@@ -211,6 +210,7 @@ public class ExprColorOf extends PropertyExpression<Object, Color> {
 		};
 	}
 
+	@SuppressWarnings({"removal"})
 	private @Nullable Colorable getColorable(Object colorable) {
 		if (colorable instanceof Item || colorable instanceof ItemType) {
 			ItemStack item = colorable instanceof Item ?
@@ -218,7 +218,6 @@ public class ExprColorOf extends PropertyExpression<Object, Color> {
 
 			if (item == null)
 				return null;
-			//noinspection removal
 			MaterialData data = item.getData();
 			if (data instanceof Colorable)
 				return (Colorable) data;

--- a/src/main/java/ch/njol/skript/expressions/ExprHoverList.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHoverList.java
@@ -62,8 +62,8 @@ public class ExprHoverList extends SimpleExpression<String> {
 	}
 
 	@Override
-	@Nullable
-	public String[] get(Event event) {
+	@SuppressWarnings({"removal"})
+	public String @Nullable [] get(Event event) {
 		if (!(event instanceof PaperServerListPingEvent))
 			return null;
 
@@ -96,8 +96,8 @@ public class ExprHoverList extends SimpleExpression<String> {
 		return null;
 	}
 
-	@SuppressWarnings("null")
 	@Override
+	@SuppressWarnings({"null", "removal"})
 	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		if (!(event instanceof PaperServerListPingEvent))
 			return;

--- a/src/main/java/ch/njol/skript/expressions/ExprMaxItemUseTime.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprMaxItemUseTime.java
@@ -1,11 +1,7 @@
 package ch.njol.skript.expressions;
 
 import ch.njol.skript.Skript;
-import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
-import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.RequiredPlugins;
-import ch.njol.skript.doc.Since;
+import ch.njol.skript.doc.*;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
 import ch.njol.skript.util.Timespan;
 import org.bukkit.inventory.ItemStack;
@@ -31,8 +27,8 @@ public class ExprMaxItemUseTime extends SimplePropertyExpression<ItemStack, Time
 	}
 
 	@Override
-	@Nullable 
-	public Timespan convert(ItemStack item) {
+	@SuppressWarnings("removal")
+	public @Nullable Timespan convert(ItemStack item) {
 		return new Timespan(Timespan.TimePeriod.TICK, item.getMaxItemUseDuration());
 	}
 

--- a/src/main/java/ch/njol/skript/lang/SelfRegisteringSkriptEvent.java
+++ b/src/main/java/ch/njol/skript/lang/SelfRegisteringSkriptEvent.java
@@ -20,6 +20,7 @@ public abstract class SelfRegisteringSkriptEvent extends SkriptEvent {
 	 * Normally, that method would register the parsed trigger with {@link ch.njol.skript.SkriptEventHandler}.
 	 * A reference to the {@link Trigger} is available through {@link #trigger}.
 	 */
+	@Deprecated
 	public abstract void register(Trigger t);
 
 	/**
@@ -30,6 +31,7 @@ public abstract class SelfRegisteringSkriptEvent extends SkriptEvent {
 	 * Normally, that method would unregister the parsed trigger with {@link ch.njol.skript.SkriptEventHandler}.
 	 * A reference to the {@link Trigger} is available through {@link #trigger}.
 	 */
+	@Deprecated
 	public abstract void unregister(Trigger t);
 
 	/**
@@ -39,6 +41,7 @@ public abstract class SelfRegisteringSkriptEvent extends SkriptEvent {
 	 * @deprecated This method should no longer be used.
 	 * Each trigger should be unregistered through {@link #unregister(Trigger)}.
 	 */
+	@Deprecated
 	public abstract void unregisterAll();
 
 	@Override

--- a/src/main/java/ch/njol/skript/registrations/EventValues.java
+++ b/src/main/java/ch/njol/skript/registrations/EventValues.java
@@ -130,6 +130,7 @@ public class EventValues {
 	 */
 	@Deprecated(forRemoval = true)
 	@SafeVarargs
+	@SuppressWarnings({"removal"})
 	public static <T, E extends Event> void registerEventValue(
 		Class<E> event, Class<T> type,
 		Getter<T, E> getter, int time,
@@ -143,6 +144,7 @@ public class EventValues {
 	 * @deprecated Use {@link #registerEventValue(Class, Class, Converter, int)} instead.
 	 */
 	@Deprecated(forRemoval = true)
+	@SuppressWarnings({"removal"})
 	public static <T, E extends Event> void registerEventValue(
 		Class<E> event, Class<T> type,
 		Getter<T, E> getter, int time

--- a/src/main/java/ch/njol/skript/sections/EffSecShoot.java
+++ b/src/main/java/ch/njol/skript/sections/EffSecShoot.java
@@ -14,7 +14,6 @@ import ch.njol.skript.lang.Trigger;
 import ch.njol.skript.lang.TriggerItem;
 import ch.njol.skript.registrations.EventValues;
 import ch.njol.skript.util.Direction;
-import ch.njol.skript.util.Getter;
 import ch.njol.skript.variables.Variables;
 import ch.njol.util.Kleenean;
 import org.bukkit.Location;
@@ -145,18 +144,10 @@ public class EffSecShoot extends EffectSection {
 			"shoot %entitydatas% [from %livingentities/locations%] [(at|with) (speed|velocity) %-number%] [%-direction%]",
 			"(make|let) %livingentities/locations% shoot %entitydatas% [(at|with) (speed|velocity) %-number%] [%-direction%]"
 		);
-		EventValues.registerEventValue(ShootEvent.class, Entity.class, new Getter<Entity, ShootEvent>() {
-			@Override
-			public @Nullable Entity get(ShootEvent shootEvent) {
-				return shootEvent.getProjectile();
-			}
-		}, EventValues.TIME_NOW);
-		EventValues.registerEventValue(ShootEvent.class, Projectile.class, new Getter<Projectile, ShootEvent>() {
-			@Override
-			public @Nullable Projectile get(ShootEvent shootEvent) {
-				return shootEvent.getProjectile() instanceof Projectile projectile ? projectile : null;
-			}
-		}, EventValues.TIME_NOW);
+		EventValues.registerEventValue(ShootEvent.class, Entity.class, ShootEvent::getProjectile, EventValues.TIME_NOW);
+		EventValues.registerEventValue(ShootEvent.class, Projectile.class, shootEvent -> shootEvent.getProjectile()
+			instanceof Projectile projectile ? projectile : null,
+			EventValues.TIME_NOW);
 
 		if (!Skript.isRunningMinecraft(1, 20, 3)) {
 			try {

--- a/src/main/java/ch/njol/skript/timings/SkriptTimings.java
+++ b/src/main/java/ch/njol/skript/timings/SkriptTimings.java
@@ -9,12 +9,13 @@ import co.aikar.timings.Timings;
 /**
  * Static utils for Skript timings.
  */
+@SuppressWarnings("removal")
 public class SkriptTimings {
-	
+
 	private static volatile boolean enabled;
 	@SuppressWarnings("null")
 	private static Skript skript; // Initialized on Skript load, before any timings would be used anyway
-	
+
 	@Nullable
 	public static Object start(String name) {
 		if (!enabled()) // Timings disabled :(
@@ -24,25 +25,25 @@ public class SkriptTimings {
 		assert timing != null;
 		return timing;
 	}
-	
+
 	public static void stop(@Nullable Object timing) {
 		if (timing == null) // Timings disabled...
 			return;
 		((Timing) timing).stopTimingIfSync();
 	}
-	
+
 	public static boolean enabled() {
 		// First check if we can run timings (enabled in settings + running Paper)
 		// After that (we know that class exists), check if server has timings running
 		return enabled && Timings.isTimingsEnabled();
 	}
-	
+
 	public static void setEnabled(boolean flag) {
 		enabled = flag;
 	}
-	
+
 	public static void setSkript(Skript plugin) {
 		skript = plugin;
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/util/BlockStateBlock.java
+++ b/src/main/java/ch/njol/skript/util/BlockStateBlock.java
@@ -457,6 +457,7 @@ public class BlockStateBlock implements Block {
 	}
 
 	@Override
+	@SuppressWarnings("removal")
 	public BlockSoundGroup getSoundGroup() {
 		return state.getBlock().getSoundGroup();
 	}
@@ -467,6 +468,7 @@ public class BlockStateBlock implements Block {
 	}
 
 	@Override
+	@SuppressWarnings("removal")
 	public String getTranslationKey() {
 		return state.getBlock().getTranslationKey();
 	}
@@ -482,6 +484,7 @@ public class BlockStateBlock implements Block {
 	}
 
 	@Override
+	@SuppressWarnings("removal")
 	public boolean isValidTool(@NotNull ItemStack itemStack) {
 		return state.getBlock().isValidTool(itemStack);
 	}
@@ -507,6 +510,7 @@ public class BlockStateBlock implements Block {
 	}
 
 	@Override
+	@SuppressWarnings("removal")
 	public @NotNull String translationKey() {
 		return state.getBlock().getTranslationKey();
 	}

--- a/src/main/java/ch/njol/skript/util/DelayedChangeBlock.java
+++ b/src/main/java/ch/njol/skript/util/DelayedChangeBlock.java
@@ -438,6 +438,7 @@ public class DelayedChangeBlock implements Block {
 	}
 
 	@Override
+	@SuppressWarnings("removal")
 	public BlockSoundGroup getSoundGroup() {
 		return block.getSoundGroup();
 	}
@@ -448,6 +449,7 @@ public class DelayedChangeBlock implements Block {
 	}
 
 	@Override
+	@SuppressWarnings("removal")
 	public String getTranslationKey() {
 		return block.getTranslationKey();
 	}
@@ -463,6 +465,7 @@ public class DelayedChangeBlock implements Block {
 	}
 
 	@Override
+	@SuppressWarnings("removal")
 	public boolean isValidTool(@NotNull ItemStack itemStack) {
 		return block.isValidTool(itemStack);
 	}
@@ -489,6 +492,7 @@ public class DelayedChangeBlock implements Block {
 	}
 
 	@Override
+	@SuppressWarnings("removal")
 	public @NotNull String translationKey() {
 		return block.getTranslationKey();
 	}

--- a/src/main/java/ch/njol/skript/util/PotionDataUtils.java
+++ b/src/main/java/ch/njol/skript/util/PotionDataUtils.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.Nullable;
 // Bukkit does not provide a way to get a PotionEffect from PotionData
 // This class allows us to convert base PotionData of an item into a PotionEffect
 public enum PotionDataUtils {
-	
+
 	FIRE_RESISTANCE(PotionType.FIRE_RESISTANCE, false, false, 3600, 0),
 	FIRE_RESISTANCE_LONG(PotionType.FIRE_RESISTANCE, true, false, 9600, 0),
 	HARMING(PotionEffectUtils.HAS_OLD_POTION_FIELDS ? "INSTANT_DAMAGE" : "HARMING", false, false, 1, 0),
@@ -52,7 +52,7 @@ public enum PotionDataUtils {
 	WATER_BREATHING_LONG(PotionType.WATER_BREATHING, true, false, 9600, 0),
 	WEAKNESS(PotionType.WEAKNESS, false, false, 1800, 0),
 	WEAKNESS_LONG(PotionType.WEAKNESS, false, false, 4800, 0);
-	
+
 	@Nullable
 	private String name;
 	@Nullable
@@ -61,7 +61,7 @@ public enum PotionDataUtils {
 	private final boolean upgraded;
 	private final int duration;
 	private final int amplifier;
-	
+
 	PotionDataUtils(PotionType potionType, boolean extended, boolean upgraded, int duration, int amplifier) {
 		this.potionType = potionType;
 		this.extended = extended;
@@ -69,7 +69,7 @@ public enum PotionDataUtils {
 		this.duration = duration;
 		this.amplifier = amplifier;
 	}
-	
+
 	PotionDataUtils(String potionType, boolean extended, boolean upgraded, int duration, int amplifier) {
 		try {
 			this.potionType = PotionType.valueOf(potionType.toUpperCase(Locale.ENGLISH));
@@ -82,14 +82,14 @@ public enum PotionDataUtils {
 		this.duration = duration;
 		this.amplifier = amplifier;
 	}
-	
+
 	/**
 	 * Convert {@link PotionData} to a {@link PotionEffect}
 	 *
 	 * @param potionData PotionData to convert
 	 * @return List of PotionEffects from the data
 	 */
-	@SuppressWarnings("null")
+	@SuppressWarnings({"removal", "null"})
 	public static List<PotionEffect> getPotionEffects(PotionData potionData) {
 		List<PotionEffect> potionEffects = new ArrayList<>();
 		for (PotionDataUtils value : PotionDataUtils.values()) {
@@ -109,7 +109,7 @@ public enum PotionDataUtils {
 
 	private static final PotionEffectType SLOW = PotionEffectUtils.HAS_OLD_POTION_FIELDS ? PotionEffectType.getByName("SLOW") : PotionEffectType.SLOWNESS;
 	private static final PotionEffectType DAMAGE_RESISTANCE = PotionEffectUtils.HAS_OLD_POTION_FIELDS ? PotionEffectType.getByName("DAMAGE_RESISTANCE") : PotionEffectType.RESISTANCE;
-	
+
 	// Bukkit does not account for the fact that Turtle Master has 2 potion effects
 	@SuppressWarnings("null")
 	private static List<PotionEffect> getSpecialTurtle(PotionDataUtils data) {
@@ -117,7 +117,7 @@ public enum PotionDataUtils {
 		int duration = data.extended ? 800 : 400;
 		int slowAmp = data.upgraded ? 5 : 3;
 		int resistanceAmp = data.upgraded ? 3 : 2;
-		
+
 		// This is a stupid bandaid because for some reason Skript wont compare these with potion effects from Skript
 		PotionEffectType slow = PotionEffectUtils.parseByEffectType(SLOW);
 		PotionEffectType damage = PotionEffectUtils.parseByEffectType(DAMAGE_RESISTANCE);
@@ -127,5 +127,5 @@ public enum PotionDataUtils {
 		}
 		return potionEffects;
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/util/PotionEffectUtils.java
+++ b/src/main/java/ch/njol/skript/util/PotionEffectUtils.java
@@ -7,7 +7,6 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.ThrownPotion;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.inventory.meta.SuspiciousStewMeta;
@@ -22,7 +21,7 @@ import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.localization.Language;
 import ch.njol.skript.localization.LanguageChangeListener;
 
-@SuppressWarnings("deprecation")
+@SuppressWarnings({"deprecation", "removal"})
 public abstract class PotionEffectUtils {
 
 	private static final boolean HAS_SUSPICIOUS_META = Skript.classExists("org.bukkit.inventory.meta.SuspiciousStewMeta");
@@ -43,7 +42,7 @@ public abstract class PotionEffectUtils {
 		}
 		return i;
 	}
-	
+
 	static {
 		Language.addListener(new LanguageChangeListener() {
 			@Override
@@ -64,12 +63,12 @@ public abstract class PotionEffectUtils {
 			}
 		});
 	}
-	
+
 	@Nullable
 	public static PotionEffectType parseType(final String s) {
 		return types.get(s.toLowerCase(Locale.ENGLISH));
 	}
-	
+
 	// This is a stupid bandaid to fix comparison issues when converting potion datas
 	@Nullable
 	public static PotionEffectType parseByEffectType(PotionEffectType t) {
@@ -80,11 +79,11 @@ public abstract class PotionEffectUtils {
 		}
 		return null;
 	}
-	
+
 	public static String toString(PotionEffectType t) {
 		return names[t.getId()];
 	}
-	
+
 	// REMIND flags?
 	public static String toString(PotionEffectType t, int flags) {
 		return names[t.getId()];
@@ -165,10 +164,10 @@ public abstract class PotionEffectUtils {
 			case "luck":
 				return PotionType.LUCK;
 		}
-		
+
 		return null;
 	}
-	
+
 	/**
 	 * Wrapper around deprecated API function, in case it gets removed.
 	 * Changing one method is easier that changing loads of them from different expressions.
@@ -179,7 +178,7 @@ public abstract class PotionEffectUtils {
 	public static PotionType effectToType(PotionEffectType effect) {
 		return PotionType.getByEffect(effect);
 	}
-	
+
 	/**
 	 * Get potion string representation.
 	 * @param effect
@@ -188,17 +187,17 @@ public abstract class PotionEffectUtils {
 	 * @return
 	 */
 	public static String getPotionName(@Nullable PotionEffectType effect, boolean extended, boolean strong) {
-		if (effect == null) return "bottle of water"; 
-		
+		if (effect == null) return "bottle of water";
+
 		String s = "";
 		if (extended) s += "extended";
 		else if (strong) s += "strong";
 		s += " potion of ";
 		s += toString(effect);
-		
+
 		return s;
 	}
-	
+
 	/**
 	 * Clear all the active {@link PotionEffect PotionEffects} from an Entity
 	 *
@@ -207,7 +206,7 @@ public abstract class PotionEffectUtils {
 	public static void clearAllEffects(LivingEntity entity) {
 		entity.getActivePotionEffects().forEach(potionEffect -> entity.removePotionEffect(potionEffect.getType()));
 	}
-	
+
 	/**
 	 * Add PotionEffects to an entity
 	 *
@@ -223,11 +222,11 @@ public abstract class PotionEffectUtils {
 				effect = new PotionEffect((PotionEffectType) object, 15 * 20, 0, false);
 			else
 				continue;
-			
+
 			entity.addPotionEffect(effect);
 		}
 	}
-	
+
 	/**
 	 * Remove a PotionEffect from an entity
 	 *
@@ -243,11 +242,11 @@ public abstract class PotionEffectUtils {
 				effectType = (PotionEffectType) object;
 			else
 				continue;
-			
+
 			entity.removePotionEffect(effectType);
 		}
 	}
-	
+
 	/**
 	 * Clear all {@link PotionEffect PotionEffects} from an ItemType
 	 *
@@ -261,7 +260,7 @@ public abstract class PotionEffectUtils {
 			((SuspiciousStewMeta) meta).clearCustomEffects();
 		itemType.setItemMeta(meta);
 	}
-	
+
 	/**
 	 * Add PotionEffects to an ItemTye
 	 *
@@ -278,7 +277,7 @@ public abstract class PotionEffectUtils {
 				effect = new PotionEffect((PotionEffectType) object, 15 * 20, 0, false);
 			else
 				continue;
-			
+
 			if (meta instanceof PotionMeta)
 				((PotionMeta) meta).addCustomEffect(effect, false);
 			else if (HAS_SUSPICIOUS_META && meta instanceof SuspiciousStewMeta)
@@ -286,7 +285,7 @@ public abstract class PotionEffectUtils {
 		}
 		itemType.setItemMeta(meta);
 	}
-	
+
 	/**
 	 * Remove a PotionEffect from an ItemType
 	 *
@@ -295,7 +294,7 @@ public abstract class PotionEffectUtils {
 	 */
 	public static void removeEffects(ItemType itemType, Object[] effects) {
 		ItemMeta meta = itemType.getItemMeta();
-		
+
 		for (Object object : effects) {
 			PotionEffectType effectType;
 			if (object instanceof PotionEffect)
@@ -304,7 +303,7 @@ public abstract class PotionEffectUtils {
 				effectType = (PotionEffectType) object;
 			else
 				continue;
-			
+
 			if (meta instanceof PotionMeta)
 				((PotionMeta) meta).removeCustomEffect(effectType);
 			else if (HAS_SUSPICIOUS_META && meta instanceof SuspiciousStewMeta)

--- a/src/main/java/ch/njol/skript/util/Task.java
+++ b/src/main/java/ch/njol/skript/util/Task.java
@@ -16,44 +16,44 @@ import ch.njol.util.Closeable;
  * @author Peter Güttinger
  */
 public abstract class Task implements Runnable, Closeable {
-	
+
 	private final Plugin plugin;
 	private final boolean async;
 	private long period = -1;
-	
+
 	private int taskID = -1;
-	
+
 	public Task(final Plugin plugin, final long delay, final long period) {
 		this(plugin, delay, period, false);
 	}
-	
+
 	public Task(final Plugin plugin, final long delay, final long period, final boolean async) {
 		this.plugin = plugin;
 		this.period = period;
 		this.async = async;
 		schedule(delay);
 	}
-	
+
 	public Task(final Plugin plugin, final long delay) {
 		this(plugin, delay, false);
 	}
-	
+
 	public Task(final Plugin plugin, final long delay, final boolean async) {
 		this.plugin = plugin;
 		this.async = async;
 		schedule(delay);
 	}
-	
+
 	/**
 	 * Only call this if the task is not alive.
-	 * 
+	 *
 	 * @param delay
 	 */
 	private void schedule(final long delay) {
 		assert !isAlive();
 		if (!Skript.getInstance().isEnabled())
 			return;
-		
+
 		if (period == -1) {
 			if (async) {
 				taskID = Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, this, delay).getTaskId();
@@ -69,7 +69,7 @@ public abstract class Task implements Runnable, Closeable {
 		}
 		assert taskID != -1;
 	}
-	
+
 	/**
 	 * @return Whether this task is still running, i.e. whether it will run later or is currently running.
 	 */
@@ -78,7 +78,7 @@ public abstract class Task implements Runnable, Closeable {
 			return false;
 		return Bukkit.getScheduler().isQueued(taskID) || Bukkit.getScheduler().isCurrentlyRunning(taskID);
 	}
-	
+
 	/**
 	 * Cancels this task.
 	 */
@@ -88,15 +88,15 @@ public abstract class Task implements Runnable, Closeable {
 			taskID = -1;
 		}
 	}
-	
+
 	@Override
 	public void close() {
 		cancel();
 	}
-	
+
 	/**
 	 * Re-schedules the task to run next after the given delay. If this task was repeating it will continue so using the same period as before.
-	 * 
+	 *
 	 * @param delay
 	 */
 	public void setNextExecution(final long delay) {
@@ -104,10 +104,10 @@ public abstract class Task implements Runnable, Closeable {
 		cancel();
 		schedule(delay);
 	}
-	
+
 	/**
 	 * Sets the period of this task. This will re-schedule the task to be run next after the given period if the task is still running.
-	 * 
+	 *
 	 * @param period Period in ticks or -1 to cancel the task and make it non-repeating
 	 */
 	public void setPeriod(final long period) {
@@ -121,7 +121,7 @@ public abstract class Task implements Runnable, Closeable {
 				schedule(period);
 		}
 	}
-	
+
 	/**
 	 * Equivalent to <tt>{@link #callSync(Callable, Plugin) callSync}(c, {@link Skript#getInstance()})</tt>
 	 */
@@ -129,12 +129,12 @@ public abstract class Task implements Runnable, Closeable {
 	public static <T> T callSync(final Callable<T> c) {
 		return callSync(c, Skript.getInstance());
 	}
-	
+
 	/**
 	 * Calls a method on Bukkit's main thread.
 	 * <p>
 	 * Hint: Use a Callable&lt;Void&gt; to make a task which blocks your current thread until it is completed.
-	 * 
+	 *
 	 * @param c The method
 	 * @param p The plugin that owns the task. Must be enabled.
 	 * @return What the method returned or null if it threw an error or was stopped (usually due to the server shutting down)
@@ -157,8 +157,8 @@ public abstract class Task implements Runnable, Closeable {
 			}
 		} catch (final ExecutionException e) {
 			Skript.exception(e);
-		} catch (final CancellationException e) {} catch (final ThreadDeath e) {}// server shutting down
+		} catch (final CancellationException e) {}
 		return null;
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/util/visual/VisualEffects.java
+++ b/src/main/java/ch/njol/skript/util/visual/VisualEffects.java
@@ -231,6 +231,7 @@ public class VisualEffects {
 	}
 
 	// exists to avoid NoClassDefFoundError from Vibration
+	@SuppressWarnings({"removal"})
 	private static final class VibrationUtils {
 		private static Vibration buildVibration(Object[] data, Location location) {
 			int arrivalTime = -1;
@@ -240,14 +241,14 @@ public class VisualEffects {
 				Entity entity = (Entity) data[0];
 				if (arrivalTime == -1)
 					arrivalTime = (int) (location.distance(entity.getLocation()) / 20);
-				//noinspection removal - new constructor only exists on newer versions
+				// new constructor only exists on newer versions
 				return new Vibration(location, new Vibration.Destination.EntityDestination(entity), arrivalTime);
 			}
 			// assume it's a location
 			Location destination = data[0] != null ? (Location) data[0] : location;
 			if (arrivalTime == -1)
 				arrivalTime = (int) (location.distance(destination) / 20);
-			//noinspection removal - new constructor only exists on newer versions
+			// new constructor only exists on newer versions
 			return new Vibration(location, new Vibration.Destination.BlockDestination(destination), arrivalTime);
 		}
 	}


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
There are about 70 warnings when you build Skript. Most of these are unavoidable: we need to use deprecated methods for cross-version compatibility.
Unfortunately, inline suppressions don't prevent them from being reported during build.
This makes it hard to spot when something's actually an issue, because it gets buried in all the other warnings.

I have manually silenced all of the (current) removal warnings, since we have no choice about using most of them.
A couple I could actually fix (there were actually ways around a few that were probably just missed at the time) and there were some warnings from our own deprecated classes being used (by us).

### Is there a danger that problems will be missed?
Maybe, but realistically we are ignoring the warnings anyway currently, and we only actually change stuff when a method stops working entirely.

### Why not just silence all removal warnings for the project?

Obviously, new warnings will appear when other methods become deprecated, and it's important we get some heads-up about that, because it might be something we actually need to fix.

