### PR TITLE
Fix a conflict with EffSend and EffConnect

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffConnect.java
+++ b/src/main/java/ch/njol/skript/effects/EffConnect.java
@@ -37,7 +37,8 @@ public class EffConnect extends Effect {
 
 	static {
 		Skript.registerEffect(EffConnect.class,
-				"(send|connect) %players% to [proxy|bungeecord] [server] %string%",
+				"connect %players% to [proxy|bungeecord] [server] %string%",
+				"send %players% to [proxy|bungeecord] server %string%",
 				"transfer %players% to server %string% [on port %-number%]"
 		);
 	}

--- a/src/main/java/ch/njol/skript/effects/EffConnect.java
+++ b/src/main/java/ch/njol/skript/effects/EffConnect.java
@@ -52,7 +52,7 @@ public class EffConnect extends Effect {
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		players = (Expression<Player>) exprs[0];
 		server = (Expression<String>) exprs[1];
-		transfer = matchedPattern == 1;
+		transfer = matchedPattern == 2;
 
 		if (transfer) {
 			port = (Expression<Number>) exprs[2];

--- a/src/test/java/org/skriptlang/skript/test/tests/regression/EffSendEffConnectConflict7517Test.java
+++ b/src/test/java/org/skriptlang/skript/test/tests/regression/EffSendEffConnectConflict7517Test.java
@@ -1,0 +1,46 @@
+package org.skriptlang.skript.test.tests.regression;
+
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.TriggerItem;
+import ch.njol.skript.lang.util.ContextlessEvent;
+import ch.njol.skript.test.runner.SkriptJUnitTest;
+import ch.njol.skript.variables.Variables;
+import org.bukkit.command.CommandSender;
+import org.bukkit.event.Event;
+import org.easymock.Capture;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class EffSendEffConnectConflict7517Test extends SkriptJUnitTest {
+
+	private static final String MESSAGE = "Hello, world!";
+
+	private CommandSender sender;
+	private Effect sendEffect;
+
+	@Before
+	public void setup() {
+		sender = EasyMock.niceMock(CommandSender.class);
+		sendEffect = Effect.parse("send {_message} to {_sender}", null);
+		if (sendEffect == null)
+			throw new IllegalStateException();
+	}
+
+	@Test
+	public void test() {
+		Event event = ContextlessEvent.get();
+		Variables.setVariable("sender", sender, event, true);
+		Variables.setVariable("message", MESSAGE, event, true);
+
+		Capture<String> messageCapture = EasyMock.newCapture();
+		sender.sendMessage(EasyMock.capture(messageCapture));
+		EasyMock.replay(sender);
+
+		TriggerItem.walk(sendEffect, event);
+		EasyMock.verify(sender);
+		Assert.assertEquals(MESSAGE, messageCapture.getValue());
+	}
+
+}


### PR DESCRIPTION
### Description
This PR fixes a possible conflict with the `send` effect and the `connect` effect having the same pattern `send x to y`, which causes the parser to pick the `connect` effect when both of those expressions have unknown types. This is fixed by making the `server` keyword required when using the `send` pattern in the `connect` effect

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #7517
