### PR TITLE
Improve EffKill's description

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffKill.java
+++ b/src/main/java/ch/njol/skript/effects/EffKill.java
@@ -20,8 +20,7 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.jetbrains.annotations.Nullable;
 
 @Name("Kill")
-@Description({"Kills an entity.",
-		"Note: This effect does not set the entity's health to 0 (which causes issues), but damages the entity by 100 times its maximum health."})
+@Description("Kills an entity.")
 @Examples({"kill the player",
 		"kill all creepers in the player's world",
 		"kill all endermen, witches and bats"})


### PR DESCRIPTION
### Description
Regarding my PR on EffKill improvements (#7148), I forgot to change the description, since this wil always kill the player, and not just damage them by their health times 100, and the user didn't really need to know that anyways. 

---
**Target Minecraft Versions:** any 
**Requirements:** none
**Related Issues:** none
