### PR TITLE
EffAssert - fix null error when 'errorMsg' is not set

### DIFF
--- a/src/main/java/ch/njol/skript/test/runner/EffAssert.java
+++ b/src/main/java/ch/njol/skript/test/runner/EffAssert.java
@@ -89,7 +89,7 @@ public class EffAssert extends Effect {
 			return this.getNext();
 
 		if (condition.check(event) == shouldFail) {
-			String message = errorMsg.getOptionalSingle(event).orElse(DEFAULT_ERROR);
+			String message = errorMsg != null ? errorMsg.getOptionalSingle(event).orElse(DEFAULT_ERROR) : DEFAULT_ERROR;
 
 			// generate expected/got message if possible
 			String expectedMessage = "";


### PR DESCRIPTION
### Description
This PR aims to fix a null error in EffAssert when `errorMsg` is not set.
(First pattern `"assert <.+> [(1:to fail)]"` does not require a message)
`errorMsg` only gets set for other patterns that include a string

<img width="470" alt="Screenshot 2025-01-05 at 10 32 25 PM" src="https://github.com/user-attachments/assets/18d7836a-e22e-4582-b940-f005cd8f04d3" />

<details>
  <summary>See Error</summary>

```sh
[22:31:11 ERROR]: #!#! 
[22:31:11 ERROR]: #!#! [Skript] Severe Error:
[22:31:11 ERROR]: #!#! 
[22:31:11 ERROR]: #!#! Skript is running with developer command-line options. Consider disabling them if not a developer.
[22:31:11 ERROR]: #!#! 
[22:31:11 ERROR]: #!#! Stack trace:
[22:31:11 ERROR]: #!#! Caused by: java.lang.NullPointerException: Cannot invoke "ch.njol.skript.lang.Expression.getOptionalSingle(org.bukkit.event.Event)" because "this.errorMsg" is null
[22:31:11 ERROR]: #!#!     at Skript-2.10.0-pre1.jar//ch.njol.skript.test.runner.EffAssert.walk(EffAssert.java:92)
[22:31:11 ERROR]: #!#!     at Skript-2.10.0-pre1.jar//ch.njol.skript.lang.TriggerItem.walk(TriggerItem.java:67)
[22:31:11 ERROR]: #!#!     at Skript-2.10.0-pre1.jar//ch.njol.skript.lang.Trigger.execute(Trigger.java:33)
[22:31:11 ERROR]: #!#!     at Skript-2.10.0-pre1.jar//ch.njol.skript.SkriptEventHandler.lambda$execute$2(SkriptEventHandler.java:165)
[22:31:11 ERROR]: #!#!     at Skript-2.10.0-pre1.jar//ch.njol.skript.SkriptEventHandler.lambda$execute$3(SkriptEventHandler.java:176)
[22:31:11 ERROR]: #!#!     at Skript-2.10.0-pre1.jar//ch.njol.skript.util.Task.callSync(Task.java:147)
[22:31:11 ERROR]: #!#!     at Skript-2.10.0-pre1.jar//ch.njol.skript.util.Task.callSync(Task.java:131)
[22:31:11 ERROR]: #!#!     at Skript-2.10.0-pre1.jar//ch.njol.skript.SkriptEventHandler.execute(SkriptEventHandler.java:174)
[22:31:11 ERROR]: #!#!     at Skript-2.10.0-pre1.jar//ch.njol.skript.SkriptEventHandler.check(SkriptEventHandler.java:120)
[22:31:11 ERROR]: #!#!     at Skript-2.10.0-pre1.jar//ch.njol.skript.SkriptEventHandler$PriorityListener.lambda$new$0(SkriptEventHandler.java:46)
[22:31:11 ERROR]: #!#!     at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80)
[22:31:11 ERROR]: #!#!     at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70)
[22:31:11 ERROR]: #!#!     at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54)
[22:31:11 ERROR]: #!#!     at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131)
[22:31:11 ERROR]: #!#!     at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628)
[22:31:11 ERROR]: #!#!     at Skript-2.10.0-pre1.jar//ch.njol.skript.SkriptCommand.lambda$onCommand$10(SkriptCommand.java:423)
[22:31:11 ERROR]: #!#!     at org.bukkit.craftbukkit.scheduler.CraftTask.run(CraftTask.java:78)
[22:31:11 ERROR]: #!#!     at org.bukkit.craftbukkit.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:474)
[22:31:11 ERROR]: #!#!     at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1659)
[22:31:11 ERROR]: #!#!     at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1529)
[22:31:11 ERROR]: #!#!     at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1251)
[22:31:11 ERROR]: #!#!     at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:310)
[22:31:11 ERROR]: #!#!     at java.base/java.lang.Thread.run(Thread.java:1570)
[22:31:11 ERROR]: #!#! 
[22:31:11 ERROR]: #!#! Skript: 2.10.0-pre1 (unknown)
[22:31:11 ERROR]: #!#!     Flavor: selfbuilt-unknown
[22:31:11 ERROR]: #!#!     Date: unknown
[22:31:11 ERROR]: #!#! Bukkit: 1.21.4-R0.1-SNAPSHOT
[22:31:11 ERROR]: #!#! Minecraft: 1.21.4
[22:31:11 ERROR]: #!#! Java: 22.0.2 (OpenJDK 64-Bit Server VM 22.0.2+9)
[22:31:11 ERROR]: #!#! OS: Mac OS X aarch64 15.2
[22:31:11 ERROR]: #!#! 
[22:31:11 ERROR]: #!#! Server platform: Paper
[22:31:11 ERROR]: #!#! 
[22:31:11 ERROR]: #!#! Current node: null
[22:31:11 ERROR]: #!#! Current item: assert max height of {_w} (as org.bukkit.World) is equal to [[long:321]] (comparator: ch.njol.skript.classes.data.DefaultComparators$1@32e6e3c1)
[22:31:11 ERROR]: #!#! Current trigger: test "SkBee - ExprWorldHeight" (test case) (../../../../../../../IdeaProjects/Skript/SkBee/src/test/scripts/elements/other/expressions/ExprWorldHeight.sk, line 1)
[22:31:11 ERROR]: #!#! Thread: Server thread
[22:31:11 ERROR]: #!#! Language: english
[22:31:11 ERROR]: #!#! Link parse mode: DISABLED
[22:31:11 ERROR]: #!#! End of Error.
[22:31:11 ERROR]: #!#! 
```

</details>

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
