### PR TITLE
Examples for the experimental features.

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprQueue.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprQueue.java
@@ -47,7 +47,7 @@ public class ExprQueue extends SimpleExpression<SkriptQueue> {
 
 	static {
 		Skript.registerExpression(ExprQueue.class, SkriptQueue.class, ExpressionType.COMBINED,
-			"[a] new queue [(of|with) %-objects%]");
+			"[a] [new] queue [(of|with) %-objects%]");
 	}
 
 	private @Nullable Expression<?> contents;
@@ -88,8 +88,8 @@ public class ExprQueue extends SimpleExpression<SkriptQueue> {
 	@Override
 	public String toString(@Nullable Event event, boolean debug) {
 		if (contents == null)
-			return "a new queue";
-		return "a new queue of " + contents.toString(event, debug);
+			return "a queue";
+		return "a queue of " + contents.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/registrations/Feature.java
+++ b/src/main/java/ch/njol/skript/registrations/Feature.java
@@ -11,6 +11,7 @@ import org.skriptlang.skript.lang.experiment.LifeCycle;
  * Experimental feature toggles as provided by Skript itself.
  */
 public enum Feature implements Experiment {
+	EXAMPLES("examples", LifeCycle.STABLE),
 	QUEUES("queues", LifeCycle.EXPERIMENTAL),
 	FOR_EACH_LOOPS("for loop", LifeCycle.EXPERIMENTAL, "for [each] loop[s]"),
 	SCRIPT_REFLECTION("reflection", LifeCycle.EXPERIMENTAL, "[script] reflection"),

--- a/src/main/java/ch/njol/skript/sections/SecFor.java
+++ b/src/main/java/ch/njol/skript/sections/SecFor.java
@@ -107,7 +107,12 @@ public class SecFor extends SecLoop {
 					.getName() + " implements Container but is missing the required @ContainerType annotation");
 			this.expression = new ContainerExpression((Expression<? extends Container<?>>) expression, type.value());
 		}
-		if (expression.isSingle()) {
+		if (this.getParser().hasExperiment(Feature.QUEUES) // Todo: change this if other iterable things are added
+			&& expression.isSingle()
+			&& (expression instanceof Variable<?> || Iterable.class.isAssignableFrom(expression.getReturnType()))) {
+			// Some expressions return one thing but are potentially iterable anyway, e.g. queues
+			super.iterableSingle = true;
+		} else if (expression.isSingle()) {
 			Skript.error("Can't loop '" + expression + "' because it's only a single value");
 			return false;
 		}

--- a/src/main/java/ch/njol/skript/sections/SecLoop.java
+++ b/src/main/java/ch/njol/skript/sections/SecLoop.java
@@ -132,11 +132,14 @@ public class SecLoop extends LoopSection {
 				Object value = expression.getSingle(event);
 				if (value instanceof Iterable<?> iterable) {
 					iter = iterable.iterator();
+					// Guaranteed to be ordered so we try it first
+				} else if (value instanceof Container<?> container) {
+					iter = container.containerIterator();
 				} else {
 					iter = Collections.singleton(value).iterator();
 				}
 			} else {
-				iter = expression instanceof Variable variable ? variable.variablesIterator(event) :
+				iter = expression instanceof Variable<?> variable ? variable.variablesIterator(event) :
 					expression.iterator(event);
 				if (iter != null && iter.hasNext()) {
 					iteratorMap.put(event, iter);

--- a/src/main/java/ch/njol/skript/sections/SecLoop.java
+++ b/src/main/java/ch/njol/skript/sections/SecLoop.java
@@ -10,6 +10,7 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.*;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.ContainerExpression;
+import ch.njol.skript.registrations.Feature;
 import ch.njol.skript.util.Container;
 import ch.njol.skript.util.Container.ContainerType;
 import ch.njol.skript.util.LiteralUtils;
@@ -19,10 +20,7 @@ import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
 
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.WeakHashMap;
+import java.util.*;
 
 @Name("Loop")
 @Description({
@@ -85,6 +83,7 @@ public class SecLoop extends LoopSection {
 	private boolean guaranteedToLoop;
 	private Object nextValue = null;
 	private boolean loopPeeking;
+	protected boolean iterableSingle;
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -107,7 +106,12 @@ public class SecLoop extends LoopSection {
 			this.expression = new ContainerExpression((Expression<? extends Container<?>>) expression, type.value());
 		}
 
-		if (expression.isSingle()) {
+		if (this.getParser().hasExperiment(Feature.QUEUES) // Todo: change this if other iterable things are added
+			&& expression.isSingle()
+			&& (expression instanceof Variable<?> || Iterable.class.isAssignableFrom(expression.getReturnType()))) {
+			// Some expressions return one thing but are potentially iterable anyway, e.g. queues
+			this.iterableSingle = true;
+		} else if (expression.isSingle()) {
 			Skript.error("Can't loop '" + expression + "' because it's only a single value");
 			return false;
 		}
@@ -124,11 +128,21 @@ public class SecLoop extends LoopSection {
 	protected @Nullable TriggerItem walk(Event event) {
 		Iterator<?> iter = iteratorMap.get(event);
 		if (iter == null) {
-			iter = expression instanceof Variable variable ? variable.variablesIterator(event) : expression.iterator(event);
-			if (iter != null && iter.hasNext()) {
-				iteratorMap.put(event, iter);
+			if (iterableSingle) {
+				Object value = expression.getSingle(event);
+				if (value instanceof Iterable<?> iterable) {
+					iter = iterable.iterator();
+				} else {
+					iter = Collections.singleton(value).iterator();
+				}
 			} else {
-				iter = null;
+				iter = expression instanceof Variable variable ? variable.variablesIterator(event) :
+					expression.iterator(event);
+				if (iter != null && iter.hasNext()) {
+					iteratorMap.put(event, iter);
+				} else {
+					iter = null;
+				}
 			}
 		}
 

--- a/src/main/java/ch/njol/skript/structures/StructExample.java
+++ b/src/main/java/ch/njol/skript/structures/StructExample.java
@@ -21,9 +21,10 @@ import org.skriptlang.skript.lang.structure.Structure;
 	"They are used as miniature tutorials for demonstrating code snippets in the example files.",
 	"Scripts containing an example are seen as 'examples' by the parser and may have special safety restrictions."
 })
-@Examples({
-	"example:",
-	"\tbroadcast \"hello world\""
+@Examples({"""
+	example:
+		broadcast "hello world"
+		# this is never run"""
 })
 @Since("INSERT VERSION")
 public class StructExample extends Structure {

--- a/src/main/java/ch/njol/skript/structures/StructExample.java
+++ b/src/main/java/ch/njol/skript/structures/StructExample.java
@@ -1,0 +1,73 @@
+package ch.njol.skript.structures;
+
+import ch.njol.skript.ScriptLoader;
+import ch.njol.skript.Skript;
+import ch.njol.skript.config.SectionNode;
+import ch.njol.skript.doc.*;
+import ch.njol.skript.lang.Literal;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.function.FunctionEvent;
+import ch.njol.skript.lang.parser.ParserInstance;
+import ch.njol.skript.registrations.Feature;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.lang.entry.EntryContainer;
+import org.skriptlang.skript.lang.structure.Structure;
+
+@NoDoc
+@Name("Example")
+@Description({
+	"Examples are structures that are parsed, but will never be run.",
+	"They are used as miniature tutorials for demonstrating code snippets in the example files.",
+	"Scripts containing an example are seen as 'examples' by the parser and may have special safety restrictions."
+})
+@Examples({
+	"example:",
+	"\tbroadcast \"hello world\""
+})
+@Since("INSERT VERSION")
+public class StructExample extends Structure {
+
+	public static final Priority PRIORITY = new Priority(550);
+
+	static {
+		Skript.registerStructure(StructExample.class,
+			"example"
+		);
+	}
+
+	private SectionNode source;
+
+	@Override
+	public boolean init(Literal<?>[] literals, int matchedPattern, ParseResult parseResult,
+						@Nullable EntryContainer entryContainer) {
+		if (!this.getParser().hasExperiment(Feature.EXAMPLES))
+			return false;
+		assert entryContainer != null; // cannot be null for non-simple structures
+		this.source = entryContainer.getSource();
+		return true;
+	}
+
+	@Override
+	public boolean load() {
+		ParserInstance parser = this.getParser();
+		// This acts like a 'function' except without some of the features (e.g. returns)
+		// The code is parsed and loaded, but then discarded since it will never be run
+		// This allows things like parse problems and errors to be detected.
+		parser.setCurrentEvent("example", FunctionEvent.class);
+		ScriptLoader.loadItems(source);
+		parser.deleteCurrentEvent();
+		return true;
+	}
+
+	@Override
+	public Priority getPriority() {
+		return PRIORITY;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "function";
+	}
+
+}

--- a/src/main/java/ch/njol/skript/structures/StructExample.java
+++ b/src/main/java/ch/njol/skript/structures/StructExample.java
@@ -67,7 +67,7 @@ public class StructExample extends Structure {
 
 	@Override
 	public String toString(@Nullable Event event, boolean debug) {
-		return "function";
+		return "example";
 	}
 
 }

--- a/src/main/java/org/skriptlang/skript/lang/util/SkriptQueue.java
+++ b/src/main/java/org/skriptlang/skript/lang/util/SkriptQueue.java
@@ -1,6 +1,7 @@
 package org.skriptlang.skript.lang.util;
 
 import ch.njol.skript.lang.util.common.AnyAmount;
+import ch.njol.skript.util.Container;
 import ch.njol.yggdrasil.YggdrasilSerializable;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,8 +11,9 @@ import java.util.*;
  * A queue of elements.
  * Elements will only be added to the queue if they are not null, with nothing happening if the elements are null.
  */
+@Container.ContainerType(Object.class)
 public class SkriptQueue extends LinkedList<@NotNull Object>
-	implements Deque<Object>, Queue<Object>, YggdrasilSerializable, AnyAmount {
+	implements Deque<Object>, Queue<Object>, YggdrasilSerializable, AnyAmount, Container<Object> {
 
 	@Override
 	public boolean add(Object element) {
@@ -95,6 +97,11 @@ public class SkriptQueue extends LinkedList<@NotNull Object>
 	@Override
 	public @NotNull Number amount() {
 		return this.size();
+	}
+
+	@Override
+	public Iterator<Object> containerIterator() {
+		return this.iterator();
 	}
 
 }

--- a/src/main/resources/scripts/-examples/chest menus.sk
+++ b/src/main/resources/scripts/-examples/chest menus.sk
@@ -5,11 +5,11 @@
 #
 
 command /simplechest:
-    permission: skript.example.chest
-    trigger:
-        set {_chest} to a new chest inventory named "Simple Chest"
-        set slot 0 of {_chest} to apple # Slots are numbered 0, 1, 2...
-        open {_chest} to player
+	permission: skript.example.chest
+	trigger:
+		set {_chest} to a new chest inventory named "Simple Chest"
+		set slot 0 of {_chest} to apple # Slots are numbered 0, 1, 2...
+		open {_chest} to player
 
 #
 # An example of listening for click events in a chest inventory.
@@ -17,19 +17,19 @@ command /simplechest:
 #
 
 command /chestmenu:
-    permission: skript.example.menu
-    trigger:
-        set {_menu} to a new chest inventory with 1 row named "Simple Menu"
-        set slot 4 of {_menu} to stone named "Button" # Slots are numbered 0, 1, 2...
-        open {_menu} to player
+	permission: skript.example.menu
+	trigger:
+		set {_menu} to a new chest inventory with 1 row named "Simple Menu"
+		set slot 4 of {_menu} to stone named "Button" # Slots are numbered 0, 1, 2...
+		open {_menu} to player
 
 on inventory click: # Listen for players clicking in an inventory.
-    name of event-inventory is "Simple Menu" # Make sure it's our menu.
-    cancel event
-    if index of event-slot is 4: # The button slot.
-        send "You clicked the button."
-    else:
-        send "You didn't click the button."
+	name of event-inventory is "Simple Menu" # Make sure it's our menu.
+	cancel event
+	if index of event-slot is 4: # The button slot.
+		send "You clicked the button."
+	else:
+		send "You didn't click the button."
 
 #
 # An example of making and filling a fancy inventory with a function.
@@ -37,26 +37,26 @@ on inventory click: # Listen for players clicking in an inventory.
 #
 
 aliases:
-    menu items = TNT, lava bucket, string, coal, oak planks
+	menu items = TNT, lava bucket, string, coal, oak planks
 
-function makeMenu(name: text, rows: number) :: inventory:
-    set {_gui} to a new chest inventory with {_rows} rows with name {_name}
-    loop {_rows} * 9 times: # Fill the inventory with random items.
-        set slot loop-number - 1 of {_gui} to random item out of menu items
-    return {_gui}
+function make_menu(name: text, rows: number) :: inventory:
+	set {_gui} to a new chest inventory with {_rows} rows with name {_name}
+	loop {_rows} * 9 times: # Fill the inventory with random items.
+		set slot loop-number - 1 of {_gui} to random item out of menu items
+	return {_gui}
 
 command /fancymenu:
-    permission: skript.example.menu
-    trigger:
-        set {_menu} to makeMenu("hello", 4)
-        add {_menu} to {my inventories::*} # Prepare to listen to this inventory.
-        open {_menu} to player
+	permission: skript.example.menu
+	trigger:
+		set {_menu} to make_menu("hello", 4)
+		add {_menu} to {my inventories::*} # Prepare to listen to this inventory.
+		open {_menu} to player
 
 on inventory click: # Listen for players clicking in any inventory.
-    if {my inventories::*} contains event-inventory: # Make sure it's our menu.
-        cancel event
-        send "You clicked slot %index of event-slot%!"
+	if {my inventories::*} contains event-inventory: # Make sure it's our menu.
+		cancel event
+		send "You clicked slot %index of event-slot%!"
 
 on inventory close: # No longer need to listen to this inventory.
-    {my inventories::*} contains event-inventory
-    remove event-inventory from {my inventories::*}
+	{my inventories::*} contains event-inventory
+	remove event-inventory from {my inventories::*}

--- a/src/main/resources/scripts/-examples/commands.sk
+++ b/src/main/resources/scripts/-examples/commands.sk
@@ -48,8 +48,8 @@ command /home <text> [<text>]:
 #
 
 aliases:
-    # Creates an alias `blacklisted` for this list of items.
-    blacklisted = TNT, bedrock, obsidian, spawner, lava, lava bucket
+	# Creates an alias `blacklisted` for this list of items.
+	blacklisted = TNT, bedrock, obsidian, spawner, lava, lava bucket
 
 command /item <items>:
 	description: Give yourself some items.

--- a/src/main/resources/scripts/-examples/commands.sk
+++ b/src/main/resources/scripts/-examples/commands.sk
@@ -5,10 +5,10 @@
 #
 
 command /broadcast <text>:
-    permission: skript.example.broadcast
-    description: Broadcasts a message to everybody.
-    trigger:
-        broadcast arg-text
+	permission: skript.example.broadcast
+	description: Broadcasts a message to everybody.
+	trigger:
+		broadcast arg-text
 
 #
 # A simple /home command that allows players to set, remove and travel to homes.
@@ -17,29 +17,29 @@ command /broadcast <text>:
 #
 
 command /home <text> [<text>]:
-    description: Set, delete or travel to your home.
-    usage: /home set/remove <name>, /home <name>
-    permission: skript.example.home
-    executable by: players
-    trigger:
-        if arg-1 is "set":
-            if arg-2 is set:
-                set {homes::%uuid of player%::%arg-2%} to player's location
-                send "Set your home <green>%arg-2%<reset> to <grey>%location of player%<reset>" to player
-            else:
-                send "You must specify a name for this home." to player
-        else if arg-1 is "remove":
-            if arg-2 is set:
-                delete {homes::%uuid of player%::%arg-2%}
-                send "Deleted your home <green>%arg-2%<reset>" to player
-            else:
-                send "You must specify the name of this home." to player
-        else if arg-2 is set:
-            send "Correct usage: /home set/remove <name>" to player
-        else if {homes::%uuid of player%::%arg-1%} is set:
-            teleport player to {homes::%uuid of player%::%arg-1%}
-        else:
-            send "You have no home named <green>%arg-1%<reset>." to player
+	description: Set, delete or travel to your home.
+	usage: /home set/remove <name>, /home <name>
+	permission: skript.example.home
+	executable by: players
+	trigger:
+		if arg-1 is "set":
+			if arg-2 is set:
+				set {homes::%uuid of player%::%arg-2%} to player's location
+				send "Set your home <green>%arg-2%<reset> to <grey>%location of player%<reset>" to player
+			else:
+				send "You must specify a name for this home." to player
+		else if arg-1 is "remove":
+			if arg-2 is set:
+				delete {homes::%uuid of player%::%arg-2%}
+				send "Deleted your home <green>%arg-2%<reset>" to player
+			else:
+				send "You must specify the name of this home." to player
+		else if arg-2 is set:
+			send "Correct usage: /home set/remove <name>" to player
+		else if {homes::%uuid of player%::%arg-1%} is set:
+			teleport player to {homes::%uuid of player%::%arg-1%}
+		else:
+			send "You have no home named <green>%arg-1%<reset>." to player
 
 #
 # An /item command that accepts Skript item aliases.
@@ -52,20 +52,20 @@ aliases:
     blacklisted = TNT, bedrock, obsidian, spawner, lava, lava bucket
 
 command /item <items>:
-    description: Give yourself some items.
-    usage: /item <items...>
-    aliases: /i
-    executable by: players
-    permission: skript.example.item
-    cooldown: 30 seconds
-    cooldown message: You need to wait %remaining time% to use this command again.
-    cooldown bypass: skript.example.cooldown
-    trigger:
-        if player has permission "skript.example.item.all":
-            give argument to player
-        else:
-            loop argument:
-                if loop-item is not blacklisted:
-                    give loop-item to player
-                else:
-                    send "<red>%loop-item%<reset> is blacklisted and cannot be spawned." to player
+	description: Give yourself some items.
+	usage: /item <items...>
+	aliases: /i
+	executable by: players
+	permission: skript.example.item
+	cooldown: 30 seconds
+	cooldown message: You need to wait %remaining time% to use this command again.
+	cooldown bypass: skript.example.cooldown
+	trigger:
+		if player has permission "skript.example.item.all":
+			give argument to player
+		else:
+			loop argument:
+				if loop-item is not blacklisted:
+					give loop-item to player
+				else:
+					send "<red>%loop-item%<reset> is blacklisted and cannot be spawned." to player

--- a/src/main/resources/scripts/-examples/events.sk
+++ b/src/main/resources/scripts/-examples/events.sk
@@ -5,10 +5,10 @@
 #
 
 on join:
-    set the join message to "Oh look, %player% joined! :)"
+	set the join message to "Oh look, %player% joined! :)"
 
 on quit:
-    set the quit message to "Oh no, %player% left! :("
+	set the quit message to "Oh no, %player% left! :("
 
 #
 # This example cancels damage for players if they have a specific permission.
@@ -16,14 +16,14 @@ on quit:
 #
 
 on damage:
-    victim is a player
-    if the victim has permission "skript.example.damage":
-        cancel the event # Stops the default behaviour - the victim taking damage.
-    else:
-        send "Ouch! You took %damage% damage." to the victim
-        add damage to {damage::%uuid of victim%::taken}
-        if the attacker is a player:
-            add damage to {damage::%uuid of attacker%::dealt}
+	victim is a player
+	if the victim has permission "skript.example.damage":
+		cancel the event # Stops the default behaviour - the victim taking damage.
+	else:
+		send "Ouch! You took %damage% damage." to the victim
+		add damage to {damage::%uuid of victim%::taken}
+		if the attacker is a player:
+			add damage to {damage::%uuid of attacker%::dealt}
 
 #
 # This example allows players to wear specified blocks as hats.
@@ -31,14 +31,14 @@ on damage:
 #
 
 aliases: # An alias for our allowed hat items.
-    custom helmets = iron block, gold block, diamond block
+	custom helmets = iron block, gold block, diamond block
 
 on inventory click:
-    event-slot is the helmet slot of player # Check that player clicked their head slot.
-    inventory action is place all or nothing
-    player has permission "skript.example.helmet"
-    cursor slot of player is custom helmets # Check if the item is in our custom alias.
-    cancel the event
-    set {_old helmet} to the helmet of player
-    set the helmet of player to the cursor slot of player
-    set the cursor slot of player to {_old helmet}
+	event-slot is the helmet slot of player # Check that player clicked their head slot.
+	inventory action is place all or nothing
+	player has permission "skript.example.helmet"
+	cursor slot of player is custom helmets # Check if the item is in our custom alias.
+	cancel the event
+	set {_old helmet} to the helmet of player
+	set the helmet of player to the cursor slot of player
+	set the cursor slot of player to {_old helmet}

--- a/src/main/resources/scripts/-examples/experimental features/for loops.sk
+++ b/src/main/resources/scripts/-examples/experimental features/for loops.sk
@@ -8,7 +8,7 @@ example: # A simple loop
 
 	# For-loops allow you to extract the loop value directly into a variable
 	for each {_player} in all players:
-    send "Hello!" to {_player}
+		send "Hello!" to {_player}
 
   # This is exactly the same as using a regular loop and loop-value
   loop all players:

--- a/src/main/resources/scripts/-examples/experimental features/for loops.sk
+++ b/src/main/resources/scripts/-examples/experimental features/for loops.sk
@@ -20,7 +20,7 @@ example: # Nested loops
 	# For loops are designed to help when nesting multiple loops
 	for each {_word} in {words::*}:
 		for each {_player} in all players:
-			send "The word is " + {_word} to {_player}
+			send "The word is %{_word}%" to {_player}
 
 	# This is exactly the same as the following
 	loop {words::*}:

--- a/src/main/resources/scripts/-examples/experimental features/for loops.sk
+++ b/src/main/resources/scripts/-examples/experimental features/for loops.sk
@@ -1,0 +1,50 @@
+using examples
+
+# This flag enables the experimental 'for each loops' feature within this file
+using for loops
+
+
+example: # A simple loop
+
+	# For-loops allow you to extract the loop value directly into a variable
+	for each {_player} in all players:
+    send "Hello!" to {_player}
+
+  # This is exactly the same as using a regular loop and loop-value
+  loop all players:
+    send "Hello!" to loop-value
+
+
+example: # Nested loops
+
+  # For loops are designed to help when nesting multiple loops
+  for each {_word} in {words::*}:
+    for each {_player} in all players:
+      send "The word is " + {_word} to {_player}
+
+  # This is exactly the same as the following
+  loop {words::*}:
+    loop all players:
+      send "The word is %loop-value-1%" to loop-value-2
+
+
+example: # Keeping the last value
+
+  # Since the loop value is extracted to a variable,
+  # this is still available at the end of the loop
+  for {_player} in all players:
+    send "Hello!" to {_player}
+
+  # The final player to be looped is still in the variable
+  send "(You're my favourite)" to {_player}
+
+
+example: # Index and value
+
+  # For a list with keys, you can extract both the key and the value
+  for index {_number}, value {_value} in {my list::*}:
+    broadcast "%{_number}%. %{_value}%"
+
+  # You can also loop only the indices
+  for index {_key} in {my list::*}:
+    broadcast {_key}

--- a/src/main/resources/scripts/-examples/experimental features/for loops.sk
+++ b/src/main/resources/scripts/-examples/experimental features/for loops.sk
@@ -10,41 +10,41 @@ example: # A simple loop
 	for each {_player} in all players:
 		send "Hello!" to {_player}
 
-  # This is exactly the same as using a regular loop and loop-value
-  loop all players:
-    send "Hello!" to loop-value
+	# This is exactly the same as using a regular loop and loop-value
+	loop all players:
+		send "Hello!" to loop-value
 
 
 example: # Nested loops
 
-  # For loops are designed to help when nesting multiple loops
-  for each {_word} in {words::*}:
-    for each {_player} in all players:
-      send "The word is " + {_word} to {_player}
+	# For loops are designed to help when nesting multiple loops
+	for each {_word} in {words::*}:
+		for each {_player} in all players:
+			send "The word is " + {_word} to {_player}
 
-  # This is exactly the same as the following
-  loop {words::*}:
-    loop all players:
-      send "The word is %loop-value-1%" to loop-value-2
+	# This is exactly the same as the following
+	loop {words::*}:
+		loop all players:
+			send "The word is %loop-value-1%" to loop-value-2
 
 
 example: # Keeping the last value
 
-  # Since the loop value is extracted to a variable,
-  # this is still available at the end of the loop
-  for {_player} in all players:
-    send "Hello!" to {_player}
+	# Since the loop value is extracted to a variable,
+	# this is still available at the end of the loop
+	for {_player} in all players:
+		send "Hello!" to {_player}
 
-  # The final player to be looped is still in the variable
-  send "(You're my favourite)" to {_player}
+	# The final player to be looped is still in the variable
+	send "(You're my favourite)" to {_player}
 
 
 example: # Index and value
 
-  # For a list with keys, you can extract both the key and the value
-  for index {_number}, value {_value} in {my list::*}:
-    broadcast "%{_number}%. %{_value}%"
+	# For a list with keys, you can extract both the key and the value
+	for index {_number}, value {_value} in {my list::*}:
+		broadcast "%{_number}%. %{_value}%"
 
-  # You can also loop only the indices
-  for index {_key} in {my list::*}:
-    broadcast {_key}
+	# You can also loop only the indices
+	for index {_key} in {my list::*}:
+		broadcast {_key}

--- a/src/main/resources/scripts/-examples/experimental features/queues.sk
+++ b/src/main/resources/scripts/-examples/experimental features/queues.sk
@@ -1,0 +1,175 @@
+using examples
+
+# This flag enables the experimental 'queues' feature within this file
+using queues
+
+example: # Creating queues
+
+	# Queues are a storage container for objects.
+	set {queue} to a queue
+
+	# Queues function like {lists::*} but are a single variable.
+	add "hello" to {queue}
+	remove "hello" from {queue}
+	clear {queue}
+
+	# You can create a queue with some initial items in it
+	set {queue} to a queue of "hello" and "world"
+
+	# You can also create a queue of things from a list
+	# Anything can go in a queue
+	set {my items::*} to potato, apple and carrot
+	set {queue} to a queue of {my items::*}
+
+
+example: # Taking items from a queue
+
+	set {queue} to a queue of "hello" and "world"
+
+	# Asking for an item from the queue also removes it
+	the first element of {queue} is "hello"
+	# 'hello' is gone
+
+	the first element of {queue} is "world"
+	# 'world' is gone
+
+	{queue} is empty
+
+
+example: # Taking items from the end of a queue
+
+	set {queue} to a queue of "hello" and "world"
+
+	the last element of {queue} is "world"
+	# 'world' is gone
+
+	the last element of {queue} is "hello"
+	# 'hello' is gone
+
+	{queue} is empty
+
+
+example: # Processing a queue
+
+	# Queues are First In, First Out (FIFO)
+	# This means new items are added to the END, and removed from the START
+
+	set {queue} to a queue of "hello"
+
+	add "world" to {queue}
+	# Queue is now 'hello', 'world'
+	broadcast the first element of {queue}
+	# 'hello' is gone
+
+	add "hello" to {queue}
+	# Queue is now 'world', 'hello'
+
+
+example: # Looping a queue
+
+	# Looping items in a queue also removes them
+	set {queue} to a queue of all players
+
+	loop {queue}:
+		send "Good morning!" to loop-value
+
+	# All the items were processed
+	{queue} is empty
+
+	# This means queues are good for pausing and resuming a task
+	# without losing your progress!
+	set {queue} to a queue of all players
+	set {count} to 0
+
+	loop {queue}:
+		teleport loop-value to {my cool battle arena}
+		# Each player is removed in this loop
+		add 1 to {count}
+
+		if {count} is 10:
+			# We have too many players in the battle arena for now!
+			exit loop
+
+	wait 1 minute
+	# Only the players we didn't loop before are still in the queue
+	loop {queue}:
+		teleport loop-value to {my cool battle arena}
+
+
+example: # Turning a queue into a list
+
+	set {queue} to a queue of "hello" and "world"
+	# We can copy the items in the queue into a list
+	set {my list::*} to dequeued {queue}
+	{my list::*} is "hello" and "world"
+	# Deconstructing the queue does not remove them from the queue
+
+	the first 2 elements in {queue} are "hello" and "world"
+	# But asking for the elements does!
+	{queue} is empty
+
+
+example: # Peeking at a queue without removing items
+
+	# Sometimes, we want to check what the next item will be, without removing it
+	set {queue} to a queue of "hello" and "world"
+	# We can 'peek' at the first and last elements
+	the start of {queue} is "hello"
+	the end of {queue} is "world"
+
+	# We can also change these values
+	set the end of {queue} to "there"
+	# The queue is now 'hello', 'there'
+
+	# The other change effects (set, add, remove, delete) also work here
+	add "well," to the start of {queue}
+	# The queue is now 'well,', 'hello', 'there'
+
+	delete the end of {queue}
+	# The queue is now 'well,', 'hello'
+
+
+using for loops
+example: # Continuous processing of a queue
+
+	# Create a queue of all players (now) and some items
+	set {players} to a queue of all players
+	set {gifts} to potato, apple and carrot
+
+	# This will keep cycling through the 'players' and 'gifts' queues
+	# until all of the initial players are no longer online
+	for each {_player} in {players}:
+		{_player} is online
+		set {_item} to the first element of {gifts}
+		give {_item} to {_player}
+
+		# Add the player and item back to their queue
+		add {_player} to {players}
+		add {_item} to {gifts}
+		# As items are added to the END of a queue, this will cycle round in order
+
+		# This will loop forever, so we want a delay
+		wait 30 seconds
+
+
+#
+# A queue for rotating periodical announcements
+#
+
+on script load:
+	# Create an empty queue
+	set {advert messages} to a queue
+
+	# Add some messages to it
+	add "Welcome to my server!" to {advert messages}
+	add "All furniture, 5%% off in store and online!" to {advert messages}
+	add "Discount sale on christmas trees!" to {advert messages}
+	add "Vote for [candidate name]!" to {advert messages}
+
+every 3 minutes:
+	# Take the first message out of the queue
+	set {_message} to the first element of {advert messages}
+	broadcast "<red>" + {_message}
+
+	# Add the message back to the end of the queue
+	add {_message} to {advert messages}

--- a/src/main/resources/scripts/-examples/experimental features/queues.sk
+++ b/src/main/resources/scripts/-examples/experimental features/queues.sk
@@ -134,7 +134,7 @@ example: # Continuous processing of a queue
 
 	# Create a queue of all players (now) and some items
 	set {players} to a queue of all players
-	set {gifts} to potato, apple and carrot
+	set {gifts} to a queue of potato, apple and carrot
 
 	# This will keep cycling through the 'players' and 'gifts' queues
 	# until all of the initial players are no longer online

--- a/src/main/resources/scripts/-examples/experimental features/script reflection.sk
+++ b/src/main/resources/scripts/-examples/experimental features/script reflection.sk
@@ -92,9 +92,8 @@ These allow you to check values from these files.
 
 Configs are arranged as a tree of 'nodes', which have values:
 
-node name: value
-node name: value
-
+regular node: value
+regular node: value
 section node: # This node contains more nodes!
 	regular node: value
 	regular node: value

--- a/src/main/resources/scripts/-examples/experimental features/script reflection.sk
+++ b/src/main/resources/scripts/-examples/experimental features/script reflection.sk
@@ -1,0 +1,245 @@
+using examples
+
+# This flag enables the experimental 'script reflection' feature within this file
+# Script reflection is a collection of powerful tools for scripts to inspect themselves
+using script reflection
+
+
+###
+THE BASICS
+=====
+
+'Reflection' is for something to look at itself (like in a mirror).
+
+Script reflection is a collection of powerful tools for scripts to inspect themselves.
+
+We can start with basic access to scripts.
+###
+
+
+example: # Getting a script
+
+	# You can obtain the current script
+	set {script} to the current script
+	{script} exists
+
+	# You can also find a script by name
+	set {script} to the script named "my cool script.sk"
+
+	# Even if it's in a folder
+	set {script} to the script named "examples/events.sk"
+
+	# Even if it's not enabled
+	set {script} to the script named "-disabled script.sk"
+
+
+example: # Looping scripts
+
+	# It's possible to find multiple scripts at a time.
+	set {scripts::*} to all loaded scripts
+	set {scripts::*} to to the scripts named "my script.sk" and "my cooler script.sk"
+	set {scripts::*} to the scripts in folder "examples/"
+
+	loop all loaded scripts:
+		broadcast name of loop-value
+
+
+example: # The name and path of a script
+
+	# Scripts have a name, which is their file name (without .sk)
+	set {script} to the script named "my script.sk"
+	the name of {script} is "my script"
+
+	# This doesn't include their folder name
+	set {script} to the script named "folder/my script.sk"
+	the name of {script} is "my script"
+
+	# However, if you just print out a script, it will include the whole path
+	set {script} to the script named "folder/my script.sk"
+	"%{script}%" is "folder/my script.sk"
+
+
+example: # Enabling, disabling and loading scripts
+
+	# You can enable a disabled script
+	set {script} to the script named "-disabled script.sk"
+	# This parses and loads its code
+	enable {script}
+
+	# Now that it's been enabled, you can disable it again
+	set {script} to the script named "disabled script.sk"
+	# This unloads its code and renames the script
+	disable {script}
+
+	# A disabled script is skipped when Skript loads
+	# If you want to remove it temporarily, you can `unload` it
+	set {script} to the script named "my cool script.sk"
+	unload {script}
+
+	# You can then load it again, which is the same as enabling
+	load {script}
+
+	# Or just reload it
+	reload {script}
+
+
+###
+CONFIGS
+=====
+
+There are also tools provided for reading Skript's built-in configuration files.
+These allow you to check values from these files.
+
+Configs are arranged as a tree of 'nodes', which have values:
+
+node name: value
+node name: value
+
+section node: # This node contains more nodes!
+	regular node: value
+	regular node: value
+	another section node: # Sections can contain sections!
+		regular node: value
+###
+
+
+example: # Get the Skript config
+
+	set {_config} to the skript config
+	{_config} exists
+
+
+example: # Reading a simple node value
+
+	# Since configs are arranged in 'nodes' which have values,
+	# we just need to ask for these nodes, and then ask for their values
+
+	# You can get a node value directly from a config by name
+	set {_value} to the boolean value at "color codes reset formatting" in the skript config
+	broadcast "Do colour codes reset formatting? %{_value}%"
+
+	# You can also get a node specifically
+	set {_node} to the node "number accuracy" of {_config}
+	# And then check its value
+	set {_value} to the number value of {_node}
+	broadcast "Number accuracy: %{_value}%"
+
+
+example: # Value conversion
+
+	set {_node} to the node "number accuracy" of the skript config
+
+	# By specifying the TYPE of value you want, it is automatically parsed and converted
+	set {_value} to the text value of {_node}
+	{_value} is a text
+
+	set {_value} to the number value of {_node}
+	{_value} is a number
+
+	delete {_value}
+
+	# If it is impossible to convert or parse the value to what you asked for,
+	# it will be nothing
+	set {_value} to the player value of {_node}
+	# '0.1' can't be converted to a player
+	{_value} does not exist
+
+
+example: # Looping nodes
+
+	# A config can be treated as a node
+	set {_node} to the the skript config
+	# The nodes inside a section (or a config)
+	loop the nodes of {_node}:
+		# Nodes have a name
+		broadcast the name of loop-value
+
+
+###
+MORE CONFIGS
+=====
+
+Scripts themselves are stored as configs, where each line is a node.
+This means that you are able to read the content of a script.
+
+The examples in this section will use a 'my script.sk' which has the following code:
+
+on first join:
+	give apple to the player
+
+on damage:
+	if the attacker exists:
+		teleport the attacker to the victim
+###
+
+
+example: # Reading a script
+
+	# A script is also a config
+	set {script} to the script named "my script.sk"
+
+	# The code in each line is the node name
+	set {node} to the node "on first join" in {script}
+
+	# This event is a section, so we can loop it
+	loop the nodes of {node}:
+		# There is only one line (node) in the section
+		the name of loop-value is "give apple to the player"
+
+	# You can traverse the node tree like this
+	set {node} to the node "on damage" in {script}
+	set {node} to the node "if the attacker exists" in {node}
+	# The first line inside that section
+	set {node} to the first element of nodes of {node}
+
+	the name of {node} is "teleport the attacker to the victim"
+
+
+
+###
+FUNCTIONS
+=====
+
+The final part of script reflection is the ability to find and run a function.
+###
+
+example: # Finding a function
+
+	# You can find a function by name
+	set {my function} to the function "my_function"
+	set {my function} to the function "my_function()"
+
+	# You can also find a function from a particular script
+	set {my function} to the function "my_function" from {my script}
+
+	# You can even get multiple functions at once
+	set {functions::*} to all functions from the current script
+
+
+example: # Running a function
+
+	set {my function} to the function "my_function()"
+	# You can now run this function
+	run {my function}
+
+	# You can also provide the arguments for running this function
+	run {my function} with arguments "hello" and 7.5
+
+
+example: # The result of a function
+
+	# Some functions return a result
+	set {my function} to the function "my_function()"
+	# Asking for the result runs the function
+	set {result} to the result of {my function}
+
+	# You can also ask for the result with arguments
+	set {result} to the result of {my function} with arguments "hello" and 7.5
+
+
+# An example command to run a function by name
+command /func <text>:
+	permission: skript.example.reflection
+	trigger:
+		set {_function} to the function arg-text
+		run {_function}

--- a/src/main/resources/scripts/-examples/experimental features/script reflection.sk
+++ b/src/main/resources/scripts/-examples/experimental features/script reflection.sk
@@ -20,25 +20,25 @@ We can start with basic access to scripts.
 example: # Getting a script
 
 	# You can obtain the current script
-	set {script} to the current script
-	{script} exists
+	set {_script} to the current script
+	{_script} exists
 
 	# You can also find a script by name
-	set {script} to the script named "my cool script.sk"
+	set {_script} to the script named "my cool script.sk"
 
 	# Even if it's in a folder
-	set {script} to the script named "examples/events.sk"
+	set {_script} to the script named "examples/events.sk"
 
 	# Even if it's not enabled
-	set {script} to the script named "-disabled script.sk"
+	set {_script} to the script named "-disabled script.sk"
 
 
 example: # Looping scripts
 
 	# It's possible to find multiple scripts at a time.
-	set {scripts::*} to all loaded scripts
-	set {scripts::*} to to the scripts named "my script.sk" and "my cooler script.sk"
-	set {scripts::*} to the scripts in folder "examples/"
+	set {_scripts::*} to all loaded scripts
+	set {_scripts::*} to the scripts named "my script.sk" and "my cooler script.sk"
+	set {_scripts::*} to the scripts in folder "examples/"
 
 	loop all loaded scripts:
 		broadcast name of loop-value
@@ -47,40 +47,40 @@ example: # Looping scripts
 example: # The name and path of a script
 
 	# Scripts have a name, which is their file name (without .sk)
-	set {script} to the script named "my script.sk"
-	the name of {script} is "my script"
+	set {_script} to the script named "my script.sk"
+	the name of {_script} is "my script"
 
 	# This doesn't include their folder name
-	set {script} to the script named "folder/my script.sk"
-	the name of {script} is "my script"
+	set {_script} to the script named "folder/my script.sk"
+	the name of {_script} is "my script"
 
 	# However, if you just print out a script, it will include the whole path
-	set {script} to the script named "folder/my script.sk"
-	"%{script}%" is "folder/my script.sk"
+	set {_script} to the script named "folder/my script.sk"
+	"%{_script}%" is "folder/my script.sk"
 
 
 example: # Enabling, disabling and loading scripts
 
 	# You can enable a disabled script
-	set {script} to the script named "-disabled script.sk"
+	set {_script} to the script named "-disabled script.sk"
 	# This parses and loads its code
-	enable {script}
+	enable {_script}
 
 	# Now that it's been enabled, you can disable it again
-	set {script} to the script named "disabled script.sk"
+	set {_script} to the script named "disabled script.sk"
 	# This unloads its code and renames the script
-	disable {script}
+	disable {_script}
 
 	# A disabled script is skipped when Skript loads
 	# If you want to remove it temporarily, you can `unload` it
-	set {script} to the script named "my cool script.sk"
-	unload {script}
+	set {_script} to the script named "my cool script.sk"
+	unload {_script}
 
 	# You can then load it again, which is the same as enabling
-	load {script}
+	load {_script}
 
 	# Or just reload it
-	reload {script}
+	reload {_script}
 
 
 ###
@@ -147,7 +147,7 @@ example: # Value conversion
 example: # Looping nodes
 
 	# A config can be treated as a node
-	set {_node} to the the skript config
+	set {_node} to the skript config
 	# The nodes inside a section (or a config)
 	loop the nodes of {_node}:
 		# Nodes have a name
@@ -175,23 +175,23 @@ on damage:
 example: # Reading a script
 
 	# A script is also a config
-	set {script} to the script named "my script.sk"
+	set {_script} to the script named "my script.sk"
 
 	# The code in each line is the node name
-	set {node} to the node "on first join" in {script}
+	set {_node} to the node "on first join" in {_script}
 
 	# This event is a section, so we can loop it
-	loop the nodes of {node}:
+	loop the nodes of {_node}:
 		# There is only one line (node) in the section
 		the name of loop-value is "give apple to the player"
 
 	# You can traverse the node tree like this
-	set {node} to the node "on damage" in {script}
-	set {node} to the node "if the attacker exists" in {node}
+	set {_node} to the node "on damage" in {_script}
+	set {_node} to the node "if the attacker exists" in {_node}
 	# The first line inside that section
-	set {node} to the first element of nodes of {node}
+	set {_node} to the first element of nodes of {_node}
 
-	the name of {node} is "teleport the attacker to the victim"
+	the name of {_node} is "teleport the attacker to the victim"
 
 
 
@@ -205,35 +205,35 @@ The final part of script reflection is the ability to find and run a function.
 example: # Finding a function
 
 	# You can find a function by name
-	set {my function} to the function "my_function"
-	set {my function} to the function "my_function()"
+	set {_my function} to the function "my_function"
+	set {_my function} to the function "my_function()"
 
 	# You can also find a function from a particular script
-	set {my function} to the function "my_function" from {my script}
+	set {_my function} to the function "my_function" from {_my script}
 
 	# You can even get multiple functions at once
-	set {functions::*} to all functions from the current script
+	set {_functions::*} to all functions from the current script
 
 
 example: # Running a function
 
-	set {my function} to the function "my_function()"
+	set {_my function} to the function "my_function()"
 	# You can now run this function
-	run {my function}
+	run {_my function}
 
 	# You can also provide the arguments for running this function
-	run {my function} with arguments "hello" and 7.5
+	run {_my function} with arguments "hello" and 7.5
 
 
 example: # The result of a function
 
 	# Some functions return a result
-	set {my function} to the function "my_function()"
+	set {_my function} to the function "my_function()"
 	# Asking for the result runs the function
-	set {result} to the result of {my function}
+	set {_result} to the result of {_my function}
 
 	# You can also ask for the result with arguments
-	set {result} to the result of {my function} with arguments "hello" and 7.5
+	set {_result} to the result of {_my function} with arguments "hello" and 7.5
 
 
 # An example command to run a function by name

--- a/src/main/resources/scripts/-examples/functions.sk
+++ b/src/main/resources/scripts/-examples/functions.sk
@@ -34,22 +34,22 @@ command /appleexample:
 # Please note that self-calling functions can loop infinitely, so use with caution.
 #
 
-function destroyGold(source: block) :: blocks:
-    add {_source} to {_found::*}
-    break {_source} naturally using an iron pickaxe
-    loop blocks in radius 1 of {_source}:
-        loop-block is a gold ore block
-        break loop-block naturally using an iron pickaxe
-        if {_found::*} does not contain loop-block:
-            add destroyGold(loop-block) to {_found::*}
-    return {_found::*}
+function destroy_gold(source: block) :: blocks:
+	add {_source} to {_found::*}
+	break {_source} naturally using an iron pickaxe
+	loop blocks in radius 1 of {_source}:
+		loop-block is a gold ore block
+		break loop-block naturally using an iron pickaxe
+		if {_found::*} does not contain loop-block:
+			add destroy_gold(loop-block) to {_found::*}
+	return {_found::*}
 
 command /oreexample:
-    permission: skript.example.ore
-    trigger:
-        if the player's target block is a gold ore block:
-            send "Destroying all connected ore."
-            set {_found::*} to destroyGold(player's target block)
-            send "Destroyed %size of {_found::*}% connected ores!"
-        else:
-            send "<red>You must be looking at an ore block!"
+	permission: skript.example.ore
+	trigger:
+		if the player's target block is a gold ore block:
+			send "Destroying all connected ore."
+			set {_found::*} to destroy_gold(player's target block)
+			send "Destroyed %size of {_found::*}% connected ores!"
+		else:
+			send "<red>You must be looking at an ore block!"

--- a/src/main/resources/scripts/-examples/functions.sk
+++ b/src/main/resources/scripts/-examples/functions.sk
@@ -4,30 +4,30 @@
 # This demonstrates how to declare and run a simple function.
 #
 
-function sayMessage(message: text):
-    broadcast {_message} # our message argument is available in `{_message}`.
+function say_message(message: text):
+	broadcast {_message} # our message argument is available in `{_message}`.
 
 on first join:
-    wait 1 second
-    sayMessage("Welcome, %player%!") # Runs the `sayMessage` function.
+	wait 1 second
+	say_message("Welcome, %player%!") # Runs the `say_message` function.
 
 #
 # An example of a function with multiple parameters and a return type.
 # This demonstrates how to return a value and use it.
 #
 
-function giveApple(name: text, amount: number) :: item:
-    set {_item} to an apple
-    set the name of {_item} to {_name}
-    set the item amount of {_item} to {_amount}
-    return {_item} # Gives this value to the code that called the function.
+function give_apple(name: text, amount: number) :: item:
+	set {_item} to an apple
+	set the name of {_item} to {_name}
+	set the item amount of {_item} to {_amount}
+	return {_item} # Gives this value to the code that called the function.
 
 command /appleexample:
-    permission: skript.example.apple
-    trigger:
-        send "Giving you an apple!"
-        set {_item} to giveApple("Banana", 4)
-        give player {_item}
+	permission: skript.example.apple
+	trigger:
+		send "Giving you an apple!"
+		set {_item} to give_apple("Banana", 4)
+		give player {_item}
 
 #
 # An example of a recursive (self-calling) function that is used to repeat a complex task.

--- a/src/main/resources/scripts/-examples/loops.sk
+++ b/src/main/resources/scripts/-examples/loops.sk
@@ -66,9 +66,9 @@ command /anotherloopexample:
 			send "%loop-index%. %loop-value%"
 			give loop-value to player
 
-        loop blocks in radius 2 of player:
-            loop-block is a chest
-            loop items in loop-block: # Loop-block comes from the first loop, loop-item from the second.
-                loop-item is a dirt block # Matches any dirt block item
-                send "%loop-block% contains %loop-item%!"
-                exit loop # Exits the item loop.
+		loop blocks in radius 2 of player:
+			loop-block is a chest
+			loop items in loop-block: # Loop-block comes from the first loop, loop-item from the second.
+				loop-item is a dirt block # Matches any dirt block item
+				send "%loop-block% contains %loop-item%!"
+				exit loop # Exits the item loop.

--- a/src/main/resources/scripts/-examples/loops.sk
+++ b/src/main/resources/scripts/-examples/loops.sk
@@ -5,15 +5,15 @@
 #
 
 command /loopexample:
-    permission: skript.example.loop
-    trigger:
-        set {_number} to 5
-        loop {_number} times: # Runs `{_number}` times.
-            send "The number is %loop-number%."
+	permission: skript.example.loop
+	trigger:
+		set {_number} to 5
+		loop {_number} times: # Runs `{_number}` times.
+			send "The number is %loop-number%."
 
-        set {_list::*} to "apple", "banana" and "orange"
-        loop {_list::*}: # Runs for each value in the list.
-            send "The word is: %loop-value%"
+		set {_list::*} to "apple", "banana" and "orange"
+		loop {_list::*}: # Runs for each value in the list.
+			send "The word is: %loop-value%"
 
 #
 # Examples for while-loops, which run as long as the condition is true.
@@ -21,31 +21,31 @@ command /loopexample:
 #
 
 command /whileexample:
-    permission: skript.example.while
-    trigger:
-        set {_number} to 5
-        while {_number} is greater than 0:
-            send "The number is %{_number}%"
-            remove a random number between 0 and 2 from {_number}
-        send "Finished counting down."
+	permission: skript.example.while
+	trigger:
+		set {_number} to 5
+		while {_number} is greater than 0:
+			send "The number is %{_number}%"
+			remove a random number between 0 and 2 from {_number}
+		send "Finished counting down."
 
-        while true is true: # this will run forever
-            add "banana" to {_list::*}
-            if size of {_list::*} is 10:
-                exit loop
-        send "The list has %size of {_list::*}% bananas."
+		while true is true: # this will run forever
+			add "banana" to {_list::*}
+			if size of {_list::*} is 10:
+				exit loop
+		send "The list has %size of {_list::*}% bananas."
 
 command /dowhileexample:
-    permission: skript.example.dowhile
-    trigger:
-        set {_number} to a random integer between 0 and 6 # The player will get 1 to 3 apples.
-        do while {_number} is greater than 3: # This will always run at least once, even if `{_number} is less than or equal to 3`.
-            give the player an apple
-            remove 1 from {_number}
-        send "Finished giving out apples!"
+	permission: skript.example.dowhile
+	trigger:
+		set {_number} to a random integer between 0 and 6 # The player will get 1 to 3 apples.
+		do while {_number} is greater than 3: # This will always run at least once, even if `{_number} is less than or equal to 3`.
+			give the player an apple
+			remove 1 from {_number}
+		send "Finished giving out apples!"
 
-        do while true is false: # This will run once - the condition is checked AFTER the code is executed.
-            send "I will run only once!"
+		do while true is false: # This will run once - the condition is checked AFTER the code is executed.
+			send "I will run only once!"
 
 #
 # Examples for looping collections of specific types, such as players, blocks and items.
@@ -53,18 +53,18 @@ command /dowhileexample:
 #
 
 command /anotherloopexample:
-    permission: skript.example.loop
-    trigger:
-        send "Listing all players:"
-        loop all players: # Remember - player is the command sender, loop-player is the loop value.
-            send " - %loop-player%"
-            if loop-player has permission "skript.example.apple":
-                give loop-player an apple named "Potato"
+	permission: skript.example.loop
+	trigger:
+		send "Listing all players:"
+		loop all players: # Remember - player is the command sender, loop-player is the loop value.
+			send " - %loop-player%"
+			if loop-player has permission "skript.example.apple":
+				give loop-player an apple named "Potato"
 
-        set {_items::*} to stone, oak planks and an apple
-        loop {_items::*}:
-            send "%loop-index%. %loop-value%"
-            give loop-value to player
+		set {_items::*} to stone, oak planks and an apple
+		loop {_items::*}:
+			send "%loop-index%. %loop-value%"
+			give loop-value to player
 
         loop blocks in radius 2 of player:
             loop-block is a chest

--- a/src/main/resources/scripts/-examples/options and meta.sk
+++ b/src/main/resources/scripts/-examples/options and meta.sk
@@ -4,15 +4,15 @@
 #
 
 options:
-    my server name: Server Name
-    condition: player is alive
-    nice message: "You're alive!"
+	my server name: Server Name
+	condition: player is alive
+	nice message: "You're alive!"
 
 on join:
-    send "Welcome to {@my server name}"
-    # Options don't need `%...%` since they are raw inputs.
-    if {@condition}: # The raw `player is alive` is copied here during parsing.
-        send {@nice message}
+	send "Welcome to {@my server name}"
+	# Options don't need `%...%` since they are raw inputs.
+	if {@condition}: # The raw `player is alive` is copied here during parsing.
+		send {@nice message}
 
 #
 # An example of custom aliases for groups of items.
@@ -20,11 +20,11 @@ on join:
 #
 
 aliases:
-    pretty items = iron ingot, gold ingot, diamond
+	pretty items = iron ingot, gold ingot, diamond
 
 on join:
-    player has permission "skript.example.aliases"
-    give player random item out of pretty items # A random item from our alias.
+	player has permission "skript.example.aliases"
+	give player random item out of pretty items # A random item from our alias.
 
 #
 # An example showing how default variables can be used.
@@ -37,8 +37,8 @@ variables:
     {some variable} = "Hello"
 
 command /variabletest:
-    permission: skript.example.variables
-    trigger:
-        add 1 to {score::%player%}
-        send "Your score is now %{score::%player%}%."
-        send {some variable}
+	permission: skript.example.variables
+	trigger:
+		add 1 to {score::%player%}
+		send "Your score is now %{score::%player%}%."
+		send {some variable}

--- a/src/main/resources/scripts/-examples/options and meta.sk
+++ b/src/main/resources/scripts/-examples/options and meta.sk
@@ -33,8 +33,8 @@ on join:
 #
 
 variables:
-    {score::%player%} = 100
-    {some variable} = "Hello"
+	{score::%player%} = 100
+	{some variable} = "Hello"
 
 command /variabletest:
 	permission: skript.example.variables

--- a/src/main/resources/scripts/-examples/text formatting.sk
+++ b/src/main/resources/scripts/-examples/text formatting.sk
@@ -8,11 +8,11 @@
 #
 
 command /color:
-    permission: skript.example.color
-    trigger:
-        send "&6This message is golden."
-        send "<light red><bold>This message is light red and bold."
-        send "<#FF0000>This message is red."
+	permission: skript.example.color
+	trigger:
+		send "&6This message is golden."
+		send "<light red><bold>This message is light red and bold."
+		send "<#FF0000>This message is red."
 
 #
 # Other formatting options are also available.
@@ -20,19 +20,19 @@ command /color:
 #
 
 command /forum:
-    permission: skript.example.link
-    trigger:
-        send "To visit the website, [<link:https://google.com><tooltip:click here>click here<reset>]"
+	permission: skript.example.link
+	trigger:
+		send "To visit the website, [<link:https://google.com><tooltip:click here>click here<reset>]"
 
 command /copy <text>:
-    permission: skript.example.copy
-    trigger:
-        # Insertion: when the player shift clicks on the message, it will add the text to their text box.
-        # To use variables and other expressions with these tags, you have to send the text as `formatted`.
-        send formatted "<insertion:%arg-1%>%arg-1%"
+	permission: skript.example.copy
+	trigger:
+		# Insertion: when the player shift clicks on the message, it will add the text to their text box.
+		# To use variables and other expressions with these tags, you have to send the text as `formatted`.
+		send formatted "<insertion:%arg-1%>%arg-1%"
 
 command /suggest:
-    permission: skript.example.suggest
-    trigger:
-        send "<cmd:/say hi>Click here to run the command /say hi"
-        send "<sgt:/say hi>Click here to suggest the command /say hi"
+	permission: skript.example.suggest
+	trigger:
+		send "<cmd:/say hi>Click here to run the command /say hi"
+		send "<sgt:/say hi>Click here to suggest the command /say hi"

--- a/src/main/resources/scripts/-examples/timings.sk
+++ b/src/main/resources/scripts/-examples/timings.sk
@@ -4,7 +4,7 @@
 #
 
 at 18:00:
-    set the time to 7:00
+	set the time to 7:00
 
 #
 # This example schedules a repeating action. Each time the delay elapses, the trigger will be run.
@@ -12,25 +12,25 @@ at 18:00:
 #
 
 every 5 minutes:
-    broadcast "Did you know that five minutes have passed?"
-    loop all players:
-        if loop-player has permission "skript.example.apple":
-            give loop-player an apple
+	broadcast "Did you know that five minutes have passed?"
+	loop all players:
+		if loop-player has permission "skript.example.apple":
+			give loop-player an apple
 
 #
 # This example shows how the `wait` effect can be used to delay code being run.
 #
 
 command /waitexample:
-    permission: skript.example.wait
-    trigger:
-        send "Waiting for two seconds..."
-        wait 2 seconds
-        send "Finished waiting!"
+	permission: skript.example.wait
+	trigger:
+		send "Waiting for two seconds..."
+		wait 2 seconds
+		send "Finished waiting!"
 
-        send "Counting to five."
-        set {_count} to 0
-        while {_count} is less than 5:
-            wait 3 ticks # Minecraft game ticks: 20 ticks = 1 second.
-            add 0.5 to {_count}
-        send "Finished counting!"
+		send "Counting to five."
+		set {_count} to 0
+		while {_count} is less than 5:
+			wait 3 ticks # Minecraft game ticks: 20 ticks = 1 second.
+			add 0.5 to {_count}
+		send "Finished counting!"

--- a/src/main/resources/scripts/-examples/variables.sk
+++ b/src/main/resources/scripts/-examples/variables.sk
@@ -7,13 +7,13 @@
 #
 
 command /timer:
-    permission: skript.example.timer
-    trigger:
-        if {timer} is set:
-            send "This command was last run %time since {timer}% ago."
-        else:
-            send "This command has never been run."
-        set {timer} to now
+	permission: skript.example.timer
+	trigger:
+		if {timer} is set:
+			send "This command was last run %time since {timer}% ago."
+		else:
+			send "This command has never been run."
+		set {timer} to now
 
 #
 # This example stores two items in a global list variable `{items::%uuid of player%::*}`.
@@ -21,17 +21,17 @@ command /timer:
 #
 
 on join:
-    set {items::%uuid of player%::helmet} to player's helmet
-    set {items::%uuid of player%::boots} to player's boots
-    send "Stored your helmet and boots."
+	set {items::%uuid of player%::helmet} to player's helmet
+	set {items::%uuid of player%::boots} to player's boots
+	send "Stored your helmet and boots."
 
 command /outfit:
-    executable by: players
-    permission: skript.example.outfit
-    trigger:
-        give player {items::%uuid of player%::*} # gives the contents of the list
-        clear {items::%uuid of player%::*} # clears this list
-        send "Gave you the helmet and boots you joined with."
+	executable by: players
+	permission: skript.example.outfit
+	trigger:
+		give player {items::%uuid of player%::*} # gives the contents of the list
+		clear {items::%uuid of player%::*} # clears this list
+		send "Gave you the helmet and boots you joined with."
 
 #
 # An example of adding, looping and removing the contents of a list variable.
@@ -39,15 +39,15 @@ command /outfit:
 #
 
 command /shoppinglist:
-    permission: skript.example.list
-    trigger:
-        add "bacon" to {_shopping list::*}
-        add "eggs" to {_shopping list::*}
-        add "oats" and "sugar" to {_shopping list::*}
-        send "You have %size of {_shopping list::*}% things in your shopping list:"
-        loop {_shopping list::*}:
-            send "%loop-index%. %loop-value%"
-        send "You bought some %{_shopping list::1}%!"
-        remove "bacon" from {_shopping list::*}
-        send "Removing bacon from your list."
-        send "You now have %size of {_shopping list::*}% things in your shopping list."
+	permission: skript.example.list
+	trigger:
+		add "bacon" to {_shopping list::*}
+		add "eggs" to {_shopping list::*}
+		add "oats" and "sugar" to {_shopping list::*}
+		send "You have %size of {_shopping list::*}% things in your shopping list:"
+		loop {_shopping list::*}:
+			send "%loop-index%. %loop-value%"
+		send "You bought some %{_shopping list::1}%!"
+		remove "bacon" from {_shopping list::*}
+		send "Removing bacon from your list."
+		send "You now have %size of {_shopping list::*}% things in your shopping list."

--- a/src/test/skript/tests/syntaxes/expressions/ExprQueue.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprQueue.sk
@@ -1,15 +1,15 @@
 using queues
 
 test "queue creation":
-	set {_queue} to a new queue
+	set {_queue} to a queue
 	assert {_queue} exists with "queue was not created"
 
 	delete {_queue}
-	set {_queue} to a new queue of "hello" and "there"
+	set {_queue} to a queue of "hello" and "there"
 	assert {_queue} exists with "queue was not created"
 
 test "queue polling behaviour":
-	set {_queue} to a new queue of "hello" and "there"
+	set {_queue} to a queue of "hello" and "there"
 
 	set {_word} to the first element in {_queue}
 	assert {_word} is "hello" with "element not polled"
@@ -17,7 +17,7 @@ test "queue polling behaviour":
 	set {_word} to the first element in {_queue}
 	assert {_word} is "there" with "element not polled"
 
-	set {_queue} to a new queue of "hello" and "there"
+	set {_queue} to a queue of "hello" and "there"
 
 	set {_word} to the last element in {_queue}
 	assert {_word} is "there" with "element not polled"
@@ -27,7 +27,7 @@ test "queue polling behaviour":
 	assert {_queue} is empty with "queue was not empty"
 
 test "queue start/end":
-	set {_queue} to a new queue of "hello" and "there"
+	set {_queue} to a queue of "hello" and "there"
 
 	set {_word} to the start of {_queue}
 	assert {_word} is "hello" with "element not found"
@@ -44,13 +44,13 @@ test "queue start/end":
 	assert {_queue} is empty with "queue was not empty"
 
 test "queue emptiness":
-	set {_queue} to a new queue
+	set {_queue} to a queue
 	assert {_queue} is empty with "queue was not empty"
 
-	set {_queue} to a new queue of "hello" and "there"
+	set {_queue} to a queue of "hello" and "there"
 	assert {_queue} is not empty with "queue was empty"
 
-	set {_queue} to a new queue
+	set {_queue} to a queue
 	add "hello" to {_queue}
 	assert {_queue} is not empty with "queue was empty"
 	set {_var} to the first element in {_queue}
@@ -58,7 +58,7 @@ test "queue emptiness":
 
 test "dequeue queue":
 
-	set {_queue} to a new queue of "hello" and "there"
+	set {_queue} to a queue of "hello" and "there"
 	assert {_queue} is not empty with "queue was empty"
 
 	set {_words::*} to dequeued {_queue}
@@ -69,3 +69,15 @@ test "dequeue queue":
 	assert {_words::*} are "hello" and "there" with "elements not polled"
 
 	assert {_queue} is empty with "queue was not empty"
+
+using for loops
+test "loop queue":
+	set {_queue} to a queue of "hello" and "there"
+	set {_count} to 0
+
+	for each {_word} in {_queue}:
+		add 1 to {_count}
+		if {_count} is less than 10:
+			add {_word} to {_queue}
+
+	assert {_count} is 11

--- a/src/test/skript/tests/syntaxes/expressions/ExprScript.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprScript.sk
@@ -4,7 +4,7 @@ options:
 	test: (join ("..", "..", "..", "..", "..", "..", "src", "test", "skript", "tests" and "") by file_separator())
 
 	# Princess test script is in another castle, Mario!
-	# paths are relativised to the ", "scripts", " directory
+	# paths are relativised to the "/scripts/" directory
 	# but we are loading these scripts from the test folder :(
 
 using script reflection

--- a/src/test/skript/tests/syntaxes/structures/StructExample.sk
+++ b/src/test/skript/tests/syntaxes/structures/StructExample.sk
@@ -1,0 +1,21 @@
+using examples
+
+example:
+	# None of this should be run
+	broadcast "foo bar"
+	wait 1 second
+	broadcast "hello world"
+
+example:
+	spawn a pig at spawn of world "world"
+
+parse:
+	results: {examples::*}
+	code:
+		example:
+			aldhfgfkudshgk
+
+test "examples":
+	# Examples should get parsed
+	assert {examples::*} contains "Can't understand this condition/effect: aldhfgfkudshgk" with "%{examples::*}%"
+	delete {examples::*}


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
To help give testers some initiative, I've created some example scripts for `2.10`'s experimental features (queues, for each loops, script reflection).

I've also tweaked an issue I noticed with queues (namely, you couldn't loop them as a variable since they looked like a single value). I think this issue is probably more widespread (any containerised value) but that will need investigating later.

I added a new structure specifically for examples: `example`!
Code in this structure is parsed (so examples would still report parse errors) but the code is discarded and never run.
```applescript
example:
    kill the player
    teleport the player to {the moon}
    # Nothing here gets run
```

This can be used to set up little code snippet examples, without needing to create some involved structure.
The existing example scripts all have to be whole things (events, commands, etc.) and it can be quite complicated to make a clean example for some features. I'm hoping this will encourage some more introductory content to be made.
