### PR TITLE
RegistryParser - fix pulling from the lang file on custom entries

### DIFF
--- a/src/main/java/ch/njol/skript/classes/registry/RegistryParser.java
+++ b/src/main/java/ch/njol/skript/classes/registry/RegistryParser.java
@@ -47,7 +47,7 @@ public class RegistryParser<R extends Keyed> extends Parser<R> {
 			String namespace = namespacedKey.getNamespace();
 			String key = namespacedKey.getKey();
 			String keyWithSpaces = key.replace("_", " ");
-			String languageKey = languageNode + "." + key;
+			String languageKey;
 
 			// Put the full namespaced key as a pattern
 			parseMap.put(namespacedKey.toString(), registryObject);
@@ -55,6 +55,9 @@ public class RegistryParser<R extends Keyed> extends Parser<R> {
 			// If the object is a vanilla Minecraft object, we'll add the key with spaces as a pattern
 			if (namespace.equalsIgnoreCase(NamespacedKey.MINECRAFT)) {
 				parseMap.put(keyWithSpaces, registryObject);
+				languageKey = languageNode + "." + key;
+			} else {
+				languageKey = namespacedKey.toString();
 			}
 
 			String[] options = Language.getList(languageKey);


### PR DESCRIPTION
### Description
This PR aims to fix a tiny little bug with lang nodes in the RegistryParser.

What I noticed is if the lang file contains an entry that matches a custom entry, Skript attempts to use it, when it should only use `minecraft` namespaced entries.

Ex:
In the lang file under biomes, we have `desert_lakes` (Im assuming an old MC biome?!?!?)
<img width="405" alt="Screenshot 2025-01-26 at 11 11 28 AM" src="https://github.com/user-attachments/assets/0bdfd1e8-0a52-406b-921b-b12866153eee" />

When using a data pack that has `packname:desert_lakes` it grabs from the lang file.
<img width="420" alt="Screenshot 2025-01-26 at 11 12 20 AM" src="https://github.com/user-attachments/assets/faea25d6-2071-4af5-98df-66465f91cfd4" />

This shouldn't happen.
We shouldn't be looking in the lang file for non-Minecraft entries.

The change I have implemented here was to only grab from the lang file if it's a minecraft namespaced object.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
