### PR TITLE
Parsing stack (#5277)

### DIFF
--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -12,7 +12,9 @@ import ch.njol.skript.expressions.ExprParse;
 import ch.njol.skript.lang.function.ExprFunctionCall;
 import ch.njol.skript.lang.function.FunctionReference;
 import ch.njol.skript.lang.function.Functions;
+import ch.njol.skript.lang.parser.ParseStackOverflowException;
 import ch.njol.skript.lang.parser.ParserInstance;
+import ch.njol.skript.lang.parser.ParsingStack;
 import ch.njol.skript.lang.util.SimpleLiteral;
 import ch.njol.skript.localization.Language;
 import ch.njol.skript.localization.Message;
@@ -183,6 +185,7 @@ public class SkriptParser {
 	}
 
 	private <T extends SyntaxElement> @Nullable T parse(Iterator<? extends SyntaxElementInfo<? extends T>> source) {
+		ParsingStack parsingStack = getParser().getParsingStack();
 		try (ParseLogHandler log = SkriptLogger.startParseLogHandler()) {
 			while (source.hasNext()) {
 				SyntaxElementInfo<? extends T> info = source.next();
@@ -193,15 +196,25 @@ public class SkriptParser {
 						assert pattern != null;
 						ParseResult parseResult;
 						try {
+							parsingStack.push(new ParsingStack.Element(info, i));
 							parseResult = parse_i(pattern);
 						} catch (MalformedPatternException e) {
 							String message = "pattern compiling exception, element class: " + info.getElementClass().getName();
 							try {
 								JavaPlugin providingPlugin = JavaPlugin.getProvidingPlugin(info.getElementClass());
 								message += " (provided by " + providingPlugin.getName() + ")";
-							} catch (IllegalArgumentException | IllegalStateException ignored) {}
-							throw new RuntimeException(message, e);
+							} catch (IllegalArgumentException | IllegalStateException ignored) {
+							}
 
+							throw new RuntimeException(message, e);
+						} catch (StackOverflowError e) {
+							// Parsing caused a stack overflow, possibly due to too long lines
+							throw new ParseStackOverflowException(e, new ParsingStack(parsingStack));
+						} finally {
+							// Recursive parsing call done, pop the element from the parsing stack
+							ParsingStack.Element stackElement = parsingStack.pop();
+
+							assert stackElement.getSyntaxElementInfo() == info && stackElement.getPatternIndex() == i;
 						}
 						if (parseResult != null) {
 							assert parseResult.source != null; // parse results from parse_i have a source
@@ -249,6 +262,8 @@ public class SkriptParser {
 					}
 				}
 			}
+
+			// No successful syntax elements parsed, print errors and return
 			log.printError();
 			return null;
 		}

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -196,7 +196,7 @@ public class SkriptParser {
 						assert pattern != null;
 						ParseResult parseResult;
 						try {
-							parsingStack.push(new ParsingStack.Element(info, i));
+							parsingStack.push(new ParsingStack.Element(info, patternIndex));
 							parseResult = parse_i(pattern);
 						} catch (MalformedPatternException e) {
 							String message = "pattern compiling exception, element class: " + info.getElementClass().getName();
@@ -213,7 +213,7 @@ public class SkriptParser {
 							// Recursive parsing call done, pop the element from the parsing stack
 							ParsingStack.Element stackElement = parsingStack.pop();
 
-							assert stackElement.getSyntaxElementInfo() == info && stackElement.getPatternIndex() == i;
+							assert stackElement.syntaxElementInfo() == info && stackElement.patternIndex() == patternIndex;
 						}
 						if (parseResult != null) {
 							assert parseResult.source != null; // parse results from parse_i have a source

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -203,8 +203,7 @@ public class SkriptParser {
 							try {
 								JavaPlugin providingPlugin = JavaPlugin.getProvidingPlugin(info.getElementClass());
 								message += " (provided by " + providingPlugin.getName() + ")";
-							} catch (IllegalArgumentException | IllegalStateException ignored) {
-							}
+							} catch (IllegalArgumentException | IllegalStateException ignored) { }
 
 							throw new RuntimeException(message, e);
 						} catch (StackOverflowError e) {

--- a/src/main/java/ch/njol/skript/lang/parser/ParseStackOverflowException.java
+++ b/src/main/java/ch/njol/skript/lang/parser/ParseStackOverflowException.java
@@ -1,0 +1,50 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.lang.parser;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+/**
+ * An exception noting that a {@link StackOverflowError} has occurred
+ * during Skript parsing. Contains information about the {@link ParsingStack}
+ * from when the stack overflow occurred.
+ */
+public class ParseStackOverflowException extends RuntimeException {
+
+	private final ParsingStack parsingStack;
+
+	public ParseStackOverflowException(StackOverflowError cause, ParsingStack parsingStack) {
+		super(createMessage(parsingStack), cause);
+		this.parsingStack = parsingStack;
+	}
+
+	/**
+	 * Creates the exception message from the given {@link ParsingStack}.
+	 */
+	private static String createMessage(ParsingStack stack) {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+		PrintStream printStream = new PrintStream(baos);
+		stack.print(printStream);
+
+		return baos.toString();
+	}
+
+}

--- a/src/main/java/ch/njol/skript/lang/parser/ParseStackOverflowException.java
+++ b/src/main/java/ch/njol/skript/lang/parser/ParseStackOverflowException.java
@@ -1,21 +1,3 @@
-/**
- *   This file is part of Skript.
- *
- *  Skript is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  Skript is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Copyright Peter Güttinger, SkriptLang team and contributors
- */
 package ch.njol.skript.lang.parser;
 
 import java.io.ByteArrayOutputStream;
@@ -28,7 +10,7 @@ import java.io.PrintStream;
  */
 public class ParseStackOverflowException extends RuntimeException {
 
-	private final ParsingStack parsingStack;
+	protected final ParsingStack parsingStack;
 
 	public ParseStackOverflowException(StackOverflowError cause, ParsingStack parsingStack) {
 		super(createMessage(parsingStack), cause);
@@ -39,12 +21,12 @@ public class ParseStackOverflowException extends RuntimeException {
 	 * Creates the exception message from the given {@link ParsingStack}.
 	 */
 	private static String createMessage(ParsingStack stack) {
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ByteArrayOutputStream stream = new ByteArrayOutputStream();
 
-		PrintStream printStream = new PrintStream(baos);
+		PrintStream printStream = new PrintStream(stream);
 		stack.print(printStream);
 
-		return baos.toString();
+		return stream.toString();
 	}
 
 }

--- a/src/main/java/ch/njol/skript/lang/parser/ParserInstance.java
+++ b/src/main/java/ch/njol/skript/lang/parser/ParserInstance.java
@@ -465,6 +465,11 @@ public final class ParserInstance implements Experimented {
 
 	private final ParsingStack parsingStack = new ParsingStack();
 
+	/**
+	 * Gets the current parsing stack.
+	 * <p>
+	 * Although the stack can be modified, doing so is not recommended.
+	 */
 	public ParsingStack getParsingStack() {
 		return parsingStack;
 	}

--- a/src/main/java/ch/njol/skript/lang/parser/ParserInstance.java
+++ b/src/main/java/ch/njol/skript/lang/parser/ParserInstance.java
@@ -461,6 +461,14 @@ public final class ParserInstance implements Experimented {
 		return indentation;
 	}
 
+	// Parsing stack
+
+	private final ParsingStack parsingStack = new ParsingStack();
+
+	public ParsingStack getParsingStack() {
+		return parsingStack;
+	}
+
 	// Experiments API
 
 	@Override

--- a/src/main/java/ch/njol/skript/lang/parser/ParserInstance.java
+++ b/src/main/java/ch/njol/skript/lang/parser/ParserInstance.java
@@ -25,11 +25,7 @@ import org.skriptlang.skript.lang.script.Script;
 import org.skriptlang.skript.lang.structure.Structure;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Function;
 
 public final class ParserInstance implements Experimented {
@@ -718,8 +714,8 @@ public final class ParserInstance implements Experimented {
 	@Deprecated
 	public @Nullable SkriptEvent getCurrentSkriptEvent() {
 		Structure structure = getCurrentStructure();
-		if (structure instanceof SkriptEvent)
-			return (SkriptEvent) structure;
+		if (structure instanceof SkriptEvent event)
+			return event;
 		return null;
 	}
 
@@ -728,7 +724,7 @@ public final class ParserInstance implements Experimented {
 	 */
 	@Deprecated
 	public void setCurrentSkriptEvent(@Nullable SkriptEvent currentSkriptEvent) {
-		setCurrentStructure(currentSkriptEvent);
+		this.setCurrentStructure(currentSkriptEvent);
 	}
 
 	/**
@@ -736,7 +732,7 @@ public final class ParserInstance implements Experimented {
 	 */
 	@Deprecated
 	public void deleteCurrentSkriptEvent() {
-		setCurrentStructure(null);
+		this.setCurrentStructure(null);
 	}
 
 	/**

--- a/src/main/java/ch/njol/skript/lang/parser/ParsingStack.java
+++ b/src/main/java/ch/njol/skript/lang/parser/ParsingStack.java
@@ -71,6 +71,8 @@ public class ParsingStack implements Iterable<ParsingStack.Element> {
 	 * Returns the element at the given index in the stack,
 	 * starting with the top element at index 0.
 	 *
+	 * @param index the index in stack.
+	 *
 	 * @throws IndexOutOfBoundsException if the index is not appointed
 	 * 									  to an element in the stack.
 	 */
@@ -119,6 +121,8 @@ public class ParsingStack implements Iterable<ParsingStack.Element> {
 
 	/**
 	 * Prints this stack to the given {@link PrintStream}.
+	 *
+	 * @param printStream a {@link PrintStream} to print the stack to.
 	 */
 	public void print(PrintStream printStream) {
 		// Synchronized to assure it'll all be printed at once,

--- a/src/main/java/ch/njol/skript/lang/parser/ParsingStack.java
+++ b/src/main/java/ch/njol/skript/lang/parser/ParsingStack.java
@@ -144,20 +144,7 @@ public class ParsingStack implements Iterable<ParsingStack.Element> {
 	 */
 	@Override
 	public Iterator<Element> iterator() {
-		Iterator<Element> iterator = stack.iterator();
-
-		// Wrap iterator to disable element removal support
-		return new Iterator<Element>() {
-			@Override
-			public boolean hasNext() {
-				return iterator.hasNext();
-			}
-
-			@Override
-			public Element next() {
-				return iterator.next();
-			}
-		};
+		return Collections.unmodifiableList(stack).iterator();
 	}
 
 	/**

--- a/src/main/java/ch/njol/skript/lang/parser/ParsingStack.java
+++ b/src/main/java/ch/njol/skript/lang/parser/ParsingStack.java
@@ -25,6 +25,7 @@ import ch.njol.skript.lang.SyntaxElementInfo;
 import ch.njol.util.Kleenean;
 
 import java.io.PrintStream;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 

--- a/src/main/java/ch/njol/skript/lang/parser/ParsingStack.java
+++ b/src/main/java/ch/njol/skript/lang/parser/ParsingStack.java
@@ -71,8 +71,8 @@ public class ParsingStack implements Iterable<ParsingStack.Element> {
 	 * Returns the element at the given index in the stack,
 	 * starting with the top element at index 0.
 	 *
-	 * @throws IndexOutOfBoundsException if the given index does not point to
-	 * 										an element in the stack.
+	 * @throws IndexOutOfBoundsException if the index is not appointed
+	 * 									  to an element in the stack.
 	 */
 	public Element peek(int index) throws IndexOutOfBoundsException {
 		if (index < 0 || index >= size()) {
@@ -99,8 +99,8 @@ public class ParsingStack implements Iterable<ParsingStack.Element> {
 	/**
 	 * Adds the given element to the top of the stack.
 	 */
-	public void push(Element e) {
-		stack.push(e);
+	public void push(Element element) {
+		stack.push(element);
 	}
 
 	/**
@@ -132,8 +132,8 @@ public class ParsingStack implements Iterable<ParsingStack.Element> {
 				printStream.println("<empty>");
 			} else {
 				for (Element element : stack) {
-					printStream.println("\t" + element.getSyntaxElementClass().getName()
-						+ " @ " + element.getPatternIndex());
+					printStream.println("\t" + element.getSyntaxElementClass().getName() +
+						" @ " + element.getPatternIndex());
 				}
 			}
 		}
@@ -210,7 +210,7 @@ public class ParsingStack implements Iterable<ParsingStack.Element> {
 		}
 
 		/**
-		 * Gets all patterns registered with syntax element
+		 * Gets all patterns registered with the syntax element
 		 * of this stack element.
 		 */
 		public String[] getPatterns() {

--- a/src/main/java/ch/njol/skript/lang/parser/ParsingStack.java
+++ b/src/main/java/ch/njol/skript/lang/parser/ParsingStack.java
@@ -1,0 +1,152 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright Peter Güttinger, SkriptLang team and contributors
+ */
+package ch.njol.skript.lang.parser;
+
+import ch.njol.skript.lang.SyntaxElement;
+import ch.njol.skript.lang.SyntaxElementInfo;
+
+import java.io.PrintStream;
+import java.util.Iterator;
+import java.util.Stack;
+
+/**
+ * A stack that keeps track of what Skript is currently parsing.
+ */
+public class ParsingStack implements Iterable<ParsingStack.Element> {
+
+	private final Stack<Element> stack;
+
+	/**
+	 * Creates an empty parsing stack.
+	 */
+	public ParsingStack() {
+		this.stack = new Stack<>();
+	}
+
+	/**
+	 * Creates a parsing stack containing all elements
+	 * of another given parsing stack.
+	 */
+	public ParsingStack(ParsingStack parsingStack) {
+		Stack<Element> stack = new Stack<>();
+		stack.addAll(parsingStack.stack);
+		this.stack = stack;
+	}
+
+	/**
+	 * Removes and returns the top element of this stack.
+	 */
+	public Element pop() {
+		return stack.pop();
+	}
+
+	/**
+	 * Adds the given element to the top of the stack.
+	 */
+	public void push(Element e) {
+		stack.push(e);
+	}
+
+	/**
+	 * Check if this stack is empty.
+	 */
+	public boolean isEmpty() {
+		return stack.isEmpty();
+	}
+
+	/**
+	 * Prints this stack to the given {@link PrintStream}.
+	 */
+	public void print(PrintStream printStream) {
+		// Synchronized to assure it'll all be printed at once,
+		//  PrintStream uses synchronization on itself internally, justifying warning suppression
+
+		//noinspection SynchronizationOnLocalVariableOrMethodParameter
+		synchronized (printStream) {
+			printStream.println("Stack:");
+
+			for (Element element : stack) {
+				printStream.println("\t" + element.getSyntaxElementClass().getName() + " @ " + element.getPatternIndex());
+			}
+		}
+	}
+
+	@Override
+	public Iterator<Element> iterator() {
+		return stack.iterator();
+	}
+
+	/**
+	 * A stack element, containing details about the syntax element it is about.
+	 */
+	public static class Element {
+
+		private final SyntaxElementInfo<?> syntaxElementInfo;
+		private final int patternIndex;
+
+		public Element(SyntaxElementInfo<?> syntaxElementInfo, int patternIndex) {
+			this.syntaxElementInfo = syntaxElementInfo;
+			this.patternIndex = patternIndex;
+		}
+
+		/**
+		 * Gets the raw {@link SyntaxElementInfo} of this stack element.
+		 * <p>
+		 * For ease of use, consider using other getters of this class.
+		 *
+		 * @see #getSyntaxElementClass()
+		 * @see #getPattern()
+		 */
+		public SyntaxElementInfo<?> getSyntaxElementInfo() {
+			return syntaxElementInfo;
+		}
+
+		/**
+		 * Gets the index to the registered patterns for the syntax element
+		 * of this stack element.
+		 */
+		public int getPatternIndex() {
+			return patternIndex;
+		}
+
+		/**
+		 * Gets the syntax element class of this stack element.
+		 */
+		public Class<? extends SyntaxElement> getSyntaxElementClass() {
+			return syntaxElementInfo.getElementClass();
+		}
+
+		/**
+		 * Gets the pattern that was matched for this stack element.
+		 */
+		public String getPattern() {
+			return syntaxElementInfo.getPatterns()[patternIndex];
+		}
+
+		/**
+		 * Gets all patterns registered with syntax element
+		 * of this stack element.
+		 */
+		public String[] getPatterns() {
+			return syntaxElementInfo.getPatterns();
+		}
+
+	}
+
+}

--- a/src/main/java/ch/njol/skript/lang/parser/ParsingStack.java
+++ b/src/main/java/ch/njol/skript/lang/parser/ParsingStack.java
@@ -26,7 +26,7 @@ import ch.njol.util.Kleenean;
 
 import java.io.PrintStream;
 import java.util.Iterator;
-import java.util.Stack;
+import java.util.LinkedList;
 
 /**
  * A stack that keeps track of what Skript is currently parsing.
@@ -37,13 +37,13 @@ import java.util.Stack;
  */
 public class ParsingStack implements Iterable<ParsingStack.Element> {
 
-	private final Stack<Element> stack;
+	private final LinkedList<Element> stack;
 
 	/**
 	 * Creates an empty parsing stack.
 	 */
 	public ParsingStack() {
-		this.stack = new Stack<>();
+		this.stack = new LinkedList<>();
 	}
 
 	/**
@@ -51,10 +51,7 @@ public class ParsingStack implements Iterable<ParsingStack.Element> {
 	 * of another given parsing stack.
 	 */
 	public ParsingStack(ParsingStack parsingStack) {
-		Stack<Element> stack = new Stack<>();
-		stack.addAll(parsingStack.stack);
-
-		this.stack = stack;
+		this.stack = new LinkedList<>(parsingStack.stack);
 	}
 
 	/**
@@ -82,7 +79,7 @@ public class ParsingStack implements Iterable<ParsingStack.Element> {
 			throw new IndexOutOfBoundsException("Index: " + index);
 		}
 
-		return stack.get(size() - index);
+		return stack.get(index);
 	}
 
 	/**
@@ -96,7 +93,7 @@ public class ParsingStack implements Iterable<ParsingStack.Element> {
 			throw new IllegalStateException("Stack is empty");
 		}
 
-		return peek(0);
+		return stack.peek();
 	}
 
 	/**
@@ -142,6 +139,9 @@ public class ParsingStack implements Iterable<ParsingStack.Element> {
 		}
 	}
 
+	/**
+	 * Iterate over the stack, starting at the top.
+	 */
 	@Override
 	public Iterator<Element> iterator() {
 		Iterator<Element> iterator = stack.iterator();

--- a/src/main/java/ch/njol/skript/lang/parser/ParsingStack.java
+++ b/src/main/java/ch/njol/skript/lang/parser/ParsingStack.java
@@ -46,14 +46,50 @@ public class ParsingStack implements Iterable<ParsingStack.Element> {
 	public ParsingStack(ParsingStack parsingStack) {
 		Stack<Element> stack = new Stack<>();
 		stack.addAll(parsingStack.stack);
+
 		this.stack = stack;
 	}
 
 	/**
 	 * Removes and returns the top element of this stack.
+	 *
+	 * @throws IllegalStateException if the stack is empty.
 	 */
-	public Element pop() {
+	public Element pop() throws IllegalStateException {
+		if (stack.isEmpty()) {
+			throw new IllegalStateException("Stack is empty");
+		}
+
 		return stack.pop();
+	}
+
+	/**
+	 * Returns the element at the given index in the stack,
+	 * starting with the top element at index 0.
+	 *
+	 * @throws IndexOutOfBoundsException if the given index does not point to
+	 * 										an element in the stack.
+	 */
+	public Element peek(int index) throws IndexOutOfBoundsException {
+		if (index < 0 || index >= size()) {
+			throw new IndexOutOfBoundsException("Index: " + index);
+		}
+
+		return stack.get(size() - index);
+	}
+
+	/**
+	 * Returns the top element of the stack.
+	 * Equivalent to {@code peek(0)}.
+	 *
+	 * @throws IllegalStateException if the stack is empty.
+	 */
+	public Element peek() throws IllegalStateException {
+		if (stack.isEmpty()) {
+			throw new IllegalStateException("Stack is empty");
+		}
+
+		return peek(0);
 	}
 
 	/**
@@ -71,6 +107,13 @@ public class ParsingStack implements Iterable<ParsingStack.Element> {
 	}
 
 	/**
+	 * Gets the size of the stack.
+	 */
+	public int size() {
+		return stack.size();
+	}
+
+	/**
 	 * Prints this stack to the given {@link PrintStream}.
 	 */
 	public void print(PrintStream printStream) {
@@ -81,15 +124,33 @@ public class ParsingStack implements Iterable<ParsingStack.Element> {
 		synchronized (printStream) {
 			printStream.println("Stack:");
 
-			for (Element element : stack) {
-				printStream.println("\t" + element.getSyntaxElementClass().getName() + " @ " + element.getPatternIndex());
+			if (stack.isEmpty()) {
+				printStream.println("<empty>");
+			} else {
+				for (Element element : stack) {
+					printStream.println("\t" + element.getSyntaxElementClass().getName()
+						+ " @ " + element.getPatternIndex());
+				}
 			}
 		}
 	}
 
 	@Override
 	public Iterator<Element> iterator() {
-		return stack.iterator();
+		Iterator<Element> iterator = stack.iterator();
+
+		// Wrap iterator to disable element removal support
+		return new Iterator<Element>() {
+			@Override
+			public boolean hasNext() {
+				return iterator.hasNext();
+			}
+
+			@Override
+			public Element next() {
+				return iterator.next();
+			}
+		};
 	}
 
 	/**
@@ -101,6 +162,8 @@ public class ParsingStack implements Iterable<ParsingStack.Element> {
 		private final int patternIndex;
 
 		public Element(SyntaxElementInfo<?> syntaxElementInfo, int patternIndex) {
+			assert patternIndex >= 0 && patternIndex < syntaxElementInfo.getPatterns().length;
+
 			this.syntaxElementInfo = syntaxElementInfo;
 			this.patternIndex = patternIndex;
 		}

--- a/src/main/java/ch/njol/skript/lang/parser/ParsingStack.java
+++ b/src/main/java/ch/njol/skript/lang/parser/ParsingStack.java
@@ -18,8 +18,11 @@
  */
 package ch.njol.skript.lang.parser;
 
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.SyntaxElement;
 import ch.njol.skript.lang.SyntaxElementInfo;
+import ch.njol.util.Kleenean;
 
 import java.io.PrintStream;
 import java.util.Iterator;
@@ -27,6 +30,10 @@ import java.util.Stack;
 
 /**
  * A stack that keeps track of what Skript is currently parsing.
+ * <p>
+ * When accessing the stack from within {@link SyntaxElement#init(Expression[], int, Kleenean, SkriptParser.ParseResult)},
+ * the stack element corresponding to that {@link SyntaxElement} is <b>not</b>
+ * on the parsing stack.
  */
 public class ParsingStack implements Iterable<ParsingStack.Element> {
 

--- a/src/main/java/ch/njol/skript/lang/parser/ParsingStack.java
+++ b/src/main/java/ch/njol/skript/lang/parser/ParsingStack.java
@@ -1,21 +1,3 @@
-/**
- *   This file is part of Skript.
- *
- *  Skript is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  Skript is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Copyright Peter Güttinger, SkriptLang team and contributors
- */
 package ch.njol.skript.lang.parser;
 
 import ch.njol.skript.lang.Expression;
@@ -32,7 +14,8 @@ import java.util.LinkedList;
 /**
  * A stack that keeps track of what Skript is currently parsing.
  * <p>
- * When accessing the stack from within {@link SyntaxElement#init(Expression[], int, Kleenean, SkriptParser.ParseResult)},
+ * When accessing the stack from within
+ * {@link SyntaxElement#init(Expression[], int, Kleenean, SkriptParser.ParseResult)},
  * the stack element corresponding to that {@link SyntaxElement} is <b>not</b>
  * on the parsing stack.
  */
@@ -73,9 +56,8 @@ public class ParsingStack implements Iterable<ParsingStack.Element> {
 	 * starting with the top element at index 0.
 	 *
 	 * @param index the index in stack.
-	 *
 	 * @throws IndexOutOfBoundsException if the index is not appointed
-	 * 									  to an element in the stack.
+	 *                                   to an element in the stack.
 	 */
 	public Element peek(int index) throws IndexOutOfBoundsException {
 		if (index < 0 || index >= size()) {
@@ -138,7 +120,7 @@ public class ParsingStack implements Iterable<ParsingStack.Element> {
 			} else {
 				for (Element element : stack) {
 					printStream.println("\t" + element.getSyntaxElementClass().getName() +
-						" @ " + element.getPatternIndex());
+						" @ " + element.patternIndex());
 				}
 			}
 		}
@@ -155,16 +137,10 @@ public class ParsingStack implements Iterable<ParsingStack.Element> {
 	/**
 	 * A stack element, containing details about the syntax element it is about.
 	 */
-	public static class Element {
+	public record Element(SyntaxElementInfo<?> syntaxElementInfo, int patternIndex) {
 
-		private final SyntaxElementInfo<?> syntaxElementInfo;
-		private final int patternIndex;
-
-		public Element(SyntaxElementInfo<?> syntaxElementInfo, int patternIndex) {
+		public Element {
 			assert patternIndex >= 0 && patternIndex < syntaxElementInfo.getPatterns().length;
-
-			this.syntaxElementInfo = syntaxElementInfo;
-			this.patternIndex = patternIndex;
 		}
 
 		/**
@@ -175,7 +151,8 @@ public class ParsingStack implements Iterable<ParsingStack.Element> {
 		 * @see #getSyntaxElementClass()
 		 * @see #getPattern()
 		 */
-		public SyntaxElementInfo<?> getSyntaxElementInfo() {
+		@Override
+		public SyntaxElementInfo<?> syntaxElementInfo() {
 			return syntaxElementInfo;
 		}
 
@@ -183,7 +160,8 @@ public class ParsingStack implements Iterable<ParsingStack.Element> {
 		 * Gets the index to the registered patterns for the syntax element
 		 * of this stack element.
 		 */
-		public int getPatternIndex() {
+		@Override
+		public int patternIndex() {
 			return patternIndex;
 		}
 


### PR DESCRIPTION
Re-opening the abandoned #5277 with updated changes.

### Description
> This PR adds the parsing stack. This is a stack that keeps track of which syntax elements are currently being parsed.
With this feature, you could for example check in an expression's init method which expression it's being used in, or which effect is using the expression.

> Each stack element contains the `SyntaxElementInfo` (which contains info such as the syntax element class and the patterns), and which exact pattern was used.

> This PR also catches `StackOverflowError`s that occur during parsing, and adds the parsing stack to the exception message. AFAIK these exceptions are rare here, but the extra details don't hurt. Example stack trace (warning: long): https://pastebin.com/CNynV19h

> I also plan to add a watchdog system where Skript would detect when parsing is taking a long time (either in general, or for a specific line / trigger), at which point Skript could print some warning message, including the parsing stack and possibly more information, to console.

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** none
