### PR TITLE
Fiix getArray mistake in CondIsTagged, add runtime error for bad namespace keys in ExprTag

### DIFF
--- a/src/main/java/org/skriptlang/skript/bukkit/tags/elements/CondIsTagged.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/tags/elements/CondIsTagged.java
@@ -53,7 +53,7 @@ public class CondIsTagged extends Condition {
 
 	@Override
 	public boolean check(Event event) {
-		Tag<Keyed>[] tags = this.tags.getArray(event);
+		Tag<Keyed>[] tags = this.tags.getAll(event);
 		if (tags.length == 0)
 			return isNegated();
 		boolean and = this.tags.getAnd();

--- a/src/main/java/org/skriptlang/skript/bukkit/tags/elements/ExprTag.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/tags/elements/ExprTag.java
@@ -100,8 +100,7 @@ public class ExprTag extends SimpleExpression<Tag> implements SyntaxRuntimeError
 					key = new NamespacedKey(namespace, name);
 				}
 			} catch (IllegalArgumentException e) {
-				error("Invalid tag key: '" + name + "'. Tags may only contain a-z, 0-9, _, ., /, or - characters.");
-				continue;
+				key = null;
 			}
 			if (key == null) {
 				error("Invalid tag key: '" + name + "'. Tags may only contain a-z, 0-9, _, ., /, or - characters.");

--- a/src/main/java/org/skriptlang/skript/bukkit/tags/elements/ExprTag.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/tags/elements/ExprTag.java
@@ -1,6 +1,7 @@
 package org.skriptlang.skript.bukkit.tags.elements;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Keywords;
@@ -22,6 +23,7 @@ import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.bukkit.tags.TagModule;
 import org.skriptlang.skript.bukkit.tags.TagType;
 import org.skriptlang.skript.bukkit.tags.sources.TagOrigin;
+import org.skriptlang.skript.log.runtime.SyntaxRuntimeErrorProducer;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -51,7 +53,7 @@ import java.util.List;
 @Since("2.10")
 @RequiredPlugins("Paper (paper tags)")
 @Keywords({"blocks", "minecraft tag", "type", "category"})
-public class ExprTag extends SimpleExpression<Tag> {
+public class ExprTag extends SimpleExpression<Tag> implements SyntaxRuntimeErrorProducer {
 
 	static {
 		Skript.registerExpression(ExprTag.class, Tag.class, ExpressionType.COMBINED,
@@ -63,6 +65,8 @@ public class ExprTag extends SimpleExpression<Tag> {
 	private TagOrigin origin;
 	private boolean datapackOnly;
 
+	private Node node;
+
 	@Override
 	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		//noinspection unchecked
@@ -70,6 +74,7 @@ public class ExprTag extends SimpleExpression<Tag> {
 		types = TagType.fromParseMark(parseResult.mark);
 		origin = TagOrigin.fromParseTags(parseResult.tags);
 		datapackOnly = origin == TagOrigin.BUKKIT && parseResult.hasTag("datapack");
+		node = getParser().getNode();
 		return true;
 	}
 
@@ -87,14 +92,21 @@ public class ExprTag extends SimpleExpression<Tag> {
 		nextName: for (String name : names) {
 			// get key
 			NamespacedKey key;
-			if (name.contains(":")) {
-				key = NamespacedKey.fromString(name);
-			} else {
-				// populate namespace if not provided
-				key = new NamespacedKey(namespace, name);
-			}
-			if (key == null)
+			try {
+				if (name.contains(":")) {
+					key = NamespacedKey.fromString(name);
+				} else {
+					// populate namespace if not provided
+					key = new NamespacedKey(namespace, name);
+				}
+			} catch (IllegalArgumentException e) {
+				error("Invalid tag key: '" + name + "'. Tags may only contain a-z, 0-9, _, ., or - characters.");
 				continue;
+			}
+			if (key == null) {
+				error("Invalid tag key: '" + name + "'. Tags may only contain a-z, 0-9, _, ., or - characters.");
+				continue;
+			}
 
 			Tag<?> tag;
 			for (TagType<?> type : types) {
@@ -120,6 +132,11 @@ public class ExprTag extends SimpleExpression<Tag> {
 	@SuppressWarnings("rawtypes")
 	public Class<? extends Tag> getReturnType() {
 		return Tag.class;
+	}
+
+	@Override
+	public Node getNode() {
+		return node;
 	}
 
 	@Override

--- a/src/main/java/org/skriptlang/skript/bukkit/tags/elements/ExprTag.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/tags/elements/ExprTag.java
@@ -100,11 +100,11 @@ public class ExprTag extends SimpleExpression<Tag> implements SyntaxRuntimeError
 					key = new NamespacedKey(namespace, name);
 				}
 			} catch (IllegalArgumentException e) {
-				error("Invalid tag key: '" + name + "'. Tags may only contain a-z, 0-9, _, ., or - characters.");
+				error("Invalid tag key: '" + name + "'. Tags may only contain a-z, 0-9, _, ., /, or - characters.");
 				continue;
 			}
 			if (key == null) {
-				error("Invalid tag key: '" + name + "'. Tags may only contain a-z, 0-9, _, ., or - characters.");
+				error("Invalid tag key: '" + name + "'. Tags may only contain a-z, 0-9, _, ., /, or - characters.");
 				continue;
 			}
 

--- a/src/test/skript/tests/regressions/7471-is tagged or list.sk
+++ b/src/test/skript/tests/regressions/7471-is tagged or list.sk
@@ -1,0 +1,6 @@
+test "is tagged or list":
+	register a custom item tag named "or_list_tag_1" using oak log
+	register a custom item tag named "or_list_tag_2" using spruce log
+
+	loop 10 times:
+		assert oak log is tagged as custom tag "or_list_tag_1" or custom tag "or_list_tag_2"


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

changes getArray to getAnd in CondIsTagged to fix #7471
adds runtime error to catch invalid tags in ExprTag

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7471 <!-- Links to related issues -->
