### PR TITLE
Removes no-keyword pattern from ExprNewBannerPattern

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprNewBannerPattern.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNewBannerPattern.java
@@ -32,8 +32,7 @@ public class ExprNewBannerPattern extends SimpleExpression<Pattern> {
 
 	static {
 		Skript.registerExpression(ExprNewBannerPattern.class, Pattern.class, ExpressionType.PATTERN_MATCHES_EVERYTHING,
-			"[a] %bannerpatterntype% colo[u]red %color%",
-			"[a] %*color% %bannerpatterntype%");
+			"[a] %bannerpatterntype% colo[u]red %color%");
 	}
 
 	private Expression<PatternType> selectedPattern;

--- a/src/main/java/ch/njol/skript/expressions/ExprNewBannerPattern.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNewBannerPattern.java
@@ -24,14 +24,12 @@ import org.jetbrains.annotations.Nullable;
 	"remove {_pattern} from banner patterns of {_banneritem}",
 	"set the 1st banner pattern of block at location(0,0,0) to {_pattern}",
 	"clear the 1st banner pattern of block at location(0,0,0)",
-	"",
-	"set {_pattern} to a red mojang banner pattern"
 })
 @Since("2.10")
 public class ExprNewBannerPattern extends SimpleExpression<Pattern> {
 
 	static {
-		Skript.registerExpression(ExprNewBannerPattern.class, Pattern.class, ExpressionType.PATTERN_MATCHES_EVERYTHING,
+		Skript.registerExpression(ExprNewBannerPattern.class, Pattern.class, ExpressionType.COMBINED,
 			"[a] %bannerpatterntype% colo[u]red %color%");
 	}
 
@@ -39,18 +37,10 @@ public class ExprNewBannerPattern extends SimpleExpression<Pattern> {
 	private Expression<Color> selectedColor;
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		if (matchedPattern == 0) {
-			//noinspection unchecked
-			selectedPattern = (Expression<PatternType>) exprs[0];
-			//noinspection unchecked
-			selectedColor = (Expression<Color>) exprs[1];
-		} else {
-			//noinspection unchecked
-			selectedPattern = (Expression<PatternType>) exprs[1];
-			//noinspection unchecked
-			selectedColor = (Expression<Color>) exprs[0];
-		}
+		selectedPattern = (Expression<PatternType>) exprs[0];
+		selectedColor = (Expression<Color>) exprs[1];
 		return true;
 	}
 


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

This pattern was responsible for significant slowdown in parsing due to its lack of required keywords.
Removing this pattern caused one test case of 3000 structures to go from a 4 minute parse time to a 1 minute parse time.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
