### PR TITLE
HTMLGenerator - fix new line in "since" not working

### DIFF
--- a/src/main/java/ch/njol/skript/doc/HTMLGenerator.java
+++ b/src/main/java/ch/njol/skript/doc/HTMLGenerator.java
@@ -384,15 +384,7 @@ public class HTMLGenerator extends DocumentationGenerator {
 
 			i += Character.charCount(c);
 		}
-		return replaceBr(sb.toString());
-	}
-
-	/**
-	 * Replaces specifically `<br/>` with `\n` - This is useful in code blocks where you can't use newlines due to the
-	 * minifyHtml method (execute after minifyHtml)
-	 */
-	private static String replaceBr(String page) {
-		return page.replaceAll("<br/>", "\n");
+		return sb.toString();
 	}
 
 	private static String handleIf(String desc, String start, boolean value) {
@@ -434,7 +426,7 @@ public class HTMLGenerator extends DocumentationGenerator {
 
 		// Since
 		Since since = c.getAnnotation(Since.class);
-		desc = desc.replace("${element.since}", Joiner.on("<br>").join(getDefaultIfNullOrEmpty((since != null ? since.value() : null), "Unknown")));
+		desc = desc.replace("${element.since}", Joiner.on("<br/>").join(getDefaultIfNullOrEmpty((since != null ? since.value() : null), "Unknown")));
 
 		Keywords keywords = c.getAnnotation(Keywords.class);
 		desc = desc.replace("${element.keywords}", keywords == null ? "" : Joiner.on(", ").join(keywords.value()));

--- a/src/main/java/ch/njol/skript/doc/HTMLGenerator.java
+++ b/src/main/java/ch/njol/skript/doc/HTMLGenerator.java
@@ -434,7 +434,7 @@ public class HTMLGenerator extends DocumentationGenerator {
 
 		// Since
 		Since since = c.getAnnotation(Since.class);
-		desc = desc.replace("${element.since}", Joiner.on("<br/>").join(getDefaultIfNullOrEmpty((since != null ? since.value() : null), "Unknown")));
+		desc = desc.replace("${element.since}", Joiner.on("<br>").join(getDefaultIfNullOrEmpty((since != null ? since.value() : null), "Unknown")));
 
 		Keywords keywords = c.getAnnotation(Keywords.class);
 		desc = desc.replace("${element.keywords}", keywords == null ? "" : Joiner.on(", ").join(keywords.value()));


### PR DESCRIPTION
### Description
This PR aims to do yet another doc fix, I shall call it YADF.

Anyways, in my previous PR for the since annotation supporting multiple lines, pickle had made a code suggestion to change `<br>` to `<br/>`. 

I applied the code suggestion and didn't realize til after the PR was merged (and docs were created) that it did this:
(My fault for not testing... whoopsies)
(all on the same line, but no comma)
<img width="992" alt="Screenshot 2025-01-05 at 1 40 50 AM" src="https://github.com/user-attachments/assets/47e064bb-7da2-4ff8-b841-e1322f99c7b1" />

This PR fixes that issue by reverting that suggestion:
<img width="903" alt="Screenshot 2025-01-05 at 1 41 17 AM" src="https://github.com/user-attachments/assets/b008fe70-1ac5-480b-bc13-09f3c2cf3876" />

Might be my biggest PR to date 😂 


---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
