### PR TITLE
Fix cast exception when using invalid classes with CondIsTagged

### DIFF
--- a/src/main/java/org/skriptlang/skript/bukkit/tags/elements/CondIsTagged.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/tags/elements/CondIsTagged.java
@@ -60,10 +60,15 @@ public class CondIsTagged extends Condition {
  		return elements.check(event, element -> {
 			boolean isAny = (element instanceof ItemType itemType && !itemType.isAll());
 			Keyed[] values = TagModule.getKeyed(element);
-			if (values == null)
+			if (values == null || values.length == 0)
 				return false;
 
+			Class<? extends Keyed> valueClass = values[0].getClass();
+
 			for (Tag<Keyed> tag : tags) {
+				// cursed check to ensure the tag is the same type as the values
+				if (!tag.getValues().iterator().next().getClass().isAssignableFrom(valueClass))
+					return false;
 				 if (isTagged(tag, values, !isAny)) {
 					 if (!and)
 						 return true;

--- a/src/test/skript/tests/syntaxes/conditions/CondIsTagged.sk
+++ b/src/test/skript/tests/syntaxes/conditions/CondIsTagged.sk
@@ -13,4 +13,7 @@ test "CondIsTagged":
 
 	spawn a skeleton at spawn of world "world":
 		assert entity is tagged as entity tag "minecraft:skeletons" with "skeleton is not a skeleton"
+		assert entity is not tagged as item tag "doors" with "failed to handle checking entity for item tag"
 		delete entity
+
+	assert stone sword is not tagged as entity tag "skeletons" with "failed to handle checking item for entity tag"


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Adds a check to ensure the value and the tag are actually valid to use with `isTagged()`. This is honestly a pretty awkward problem and I think the solution i have is reasonable, but not ideal. Better ideas welcome.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7452 <!-- Links to related issues -->
