### PR TITLE
ExprTagContents: Improve ReturnType

### DIFF
--- a/src/main/java/org/skriptlang/skript/bukkit/tags/elements/ExprTag.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/tags/elements/ExprTag.java
@@ -11,6 +11,7 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.ContextlessEvent;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.skript.lang.util.SimpleLiteral;
 import ch.njol.util.Kleenean;
@@ -130,8 +131,8 @@ public class ExprTag extends SimpleExpression<Tag> {
 	@Override
 	public Expression<? extends Tag> simplify() {
 		if (names instanceof Literal<String>)
-			return new SimpleLiteral<>(getArray(null), Tag.class, true);
-		return this;
+			return new SimpleLiteral<>(getArray(ContextlessEvent.get()), Tag.class, true);
+		return super.simplify();
 	}
 
 }

--- a/src/test/skript/tests/syntaxes/expressions/ExprTagContents.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprTagContents.sk
@@ -5,3 +5,8 @@ test "tags contents":
 	assert tag contents of item tag "slabs" contains oak slab with "oak slab is not a slab"
 
 	assert tag contents of entity tag "minecraft:skeletons" contains a skeleton with "skeleton is not a skeleton"
+
+	parse:
+		loop tag contents of minecraft item tag "logs":
+			add loop-item to {_list::*}
+	assert last parse logs is not set with "failed to parse tag looping (%last parse logs%)"


### PR DESCRIPTION
### Description
This PR aims to improve the return type estimation in ExprTagContents. Currently, it directly uses `type()`, which does not correspond to the actual return types of the expression (e.g. Material rather than ItemType).

I've reworked the estimation to occur at parse time and cache the result. I've also added simplification and reworked the method organization for efficiency (e.g. overriding `stream` since that's essentially what `get` was using)

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
