### PR TITLE
Increase test delay time.

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -790,7 +790,7 @@ public final class Skript extends JavaPlugin implements Listener {
 								Bukkit.getServer().shutdown();
 							}, shutdownDelay.get());
 						});
-					}, 20); // 20 ticks is necessary on 1.19.4 to allow the server time to properly load/start ticking, for some reason
+					}, 50); // 50 ticks is necessary on 1.19.4/1.20.4 to allow the server time to properly load/start ticking, for some reason
 				}
 
 				Skript.metrics = new Metrics(Skript.getInstance(), 722); // 722 is our bStats plugin ID


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Seems like tests are still intermittently failing due to the world not yet ticking.
This changes the test delay from 20 ticks to 50 ticks.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
