### PR TITLE
SkriptCommand - fix test command again

### DIFF
--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -1192,11 +1192,24 @@ public class ScriptLoader {
 
 	/**
 	 * Gets a script's file from its name, if one exists.
+	 *
 	 * @param script The script name/path
 	 * @return The script file, if one is found
 	 */
 	@Nullable
 	public static File getScriptFromName(String script) {
+		return getScriptFromName(script, Skript.getInstance().getScriptsFolder());
+	}
+
+	/**
+	 * Gets a script's file from its name and directory, if one exists.
+	 *
+	 * @param script The script name/path
+	 * @param directory The scripts (or testing scripts) directory
+	 * @return The script file, if one is found
+	 */
+	@Nullable
+	public static File getScriptFromName(String script, File directory) {
 		if (script.endsWith("/") || script.endsWith("\\")) { // Always allow '/' and '\' regardless of OS
 			script = script.replace('/', File.separatorChar).replace('\\', File.separatorChar);
 		} else if (!StringUtils.endsWithIgnoreCase(script, ".sk")) {
@@ -1209,8 +1222,7 @@ public class ScriptLoader {
 		if (script.startsWith(ScriptLoader.DISABLED_SCRIPT_PREFIX))
 			script = script.substring(ScriptLoader.DISABLED_SCRIPT_PREFIX_LENGTH);
 
-		File scriptsFolder = Skript.getInstance().getScriptsFolder();
-		File scriptFile = new File(scriptsFolder, script);
+		File scriptFile = new File(directory, script);
 		if (!scriptFile.exists()) {
 			scriptFile = new File(scriptFile.getParentFile(), ScriptLoader.DISABLED_SCRIPT_PREFIX + scriptFile.getName());
 			if (!scriptFile.exists()) {
@@ -1220,7 +1232,7 @@ public class ScriptLoader {
 		try {
 			// Unless it's a test, check if the user is asking for a script in the scripts folder
 			// and not something outside Skript's domain.
-			if (TestMode.ENABLED || scriptFile.getCanonicalPath().startsWith(scriptsFolder.getCanonicalPath() + File.separator))
+			if (TestMode.ENABLED || scriptFile.getCanonicalPath().startsWith(directory.getCanonicalPath() + File.separator))
 				return scriptFile.getCanonicalFile();
 			return null;
 		} catch (IOException e) {

--- a/src/main/java/ch/njol/skript/SkriptCommand.java
+++ b/src/main/java/ch/njol/skript/SkriptCommand.java
@@ -494,7 +494,7 @@ public class SkriptCommand implements CommandExecutor {
 
 	private static @Nullable File getScriptFromArgs(CommandSender sender, String[] args, File directoryFile) {
 		String script = StringUtils.join(args, " ", 1, args.length);
-		File f = ScriptLoader.getScriptFromName(script);
+		File f = ScriptLoader.getScriptFromName(script, directoryFile);
 		if (f == null) {
 			// Always allow '/' and '\' regardless of OS
 			boolean directory = script.endsWith("/") || script.endsWith("\\") || script.endsWith(File.separator);

--- a/src/main/java/ch/njol/skript/SkriptCommandTabCompleter.java
+++ b/src/main/java/ch/njol/skript/SkriptCommandTabCompleter.java
@@ -29,7 +29,8 @@ public class SkriptCommandTabCompleter implements TabCompleter {
 			options.add("check");
 			options.add("changes");
 		} else if (args[0].matches("(?i)(reload|disable|enable|test)") && args.length >= 2) {
-			File scripts = TestMode.DEV_MODE ? TestMode.TEST_DIR.toFile() : Skript.getInstance().getScriptsFolder();
+			boolean useTestDirectory = args[0].equalsIgnoreCase("test") && TestMode.DEV_MODE;
+			File scripts = useTestDirectory ? TestMode.TEST_DIR.toFile() : Skript.getInstance().getScriptsFolder();
 			String scriptsPathString = scripts.toPath().toString();
 			int scriptsPathLength = scriptsPathString.length();
 


### PR DESCRIPTION
### Description
This PR aims to fix the `/sk test` command yet again.
I recently realized the tab completion worked, but I was not able to actually test just one file/folder, it kept saying said file didnt exist.
I then looked over the code and realized I never actually passed the directory thru when looking for said script.
(its a mystery 🧐  how I never caught this before)
I had to add another method to allow passing the directory thru without breaking previous methods.

I also fixed an issue where the `/sk test/reload` commands both showed the same directories/files.
Now it will show the correct directories whether you're running reload or test.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
