### PR TITLE
ScriptLoader - fix error catching

### DIFF
--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -607,6 +607,8 @@ public class ScriptLoader {
 
 					openCloseable.close();
 				}
+			}).exceptionally(t -> {
+				throw Skript.exception(t);
 			});
 	}
 


### PR DESCRIPTION
### Description
This PR aims to fix an issue with ScriptLoader not catching Throwables which aren't Exceptions (ie: StackOverflowError)

I noticed this while doing a test in Dev mode. 
I made a booboo in SkBee here the toString of a condition was recursively calling itself. 
Unfortunately the test just halted, it wouldn't fail, it wouldn't throw a StackOverflowError

Exhibit A:
<img width="710" alt="Screenshot 2025-01-06 at 2 40 35 PM" src="https://github.com/user-attachments/assets/ee1b043b-fdc8-4574-9686-7379d319b9eb" />

Then I moved onto a script to test (not a Test test, just running a script).
I had a similar issue.
Exhibits B and C:
<img width="365" alt="Screenshot 2025-01-06 at 2 39 34 PM" src="https://github.com/user-attachments/assets/72addb9c-221b-468a-88e2-60b372b83746" />
<img width="487" alt="Screenshot 2025-01-06 at 2 39 21 PM" src="https://github.com/user-attachments/assets/e6630542-9c67-4441-b4f7-dca2929a93c9" />

The parser just halted. No error, no stack overflow, nothing.

After a lengthy talk with Pickle, he came to the idea that it had to do with the CompletableFutures, as they weren't catching anything.
There are a bunch of Try/Catches in the ScriptLoader, but they catch Exceptions not Throwables.
StackOverflowError extends from Throwable, not exception.

By attaching an "Exceptionally" to the CF, we're able to catch all those pesky overflows (and other throwables)
 

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
