### PR TITLE
Make operators a literal instead of expression

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondDamageCause.java
+++ b/src/main/java/ch/njol/skript/conditions/CondDamageCause.java
@@ -15,58 +15,58 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 
-/**
- * @author Peter Güttinger
- */
 @Name("Damage Cause")
-@Description("Tests what kind of damage caused a <a href='events.html#damage'>damage event</a>. Refer to the <a href='classes.html#damagecause'>Damage Cause</a> type for a list of all possible causes.")
-@Examples({"# make players use their potions of fire resistance whenever they take any kind of fire damage",
-		"on damage:",
-		"\tdamage was caused by lava, fire or burning",
-		"\tvictim is a player",
-		"\tvictim has a potion of fire resistance",
-		"\tcancel event",
-		"\tapply fire resistance to the victim for 30 seconds",
-		"\tremove 1 potion of fire resistance from the victim",
-		"# prevent mobs from dropping items under certain circumstances",
-		"on death:",
-		"\tentity is not a player",
-		"\tdamage wasn't caused by a block explosion, an attack, a projectile, a potion, fire, burning, thorns or poison",
-		"\tclear drops"})
+@Description({
+	"Tests what kind of damage caused a <a href='events.html#damage'>damage event</a>.",
+	"Refer to the <a href='classes.html#damagecause'>Damage Cause</a> type for a list of all possible causes."
+})
+@Examples({
+	"# make players use their potions of fire resistance whenever they take any kind of fire damage",
+	"on damage:",
+	"\tdamage was caused by lava, fire or burning",
+	"\tvictim is a player",
+	"\tvictim has a potion of fire resistance",
+	"\tcancel event",
+	"\tapply fire resistance to the victim for 30 seconds",
+	"\tremove 1 potion of fire resistance from the victim",
+	"# prevent mobs from dropping items under certain circumstances",
+	"on death:",
+	"\tentity is not a player",
+	"\tdamage wasn't caused by a block explosion, an attack, a projectile, a potion, fire, burning, thorns or poison",
+	"\tclear drops"
+	})
 @Since("2.0")
 public class CondDamageCause extends Condition {
-	
+
 	static {
 		Skript.registerCondition(CondDamageCause.class, "[the] damage (was|is|has)(0¦|1¦n('|o)t) [been] (caused|done|made) by %damagecause%");
 	}
-	
-	@SuppressWarnings("null")
-	private Expression<DamageCause> cause;
-	@SuppressWarnings("null")
+
 	private Expression<DamageCause> expected;
-	
-	@SuppressWarnings({"unchecked", "null"})
+	private Expression<DamageCause> cause;
+
 	@Override
-	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
+	@SuppressWarnings("unchecked")
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		cause = new EventValueExpression<>(DamageCause.class);
 		expected = (Expression<DamageCause>) exprs[0];
 		setNegated(parseResult.mark == 1);
-		return ((EventValueExpression<DamageCause>) cause).init();
+		return ((EventValueExpression<DamageCause>) cause).init(matchedPattern, isDelayed, parseResult);
 	}
-	
+
 	@Override
-	public boolean check(final Event e) {
-		final DamageCause cause = this.cause.getSingle(e);
+	public boolean check(Event event) {
+		DamageCause cause = this.cause.getSingle(event);
 		if (cause == null)
 			return false;
-		return expected.check(e,
+		return expected.check(event,
 				other -> cause == other,
 				isNegated());
 	}
-	
+
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "damage was" + (isNegated() ? " not" : "") + " caused by " + expected.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "damage was" + (isNegated() ? " not" : "") + " caused by " + expected.toString(event, debug);
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprBlock.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBlock.java
@@ -21,49 +21,51 @@ import ch.njol.skript.lang.util.ConvertedExpression;
 import ch.njol.skript.util.Direction;
 import ch.njol.util.Kleenean;
 
-/**
- * @author Peter Güttinger
- */
 @Name("Block")
-@Description({"The block involved in the event, e.g. the clicked block or the placed block.",
-		"Can optionally include a direction as well, e.g. 'block above' or 'block in front of the player'."})
-@Examples({"block is ore",
-		"set block below to air",
-		"spawn a creeper above the block",
-		"loop blocks in radius 4:",
-		"	loop-block is obsidian",
-		"	set loop-block to water",
-		"block is a chest:",
-		"	clear the inventory of the block"})
+@Description({
+	"The block involved in the event, e.g. the clicked block or the placed block.",
+	"Can optionally include a direction as well, e.g. 'block above' or 'block in front of the player'."
+})
+@Examples({
+	"block is ore",
+	"set block below to air",
+	"spawn a creeper above the block",
+	"loop blocks in radius 4:",
+	"	loop-block is obsidian",
+	"	set loop-block to water",
+	"block is a chest:",
+	"	clear the inventory of the block"
+	})
 @Since("1.0")
 public class ExprBlock extends WrapperExpression<Block> {
+
 	static {
 		Skript.registerExpression(ExprBlock.class, Block.class, ExpressionType.SIMPLE, "[the] [event-]block");
 		Skript.registerExpression(ExprBlock.class, Block.class, ExpressionType.COMBINED, "[the] block %direction% [%location%]");
 	}
-	
-	@SuppressWarnings({"unchecked", "null"})
+
 	@Override
-	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parser) {
+	@SuppressWarnings("unchecked")
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parser) {
 		if (exprs.length > 0) {
 			setExpr(new ConvertedExpression<>(Direction.combine((Expression<? extends Direction>) exprs[0],
 					(Expression<? extends Location>) exprs[1]), Block.class,
 					new ConverterInfo<>(Location.class, Block.class, new Converter<Location, Block>() {
 				@Override
-				public Block convert(final Location l) {
-					return l.getBlock();
+				public Block convert(Location location) {
+					return location.getBlock();
 				}
 			}, 0)));
 			return true;
 		} else {
 			setExpr(new EventValueExpression<>(Block.class));
-			return ((EventValueExpression<Block>) getExpr()).init();
+			return ((EventValueExpression<Block>) getExpr()).init(matchedPattern, isDelayed, parser);
 		}
 	}
-	
+
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return getExpr() instanceof EventValueExpression ? "the block" : "the block " + getExpr().toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return getExpr() instanceof EventValueExpression ? "the block" : "the block " + getExpr().toString(event, debug);
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprEventExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEventExpression.java
@@ -9,19 +9,14 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.skript.localization.Noun;
-import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.util.Utils;
 import ch.njol.util.Kleenean;
-import ch.njol.util.NonNullPair;
 import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * Provided for convenience: one can write 'event-world' instead of only 'world' to distinguish between the event-world and the loop-world.
- * 
- * @author Peter Güttinger
  */
 @NoDoc
 public class ExprEventExpression extends WrapperExpression<Object> {
@@ -39,7 +34,7 @@ public class ExprEventExpression extends WrapperExpression<Object> {
 		boolean plural = Utils.getEnglishPlural(parser.expr).getSecond();
 		EventValueExpression<?> eventValue = new EventValueExpression<>(plural ? CollectionUtils.arrayType(c) : c);
 		setExpr(eventValue);
-		return eventValue.init();
+		return eventValue.init(matchedPattern, isDelayed, parser);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprLocation.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLocation.java
@@ -17,35 +17,35 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.Direction;
 import ch.njol.util.Kleenean;
 
-/**
- * @author Peter Güttinger
- */
 @Name("Location")
 @Description("The location where an event happened (e.g. at an entity or block), or a location <a href='#ExprDirection'>relative</a> to another (e.g. 1 meter above another location).")
-@Examples({"drop 5 apples at the event-location # exactly the same as writing 'drop 5 apples'",
-		"set {_loc} to the location 1 meter above the player"})
+@Examples({
+	"drop 5 apples at the event-location # exactly the same as writing 'drop 5 apples'",
+	"set {_loc} to the location 1 meter above the player"
+})
 @Since("2.0")
 public class ExprLocation extends WrapperExpression<Location> {
+
 	static {
 		Skript.registerExpression(ExprLocation.class, Location.class, ExpressionType.SIMPLE, "[the] [event-](location|position)");
 		Skript.registerExpression(ExprLocation.class, Location.class, ExpressionType.COMBINED, "[the] (location|position) %directions% [%location%]");
 	}
-	
-	@SuppressWarnings({"unchecked", "null"})
+
 	@Override
-	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
+	@SuppressWarnings("unchecked")
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		if (exprs.length > 0) {
 			super.setExpr(Direction.combine((Expression<? extends Direction>) exprs[0], (Expression<? extends Location>) exprs[1]));
 			return true;
 		} else {
 			setExpr(new EventValueExpression<>(Location.class));
-			return ((EventValueExpression<Location>) getExpr()).init();
+			return ((EventValueExpression<Location>) getExpr()).init(matchedPattern, isDelayed, parseResult);
 		}
 	}
-	
+
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return getExpr() instanceof EventValueExpression ? "the location" : "the location " + getExpr().toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return getExpr() instanceof EventValueExpression ? "location" : "location " + getExpr().toString(event, debug);
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/expressions/base/EventValueExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/EventValueExpression.java
@@ -135,10 +135,14 @@ public class EventValueExpression<T> extends SimpleExpression<T> implements Defa
 	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parser) {
 		if (expressions.length != 0)
 			throw new SkriptAPIException(this.getClass().getName() + " has expressions in its pattern but does not override init(...)");
-		return init();
+		return init(matchedPattern,	isDelayed, parser);
 	}
 
 	@Override
+	public boolean init(int matchedPattern, Kleenean isDelayed, ParseResult parser) {
+		return init();
+	}
+
 	public boolean init() {
 		ParseLogHandler log = SkriptLogger.startParseLogHandler();
 		try {
@@ -182,9 +186,8 @@ public class EventValueExpression<T> extends SimpleExpression<T> implements Defa
 	}
 
 	@Override
-	@Nullable
 	@SuppressWarnings("unchecked")
-	protected T[] get(Event event) {
+	protected T @Nullable [] get(Event event) {
 		T value = getValue(event);
 		if (value == null)
 			return (T[]) Array.newInstance(componentType, 0);
@@ -220,16 +223,15 @@ public class EventValueExpression<T> extends SimpleExpression<T> implements Defa
 	}
 
 	@Override
-	@Nullable
 	@SuppressWarnings("unchecked")
-	public Class<?>[] acceptChange(ChangeMode mode) {
+	public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
 		if (changer == null)
 			changer = (Changer<? super T>) Classes.getSuperClassInfo(componentType).getChanger();
 		return changer == null ? null : changer.acceptChange(mode);
 	}
 
 	@Override
-	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, Object @Nullable [] delta, ChangeMode mode) {
 		if (changer == null)
 			throw new SkriptAPIException("The changer cannot be null");
 		ChangerUtils.change(changer, getArray(event), delta, mode);
@@ -262,9 +264,6 @@ public class EventValueExpression<T> extends SimpleExpression<T> implements Defa
 		return false;
 	}
 
-	/**
-	 * @return true
-	 */
 	@Override
 	public boolean isDefault() {
 		return true;
@@ -284,7 +283,7 @@ public class EventValueExpression<T> extends SimpleExpression<T> implements Defa
 	@Override
 	public String toString(@Nullable Event event, boolean debug) {
 		if (!debug || event == null)
-			return "event-" + Classes.getSuperClassInfo(componentType).getName().toString(!single);
+			return "the event-" + Classes.getSuperClassInfo(componentType).getName().toString(!single);
 		return Classes.getDebugMessage(getValue(event));
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/base/EventValueExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/EventValueExpression.java
@@ -135,7 +135,7 @@ public class EventValueExpression<T> extends SimpleExpression<T> implements Defa
 	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parser) {
 		if (expressions.length != 0)
 			throw new SkriptAPIException(this.getClass().getName() + " has expressions in its pattern but does not override init(...)");
-		return init(matchedPattern,	isDelayed, parser);
+		return init(matchedPattern, isDelayed, parser);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/lang/DefaultExpression.java
+++ b/src/main/java/ch/njol/skript/lang/DefaultExpression.java
@@ -1,5 +1,10 @@
 package ch.njol.skript.lang;
 
+import org.jetbrains.annotations.ApiStatus.ScheduledForRemoval;
+
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+
 /**
  * Represents an expression that can be used as the default value of a certain type or event.
  */
@@ -7,10 +12,26 @@ public interface DefaultExpression<T> extends Expression<T> {
 
 	/**
 	 * Called when an expression is initialized.
+	 * NOTE: Unused and does nothing.
 	 *
+	 * @deprecated Use {@link #init(int, Kleenean, ParseResult)} instead.
 	 * @return Whether the expression is valid in its context. Skript will error if false.
 	 */
-	boolean init();
+	@Deprecated
+	@ScheduledForRemoval
+	default boolean init() {
+		return false;
+	}
+
+	/**
+	 * Called when an expression is initialized.
+	 *
+	 * @param matchedPattern The index of the pattern that matched.
+	 * @param isDelayed Whether the expression is being initialized in a delayed context.
+	 * @param parseResult The result of the parse.
+	 * @return Whether the expression is valid in its context. Skript will error if false.
+	 */
+	boolean init(int matchedPattern, Kleenean isDelayed, ParseResult parseResult);
 
 	/**
 	 * @return Usually true, though this is not required, as e.g. SimpleLiteral implements DefaultExpression but is usually not the default of an event.

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -213,7 +213,7 @@ public class SkriptParser {
 									ExprInfo exprInfo = types.get(i).getExprInfo();
 									if (!exprInfo.isOptional) {
 										DefaultExpression<?> expr = getDefaultExpression(exprInfo, info.patterns[patternIndex]);
-										if (!expr.init())
+										if (!expr.init(patternIndex, getParser().getHasDelayBefore(), parseResult))
 											continue patternsLoop;
 										parseResult.exprs[i] = expr;
 									}

--- a/src/main/java/ch/njol/skript/lang/util/SimpleLiteral.java
+++ b/src/main/java/ch/njol/skript/lang/util/SimpleLiteral.java
@@ -73,7 +73,7 @@ public class SimpleLiteral<T> implements Literal<T>, DefaultExpression<T> {
 	}
 
 	@Override
-	public boolean init() {
+	public boolean init(int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		return true;
 	}
 
@@ -88,22 +88,22 @@ public class SimpleLiteral<T> implements Literal<T>, DefaultExpression<T> {
 
 	@Override
 	public T[] getArray(Event event) {
-		return this.data();
+		return getArray();
 	}
 
 	@Override
 	public T[] getAll() {
-		return this.data();
+		return getArray();
 	}
 
 	@Override
 	public T[] getAll(Event event) {
-		return this.data();
+		return getArray();
 	}
 
 	@Override
 	public T getSingle() {
-		return CollectionUtils.getRandom(data);
+		return CollectionUtils.getRandom(getArray());
 	}
 
 	@Override

--- a/src/main/java/org/skriptlang/skript/bukkit/misc/expressions/LitOperators.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/misc/expressions/LitOperators.java
@@ -1,4 +1,13 @@
-package ch.njol.skript.expressions;
+package org.skriptlang.skript.bukkit.misc.expressions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
@@ -6,41 +15,37 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
-import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.skript.lang.util.SimpleLiteral;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
-import org.bukkit.Bukkit;
-import org.bukkit.OfflinePlayer;
-import org.bukkit.entity.Player;
-import org.bukkit.event.Event;
-import org.jetbrains.annotations.Nullable;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Name("All Operators")
 @Description("The list of operators on the server.")
-@Examples("set {_ops::*} to all operators")
+@Examples("set {_ops::*} to all the operators")
 @Since("2.7")
-public class ExprOps extends SimpleExpression<OfflinePlayer> {
-	
-	private boolean nonOps;
-	
+public class LitOperators extends SimpleLiteral<OfflinePlayer> {
+
 	static {
-		Skript.registerExpression(ExprOps.class, OfflinePlayer.class, ExpressionType.SIMPLE, "[all [[of] the]|the] [server] [:non(-| )]op[erator]s");
+		Skript.registerExpression(LitOperators.class, OfflinePlayer.class, ExpressionType.SIMPLE,
+				"[all [[of] the]|the] [server] [:non(-| )]op[erator]s");
+	}
+
+	private boolean nonOps;
+
+	public LitOperators() {
+		super(Bukkit.getOperators().toArray(OfflinePlayer[]::new), OfflinePlayer.class, true);
 	}
 
 	@Override
-	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+	public boolean init(int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		nonOps = parseResult.hasTag("non");
 		return true;
 	}
 
 	@Override
-	protected OfflinePlayer[] get(Event event) {
+	public OfflinePlayer[] getArray() {
 		if (nonOps) {
 			List<Player> nonOpsList = new ArrayList<>();
 			for (Player player : Bukkit.getOnlinePlayers()) {
@@ -52,24 +57,17 @@ public class ExprOps extends SimpleExpression<OfflinePlayer> {
 		return Bukkit.getOperators().toArray(new OfflinePlayer[0]);
 	}
 
-	@Nullable
 	@Override
-	public Class<?>[] acceptChange(ChangeMode mode) {
-		if (nonOps)
-			return null;
-		switch (mode) {
-			case ADD:
-			case SET:
-			case REMOVE:
-			case RESET:
-			case DELETE:
-				return CollectionUtils.array(OfflinePlayer[].class);
-		}
-		return null;
+	public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
+		if (nonOps) return null;
+		return switch (mode) {
+			case ADD, SET, REMOVE, RESET, DELETE -> CollectionUtils.array(OfflinePlayer[].class);
+			default -> null;
+		};
 	}
 
 	@Override
-	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+	public void change(Event event, Object @Nullable [] delta, ChangeMode mode) {
 		if (delta == null && mode != ChangeMode.RESET && mode != ChangeMode.DELETE)
 			return;
 		switch (mode) {
@@ -97,11 +95,6 @@ public class ExprOps extends SimpleExpression<OfflinePlayer> {
 	@Override
 	public boolean isSingle() {
 		return false;
-	}
-
-	@Override
-	public Class<? extends OfflinePlayer> getReturnType() {
-		return OfflinePlayer.class;
 	}
 
 	@Override


### PR DESCRIPTION
### Description
- Makes the operators a literal for usages like command entry node values.
- Adds matchedPattern, isDelayed and ParseResult to the init for context within a DefaultExpression.
- Code cleaning while updating the init of the raw EventValueExpression casting syntaxes.
- ExprWorld casted the delta world object each for loop.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
