### PR TITLE
Enable regex based highlighting for runtime errors

### DIFF
--- a/src/main/java/org/skriptlang/skript/bukkit/log/runtime/BukkitRuntimeErrorConsumer.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/log/runtime/BukkitRuntimeErrorConsumer.java
@@ -67,7 +67,7 @@ public class BukkitRuntimeErrorConsumer implements RuntimeErrorConsumer {
 		ErrorSource source = error.source();
 		String code = source.lineText();
 		if (error.toHighlight() != null && !error.toHighlight().isEmpty())
-			code = code.replace("§", "&").replace(error.toHighlight(), "§f§n" + error.toHighlight() + "§7");
+			code = code.replace("§", "&").replaceFirst(error.toHighlight(), "§f§n$0§7");
 
 		SkriptLogger.sendFormatted(Bukkit.getConsoleSender(),
 				String.format(skriptInfo, source.script(), source.syntaxName(), source.syntaxType()) +

--- a/src/main/java/org/skriptlang/skript/log/runtime/RuntimeError.java
+++ b/src/main/java/org/skriptlang/skript/log/runtime/RuntimeError.java
@@ -10,5 +10,6 @@ import java.util.logging.Level;
  * @param source The source of the error
  * @param error The message to display as the error
  * @param toHighlight Optionally, the text within the emitting line to highlight.
+ *                    This should be treated as a regex pattern and will highlight the first match it finds.
  */
 public record RuntimeError(Level level, ErrorSource source, String error, @Nullable String toHighlight) { }


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Treats the highlight text as a regex pattern to allow more flexible highlighting in errors.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7446 <!-- Links to related issues -->
