### PR TITLE
Fix wrong unknown nullability on suppress warning enum

### DIFF
--- a/src/main/java/org/skriptlang/skript/lang/script/ScriptWarning.java
+++ b/src/main/java/org/skriptlang/skript/lang/script/ScriptWarning.java
@@ -43,9 +43,9 @@ public enum ScriptWarning {
 	 */
 	UNREACHABLE_CODE("unreachable code");
 
-	private final @Nullable String deprecationMessage;
 	private final String warningName;
 	private final String pattern;
+	private final @Nullable String deprecationMessage;
 
 	ScriptWarning(String warningName) {
 		this(warningName, warningName);
@@ -56,9 +56,9 @@ public enum ScriptWarning {
 	}
 
 	ScriptWarning(String warningName, String pattern, @Nullable String deprecationMessage) {
-		this.deprecationMessage = deprecationMessage;
 		this.warningName = warningName;
 		this.pattern = pattern;
+		this.deprecationMessage = deprecationMessage;
 	}
 
 	public String getWarningName() {

--- a/src/main/java/org/skriptlang/skript/lang/script/ScriptWarning.java
+++ b/src/main/java/org/skriptlang/skript/lang/script/ScriptWarning.java
@@ -82,7 +82,7 @@ public enum ScriptWarning {
 	}
 
 	/**
-	 * Prints the given message using {@link Skript#warning(String)} if the current script does not suppress deprecation warnings.
+	 * Prints the given message using {@link Skript#warning(String)} if and only if the current script does not suppress deprecation warnings.
 	 * Intended for use in {@link ch.njol.skript.lang.SyntaxElement#init(Expression[], int, Kleenean, SkriptParser.ParseResult)}.
 	 * The given message is prefixed with {@code "[Deprecated] "} to provide a common link between deprecation warnings.
 	 *

--- a/src/main/java/org/skriptlang/skript/lang/script/ScriptWarning.java
+++ b/src/main/java/org/skriptlang/skript/lang/script/ScriptWarning.java
@@ -6,7 +6,6 @@ import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.parser.ParserInstance;
 import ch.njol.util.Kleenean;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.UnknownNullability;
 
 /**
  * An enum containing {@link Script} warnings that can be suppressed.
@@ -44,9 +43,9 @@ public enum ScriptWarning {
 	 */
 	UNREACHABLE_CODE("unreachable code");
 
+	private final @Nullable String deprecationMessage;
 	private final String warningName;
 	private final String pattern;
-	private final @UnknownNullability String deprecationMessage;
 
 	ScriptWarning(String warningName) {
 		this(warningName, warningName);
@@ -57,9 +56,9 @@ public enum ScriptWarning {
 	}
 
 	ScriptWarning(String warningName, String pattern, @Nullable String deprecationMessage) {
+		this.deprecationMessage = deprecationMessage;
 		this.warningName = warningName;
 		this.pattern = pattern;
-		this.deprecationMessage = deprecationMessage;
 	}
 
 	public String getWarningName() {
@@ -75,16 +74,15 @@ public enum ScriptWarning {
 	}
 
 	/**
-	 * Returns the deprecation message of this warning, or null if the warning isn't deprecated. 
-	 * @return The deprecation message.
+	 * @return The deprecation message of this warning, or null if the warning isn't deprecated.
 	 * @see #isDeprecated()
 	 */
-	public @UnknownNullability String getDeprecationMessage() {
+	public String getDeprecationMessage() {
 		return deprecationMessage;
 	}
 
 	/**
-	 * Prints the given message using {@link Skript#warning(String)} iff the current script does not suppress deprecation warnings.
+	 * Prints the given message using {@link Skript#warning(String)} if the current script does not suppress deprecation warnings.
 	 * Intended for use in {@link ch.njol.skript.lang.SyntaxElement#init(Expression[], int, Kleenean, SkriptParser.ParseResult)}.
 	 * The given message is prefixed with {@code "[Deprecated] "} to provide a common link between deprecation warnings.
 	 *


### PR DESCRIPTION
### Description
Fix wrong unknown nullability on suppress warning enum

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
