### PR TITLE
Config Option 'variable changes until save'

### DIFF
--- a/src/main/java/ch/njol/skript/SkriptConfig.java
+++ b/src/main/java/ch/njol/skript/SkriptConfig.java
@@ -21,6 +21,7 @@ import ch.njol.skript.util.Timespan;
 import ch.njol.skript.util.Version;
 import ch.njol.skript.util.chat.ChatMessages;
 import ch.njol.skript.util.chat.LinkParseMode;
+import ch.njol.skript.variables.FlatFileStorage;
 import ch.njol.skript.variables.Variables;
 import co.aikar.timings.Timings;
 import org.bukkit.event.EventPriority;
@@ -370,6 +371,9 @@ public class SkriptConfig {
 
 	public static final Option<Integer> runtimeErrorTimeoutDuration = new Option<>("runtime errors.error timeout length", 10);
 	public static final Option<Integer> runtimeWarningTimeoutDuration = new Option<>("runtime errors.warning timeout length", 10);
+
+	public static final Option<Integer> variableChangesUntilSave = new Option<>("variable changes until save", 1000)
+		.setter(FlatFileStorage::setRequiredChangesForResave);
 
 	/**
 	 * This should only be used in special cases

--- a/src/main/java/ch/njol/skript/config/Config.java
+++ b/src/main/java/ch/njol/skript/config/Config.java
@@ -223,6 +223,7 @@ public class Config implements Comparable<Config>, Validated, NodeNavigator, Any
 		if (nodesToUpdate.isEmpty())
 			return false;
 
+		int pushed = 0;
 		for (Node node : nodesToUpdate) {
 			/*
 			 prevents nodes that are already in the config from being added again
@@ -271,8 +272,9 @@ public class Config implements Comparable<Config>, Validated, NodeNavigator, Any
 			if (existing != null) {
 				// there's already something at the node we want to add the new node
 
-				Skript.debug("Adding node %s to %s at index %s", node, parent, index);
-				parent.add(index, node);
+				Skript.debug("Adding node %s to %s at index %s", node, parent, index + pushed);
+				parent.add(index + pushed, node);
+				pushed++;
 			} else {
 				// there's nothing at the index we want to add the new node
 

--- a/src/main/java/ch/njol/skript/config/Config.java
+++ b/src/main/java/ch/njol/skript/config/Config.java
@@ -269,7 +269,7 @@ public class Config implements Comparable<Config>, Validated, NodeNavigator, Any
 			}
 
 			Node existing = parent.getAt(index);
-			if (existing != null) {
+			if (existing != null && parent.size() >= index + pushed) {
 				// there's already something at the node we want to add the new node
 
 				Skript.debug("Adding node %s to %s at index %s", node, parent, index + pushed);

--- a/src/main/java/ch/njol/skript/variables/FlatFileStorage.java
+++ b/src/main/java/ch/njol/skript/variables/FlatFileStorage.java
@@ -76,7 +76,7 @@ public class FlatFileStorage extends VariablesStorage {
 	 * The amount of {@link #changes} needed
 	 * for a new {@link #saveVariables(boolean) save}.
 	 */
-	private static final int REQUIRED_CHANGES_FOR_RESAVE = 1000;
+	private static int REQUIRED_CHANGES_FOR_RESAVE = 1000;
 
 	/**
 	 * The amount of variable changes written since the last full save.
@@ -604,6 +604,19 @@ public class FlatFileStorage extends VariablesStorage {
 		}
 
 		printWriter.println();
+	}
+
+	/**
+	 * Change the required amount of variable changes until variables are saved.
+	 * Cannot be zero or less.
+	 * @param value
+	 */
+	public static void setRequiredChangesForResave(int value) {
+		if (value <= 0) {
+			Skript.warning("Variable changes until save cannot be zero or less. Using default of 1000.");
+			value = 1000;
+		}
+		REQUIRED_CHANGES_FOR_RESAVE = value;
 	}
 
 }

--- a/src/main/resources/config.sk
+++ b/src/main/resources/config.sk
@@ -234,6 +234,14 @@ long parse time warning threshold: 0 seconds
 #   stating that the statement has taken a long time to parse.
 # A value of 0 seconds means that this warning should be disabled.
 
+variable changes until save: 1000
+# This setting controls the total number of times that global variables need to be changed
+#   until saving variables to 'variables.csv'.
+# 'set {a} to 1' is one change, 'set {b} to 2' now makes it two.
+# You cannot provide a value of zero or less.
+# WARNING: This setting should be used at your own discretion.
+#          This setting can lag your server depending on how often variables get saved and
+#          the number of variables needing to be saved.
 
 # ==== Runtime Errors ====
 


### PR DESCRIPTION
### Description
This PR aims to add a new config option allowing users to customize the number of variable changes required to be saved.

This also semi-fixes the config updater, as the copied nodes from the resource config, resulted in being in the reverse order.
Before:

https://github.com/user-attachments/assets/c0cfeceb-647e-4469-a981-4c5b7deb5a3a

After:

https://github.com/user-attachments/assets/b80f41f5-a2a6-4113-9355-71fcc333a662


---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
