### PR TITLE
Fix queue serialisation.

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
@@ -25,19 +25,21 @@ import ch.njol.skript.util.slot.Slot;
 import ch.njol.skript.util.visual.VisualEffect;
 import ch.njol.skript.util.visual.VisualEffects;
 import ch.njol.yggdrasil.Fields;
-import org.skriptlang.skript.lang.util.SkriptQueue;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.script.Script;
+import org.skriptlang.skript.lang.util.SkriptQueue;
 import org.skriptlang.skript.util.Executable;
 
 import java.io.File;
+import java.io.NotSerializableException;
 import java.io.StreamCorruptedException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Locale;
 import java.util.regex.Pattern;
 
@@ -731,7 +733,51 @@ public class SkriptClasses {
 						}
 					}
 				})
-				.serializer(new YggdrasilSerializer<>())
+				.parser(new Parser<SkriptQueue>() {
+
+					@Override
+					public boolean canParse(ParseContext context) {
+						return false;
+					}
+
+					@Override
+					public String toString(SkriptQueue queue, int flags) {
+						return Classes.toString(queue.toArray(), flags, true);
+					}
+
+					@Override
+					public String toVariableNameString(SkriptQueue queue) {
+						return this.toString(queue, 0);
+					}
+
+				})
+				.serializer(new Serializer<SkriptQueue>() {
+					@Override
+					public Fields serialize(SkriptQueue queue) throws NotSerializableException {
+						Fields fields = new Fields();
+						fields.putObject("contents", queue.toArray());
+						return fields;
+					}
+
+					@Override
+					public void deserialize(SkriptQueue queue, Fields fields)
+						throws StreamCorruptedException, NotSerializableException {
+						Object[] contents = fields.getObject("contents", Object[].class);
+						queue.clear();
+						if (contents != null)
+							queue.addAll(List.of(contents));
+					}
+
+					@Override
+					public boolean mustSyncDeserialization() {
+						return false;
+					}
+
+					@Override
+					protected boolean canBeInstantiated() {
+						return true;
+					}
+				})
 		);
 
 

--- a/src/main/java/org/skriptlang/skript/lang/util/SkriptQueue.java
+++ b/src/main/java/org/skriptlang/skript/lang/util/SkriptQueue.java
@@ -2,7 +2,6 @@ package org.skriptlang.skript.lang.util;
 
 import ch.njol.skript.lang.util.common.AnyAmount;
 import ch.njol.skript.util.Container;
-import ch.njol.yggdrasil.YggdrasilSerializable;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -13,7 +12,7 @@ import java.util.*;
  */
 @Container.ContainerType(Object.class)
 public class SkriptQueue extends LinkedList<@NotNull Object>
-	implements Deque<Object>, Queue<Object>, YggdrasilSerializable, AnyAmount, Container<Object> {
+	implements Deque<Object>, Queue<Object>, AnyAmount, Container<Object> {
 
 	@Override
 	public boolean add(Object element) {


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Queues used an automatic serialiser, but the actual node fields in a linked list are transient (because it does it manually) so none of the values actually get stored.
This makes it just save the array of values instead.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
