### PR TITLE
Supports multiple commands in EvtCommand

### DIFF
--- a/src/main/java/ch/njol/skript/events/EvtCommand.java
+++ b/src/main/java/ch/njol/skript/events/EvtCommand.java
@@ -12,54 +12,63 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.StringUtils;
 import ch.njol.util.coll.CollectionUtils;
 
-/**
- * @author Peter Güttinger
- */
-@SuppressWarnings("unchecked")
+import java.util.Arrays;
+
 public class EvtCommand extends SkriptEvent { // TODO condition to check whether a given command exists, & a conditon to check whether it's a custom skript command
 	static {
-		Skript.registerEvent("Command", EvtCommand.class, CollectionUtils.array(PlayerCommandPreprocessEvent.class, ServerCommandEvent.class), "command [%-string%]")
+		Skript.registerEvent("Command", EvtCommand.class, CollectionUtils.array(PlayerCommandPreprocessEvent.class, ServerCommandEvent.class), "command [%-strings%]")
 				.description("Called when a player enters a command (not necessarily a Skript command) but you can check if command is a skript command, see <a href='conditions.html#CondIsSkriptCommand'>Is a Skript command condition</a>.")
 				.examples("on command:", "on command \"/stop\":", "on command \"pm Njol \":")
 				.since("2.0");
 	}
 	
-	@Nullable
-	private String command = null;
+	private String @Nullable [] commands = null;
+	private Literal<String> commandsLit;
 
 	@Override
 	@SuppressWarnings("null")
 	public boolean init(final Literal<?>[] args, final int matchedPattern, final ParseResult parser) {
 		if (args[0] != null) {
-			command = ((Literal<String>) args[0]).getSingle();
-			if (command.startsWith("/"))
-				command = command.substring(1);
+			//noinspection unchecked
+			commandsLit = ((Literal<String>) args[0]);
+			commands = commandsLit.getAll();
+			for (int i = 0; i < commands.length; i++) {
+				if (commands[i].startsWith("/"))
+					commands[i] = commands[i].substring(1);
+			}
 		}
 		return true;
 	}
 
 	@Override
 	@SuppressWarnings("null")
-	public boolean check(final Event e) {
-		if (e instanceof ServerCommandEvent && ((ServerCommandEvent) e).getCommand().isEmpty())
+	public boolean check(Event event) {
+		if (event instanceof ServerCommandEvent serverCommandEvent && serverCommandEvent.getCommand().isEmpty())
 			return false;
 
-		if (command == null)
+		if (commands == null)
 			return true;
-		final String message;
-		if (e instanceof PlayerCommandPreprocessEvent) {
-			assert ((PlayerCommandPreprocessEvent) e).getMessage().startsWith("/");
-			message = ((PlayerCommandPreprocessEvent) e).getMessage().substring(1);
+
+		String message;
+		if (event instanceof PlayerCommandPreprocessEvent playerCommandPreprocessEvent) {
+			assert playerCommandPreprocessEvent.getMessage().startsWith("/");
+			message = playerCommandPreprocessEvent.getMessage().substring(1);
 		} else {
-			message = ((ServerCommandEvent) e).getCommand();
+			assert event instanceof ServerCommandEvent;
+			message = ((ServerCommandEvent) event).getCommand();
 		}
-		return StringUtils.startsWithIgnoreCase(message, command)
-				&& (command.contains(" ") || message.length() == command.length() || Character.isWhitespace(message.charAt(command.length()))); // if only the command is given, match that command only
+
+		return Arrays.stream(commands).anyMatch(candidateCommand ->
+				StringUtils.startsWithIgnoreCase(message, candidateCommand) // matches the command label
+				&& (candidateCommand.contains(" ") // if candidate contains arguments, then any command that starts with the candidate is a match
+					|| message.length() == candidateCommand.length() // exact match
+					|| Character.isWhitespace(message.charAt(candidateCommand.length()) // matches label with space after
+				)));
 	}
 	
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "command" + (command != null ? " /" + command : "");
+	public String toString(@Nullable Event event, boolean debug) {
+		return "command" + (commandsLit != null ? " " + commandsLit.toString(event, debug) : "");
 	}
 	
 }

--- a/src/test/skript/tests/syntaxes/structures/EvtCommand.sk
+++ b/src/test/skript/tests/syntaxes/structures/EvtCommand.sk
@@ -1,0 +1,24 @@
+
+
+on command "testing1":
+	add 1 to {evt-command::one command}
+
+
+on command "testing1 argument":
+	add 1 to {evt-command::one command with argument}
+
+on command "testing1" or "testing2":
+	add 1 to {evt-command::both}
+
+test "command event":
+	execute console command "/testing1"
+	execute console command "/testing1 argument"
+	execute console command "/testing1 argument 2"
+	execute console command "/testing2"
+	execute console command "/testing2 argument"
+
+	assert {evt-command::one command} is 3 with "testing1 command event triggered the wrong amount of times"
+	assert {evt-command::one command with argument} is 2 with "testing1 argument command event triggered the wrong amount of times"
+	assert {evt-command::both} is 5 with "testing1 or testing2 command event triggered the wrong amount of times"
+
+	delete {evt-command::*}


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Allows the use of `on command "x" and "y"`.
Users were getting confused with `on command "x" or y"` varying in behavior due to which was selected during parsing.

The event now allows any number of commands and will trigger when any are detected.

I know this is not a bug, but I would like to treat it as if it were, since the previous behavior was confusing and not really intended. Let me know if you disagree.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
