### PR TITLE
Module Mayhem

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -548,7 +548,7 @@ public final class Skript extends JavaPlugin implements Listener {
 				"conditions", "effects", "events", "expressions", "entity", "sections", "structures");
 			getAddonInstance().loadClasses("org.skriptlang.skript.bukkit", "misc");
 			// todo: become proper module once registry api is merged
-			FishingModule.load();
+			skript.loadModules(new FishingModule());
 			BreedingModule.load();
 			DisplayModule.load();
 			InputModule.load();

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/FishingModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/FishingModule.java
@@ -1,27 +1,22 @@
 package org.skriptlang.skript.bukkit.fishing;
 
-import ch.njol.skript.Skript;
 import org.skriptlang.skript.addon.AddonModule;
 import org.skriptlang.skript.addon.SkriptAddon;
 import org.skriptlang.skript.bukkit.fishing.elements.*;
 import org.skriptlang.skript.registration.SyntaxRegistry;
 
-import java.io.IOException;
-
 public class FishingModule implements AddonModule {
-
-	public static void load() throws IOException {
-
-		Skript.getAddonInstance().loadClasses("org.skriptlang.skript.bukkit.fishing", "elements");
-	}
 
 	@Override
 	public void load(SkriptAddon addon) {
 		SyntaxRegistry registry = addon.syntaxRegistry();
+
 		CondFishingLure.register(registry);
 		CondIsInOpenWater.register(registry);
 		EffFishingLure.register(registry);
 		EffPullHookedEntity.register(registry);
+		EvtBucketEntity.register(registry);
+		EvtFish.register(registry);
 		ExprFishingApproachAngle.register(registry);
 		ExprFishingBiteTime.register(registry);
 		ExprFishingHook.register(registry);

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/FishingModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/FishingModule.java
@@ -1,13 +1,31 @@
 package org.skriptlang.skript.bukkit.fishing;
 
 import ch.njol.skript.Skript;
+import org.skriptlang.skript.addon.AddonModule;
+import org.skriptlang.skript.addon.SkriptAddon;
+import org.skriptlang.skript.bukkit.fishing.elements.*;
+import org.skriptlang.skript.registration.SyntaxRegistry;
 
 import java.io.IOException;
 
-public class FishingModule {
+public class FishingModule implements AddonModule {
 
 	public static void load() throws IOException {
+
 		Skript.getAddonInstance().loadClasses("org.skriptlang.skript.bukkit.fishing", "elements");
+	}
+
+	@Override
+	public void load(SkriptAddon addon) {
+		SyntaxRegistry registry = addon.syntaxRegistry();
+		CondFishingLure.register(registry);
+		CondIsInOpenWater.register(registry);
+		EffFishingLure.register(registry);
+		EffPullHookedEntity.register(registry);
+		ExprFishingApproachAngle.register(registry);
+		ExprFishingBiteTime.register(registry);
+		ExprFishingHook.register(registry);
+
 	}
 
 }

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/FishingModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/FishingModule.java
@@ -25,7 +25,8 @@ public class FishingModule implements AddonModule {
 		ExprFishingApproachAngle.register(registry);
 		ExprFishingBiteTime.register(registry);
 		ExprFishingHook.register(registry);
-
+		ExprFishingHookEntity.register(registry);
+		ExprFishingWaitTime.register(registry);
 	}
 
 }

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/CondFishingLure.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/CondFishingLure.java
@@ -9,6 +9,8 @@ import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.bukkit.event.player.PlayerFishEvent;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.registration.SyntaxInfo;
+import org.skriptlang.skript.registration.SyntaxRegistry;
 
 @Name("Fishing Lure Applied")
 @Description("Checks if the lure enchantment is applied to the current fishing event.")
@@ -21,10 +23,14 @@ import org.jetbrains.annotations.Nullable;
 @Since("2.10")
 public class CondFishingLure extends Condition {
 
-	static  {
-		Skript.registerCondition(CondFishingLure.class,
-			"lure enchantment bonus is (applied|active)",
-			"lure enchantment bonus is(n't| not) (applied|active)");
+	public static void register(SyntaxRegistry registry) {
+		registry.register(SyntaxRegistry.CONDITION, SyntaxInfo.builder(CondFishingLure.class)
+			.addPatterns(
+				"lure enchantment bonus is (applied|active)",
+				"lure enchantment bonus is(n't| not) (applied|active)"
+			)
+			.build()
+		);
 	}
 
 	@Override

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/CondIsInOpenWater.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/CondIsInOpenWater.java
@@ -1,9 +1,14 @@
 package org.skriptlang.skript.bukkit.fishing.elements;
 
 import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.*;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.FishHook;
+import org.skriptlang.skript.log.runtime.SyntaxRuntimeErrorProducer;
 import org.skriptlang.skript.registration.SyntaxRegistry;
 
 @Name("Is Fish Hook in Open Water")
@@ -19,21 +24,39 @@ import org.skriptlang.skript.registration.SyntaxRegistry;
 })
 @Events("Fishing")
 @Since("2.10")
-public class CondIsInOpenWater extends PropertyCondition<Entity> {
+public class CondIsInOpenWater extends PropertyCondition<Entity> implements SyntaxRuntimeErrorProducer {
 	
 	public static void register(SyntaxRegistry registry) {
 		register(registry, CondIsInOpenWater.class, PropertyType.BE,
 			"in open water[s]", "entities");
 	}
 
+	private Node node;
+
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		node = getParser().getNode();
+		return super.init(expressions, matchedPattern, isDelayed, parseResult);
+	}
+
 	@Override
 	public boolean check(Entity entity) {
-		return entity instanceof FishHook hook && hook.isInOpenWater();
+		if (entity instanceof FishHook hook) {
+			return hook.isInOpenWater();
+		} else {
+			warning("An entity passed through wasn't a fish hook, and thus returned false by default.");
+			return false;
+		}
 	}
 
 	@Override
 	protected String getPropertyName() {
 		return "in open water";
 	}
-	
+
+	@Override
+	public Node getNode() {
+		return node;
+	}
+
 }

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/CondIsInOpenWater.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/CondIsInOpenWater.java
@@ -4,6 +4,7 @@ import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.*;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.FishHook;
+import org.skriptlang.skript.registration.SyntaxRegistry;
 
 @Name("Is Fish Hook in Open Water")
 @Description({
@@ -20,17 +21,14 @@ import org.bukkit.entity.FishHook;
 @Since("2.10")
 public class CondIsInOpenWater extends PropertyCondition<Entity> {
 	
-	static {
-		register(CondIsInOpenWater.class, PropertyType.BE,
+	public static void register(SyntaxRegistry registry) {
+		register(registry, CondIsInOpenWater.class, PropertyType.BE,
 			"in open water[s]", "entities");
 	}
 
 	@Override
 	public boolean check(Entity entity) {
-		if (!(entity instanceof FishHook hook))
-			return false;
-
-		return hook.isInOpenWater();
+		return entity instanceof FishHook hook && hook.isInOpenWater();
 	}
 
 	@Override

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/EvtBucketEntity.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/EvtBucketEntity.java
@@ -1,11 +1,11 @@
 package org.skriptlang.skript.bukkit.fishing.elements;
 
-import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.entity.EntityData;
+import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptEvent;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -18,22 +18,26 @@ import org.bukkit.event.player.PlayerBucketEntityEvent;
 import org.bukkit.event.player.PlayerEvent;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.bukkit.registration.BukkitRegistryKeys;
+import org.skriptlang.skript.bukkit.registration.BukkitSyntaxInfos;
+import org.skriptlang.skript.registration.SyntaxRegistry;
 
 import java.util.Arrays;
 import java.util.List;
 
-@Name("Bucket Catch Entity")
-@Description("Called when a player catches an entity in a bucket.")
-@Examples({
-	"on bucket catch of a puffer fish:",
-		"\tsend \"You caught a fish with a %future event-item%!\" to player"
-})
-@Since("2.10")
 public class EvtBucketEntity extends SkriptEvent {
 
-	static {
-		Skript.registerEvent("Bucket Catch Entity", EvtBucketEntity.class, PlayerBucketEntityEvent.class,
-			"bucket (catch[ing]|captur(e|ing)) [[of] %-entitydatas%]");
+	public static void register(SyntaxRegistry registry) {
+		registry.register(BukkitRegistryKeys.EVENT, BukkitSyntaxInfos.Event
+			.builder(EvtBucketEntity.class, "Bucket Catch Entity")
+			.addEvent(PlayerBucketEntityEvent.class)
+			.addDescription("Called when a player catches an entity in a bucket.")
+			.addExamples(
+				"on bucket catch of a puffer fish",
+					"\tsend \"You caught a fish with a %future event-item%!\" to player"
+			)
+			.build()
+		);
 
 		EventValues.registerEventValue(PlayerBucketEntityEvent.class, ItemStack.class, PlayerBucketEntityEvent::getOriginalBucket);
 		EventValues.registerEventValue(PlayerBucketEntityEvent.class, ItemStack.class, PlayerBucketEntityEvent::getEntityBucket, EventValues.TIME_FUTURE);

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/EvtBucketEntity.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/EvtBucketEntity.java
@@ -1,11 +1,7 @@
 package org.skriptlang.skript.bukkit.fishing.elements;
 
-import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
-import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.Since;
+import ch.njol.skript.config.Node;
 import ch.njol.skript.entity.EntityData;
-import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptEvent;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -20,22 +16,25 @@ import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.bukkit.registration.BukkitRegistryKeys;
 import org.skriptlang.skript.bukkit.registration.BukkitSyntaxInfos;
+import org.skriptlang.skript.log.runtime.SyntaxRuntimeErrorProducer;
 import org.skriptlang.skript.registration.SyntaxRegistry;
 
 import java.util.Arrays;
 import java.util.List;
 
-public class EvtBucketEntity extends SkriptEvent {
+public class EvtBucketEntity extends SkriptEvent implements SyntaxRuntimeErrorProducer {
 
 	public static void register(SyntaxRegistry registry) {
 		registry.register(BukkitRegistryKeys.EVENT, BukkitSyntaxInfos.Event
 			.builder(EvtBucketEntity.class, "Bucket Catch Entity")
 			.addEvent(PlayerBucketEntityEvent.class)
+			.addPattern("bucket (catch[ing]|captur(e|ing)) [[of] %-entitydatas%]")
 			.addDescription("Called when a player catches an entity in a bucket.")
 			.addExamples(
 				"on bucket catch of a puffer fish",
 					"\tsend \"You caught a fish with a %future event-item%!\" to player"
 			)
+			.since("2.10")
 			.build()
 		);
 
@@ -45,6 +44,7 @@ public class EvtBucketEntity extends SkriptEvent {
 		EventValues.registerEventValue(PlayerBucketEntityEvent.class, Entity.class, PlayerBucketEntityEvent::getEntity);
 	}
 
+	private Node node;
 	private EntityData<?>[] entities;
 
 	@Override
@@ -52,18 +52,25 @@ public class EvtBucketEntity extends SkriptEvent {
 		if (args[0] != null)
 			//noinspection unchecked
 			entities = ((Literal<EntityData<?>>) args[0]).getAll();
-
+		node = getParser().getNode();
 		return true;
 	}
 
 	@Override
 	public boolean check(Event event) {
-		if (!(event instanceof PlayerBucketEntityEvent bucketEvent))
+		if (!(event instanceof PlayerBucketEntityEvent bucketEvent)) {
+			error("The 'bucket catch entity' event does not apply outside of a PlayerBucketEntityEvent.");
 			return false;
+		}
 
 		return entities == null || entities.length == 0 || Arrays.stream(entities)
 			.map(EntityData::getType)
 			.anyMatch(it -> it.isInstance(bucketEvent.getEntity()));
+	}
+
+	@Override
+	public Node getNode() {
+		return node;
 	}
 
 	@Override

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/ExprFishingApproachAngle.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/ExprFishingApproachAngle.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.*;
+import ch.njol.skript.expressions.base.EventValueExpression;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
@@ -35,9 +36,10 @@ public class ExprFishingApproachAngle extends SimpleExpression<Float> implements
 	private static final float DEFAULT_MAXIMUM_DEGREES = 360;
 
 	public static void register(SyntaxRegistry registry) {
-		registry.register(SyntaxRegistry.EXPRESSION, SyntaxInfo.Expression.builder(ExprFishingApproachAngle.class, Float.class)
+		registry.register(SyntaxRegistry.EXPRESSION, SyntaxInfo.Expression
+			.builder(ExprFishingApproachAngle.class, Float.class)
 			.addPattern("(min:min[imum]|max[imum]) fish[ing] approach[ing] angle")
-			.priority(SyntaxInfo.SIMPLE)
+			.priority(EventValueExpression.DEFAULT_PRIORITY)
 			.build()
 		);
 	}

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/ExprFishingBiteTime.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/ExprFishingBiteTime.java
@@ -6,7 +6,6 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.*;
 import ch.njol.skript.expressions.base.EventValueExpression;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.skript.util.Timespan;
@@ -16,7 +15,6 @@ import org.bukkit.event.Event;
 import org.bukkit.event.player.PlayerFishEvent;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.log.runtime.SyntaxRuntimeErrorProducer;
-import org.skriptlang.skript.registration.DefaultSyntaxInfos;
 import org.skriptlang.skript.registration.SyntaxInfo;
 import org.skriptlang.skript.registration.SyntaxRegistry;
 

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/ExprFishingBiteTime.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/ExprFishingBiteTime.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.*;
+import ch.njol.skript.expressions.base.EventValueExpression;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -35,9 +36,10 @@ public class ExprFishingBiteTime extends SimpleExpression<Timespan> implements S
 
 	public static void register(SyntaxRegistry registry) {
 		if (Skript.methodExists(FishHook.class, "getTimeUntilBite"))
-			registry.register(SyntaxRegistry.EXPRESSION, SyntaxInfo.Expression.builder(ExprFishingBiteTime.class, Timespan.class)
+			registry.register(SyntaxRegistry.EXPRESSION, SyntaxInfo.Expression
+				.builder(ExprFishingBiteTime.class, Timespan.class)
 				.addPattern("fish[ing] bit(e|ing) [wait] time")
-				.priority(SyntaxInfo.SIMPLE)
+				.priority(EventValueExpression.DEFAULT_PRIORITY)
 				.build()
 			);
 	}

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/ExprFishingHook.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/ExprFishingHook.java
@@ -6,6 +6,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.FishHook;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.registration.SyntaxRegistry;
 
 @Name("Fishing Hook")
 @Description("The <a href='classes.html#entity'>fishing hook</a> in a fishing event.")
@@ -18,8 +19,8 @@ import org.jetbrains.annotations.Nullable;
 @Since("2.10")
 public class ExprFishingHook extends EventValueExpression<Entity> {
 
-	static {
-		register(ExprFishingHook.class, Entity.class, "fish[ing] (hook|bobber)");
+	public static void register(SyntaxRegistry registry) {
+		EventValueExpression.register(registry, ExprFishingHook.class, Entity.class, "fish[ing] (hook|bobber)");
 	}
 
 	public ExprFishingHook() {

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/ExprFishingHookEntity.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/ExprFishingHookEntity.java
@@ -3,8 +3,8 @@ package org.skriptlang.skript.bukkit.fishing.elements;
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.*;
+import ch.njol.skript.expressions.base.EventValueExpression;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
@@ -15,6 +15,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.player.PlayerFishEvent;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.registration.SyntaxInfo;
+import org.skriptlang.skript.registration.SyntaxRegistry;
 
 @Name("Fishing Hooked Entity")
 @Description("Returns the hooked entity in the hooked event.")
@@ -27,14 +29,17 @@ import org.jetbrains.annotations.Nullable;
 @Since("2.10")
 public class ExprFishingHookEntity extends SimpleExpression<Entity> {
 
-	static {
-		Skript.registerExpression(ExprFishingHookEntity.class, Entity.class, ExpressionType.EVENT,
-			"hook[ed] entity");
+	public static void register(SyntaxRegistry registry) {
+		registry.register(SyntaxRegistry.EXPRESSION, SyntaxInfo.Expression
+			.builder(ExprFishingHookEntity.class, Entity.class)
+			.priority(EventValueExpression.DEFAULT_PRIORITY)
+			.addPattern("hook[ed] entity")
+			.build()
+		);
 	}
 
 	@Override
-	public boolean init(Expression<?>[] expressions, int matchedPattern,
-						Kleenean isDelayed, ParseResult parseResult) {
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		if (!getParser().isCurrentEvent(PlayerFishEvent.class)) {
 			Skript.error("The 'hooked entity' expression can only be used in the fishing event.");
 			return false;

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/ExprFishingWaitTime.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/ExprFishingWaitTime.java
@@ -3,8 +3,8 @@ package org.skriptlang.skript.bukkit.fishing.elements;
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.*;
+import ch.njol.skript.expressions.base.EventValueExpression;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.skript.util.Timespan;
@@ -13,6 +13,8 @@ import org.bukkit.entity.FishHook;
 import org.bukkit.event.Event;
 import org.bukkit.event.player.PlayerFishEvent;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.registration.SyntaxInfo;
+import org.skriptlang.skript.registration.SyntaxRegistry;
 
 @Name("Fishing Wait Time")
 @Description({
@@ -31,9 +33,13 @@ public class ExprFishingWaitTime extends SimpleExpression<Timespan> {
 	private static final int DEFAULT_MINIMUM_TICKS = 5 * 20;
 	private static final int DEFAULT_MAXIMUM_TICKS = 30 * 20;
 
-	static {
-		Skript.registerExpression(ExprFishingWaitTime.class, Timespan.class, ExpressionType.EVENT,
-			"(min:min[imum]|max[imum]) fish[ing] wait[ing] time");
+	public static void register(SyntaxRegistry registry) {
+		registry.register(SyntaxRegistry.EXPRESSION, SyntaxInfo.Expression
+			.builder(ExprFishingWaitTime.class, Timespan.class)
+			.priority(EventValueExpression.DEFAULT_PRIORITY)
+			.addPattern("(min:min[imum]|max[imum]) fish[ing] wait[ing] time")
+			.build()
+		);
 	}
 
 	private boolean isMin;


### PR DESCRIPTION
### Description
This PR converts existing modules, and the syntax they register, to use the new registration API, and adds runtime errors where appropriate. Will cover all existing modules:
- [ ] Fishing
- [ ] Breeding
- [ ] Display
- [ ] Input
- [ ] Tag
- [ ] Furnace
- [ ] LootTable

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
