### PR TITLE
ParserInstance - fix throwing errors in effect commands

### DIFF
--- a/src/main/java/ch/njol/skript/lang/parser/ParserInstance.java
+++ b/src/main/java/ch/njol/skript/lang/parser/ParserInstance.java
@@ -463,13 +463,13 @@ public final class ParserInstance implements Experimented {
 
 	@Override
 	public boolean hasExperiment(String featureName) {
-		return Skript.experiments().isUsing(this.getCurrentScript(), featureName);
+		return this.isActive() && Skript.experiments().isUsing(this.getCurrentScript(), featureName);
 	}
 
 
 	@Override
 	public boolean hasExperiment(Experiment experiment) {
-		return Skript.experiments().isUsing(this.getCurrentScript(), experiment);
+		return this.isActive() && Skript.experiments().isUsing(this.getCurrentScript(), experiment);
 	}
 
 	/**


### PR DESCRIPTION
### Description
This PR aims to fix an issue with some expressions (which check for enabled experiments) throwing errors in console when used in effect commands, due to no parser instance found.
The fix here is first checking if the parser instance is active before checking if a script has a feature.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7397 
