### PR TITLE
Add event-string (LootTable) to LootGenerateEvent

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -1770,11 +1770,11 @@ public final class BukkitEventValues {
 					return event.getLootContext().getLocation();
 				}
 			}, EventValues.TIME_NOW);
-			EventValues.registerEventValue(LootGenerateEvent.class, String.class, new Getter<String, LootGenerateEvent>() {
+			EventValues.registerEventValue(LootGenerateEvent.class, LootTable.class, new Getter<LootTable, LootGenerateEvent>() {
 				@Override
 				@Nullable
 				public Location get(LootGenerateEvent event) {
-					return event.getLootTable().toString;
+					return event.getLootTable();
 				}
 			}, EventValues.TIME_NOW);
 		}

--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -1770,6 +1770,13 @@ public final class BukkitEventValues {
 					return event.getLootContext().getLocation();
 				}
 			}, EventValues.TIME_NOW);
+			EventValues.registerEventValue(LootGenerateEvent.class, String.class, new Getter<String, LootGenerateEvent>() {
+				@Override
+				@Nullable
+				public Location get(LootGenerateEvent event) {
+					return event.getLootTable().toString;
+				}
+			}, EventValues.TIME_NOW);
 		}
 
 		// EntityResurrectEvent


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
I added an event value for the loot table in a LootGenerateEvent, as it allows users more capability for modification with this event. In this commit, it is left as a string, so it would appear as `"minecraft:LOOTTABLE"`, but if it is better, LootTable classes could be registered as types and this event value is switched to event-loottable from event-string.
---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
