### PR TITLE
Fix loop behaviour from super call.

### DIFF
--- a/src/main/java/ch/njol/skript/sections/SecFor.java
+++ b/src/main/java/ch/njol/skript/sections/SecFor.java
@@ -118,7 +118,7 @@ public class SecFor extends SecLoop {
 		}
 		//</editor-fold>
 		this.loadOptionalCode(sectionNode);
-		super.setNext(this);
+		this.setInternalNext(this);
 		return true;
 	}
 

--- a/src/main/java/ch/njol/skript/sections/SecLoop.java
+++ b/src/main/java/ch/njol/skript/sections/SecLoop.java
@@ -119,7 +119,7 @@ public class SecLoop extends LoopSection {
 
 		guaranteedToLoop = guaranteedToLoop(expression);
 		loadOptionalCode(sectionNode);
-		super.setNext(this);
+		this.setInternalNext(this);
 
 		return true;
 	}
@@ -130,11 +130,11 @@ public class SecLoop extends LoopSection {
 		if (iter == null) {
 			if (iterableSingle) {
 				Object value = expression.getSingle(event);
-				if (value instanceof Iterable<?> iterable) {
-					iter = iterable.iterator();
-					// Guaranteed to be ordered so we try it first
-				} else if (value instanceof Container<?> container) {
+				if (value instanceof Container<?> container) {
+					// Container may have special behaviour over regular iterator
 					iter = container.containerIterator();
+				} else if (value instanceof Iterable<?> iterable) {
+					iter = iterable.iterator();
 				} else {
 					iter = Collections.singleton(value).iterator();
 				}
@@ -208,6 +208,13 @@ public class SecLoop extends LoopSection {
 	public SecLoop setNext(@Nullable TriggerItem next) {
 		actualNext = next;
 		return this;
+	}
+
+	/**
+	 * @see LoopSection#setNext(TriggerItem)
+	 */
+	protected void setInternalNext(TriggerItem item) {
+		super.setNext(item);
 	}
 
 	@Nullable

--- a/src/main/java/org/skriptlang/skript/lang/util/SkriptQueue.java
+++ b/src/main/java/org/skriptlang/skript/lang/util/SkriptQueue.java
@@ -100,7 +100,21 @@ public class SkriptQueue extends LinkedList<@NotNull Object>
 
 	@Override
 	public Iterator<Object> containerIterator() {
-		return this.iterator();
+		return new Iterator<>() {
+			@Override
+			public boolean hasNext() {
+				return !SkriptQueue.this.isEmpty();
+			}
+
+			@Override
+			public Object next() {
+				return SkriptQueue.this.pollFirst();
+			}
+
+			@Override
+			public void remove() {
+			}
+		};
 	}
 
 }

--- a/src/test/skript/tests/regressions/7536-for-loop-ending.sk
+++ b/src/test/skript/tests/regressions/7536-for-loop-ending.sk
@@ -1,0 +1,17 @@
+using for each loops
+
+test "for each loops ending (start)":
+	clear {7536 For Each::*}
+	for each {_word} in ("test", "test2"):
+		add {_word} to {7536 For Each::*}
+		for each {_word 2} in ("example", "example2"):
+			add {_word 2} to {7536 For Each::*}
+
+	assert the size of {7536 For Each::*} is 6 with "Wrong number of variables: %{7536 For Each::*}%"
+
+# Need to make sure that trigger didn't just die
+test "for each loops ending (result)":
+	assert the size of {7536 For Each::*} is 6 with "Wrong number of variables: %{7536 For Each::*}%"
+	assert {7536 For Each::*} is ("test", "example", "example2", "test2", "example", "example2") with "Wrong loop order: %{7536 For Each::*}%"
+
+	delete {7536 For Each::*}

--- a/src/test/skript/tests/syntaxes/expressions/ExprQueue.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprQueue.sk
@@ -79,7 +79,5 @@ test "loop queue":
 		add 1 to {_count}
 		if {_count} is less than 10:
 			add {_word} to {_queue}
-		broadcast {_count}
-		broadcast {_queue}
 
 	assert {_count} is 11

--- a/src/test/skript/tests/syntaxes/expressions/ExprQueue.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprQueue.sk
@@ -79,5 +79,7 @@ test "loop queue":
 		add 1 to {_count}
 		if {_count} is less than 10:
 			add {_word} to {_queue}
+		broadcast {_count}
+		broadcast {_queue}
 
 	assert {_count} is 11

--- a/src/test/skript/tests/syntaxes/sections/SecFor.sk
+++ b/src/test/skript/tests/syntaxes/sections/SecFor.sk
@@ -15,6 +15,7 @@ test "for section":
 	delete {_value}
 
 	for {_key}, {_value} in {_list::*}:
+		set {_key} to {_key} parsed as integer
 		assert {_key} is greater than 0 with "Expected key > 0, found %{_key}%"
 		assert {_key} is less than 4 with "Expected key < 4, found %{_key}%"
 		assert {_value} is greater than 0 with "Expected value > 0, found %{_value}%"
@@ -27,6 +28,7 @@ test "for section":
 
 
 	for key {_key} and value {_value} in {_list::*}:
+		set {_key} to {_key} parsed as integer
 		assert {_key} is greater than 0 with "Expected key > 0, found %{_key}%"
 		assert {_key} is less than 4 with "Expected key < 4, found %{_key}%"
 		assert {_value} is greater than 0 with "Expected value > 0, found %{_value}%"
@@ -38,6 +40,7 @@ test "for section":
 	delete {_value}
 
 	for {_key} and {_value} in {_list::*}:
+		set {_key} to {_key} parsed as integer
 		assert {_key} is greater than 0 with "Expected key > 0, found %{_key}%"
 		assert {_key} is less than 4 with "Expected key < 4, found %{_key}%"
 		assert {_value} is greater than 0 with "Expected value > 0, found %{_value}%"
@@ -50,6 +53,7 @@ test "for section":
 
 	# 'loop' syntax alternative
 	loop {_key} and {_value} in {_list::*}:
+		set {_key} to {_key} parsed as integer
 		assert {_key} is greater than 0 with "Expected key > 0, found %{_key}%"
 		assert {_key} is less than 4 with "Expected key < 4, found %{_key}%"
 		assert {_value} is greater than 0 with "Expected value > 0, found %{_value}%"


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Fixes an issue with subclasses of loop which couldn't call LoopSection's `setNext` because it was obscured by the overriding method.
This was causing triggers to terminate early (though I'm actually not sure why, it seems a bit dodgy, but this was definitely the cause). As a result, it was reporting as correct in the test system because the tests only measure for failures (and the assertions were just never being reached).

I also fixed a couple of other minor problems that had been _hidden_ by this, since their tests were getting skipped.

Fixes #7536 
