### PR TITLE
Fix missing newline and handle syntaxes without documentation in Runtime Errors.

### DIFF
--- a/src/main/java/org/skriptlang/skript/log/runtime/ErrorSource.java
+++ b/src/main/java/org/skriptlang/skript/log/runtime/ErrorSource.java
@@ -32,7 +32,8 @@ public record ErrorSource(
 	 * @return A new error source.
 	 */
 	public static @NotNull ErrorSource fromNodeAndElement(@Nullable Node node, @NotNull SyntaxElement element) {
-		String elementName = element.getClass().getAnnotation(Name.class).value().trim().replaceAll("\n", "");
+		Name annotation = element.getClass().getAnnotation(Name.class);
+		String elementName = annotation != null ? annotation.value().trim().replaceAll("\n", "") : element.getClass().getSimpleName();
 		if (node == null) {
 			return new ErrorSource(element.getSyntaxTypeName(), elementName, 0, "-unknown-", "-unknown-");
 		}

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -133,13 +133,13 @@ skript command:
 log:
 	# runtime errors
 	runtime:
-		error: <light red>The script '<gray>%s<light red>' encountered an error while executing the '<gray>%s<light red>' %s<light red>:
+		error: <light red>The script '<gray>%s<light red>' encountered an error while executing the '<gray>%s<light red>' %s<light red>:\n
 		errors skipped: <gold>%d<light red> runtime error[s] were thrown but not printed in the last frame. From: <gray>%s
 		errors timed out: <gold>Line %d<light red> of script '<gray>%s<light red>' produced too many runtime errors (<gray>%d<light red> allowed per frame). No errors from this line will be printed for %d frames.
 		error notification: <light red>Script '<gray>%s<light red>' produced runtime errors. Please check console logs for details.
 		error notification plural: <light red>Script '<gray>%s<light red>' and %d others produced runtime errors. Please check console logs for details.
 
-		warning: <yellow>The script '<gray>%s<yellow>' encountered a warning while executing the '<gray>%s<yellow>' %s<yellow>:
+		warning: <yellow>The script '<gray>%s<yellow>' encountered a warning while executing the '<gray>%s<yellow>' %s<yellow>:\n
 		warnings skipped: <yellow>%d<yellow> runtime warning[s] were thrown but not printed in the last frame. From: <gray>%s
 		warnings timed out: <gold>Line %d<yellow> of script '<gray>%s<yellow>' produced too many runtime warnings (<gray>%d<yellow> allowed per frame). No warnings from this line will be printed for %d frames.
 		warning notification: <yellow>Script '<gray>%s<yellow>' produced runtime warnings. Please check console logs for details.


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

The error/warning lines were missing a newline at their ends, and syntaxes without a Name annotation were throwing exceptions.
Fallsback to the classname when no Name annotation is found.

I think not using syntaxinfos was a mistake that should be rectified, since things like Events or functions don't have docs annotations. That's for another PR, though.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
