### PR TITLE
DocumentationIdProvider - fix getId methods returning "2"

### DIFF
--- a/src/main/java/ch/njol/skript/doc/DocumentationIdProvider.java
+++ b/src/main/java/ch/njol/skript/doc/DocumentationIdProvider.java
@@ -42,7 +42,7 @@ public class DocumentationIdProvider {
 	 */
 	private static <T> int calculateCollisionCount(Iterator<? extends T> potentialCollisions, Predicate<T> collisionCriteria,
 											Predicate<T> equalsCriteria) {
-		int collisionCount = 0;
+		int collisionCount = -1; // Start at -1 since the first match will always be in the potientials
 		while (potentialCollisions.hasNext()) {
 			T potentialCollision = potentialCollisions.next();
 			if (collisionCriteria.test(potentialCollision)) {

--- a/src/main/java/ch/njol/skript/doc/DocumentationIdProvider.java
+++ b/src/main/java/ch/njol/skript/doc/DocumentationIdProvider.java
@@ -139,7 +139,7 @@ public class DocumentationIdProvider {
 		String eventId = getEventId(eventInfo);
 		int collisionCount = calculateCollisionCount(Skript.getEvents().iterator(),
 			otherEventInfo -> eventId.equals(getEventId(otherEventInfo)),
-			otherEventInfo -> otherEventInfo == eventInfo);
+			otherEventInfo -> Arrays.equals(otherEventInfo.getPatterns(), eventInfo.getPatterns()));
 		return addCollisionSuffix(eventId, collisionCount);
 	}
 

--- a/src/main/java/ch/njol/skript/doc/DocumentationIdProvider.java
+++ b/src/main/java/ch/njol/skript/doc/DocumentationIdProvider.java
@@ -13,6 +13,7 @@ import ch.njol.skript.lang.function.Functions;
 import ch.njol.skript.registrations.Classes;
 import org.skriptlang.skript.lang.structure.Structure;
 
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.function.Predicate;
@@ -42,7 +43,7 @@ public class DocumentationIdProvider {
 	 */
 	private static <T> int calculateCollisionCount(Iterator<? extends T> potentialCollisions, Predicate<T> collisionCriteria,
 											Predicate<T> equalsCriteria) {
-		int collisionCount = -1; // Start at -1 since the first match will always be in the potentials
+		int collisionCount = 0;
 		while (potentialCollisions.hasNext()) {
 			T potentialCollision = potentialCollisions.next();
 			if (collisionCriteria.test(potentialCollision)) {
@@ -78,7 +79,7 @@ public class DocumentationIdProvider {
 		}
 		int collisionCount = calculateCollisionCount(syntaxElementIterator,
 			elementInfo -> elementInfo.getElementClass() == syntaxClass,
-			elementInfo -> elementInfo == syntaxInfo);
+			elementInfo -> Arrays.equals(elementInfo.getPatterns(), syntaxInfo.getPatterns()));
 		DocumentationId documentationIdAnnotation = syntaxClass.getAnnotation(DocumentationId.class);
 		if (documentationIdAnnotation == null) {
 			return addCollisionSuffix(syntaxClass.getSimpleName(), collisionCount);

--- a/src/main/java/ch/njol/skript/doc/DocumentationIdProvider.java
+++ b/src/main/java/ch/njol/skript/doc/DocumentationIdProvider.java
@@ -42,7 +42,7 @@ public class DocumentationIdProvider {
 	 */
 	private static <T> int calculateCollisionCount(Iterator<? extends T> potentialCollisions, Predicate<T> collisionCriteria,
 											Predicate<T> equalsCriteria) {
-		int collisionCount = -1; // Start at -1 since the first match will always be in the potientials
+		int collisionCount = -1; // Start at -1 since the first match will always be in the potentials
 		while (potentialCollisions.hasNext()) {
 			T potentialCollision = potentialCollisions.next();
 			if (collisionCriteria.test(potentialCollision)) {


### PR DESCRIPTION
### Description
This PR aims to fix an issue in the docs where most elements had a "-2" appended in the link.
This was caused by a syntax info comparison that was failing.
Switched to comparing patterns instead.
(This made sure matching elements didn't increase the id)

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7367 
