### PR TITLE
ExprPotionEffect - bring parity with EffPotion

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprPotionEffect.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPotionEffect.java
@@ -33,8 +33,8 @@ import ch.njol.util.Kleenean;
 public class ExprPotionEffect extends SimpleExpression<PotionEffect> {
 	static {
 		Skript.registerExpression(ExprPotionEffect.class, PotionEffect.class, ExpressionType.COMBINED,
-			"[new] [:ambient] potion effect of %potioneffecttype% [potion] [[[of] tier] %-number%] [noparticles:without [any] particles] [icon:(whilst hiding [the]|without (the|a)) [potion] icon] [for %-timespan%]",
-			"[new] infinite [:ambient] potion effect of %potioneffecttype% [potion] [[[of] tier] %-number%] [noparticles:without [any] particles] [icon:(whilst hiding [the]|without (the|a)) [potion] icon]");
+			"[new] [:ambient] potion effect of %potioneffecttype% [potion] [[[of] tier] %-number%] [noparticles:without [any] particles] [icon:without (the|a) [potion] icon] [for %-timespan%]",
+			"[new] infinite [:ambient] potion effect of %potioneffecttype% [potion] [[[of] tier] %-number%] [noparticles:without [any] particles] [icon:without (the|a) [potion] icon]");
 	}
 	
 	@SuppressWarnings("null")

--- a/src/main/java/ch/njol/skript/expressions/ExprPotionEffect.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPotionEffect.java
@@ -29,7 +29,7 @@ import ch.njol.util.Kleenean;
 	"add {_p} to potion effects of target entity",
 	"add potion effect of speed 1 to potion effects of player"
 })
-@Since({"2.5.2", "INSERT VERSION (infinite/no icon)"})
+@Since({"2.5.2", "INSERT VERSION (infinite, no icon)"})
 public class ExprPotionEffect extends SimpleExpression<PotionEffect> {
 	static {
 		Skript.registerExpression(ExprPotionEffect.class, PotionEffect.class, ExpressionType.COMBINED,

--- a/src/test/skript/tests/syntaxes/expressions/ExprPotionEffects.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprPotionEffects.sk
@@ -19,6 +19,11 @@ test "potion effects":
 	set {_pe::4} to ambient potion effect of slowness without particles without the icon for 2 minutes
 
 	assert size of {_pe::*} = 4 with "There should have been 4 potion effects created"
+	assert "%{_pe::1}%" contains "without particles for infinity without icon" with "The potion effect should be infinite without particles or an icon"
+	assert "%{_pe::2}%" contains "ambient" and "without particles for infinity" with "The potion effect should be ambient, without particles and for infinity"
+	assert "%{_pe::3}%" contains "for 10 seconds" with "The potion effect should be for 10 seconds"
+	assert "%{_pe::4}%" contains "without particles for 2 minutes without icon" with "The potion effect should have no icon/particles for 2 minutes"
+
 	apply {_pe::*} to {_e} # Poor guy
 	assert type of potion effects of {_e} contains darkness, night vision, nausea and slowness with "The poor sheep should have had these 4 effects added"
 

--- a/src/test/skript/tests/syntaxes/expressions/ExprPotionEffects.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprPotionEffects.sk
@@ -1,7 +1,6 @@
 test "potion effects":
-	set {_l} to test-location
-	spawn a sheep at {_l}
-	set {_e} to last spawned sheep
+	spawn a sheep at test-location:
+		set {_e} to entity
 
 	set {_p} to potion effect of speed 1 without particles for 10 minutes
 	add {_p} to potion effects of {_e}
@@ -14,5 +13,14 @@ test "potion effects":
 	set {_i} to potion of slowness
 	assert type of potion effects of {_i} contains slowness with "the item should have had the slowness potion type"
 
-	kill {_e}
-	kill all dropped items in radius 10 around {_e}
+	set {_pe::1} to infinite potion effect of darkness without particles without the icon
+	set {_pe::2} to infinite ambient potion effect of night vision of tier 2 without particles
+	set {_pe::3} to potion effect of nausea for 10 seconds
+	set {_pe::4} to ambient potion effect of slowness without particles without the icon for 2 minutes
+
+	assert size of {_pe::*} = 4 with "There should have been 4 potion effects created"
+	apply {_pe::*} to {_e} # Poor guy
+	assert type of potion effects of {_e} contains darkness, night vision, nausea and slowness with "The poor sheep should have had these 4 effects added"
+
+	# We'll miss ya lil buddy
+	delete entity within {_e}


### PR DESCRIPTION
### Description
This PR aims to bring some parity between ExprPotionEffect and EffPotion.

### Changes:
- added the option to make an infinite potion effect
- added the option to hide the icon
- a little bit of syntax cleanup

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
