### PR TITLE
Fix Duplicate Secspression Logging

### DIFF
--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -1000,7 +1000,7 @@ public class ScriptLoader {
 					RetainingLogHandler backup = handler.backup();
 					handler.clear();
 
-					item = Statement.parse(expr, "Can't understand this effect: " + expr, (SectionNode) subNode, items);
+					item = Statement.parse(expr, "Can't understand this condition/effect: " + expr, (SectionNode) subNode, items);
 
 					if (item != null)
 						break find_section;
@@ -1018,7 +1018,6 @@ public class ScriptLoader {
 					continue;
 				} finally {
 					handler.printLog();
-					handler.close();
 				}
 
 				if (Skript.debug() || subNode.debug())

--- a/src/main/java/ch/njol/skript/patterns/TypePatternElement.java
+++ b/src/main/java/ch/njol/skript/patterns/TypePatternElement.java
@@ -191,7 +191,9 @@ public class TypePatternElement extends PatternElement {
 							}
 						}
 					} finally {
-						expressionLogHandler.printError();
+						if (!expressionLogHandler.isStopped()) { // we have already printed the logs
+							expressionLogHandler.printError();
+						}
 					}
 				}
 

--- a/src/test/skript/tests/misc/expression sections.sk
+++ b/src/test/skript/tests/misc/expression sections.sk
@@ -22,6 +22,13 @@ test "expression sections":
 	run {_runnable}
 	assert {_var} is true with "expression section in expression section didn't run"
 
+	# test proper logging behavior
+	parse:
+		set {_runnable} to a new runnable:
+			made up line
+			stop
+	assert size of last parse logs is 1 with "expected only one error for an invalid statement"
+	assert last parse logs contain "Can't understand this condition/effect: made up line"
 
 test "expression sections that don't work":
 	# Section with no section expression!


### PR DESCRIPTION
### Description
This PR fixes the issue where, if a secspression's section contains errors, the first error is duplicated.

<details>
<summary>Error Screenshots</summary>

![image](https://github.com/user-attachments/assets/9dc5cf88-3743-46e1-870d-11b6ad3f0da6)
![image](https://github.com/user-attachments/assets/ed86e911-e9e3-4fd0-89ac-c729d24824f3)

</details>

It turns out this issue was not related to secspressions (or Kenzie) at all! The issue was caused by a missing check in `TypePatternElement`. It was fine to omit this check previously, as it was assumed that if errors were logged during an Expression's parsing, the Expression would fail to init (and thus parsing would fail). However, with secspressions, it is possible for the Expression itself to parse/init properly, but a child element to error. As a result, both `printLog()` and `printError()` were called on the same LogHandler, causing the duplicated error. This can be simply resolved by checking whether the LogHandler is stopped (i.e. whether it already printed logs).

Additionally, I have gone ahead and made two minor tweaks to the Secspression loading. The `handler.close()` call was unnecessary, as closing is already triggered by `handler.printLog()`.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
