### PR TITLE
ExprInventorySlot - All Slots

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprInventorySlot.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprInventorySlot.java
@@ -1,14 +1,5 @@
 package ch.njol.skript.expressions;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.bukkit.entity.HumanEntity;
-import org.bukkit.event.Event;
-import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.PlayerInventory;
-import org.jetbrains.annotations.Nullable;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -22,70 +13,98 @@ import ch.njol.skript.util.slot.EquipmentSlot;
 import ch.njol.skript.util.slot.InventorySlot;
 import ch.njol.skript.util.slot.Slot;
 import ch.njol.util.Kleenean;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.event.Event;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.PlayerInventory;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Name("Inventory Slot")
-@Description({"Represents a slot in an inventory. It can be used to change the item in an inventory too."})
-@Examples({"if slot 0 of player is air:",
-	"\tset slot 0 of player to 2 stones",
-	"\tremove 1 stone from slot 0 of player",
-	"\tadd 2 stones to slot 0 of player",
-	"\tclear slot 1 of player"})
-@Since("2.2-dev24")
+@Description("Represents a slot in an inventory. It can be used to change the item in an inventory too.")
+@Examples({
+	"if slot 0 of player is air:",
+		"\tset slot 0 of player to 2 stones",
+		"\tremove 1 stone from slot 0 of player",
+		"\tadd 2 stones to slot 0 of player",
+		"\tclear slot 1 of player",
+	"",
+	"loop all of the slots of player:",
+		"\tif index of loop-value is evenly divisible by 2:",
+			"\tclear loop-value"
+})
+@Since("2.2-dev24, INSERT VERSION (all slots)")
 public class ExprInventorySlot extends SimpleExpression<Slot> {
 	
 	static {
 		Skript.registerExpression(ExprInventorySlot.class, Slot.class, ExpressionType.COMBINED,
-				"[the] slot[s] %numbers% of %inventory%", "%inventory%'[s] slot[s] %numbers%");
+			"[the] slot[s] %numbers% of %inventories%",
+			"%inventory%'[s] slot[s] %numbers%",
+			"all [[of] the] slots of %inventories%");
 	}
 
-	@SuppressWarnings("null")
-	private Expression<Number> slots;
-	@SuppressWarnings("null")
-	private Expression<Inventory> invis;
-	
-	@SuppressWarnings({"null", "unchecked"})
+	private @Nullable Expression<Number> slots;
+	private Expression<Inventory> inventories;
+	private boolean allSlots;
+
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		if (matchedPattern == 0){
-			 slots = (Expression<Number>) exprs[0];
-			 invis = (Expression<Inventory>) exprs[1];
+		allSlots = matchedPattern == 2;
+		if (allSlots) {
+			//noinspection unchecked
+			inventories = (Expression<Inventory>) exprs[0];
 		} else {
-			 slots = (Expression<Number>) exprs[1];
-			 invis = (Expression<Inventory>) exprs[0];			
+			//noinspection unchecked
+			slots = (Expression<Number>) (matchedPattern == 0 ? exprs[0] : exprs[1]);
+			//noinspection unchecked
+			inventories = (Expression<Inventory>) (matchedPattern == 0 ? exprs[1] : exprs[0]);
 		}
 		return true;
 	}
 
 	@Override
-	@Nullable
-	protected Slot[] get(Event event) {
-		Inventory invi = invis.getSingle(event);
-		if (invi == null)
-			return null;
-		
+	protected Slot @Nullable [] get(Event event) {
 		List<Slot> inventorySlots = new ArrayList<>();
-		for (Number slot : slots.getArray(event)) {
-			if (slot.intValue() >= 0 && slot.intValue() < invi.getSize()) {
-				int slotIndex = slot.intValue();
-				// Not all indices point to inventory slots. Equipment, for example
-				if (invi instanceof PlayerInventory && slotIndex >= 36) {
-					HumanEntity holder = ((PlayerInventory) invi).getHolder();
-					assert holder != null;
-					inventorySlots.add(new EquipmentSlot(holder, slotIndex));
-				} else {
-					inventorySlots.add(new InventorySlot(invi, slot.intValue()));
+		Number[] slots = this.slots != null ? this.slots.getArray(event) : null;
+		for (Inventory inventory : inventories.getArray(event)) {
+			int invSize = inventory.getSize();
+			if (allSlots) {
+				if (inventory instanceof PlayerInventory playerInventory) {
+					HumanEntity humanEntity = playerInventory.getHolder();
+					assert humanEntity != null;
+					invSize -= 4;
+					for (int i = 36; i < 40; i++)
+						inventorySlots.add(new EquipmentSlot(humanEntity, i));
+				}
+				for (int i = 0; i < invSize; i++)
+					inventorySlots.add(new InventorySlot(inventory, i));
+			} else if (slots != null) {
+				for (Number slot : slots) {
+					int slotIndex = slot.intValue();
+					if (slotIndex < 0 || slotIndex > invSize)
+						continue;
+					if (inventory instanceof PlayerInventory playerInventory && slotIndex >= 36) {
+						HumanEntity humanEntity = playerInventory.getHolder();
+						assert humanEntity != null;
+						inventorySlots.add(new EquipmentSlot(humanEntity, slotIndex));
+					} else {
+						inventorySlots.add(new InventorySlot(inventory, slotIndex));
+					}
 				}
 			}
 		}
-		
 		if (inventorySlots.isEmpty())
 			return null;
-		return inventorySlots.toArray(new Slot[inventorySlots.size()]);
+		return inventorySlots.toArray(new Slot[0]);
 	}
 	
 	@Override
 	public boolean isSingle() {
-		return slots.isSingle();
+		if (allSlots)
+			return false;
+		return slots.isSingle() && inventories.isSingle();
 	}
 
 	@Override
@@ -94,7 +113,10 @@ public class ExprInventorySlot extends SimpleExpression<Slot> {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "slots " + slots.toString(e, debug) + " of " + invis.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		if (allSlots)
+			return "all of the slots of " + inventories.toString(event, debug);
+		return "slots " + slots.toString(event, debug) + " of " + inventories.toString(event, debug);
 	}
+
 }


### PR DESCRIPTION
### Description
This PR allows users to use one syntax to grab all slots of an inventory. Rather than getting the size, looping x times and getting a slot each iteration or integers between 0 and x.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
