### PR TITLE
Fix color chars not being registered

### DIFF
--- a/src/main/java/ch/njol/skript/util/chat/ChatMessages.java
+++ b/src/main/java/ch/njol/skript/util/chat/ChatMessages.java
@@ -76,6 +76,20 @@ public class ChatMessages {
 				assert code != null;
 				registerChatCode(code);
 			}
+
+			// Re-register any missing addon chat codes
+			for (ChatCode code : addonCodes) {
+				assert code != null;
+				registerChatCode(code);
+			}
+
+			// Add formatting chars
+			addColorChar('k', SkriptChatCode.obfuscated);
+			addColorChar('l', SkriptChatCode.bold);
+			addColorChar('m', SkriptChatCode.strikethrough);
+			addColorChar('n', SkriptChatCode.underlined);
+			addColorChar('o', SkriptChatCode.italic);
+			addColorChar('r', SkriptChatCode.reset);
 		});
 	}
 	


### PR DESCRIPTION
### Description
Fixes code that was accidentally deleted in #6670. Oops!

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
