### PR TITLE
Fix Invalid Equipment Slots in CondIsWearing

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondIsWearing.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsWearing.java
@@ -57,7 +57,6 @@ public class CondIsWearing extends Condition {
 	
 	@Override
 	public boolean check(Event event) {
-		Skript.info(HAS_BODY_SLOT ? "Has body slot" : "Does not have body slot");
 		ItemType[] cachedTypes = types.getAll(event);
 
 		return entities.check(event, entity -> {

--- a/src/main/java/ch/njol/skript/conditions/CondIsWearing.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsWearing.java
@@ -59,6 +59,7 @@ public class CondIsWearing extends Condition {
 				return false; // spigot nullability, no identifier as to why this occurs
 
 			ItemStack[] contents = Arrays.stream(EquipmentSlot.values())
+				.filter(entity::canUseEquipmentSlot)
 				.map(equipment::getItem)
 				.toArray(ItemStack[]::new);
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsWearing.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsWearing.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 public class CondIsWearing extends Condition {
 
 	private static final boolean HAS_CAN_USE_SLOT_METHOD = Skript.methodExists(LivingEntity.class, "canUseEquipmentSlot", EquipmentSlot.class);
+	private static final boolean HAS_BODY_SLOT = Skript.fieldExists(EquipmentSlot.class, "BODY");
 	
 	static {
 		PropertyCondition.register(CondIsWearing.class, "wearing %itemtypes%", "livingentities");
@@ -56,6 +57,7 @@ public class CondIsWearing extends Condition {
 	
 	@Override
 	public boolean check(Event event) {
+		Skript.info(HAS_BODY_SLOT ? "Has body slot" : "Does not have body slot");
 		ItemType[] cachedTypes = types.getAll(event);
 
 		return entities.check(event, entity -> {
@@ -65,14 +67,16 @@ public class CondIsWearing extends Condition {
 
 			ItemStack[] contents = Arrays.stream(EquipmentSlot.values())
 				.filter(slot -> {
+					// this method was added in 1.20.6
 					if (HAS_CAN_USE_SLOT_METHOD)
 						return entity.canUseEquipmentSlot(slot);
 
 					// according to wiki it appears to be that these are the only ones with a body equipment slot
-					if (slot == EquipmentSlot.BODY)
+					// body slot was added in 1.20.5
+					if (HAS_BODY_SLOT && slot == EquipmentSlot.BODY)
 						return entity instanceof Donkey || entity instanceof Mule;
 
-					return false;
+					return true;
 				})
 				.map(equipment::getItem)
 				.toArray(ItemStack[]::new);

--- a/src/main/java/ch/njol/skript/conditions/CondIsWearing.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsWearing.java
@@ -13,9 +13,7 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
-import org.bukkit.entity.Donkey;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Mule;
+import org.bukkit.entity.*;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.EquipmentSlot;
@@ -70,10 +68,13 @@ public class CondIsWearing extends Condition {
 					if (HAS_CAN_USE_SLOT_METHOD)
 						return entity.canUseEquipmentSlot(slot);
 
-					// according to wiki it appears to be that these are the only ones with a body equipment slot
 					// body slot was added in 1.20.5
 					if (HAS_BODY_SLOT && slot == EquipmentSlot.BODY)
-						return entity instanceof Donkey || entity instanceof Mule;
+						// this may change in the future, but for now this is the only way to figure out
+						// if the entity can use the body slot
+						return entity instanceof Horse
+							|| entity instanceof Wolf
+							|| entity instanceof Llama;
 
 					return true;
 				})

--- a/src/test/java/org/skriptlang/skript/test/tests/regression/MissingCheckIfEntityCanUseSlot7524Test.java
+++ b/src/test/java/org/skriptlang/skript/test/tests/regression/MissingCheckIfEntityCanUseSlot7524Test.java
@@ -1,0 +1,65 @@
+package org.skriptlang.skript.test.tests.regression;
+
+import ch.njol.skript.lang.Condition;
+import ch.njol.skript.lang.util.ContextlessEvent;
+import ch.njol.skript.test.runner.SkriptJUnitTest;
+import ch.njol.skript.variables.Variables;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MissingCheckIfEntityCanUseSlot7524Test extends SkriptJUnitTest {
+
+	private Player player;
+	private EntityEquipment equipment;
+	private Condition isWearingCondition;
+
+	@Before
+	public void setup() {
+		player = EasyMock.niceMock(Player.class);
+		equipment = EasyMock.niceMock(EntityEquipment.class);
+
+		isWearingCondition = Condition.parse("{_player} is wearing diamond chestplate", null);
+		if (isWearingCondition == null)
+			throw new IllegalStateException();
+	}
+
+	@Test
+	public void test() {
+		ContextlessEvent event = ContextlessEvent.get();
+		Variables.setVariable("player", player, event, true);
+
+		EasyMock.expect(player.isValid()).andStubReturn(true);
+		EasyMock.expect(player.getEquipment()).andReturn(equipment);
+
+		EasyMock.expect(player.canUseEquipmentSlot(EquipmentSlot.CHEST)).andReturn(true);
+		EasyMock.expect(player.canUseEquipmentSlot(EquipmentSlot.LEGS)).andReturn(true);
+		EasyMock.expect(player.canUseEquipmentSlot(EquipmentSlot.FEET)).andReturn(true);
+		EasyMock.expect(player.canUseEquipmentSlot(EquipmentSlot.HEAD)).andReturn(true);
+		EasyMock.expect(player.canUseEquipmentSlot(EquipmentSlot.HAND)).andReturn(true);
+		EasyMock.expect(player.canUseEquipmentSlot(EquipmentSlot.OFF_HAND)).andReturn(true);
+		EasyMock.expect(player.canUseEquipmentSlot(EquipmentSlot.BODY)).andReturn(false);
+
+		EasyMock.expect(equipment.getItem(EquipmentSlot.CHEST)).andReturn(new ItemStack(Material.DIAMOND_CHESTPLATE));
+		EasyMock.expect(equipment.getItem(EquipmentSlot.LEGS)).andReturn(new ItemStack(Material.DIAMOND_LEGGINGS));
+		EasyMock.expect(equipment.getItem(EquipmentSlot.FEET)).andReturn(new ItemStack(Material.DIAMOND_BOOTS));
+		EasyMock.expect(equipment.getItem(EquipmentSlot.HEAD)).andReturn(new ItemStack(Material.DIAMOND_HELMET));
+		EasyMock.expect(equipment.getItem(EquipmentSlot.HAND)).andReturn(new ItemStack(Material.DIAMOND_SWORD));
+		EasyMock.expect(equipment.getItem(EquipmentSlot.OFF_HAND)).andReturn(new ItemStack(Material.DIAMOND_SHOVEL));
+
+		EasyMock.replay(player, equipment);
+
+		isWearingCondition.run(event);
+
+		EasyMock.verify(player, equipment);
+
+		Assert.assertTrue(isWearingCondition.evaluate(event).isTrue());
+	}
+
+}

--- a/src/test/java/org/skriptlang/skript/test/tests/regression/MissingCheckIfEntityCanUseSlot7524Test.java
+++ b/src/test/java/org/skriptlang/skript/test/tests/regression/MissingCheckIfEntityCanUseSlot7524Test.java
@@ -1,10 +1,12 @@
 package org.skriptlang.skript.test.tests.regression;
 
+import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.util.ContextlessEvent;
 import ch.njol.skript.test.runner.SkriptJUnitTest;
 import ch.njol.skript.variables.Variables;
 import org.bukkit.Material;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.EquipmentSlot;
@@ -15,6 +17,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class MissingCheckIfEntityCanUseSlot7524Test extends SkriptJUnitTest {
+
+	private static final boolean HAS_CAN_USE_SLOT_METHOD = Skript.methodExists(LivingEntity.class, "canUseEquipmentSlot", EquipmentSlot.class);
 
 	private Player player;
 	private EntityEquipment equipment;
@@ -38,28 +42,23 @@ public class MissingCheckIfEntityCanUseSlot7524Test extends SkriptJUnitTest {
 		EasyMock.expect(player.isValid()).andStubReturn(true);
 		EasyMock.expect(player.getEquipment()).andReturn(equipment);
 
-		EasyMock.expect(player.canUseEquipmentSlot(EquipmentSlot.CHEST)).andReturn(true);
-		EasyMock.expect(player.canUseEquipmentSlot(EquipmentSlot.LEGS)).andReturn(true);
-		EasyMock.expect(player.canUseEquipmentSlot(EquipmentSlot.FEET)).andReturn(true);
-		EasyMock.expect(player.canUseEquipmentSlot(EquipmentSlot.HEAD)).andReturn(true);
-		EasyMock.expect(player.canUseEquipmentSlot(EquipmentSlot.HAND)).andReturn(true);
-		EasyMock.expect(player.canUseEquipmentSlot(EquipmentSlot.OFF_HAND)).andReturn(true);
-		EasyMock.expect(player.canUseEquipmentSlot(EquipmentSlot.BODY)).andReturn(false);
+		if (HAS_CAN_USE_SLOT_METHOD) {
+			EasyMock.expect(player.canUseEquipmentSlot(EquipmentSlot.CHEST)).andReturn(true);
+			EasyMock.expect(player.canUseEquipmentSlot(EquipmentSlot.LEGS)).andReturn(true);
+			EasyMock.expect(player.canUseEquipmentSlot(EquipmentSlot.FEET)).andReturn(true);
+			EasyMock.expect(player.canUseEquipmentSlot(EquipmentSlot.HEAD)).andReturn(true);
+			EasyMock.expect(player.canUseEquipmentSlot(EquipmentSlot.HAND)).andReturn(true);
+			EasyMock.expect(player.canUseEquipmentSlot(EquipmentSlot.OFF_HAND)).andReturn(true);
+			EasyMock.expect(player.canUseEquipmentSlot(EquipmentSlot.BODY)).andReturn(false);
+		}
 
 		EasyMock.expect(equipment.getItem(EquipmentSlot.CHEST)).andReturn(new ItemStack(Material.DIAMOND_CHESTPLATE));
-		EasyMock.expect(equipment.getItem(EquipmentSlot.LEGS)).andReturn(new ItemStack(Material.DIAMOND_LEGGINGS));
-		EasyMock.expect(equipment.getItem(EquipmentSlot.FEET)).andReturn(new ItemStack(Material.DIAMOND_BOOTS));
-		EasyMock.expect(equipment.getItem(EquipmentSlot.HEAD)).andReturn(new ItemStack(Material.DIAMOND_HELMET));
-		EasyMock.expect(equipment.getItem(EquipmentSlot.HAND)).andReturn(new ItemStack(Material.DIAMOND_SWORD));
-		EasyMock.expect(equipment.getItem(EquipmentSlot.OFF_HAND)).andReturn(new ItemStack(Material.DIAMOND_SHOVEL));
 
 		EasyMock.replay(player, equipment);
 
-		isWearingCondition.run(event);
+		assert isWearingCondition.check(event);
 
 		EasyMock.verify(player, equipment);
-
-		Assert.assertTrue(isWearingCondition.evaluate(event).isTrue());
 	}
 
 }


### PR DESCRIPTION
### Description
This PR fixes a missing check whether an entity can use an equipment slot. For example, players cannot use the `body` equipment slot, causing an exception when using `CondIsWearing`. This was fixed by filtering the entities that can use the equipment slot inside the stream before calling `EntityEquipment#getItem(EquipmentSlot)`

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7524 <!-- Links to related issues -->
