### PR TITLE
Re-add backwards-compatible Getter methods to EventValues

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "skript-aliases"]
 	path = skript-aliases
 	url = https://github.com/SkriptLang/skript-aliases
+	branch = minimized-aliases

--- a/src/main/java/ch/njol/skript/expressions/base/EventValueExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/EventValueExpression.java
@@ -153,7 +153,7 @@ public class EventValueExpression<T> extends SimpleExpression<T> implements Defa
 					hasValue = converters.get(event) != null;
 					continue;
 				}
-				if (EventValues.hasMultipleGetters(event, type, getTime()) == Kleenean.TRUE) {
+				if (EventValues.hasMultipleConverters(event, type, getTime()) == Kleenean.TRUE) {
 					Noun typeName = Classes.getExactClassInfo(componentType).getName();
 					log.printError("There are multiple " + typeName.toString(true) + " in " + Utils.a(getParser().getCurrentEventName()) + " event. " +
 							"You must define which " + typeName + " to use.");
@@ -161,9 +161,9 @@ public class EventValueExpression<T> extends SimpleExpression<T> implements Defa
 				}
 				Converter<?, ? extends T> converter;
 				if (exact) {
-					converter = EventValues.getExactEventValueGetter(event, type, getTime());
+					converter = EventValues.getExactEventValueConverter(event, type, getTime());
 				} else {
-					converter = EventValues.getEventValueGetter(event, type, getTime());
+					converter = EventValues.getEventValueConverter(event, type, getTime());
 				}
 				if (converter != null) {
 					converters.put(event, converter);

--- a/src/main/java/ch/njol/skript/registrations/EventValues.java
+++ b/src/main/java/ch/njol/skript/registrations/EventValues.java
@@ -217,10 +217,7 @@ public class EventValues {
 	 */
 	@Deprecated(forRemoval = true)
 	public static <T, E extends Event> Kleenean hasMultipleGetters(Class<E> event, Class<T> type, int time) {
-		List<Converter<? super E, ? extends T>> getters = getEventValueConverters(event, type, time, true, false);
-		if (getters == null)
-			return Kleenean.UNKNOWN;
-		return Kleenean.get(getters.size() > 1);
+		return hasMultipleConverters(event, type, time);
 	}
 
 	/**

--- a/src/main/java/ch/njol/skript/registrations/EventValues.java
+++ b/src/main/java/ch/njol/skript/registrations/EventValues.java
@@ -166,28 +166,38 @@ public class EventValues {
 	 * @return The event's value
 	 * @see #registerEventValue(Class, Class, Converter, int)
 	 */
-	@Nullable
-	public static <T, E extends Event> T getEventValue(E e, Class<T> c, int time) {
-		@SuppressWarnings("unchecked")
-		Converter<? super E, ? extends T> getter = getEventValueGetter((Class<E>) e.getClass(), c, time);
-		if (getter == null)
+	public static <T, E extends Event> @Nullable T getEventValue(E e, Class<T> c, int time) {
+		//noinspection unchecked
+		Converter<? super E, ? extends T> converter = getEventValueConverter((Class<E>) e.getClass(), c, time);
+		if (converter == null)
 			return null;
-		return getter.convert(e);
+		return converter.convert(e);
 	}
 
 	/**
-	 * Checks that a getter exists for the exact type. No converting or subclass checking.
+	 * @deprecated Use {@link #getExactEventValueConverter(Class, Class, int)} instead.
+	 */
+	@Nullable
+	@Deprecated(forRemoval = true)
+	@SuppressWarnings({"removal"})
+	public static <T, E extends Event> Getter<? super E, ? extends T> getExactEventValueGetter(Class<E> event, Class<T> c, int time) {
+		return toGetter(getExactEventValueConverter(event, c, time));
+	}
+
+	/**
+	 * Checks that a {@link Converter} exists for the exact type. No converting or subclass checking.
 	 *
 	 * @param event the event class the getter will be getting from
-	 * @param c type of getter
+	 * @param c type of {@link Converter}
 	 * @param time the event-value's time
 	 * @return A getter to get values for a given type of events
 	 * @see #registerEventValue(Class, Class, Converter, int)
 	 * @see EventValueExpression#EventValueExpression(Class)
 	 */
 	@Nullable
-	@SuppressWarnings("unchecked")
-	public static <T, E extends Event> Converter<? super E, ? extends T> getExactEventValueGetter(Class<E> event, Class<T> c, int time) {
+	public static <T, E extends Event> Converter<? super E, ? extends T> getExactEventValueConverter(
+		Class<E> event, Class<T> c, int time
+	) {
 		List<EventValueInfo<?, ?>> eventValues = getEventValuesList(time);
 		// First check for exact classes matching the parameters.
 		for (EventValueInfo<?, ?> eventValueInfo : eventValues) {
@@ -196,54 +206,81 @@ public class EventValues {
 			if (!checkExcludes(eventValueInfo, event))
 				return null;
 			if (eventValueInfo.event.isAssignableFrom(event))
+				//noinspection unchecked
 				return (Converter<? super E, ? extends T>) eventValueInfo.converter;
 		}
 		return null;
 	}
 
 	/**
-	 * Checks if an event has multiple getters, including default ones.
-	 *
-	 * @param event the event class the getter will be getting from.
-	 * @param type type of getter.
-	 * @param time the event-value's time.
-	 * @return true or false if the event and type have multiple getters.
+	 * @deprecated Use {@link #hasMultipleConverters(Class, Class, int)} instead.
 	 */
+	@Deprecated(forRemoval = true)
 	public static <T, E extends Event> Kleenean hasMultipleGetters(Class<E> event, Class<T> type, int time) {
-		List<Converter<? super E, ? extends T>> getters = getEventValueGetters(event, type, time, true, false);
+		List<Converter<? super E, ? extends T>> getters = getEventValueConverters(event, type, time, true, false);
 		if (getters == null)
 			return Kleenean.UNKNOWN;
 		return Kleenean.get(getters.size() > 1);
 	}
 
 	/**
-	 * Returns a getter to get a value from in an event.
+	 * Checks if an event has multiple {@link Converter}s, including default ones.
+	 *
+	 * @param event the event class the {@link Converter} will be getting from.
+	 * @param type type of {@link Converter}.
+	 * @param time the event-value's time.
+	 * @return true or false if the event and type have multiple {@link Converter}s.
+	 */
+	public static <T, E extends Event> Kleenean hasMultipleConverters(Class<E> event, Class<T> type, int time) {
+		List<Converter<? super E, ? extends T>> getters = getEventValueConverters(event, type, time, true, false);
+		if (getters == null)
+			return Kleenean.UNKNOWN;
+		return Kleenean.get(getters.size() > 1);
+	}
+
+	/**
+	 * @deprecated Use {@link #getEventValueConverter(Class, Class, int)} instead.
+	 */
+	@Nullable
+	@Deprecated(forRemoval = true)
+	@SuppressWarnings({"removal"})
+	public static <T, E extends Event> Getter<? super E, ? extends T> getEventValueGetter(Class<E> event, Class<T> type, int time) {
+		return toGetter(getEventValueConverter(event, type, time, true));
+	}
+
+	/**
+	 * Returns a {@link Converter} to get a value from in an event.
 	 * <p>
 	 * Can print an error if the event value is blocked for the given event.
 	 *
-	 * @param event the event class the getter will be getting from.
-	 * @param type type of getter.
+	 * @param event the event class the {@link Converter} will be getting from.
+	 * @param type type of {@link Converter}.
 	 * @param time the event-value's time.
 	 * @return A getter to get values for a given type of events.
 	 * @see #registerEventValue(Class, Class, Converter, int)
 	 * @see EventValueExpression#EventValueExpression(Class)
 	 */
-	@Nullable
-	public static <T, E extends Event> Converter<? super E, ? extends T> getEventValueGetter(Class<E> event, Class<T> type, int time) {
-		return getEventValueGetter(event, type, time, true);
+	public static <T, E extends Event> @Nullable Converter<? super E, ? extends T> getEventValueConverter(
+		Class<E> event, Class<T> type, int time
+	) {
+		return getEventValueConverter(event, type, time, true);
 	}
 
 	@Nullable
-	private static <T, E extends Event> Converter<? super E, ? extends T> getEventValueGetter(Class<E> event, Class<T> type, int time, boolean allowDefault) {
-		List<Converter<? super E, ? extends T>> list = getEventValueGetters(event, type, time, allowDefault);
+	private static <T, E extends Event> Converter<? super E, ? extends T> getEventValueConverter(
+		Class<E> event, Class<T> type, int time, boolean allowDefault
+	) {
+		List<Converter<? super E, ? extends T>> list = getEventValueConverters(event, type, time, allowDefault);
 		if (list == null || list.isEmpty())
 			return null;
 		return list.get(0);
 	}
 
 	@Nullable
-	private static <T, E extends Event> List<Converter<? super E, ? extends T>> getEventValueGetters(Class<E> event, Class<T> type, int time, boolean allowDefault) {
-		return getEventValueGetters(event, type, time, allowDefault, true);
+	private static <T, E extends Event> List<Converter<? super E, ? extends T>> getEventValueConverters(
+		Class<E> event, Class<T> type, int time, boolean allowDefault
+	) {
+		return getEventValueConverters(event, type, time, allowDefault, true);
 	}
 
 	/*
@@ -252,11 +289,14 @@ public class EventValues {
 	 */
 	@Nullable
 	@SuppressWarnings("unchecked")
-	private static <T, E extends Event> List<Converter<? super E, ? extends T>> getEventValueGetters(Class<E> event, Class<T> type, int time, boolean allowDefault, boolean allowConverting) {
+	private static <T, E extends Event> List<Converter<? super E, ? extends T>> getEventValueConverters(
+		Class<E> event, Class<T> type, int time,
+		boolean allowDefault, boolean allowConverting
+	) {
 		List<EventValueInfo<?, ?>> eventValues = getEventValuesList(time);
 		List<Converter<? super E, ? extends T>> list = new ArrayList<>();
 		// First check for exact classes matching the parameters.
-		Converter<? super E, ? extends T> exact = getExactEventValueGetter(event, type, time);
+		Converter<? super E, ? extends T> exact = getExactEventValueConverter(event, type, time);
 		if (exact != null) {
 			list.add(exact);
 			return list;
@@ -312,13 +352,14 @@ public class EventValues {
 			if (!event.equals(eventValueInfo.event))
 				continue;
 
-			Converter<? super E, ? extends T> getter = (Converter<? super E, ? extends T>) getConvertedGetter(eventValueInfo, type, false);
-			if (getter == null)
+			Converter<? super E, ? extends T> converter = (Converter<? super E, ? extends T>)
+				getConvertedConverter(eventValueInfo, type, false);
+			if (converter == null)
 				continue;
 
 			if (!checkExcludes(eventValueInfo, event))
 				return null;
-			list.add(getter);
+			list.add(converter);
 			continue;
 		}
 		if (!list.isEmpty())
@@ -329,20 +370,21 @@ public class EventValues {
 			if (!event.isAssignableFrom(eventValueInfo.event))
 				continue;
 
-			Converter<? super E, ? extends T> getter = (Converter<? super E, ? extends T>) getConvertedGetter(eventValueInfo, type, true);
-			if (getter == null)
+			Converter<? super E, ? extends T> converter = (Converter<? super E, ? extends T>)
+				getConvertedConverter(eventValueInfo, type, true);
+			if (converter == null)
 				continue;
 
 			if (!checkExcludes(eventValueInfo, event))
 				return null;
-			list.add(getter);
+			list.add(converter);
 			continue;
 		}
 		if (!list.isEmpty())
 			return list;
 		// If the check should try again matching event values with a 0 time (most event values).
 		if (allowDefault && time != 0)
-			return getEventValueGetters(event, type, 0, false);
+			return getEventValueConverters(event, type, 0, false);
 		return null;
 	}
 
@@ -375,7 +417,9 @@ public class EventValues {
 	 * @return The found Converter wrapped in a Getter object, or null if no Converter was found.
 	 */
 	@Nullable
-	private static <E extends Event, F, T> Converter<? super E, ? extends T> getConvertedGetter(EventValueInfo<E, F> info, Class<T> to, boolean checkInstanceOf) {
+	private static <E extends Event, F, T> Converter<? super E, ? extends T> getConvertedConverter(
+		EventValueInfo<E, F> info, Class<T> to, boolean checkInstanceOf
+	) {
 		Converter<? super F, ? extends T> converter = Converters.getConverter(info.c, to);
 
 		if (converter == null)
@@ -391,12 +435,26 @@ public class EventValues {
 		};
 	}
 
+	@Deprecated(forRemoval = true)
+	@SuppressWarnings({"removal"})
+	private static <A, B> Getter<B, A> toGetter(Converter<A, B> converter) {
+		if (converter == null)
+			return null;
+
+		return new Getter<>() {
+			@Override
+			public @Nullable B get(A arg) {
+				return converter.convert(arg);
+			}
+		};
+	}
+
 	public static boolean doesExactEventValueHaveTimeStates(Class<? extends Event> event, Class<?> c) {
-		return getExactEventValueGetter(event, c, TIME_PAST) != null || getExactEventValueGetter(event, c, TIME_FUTURE) != null;
+		return getExactEventValueConverter(event, c, TIME_PAST) != null || getExactEventValueConverter(event, c, TIME_FUTURE) != null;
 	}
 
 	public static boolean doesEventValueHaveTimeStates(Class<? extends Event> event, Class<?> c) {
-		return getEventValueGetter(event, c, TIME_PAST, false) != null || getEventValueGetter(event, c, TIME_FUTURE, false) != null;
+		return getEventValueConverter(event, c, TIME_PAST, false) != null || getEventValueConverter(event, c, TIME_FUTURE, false) != null;
 	}
 
 	private record EventValueInfo<E extends Event, T>(

--- a/src/main/java/ch/njol/skript/registrations/EventValues.java
+++ b/src/main/java/ch/njol/skript/registrations/EventValues.java
@@ -180,7 +180,7 @@ public class EventValues {
 	@Nullable
 	@Deprecated(forRemoval = true)
 	@SuppressWarnings({"removal"})
-	public static <T, E extends Event> Getter<? super E, ? extends T> getExactEventValueGetter(Class<E> event, Class<T> c, int time) {
+	public static <T, E extends Event> Getter<? extends T, ? super E> getExactEventValueGetter(Class<E> event, Class<T> c, int time) {
 		return toGetter(getExactEventValueConverter(event, c, time));
 	}
 
@@ -195,7 +195,7 @@ public class EventValues {
 	 * @see EventValueExpression#EventValueExpression(Class)
 	 */
 	@Nullable
-	public static <T, E extends Event> Converter<? super E, ? extends T> getExactEventValueConverter(
+	public static <E extends Event, T> Converter<? super E, ? extends T> getExactEventValueConverter(
 		Class<E> event, Class<T> c, int time
 	) {
 		List<EventValueInfo<?, ?>> eventValues = getEventValuesList(time);
@@ -244,7 +244,7 @@ public class EventValues {
 	@Nullable
 	@Deprecated(forRemoval = true)
 	@SuppressWarnings({"removal"})
-	public static <T, E extends Event> Getter<? super E, ? extends T> getEventValueGetter(Class<E> event, Class<T> type, int time) {
+	public static <T, E extends Event> Getter<? extends T, ? super E> getEventValueGetter(Class<E> event, Class<T> type, int time) {
 		return toGetter(getEventValueConverter(event, type, time, true));
 	}
 


### PR DESCRIPTION
### Description
- Re-adds public Getter methods to EventValues to ensure backwards compatibility. 
  - These have been deprecated for removal. 
  - The returned Getters are just wrapping the returned Converter, visible in `#toGetter`.
- All method names have been updated as well, to accurately reflect that they return Converters now.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
