### PR TITLE
ExprName - fix not being able to get/set name of block

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/DefaultConverters.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultConverters.java
@@ -206,9 +206,11 @@ public class DefaultConverters {
 				@Override
 				public void setName(String name) {
 					BlockState state = block.getState();
-					if (state instanceof Nameable nameable)
+					if (state instanceof Nameable nameable) {
 						//noinspection deprecation
 						nameable.setCustomName(name);
+						state.update(true, false);
+					}
 				}
 			},
 			//</editor-fold>

--- a/src/main/java/ch/njol/skript/expressions/ExprName.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprName.java
@@ -99,8 +99,8 @@ public class ExprName extends SimplePropertyExpression<Object, String> {
 			serializer = BungeeComponentSerializer.get();
 
 		List<String> patterns = new ArrayList<>();
-		patterns.addAll(Arrays.asList(getPatterns("name[s]", "offlineplayers/entities/inventories/nameds")));
-		patterns.addAll(Arrays.asList(getPatterns("(display|nick|chat|custom)[ ]name[s]", "offlineplayers/entities/inventories/nameds")));
+		patterns.addAll(Arrays.asList(getPatterns("name[s]", "offlineplayers/entities/nameds/inventories")));
+		patterns.addAll(Arrays.asList(getPatterns("(display|nick|chat|custom)[ ]name[s]", "offlineplayers/entities/nameds/inventories")));
 		patterns.addAll(Arrays.asList(getPatterns("(player|tab)[ ]list name[s]", "players")));
 
 		Skript.registerExpression(ExprName.class, String.class, ExpressionType.COMBINED, patterns.toArray(new String[0]));

--- a/src/test/skript/tests/syntaxes/expressions/ExprName.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprName.sk
@@ -34,6 +34,16 @@ test "name of item":
 	set the name of {_thing} to "blob"
 	assert name of {_thing} is "blob" with "item name didn't change"
 
+test "name of block":
+	set {_data} to blockdata of block at event-location
+	set block at event-location to a chest
+	assert name of block at event-location is not set with "The block shouldn't have a name yet"
+	set name of block at event-location to "Mr Chesty"
+	assert name of block at event-location = "Mr Chesty" with "The block should have a name now"
+	reset name of block at event-location
+	assert name of block at event-location is not set with "The block should no longer have a name"
+	set block at event-location to {_data}
+
 using script reflection
 
 test "config name (new)":
@@ -53,7 +63,7 @@ test "node name (new)":
 	assert name of {_node} is "test ""name of world""" with "first node name was wrong"
 
 	set {_node} to the current script
-	set {_node} to the 4th element of nodes of {_node} # Obviously, this changes if this file changes
+	set {_node} to the 5th element of nodes of {_node} # Obviously, this changes if this file changes
 	assert name of {_node} is "using script reflection" with "4th node name was wrong"
 
 	# root node


### PR DESCRIPTION
### Description
This PR aims to fix an issue with ExprName, and not being able to get/set the name of a block.
The issue as "inventories" was before "nameds", therefor forcing the Block to convert to an Inventory.
Reordering it solves that issue.
Also, had to update the BlockState to apply the name.

Added a test as well.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7502 
