### PR TITLE
Adds second pattern to ExprVectorFromYawAndPitch

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprVectorFromYawAndPitch.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorFromYawAndPitch.java
@@ -27,7 +27,8 @@ public class ExprVectorFromYawAndPitch extends SimpleExpression<Vector> {
 
 	static {
 		Skript.registerExpression(ExprVectorFromYawAndPitch.class, Vector.class, ExpressionType.COMBINED,
-				"[a] [new] vector (from|with) yaw %number% and pitch %number%");
+			"[a] [new] vector (from|with) yaw %number% and pitch %number%",
+			"[a] [new] vector (from|with) pitch %number% and yaw %number%");
 	}
 
 	@SuppressWarnings("null")

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorFromYawAndPitch.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorFromYawAndPitch.java
@@ -17,7 +17,7 @@ import org.jetbrains.annotations.Nullable;
 
 import static ch.njol.skript.expressions.ExprYawPitch.fromYawAndPitch;
 
-@Name("Vectors - Vector from Pitch and Yaw")
+@Name("Vectors - Vector from Yaw and Pitch")
 @Description("Creates a vector from a yaw and pitch value.")
 @Examples("set {_v} to vector from yaw 45 and pitch 45")
 @Since("2.2-dev28")

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorFromYawAndPitch.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorFromYawAndPitch.java
@@ -23,27 +23,28 @@ import static ch.njol.skript.expressions.ExprYawPitch.fromYawAndPitch;
 @Since("2.2-dev28")
 public class ExprVectorFromYawAndPitch extends SimpleExpression<Vector> {
 
-	private static final double DEG_TO_RAD = Math.PI / 180;
-
 	static {
 		Skript.registerExpression(ExprVectorFromYawAndPitch.class, Vector.class, ExpressionType.COMBINED,
 			"[a] [new] vector (from|with) yaw %number% and pitch %number%",
 			"[a] [new] vector (from|with) pitch %number% and yaw %number%");
 	}
 
-	@SuppressWarnings("null")
 	private Expression<Number> pitch, yaw;
 
 	@Override
-	@SuppressWarnings({"unchecked", "null"})
+	@SuppressWarnings("unchecked")
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		yaw = (Expression<Number>) exprs[0];
-		pitch = (Expression<Number>) exprs[1];
+		if (matchedPattern == 0) {
+			yaw = (Expression<Number>) exprs[0];
+			pitch = (Expression<Number>) exprs[1];
+		} else {
+			yaw = (Expression<Number>) exprs[1];
+			pitch = (Expression<Number>) exprs[0];
+		}
 		return true;
 	}
 
 	@Override
-	@SuppressWarnings("null")
 	protected Vector[] get(Event event) {
 		Number skriptYaw = yaw.getSingle(event);
 		Number skriptPitch = pitch.getSingle(event);

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorFromYawAndPitch.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorFromYawAndPitch.java
@@ -34,13 +34,8 @@ public class ExprVectorFromYawAndPitch extends SimpleExpression<Vector> {
 	@Override
 	@SuppressWarnings("unchecked")
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		if (matchedPattern == 0) {
-			yaw = (Expression<Number>) exprs[0];
-			pitch = (Expression<Number>) exprs[1];
-		} else {
-			yaw = (Expression<Number>) exprs[1];
-			pitch = (Expression<Number>) exprs[0];
-		}
+		pitch = (Expression<Number>) exprs[matchedPattern ^ 1];
+		yaw = (Expression<Number>) exprs[matchedPattern];
 		return true;
 	}
 


### PR DESCRIPTION
### Description
Adds a second pattern to ExprVectorFromYawAndPitch, so that users aren't restricted to `vector from yaw x and pitch z`, and can now also use `vector from pitch z and yaw x`

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
