### PR TITLE
Fixes the burning time expression not returning super in the init

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprFireTicks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFireTicks.java
@@ -34,7 +34,7 @@ public class ExprFireTicks extends SimplePropertyExpression<Entity, Timespan> {
 	@Override
 	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		max = (parseResult.hasTag("max"));
-		return true;
+		return super.init(expressions, matchedPattern, isDelayed, parseResult);
 	}
 
 	@Override

--- a/src/test/skript/tests/regressions/7373-burning-time-in-section.sk
+++ b/src/test/skript/tests/regressions/7373-burning-time-in-section.sk
@@ -1,0 +1,3 @@
+test "testing piggy":
+	spawn a pig at event-location:
+		set burning time of event-entity to 9000 ticks


### PR DESCRIPTION
### Description
Fixes the burning time expression not returning super in the init

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
