### PR TITLE
Parse Effect

### DIFF
--- a/src/main/java/ch/njol/skript/classes/Changer.java
+++ b/src/main/java/ch/njol/skript/classes/Changer.java
@@ -42,7 +42,7 @@ public interface Changer<T> {
 	
 	/**
 	 * @param what The objects to change
-	 * @param delta An array with one or more instances of one or more of the the classes returned by {@link #acceptChange(ChangeMode)} for the given change mode (null for
+	 * @param delta An array with one or more instances of one or more of the classes returned by {@link #acceptChange(ChangeMode)} for the given change mode (null for
 	 *            {@link ChangeMode#DELETE} and {@link ChangeMode#RESET}). <b>This can be a Object[], thus casting is not allowed.</b>
 	 * @param mode The {@link ChangeMode} to test.
 	 * @throws UnsupportedOperationException (optional) if this method was called on an unsupported ChangeMode.

--- a/src/main/java/ch/njol/skript/effects/EffParse.java
+++ b/src/main/java/ch/njol/skript/effects/EffParse.java
@@ -1,0 +1,79 @@
+package ch.njol.skript.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.classes.Changer.ChangerUtils;
+import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.classes.Parser;
+import ch.njol.skript.lang.*;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.registrations.Classes;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+public class EffParse extends Effect {
+
+	static {
+		Skript.registerEffect(EffParse.class, "parse %~strings% as %*classinfo%");
+	}
+
+	private Expression<String> toParse;
+	private ClassInfo<?> classInfo;
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		toParse = (Expression<String>) expressions[0];
+		classInfo = ((Literal<ClassInfo<?>>) expressions[1]).getSingle();
+
+		if (classInfo.getC() == String.class) {
+			Skript.error("Parsing as text is useless as only things that are already text may be parsed");
+			return false;
+		}
+
+		if (toParse == null) {
+			return false;
+		}
+
+		Parser<?> parser = classInfo.getParser();
+		if (parser == null || !parser.canParse(ParseContext.PARSE)) {
+			Skript.error("Text cannot be parsed as " + classInfo.getName().withIndefiniteArticle());
+			return false;
+		}
+
+		if (toParse instanceof ExpressionList<String> toParseExpressions) {
+			for (int i = 0; i < toParseExpressions.getAllExpressions().size(); i++) {
+				Expression<String> expression = (Expression<String>) toParseExpressions.getAllExpressions().get(i);
+				if (!ChangerUtils.acceptsChange(expression, ChangeMode.SET, classInfo.getC())) {
+					Skript.error(toParse + " can't be set to " + classInfo.getName().withIndefiniteArticle());
+					return false;
+				}
+			}
+		} else if (!ChangerUtils.acceptsChange(toParse, ChangeMode.SET, classInfo.getC())) {
+			Skript.error(toParse + " can't be set to " + classInfo.getName().withIndefiniteArticle());
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	protected void execute(Event event) {
+		if (toParse instanceof ExpressionList<String> toParseExpressions) {
+			for (int i = 0; i < toParseExpressions.getAllExpressions().size(); i++) {
+				Expression<String> expression = (Expression<String>) toParseExpressions.getAllExpressions().get(i);
+				expression.changeInPlace(event, (stringToParse) -> Classes.parseSimple(stringToParse, classInfo.getC(), ParseContext.PARSE));
+			}
+		} else {
+			toParse.changeInPlace(event, (stringToParse) -> Classes.parseSimple(stringToParse, classInfo.getC(), ParseContext.PARSE));
+		}
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "parse " + toParse + " as " + classInfo.getName().withIndefiniteArticle();
+	}
+
+}

--- a/src/test/skript/tests/syntaxes/effects/EffParse.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffParse.sk
@@ -1,0 +1,25 @@
+test "parse effect":
+	# test single value
+	set {_value} to "5"
+	parse {_value} as int
+	assert {_value} = 5 with "couldn't parse a single value"
+
+	set {_value} to "a"
+	parse {_value} as int
+	assert {_value} isn't set with "failed parse didn't delete the value"
+
+	# test lists
+	set {_values::*} to "1", "2a", "3"
+    parse {_values::*} as int
+    assert {_values::1} = 1 with "couldn't parse a list - 1"
+    assert {_values::2} isn't set with "couldn't parse a list - 2"
+    assert {_values::3} = 3 with "couldn't parse a list - 3"
+
+	# test multiple expressions
+	set {_a} to "3"
+	set {_b} to "hello"
+	set {_c} to "5"
+	parse {_a}, {_b} and {_c} as int
+    assert {_a} = 3 with "couldn't parse multiple expressions - 1"
+    assert {_b} isn't set with "couldn't parse multiple expressions - 2"
+    assert {_c} = 5 with "couldn't parse multiple expressions - 3"


### PR DESCRIPTION
### Description
This PR adds the `parse %~strings% as %*classinfo%` effect and tests for it.

Examples:
```
set {a} to "5"
parse {a} as integer   # overwrites {a}
send {a} + 1   # 6
```
```
command clan <action: string> <other: string>:
  trigger:
    if {_action} is "invite":
      parse {_other} as player
      invite({_other})
    else if {_action} is "set-max-members":
      parse {_other} as int
      setSize({_other})
```

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #3561 