### PR TITLE
Add missing nullable check to `currentEvents`.

### DIFF
--- a/src/main/java/ch/njol/skript/lang/parser/ParserInstance.java
+++ b/src/main/java/ch/njol/skript/lang/parser/ParserInstance.java
@@ -228,6 +228,8 @@ public final class ParserInstance implements Experimented {
 	 * See also {@link #isCurrentEvent(Class[])} for checking with multiple argument classes
 	 */
 	public boolean isCurrentEvent(Class<? extends Event> event) {
+		if (currentEvents == null)
+			return false;
 		for (Class<? extends Event> currentEvent : currentEvents) {
 			// check that current event is same or child of event we want
 			if (event.isAssignableFrom(currentEvent))
@@ -622,7 +624,7 @@ public final class ParserInstance implements Experimented {
 	 *  That is, the contents of any collections will remain the same, but there is no guarantee that
 	 *  the contents themselves will remain unchanged.
 	 * @see #backup()
-	 * @see #restoreBackup(Backup) 
+	 * @see #restoreBackup(Backup)
 	 */
 	public static class Backup {
 


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Adds a missing check to see if the `currentEvents` field is set.
This fixes a problem in skript-reflect.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
