### PR TITLE
Registration API Integration

### DIFF
--- a/src/main/java/ch/njol/skript/lang/Condition.java
+++ b/src/main/java/ch/njol/skript/lang/Condition.java
@@ -113,8 +113,9 @@ public abstract class Condition extends Statement implements Conditional<Event> 
 		input = input.trim();
 		while (input.startsWith("(") && SkriptParser.next(input, 0, ParseContext.DEFAULT) == input.length())
 			input = input.substring(1, input.length() - 1);
+		var iterator = Skript.instance().syntaxRegistry().syntaxes(org.skriptlang.skript.registration.SyntaxRegistry.CONDITION).iterator();
 		//noinspection unchecked,rawtypes
-		return (Condition) SkriptParser.parse(input, (Iterator) Skript.getConditions().iterator(), defaultError);
+		return (Condition) SkriptParser.parse(input, (Iterator) iterator, defaultError);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/lang/Effect.java
+++ b/src/main/java/ch/njol/skript/lang/Effect.java
@@ -52,8 +52,9 @@ public abstract class Effect extends Statement {
 			}
 			log.clear();
 
+			var iterator = Skript.instance().syntaxRegistry().syntaxes(org.skriptlang.skript.registration.SyntaxRegistry.EFFECT).iterator();
 			//noinspection unchecked,rawtypes
-			Effect effect = (Effect) SkriptParser.parse(input, (Iterator) Skript.getEffects().iterator(), defaultError);
+			Effect effect = (Effect) SkriptParser.parse(input, (Iterator) iterator, defaultError);
 			if (effect != null) {
 				log.printLog();
 				return effect;

--- a/src/main/java/ch/njol/skript/lang/EffectSection.java
+++ b/src/main/java/ch/njol/skript/lang/EffectSection.java
@@ -54,14 +54,13 @@ public abstract class EffectSection extends Section {
 	public static @Nullable EffectSection parse(String input, @Nullable String defaultError, @Nullable SectionNode sectionNode, @Nullable List<TriggerItem> triggerItems) {
 		SectionContext sectionContext = ParserInstance.get().getData(SectionContext.class);
 
-		//noinspection unchecked,rawtypes
-		return sectionContext.modify(sectionNode, triggerItems, () ->
-			(EffectSection) SkriptParser.parse(
-				input,
-				(Iterator) Skript.getSections().stream()
-					.filter(info -> EffectSection.class.isAssignableFrom(info.getElementClass()))
-					.iterator(),
-				defaultError));
+		return sectionContext.modify(sectionNode, triggerItems, () -> {
+			var iterator = Skript.instance().syntaxRegistry().syntaxes(org.skriptlang.skript.registration.SyntaxRegistry.SECTION).stream()
+					.filter(info -> EffectSection.class.isAssignableFrom(info.type()))
+					.iterator();
+			//noinspection unchecked,rawtypes
+			return (EffectSection) SkriptParser.parse(input, (Iterator) iterator, defaultError);
+		});
 	}
 
 }

--- a/src/main/java/ch/njol/skript/lang/Section.java
+++ b/src/main/java/ch/njol/skript/lang/Section.java
@@ -159,9 +159,11 @@ public abstract class Section extends TriggerSection implements SyntaxElement {
 	@Nullable
 	public static Section parse(String expr, @Nullable String defaultError, SectionNode sectionNode, List<TriggerItem> triggerItems) {
 		SectionContext sectionContext = ParserInstance.get().getData(SectionContext.class);
-		//noinspection unchecked,rawtypes
-		return sectionContext.modify(sectionNode, triggerItems,
-			() -> (Section) SkriptParser.parse(expr, (Iterator) Skript.getSections().iterator(), defaultError));
+		return sectionContext.modify(sectionNode, triggerItems, () -> {
+			var iterator = Skript.instance().syntaxRegistry().syntaxes(org.skriptlang.skript.registration.SyntaxRegistry.SECTION).iterator();
+			//noinspection unchecked,rawtypes
+			return (Section) SkriptParser.parse(expr, (Iterator) iterator, defaultError);
+		});
 	}
 
 	static {

--- a/src/main/java/ch/njol/skript/lang/SkriptEventInfo.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptEventInfo.java
@@ -214,7 +214,7 @@ public sealed class SkriptEventInfo<E extends SkriptEvent> extends StructureInfo
 		}
 
 		@Override
-		public Builder<? extends Builder<?, E>, E> toBuilder() {
+		public BukkitSyntaxInfos.Event.Builder<? extends BukkitSyntaxInfos.Event.Builder<?, E>, E> toBuilder() {
 			return BukkitSyntaxInfos.Event.builder(type(), name())
 				.origin(origin)
 				.addPatterns(patterns())
@@ -227,36 +227,6 @@ public sealed class SkriptEventInfo<E extends SkriptEvent> extends StructureInfo
 				.addKeywords(keywords())
 				.addRequiredPlugins(requiredPlugins())
 				.addEvents(events());
-		}
-
-		@Override
-		public SyntaxOrigin origin() {
-			return origin;
-		}
-
-		@Override
-		public Class<E> type() {
-			return getElementClass();
-		}
-
-		@Override
-		public E instance() {
-			try {
-				return type().getDeclaredConstructor().newInstance();
-			} catch (InstantiationException | IllegalAccessException | InvocationTargetException |
-					 NoSuchMethodException e) {
-				throw new RuntimeException(e);
-			}
-		}
-
-		@Override
-		public @Unmodifiable Collection<String> patterns() {
-			return List.of(getPatterns());
-		}
-
-		@Override
-		public Priority priority() {
-			return SyntaxInfo.COMBINED;
 		}
 
 		@Override

--- a/src/main/java/ch/njol/skript/lang/Statement.java
+++ b/src/main/java/ch/njol/skript/lang/Statement.java
@@ -48,11 +48,12 @@ public abstract class Statement extends TriggerItem implements SyntaxElement {
 			log.clear();
 
 			Statement statement;
+			var iterator = Skript.instance().syntaxRegistry().syntaxes(org.skriptlang.skript.registration.SyntaxRegistry.STATEMENT).iterator();
 			if (node != null) {
 				Section.SectionContext sectionContext = ParserInstance.get().getData(Section.SectionContext.class);
 				statement = sectionContext.modify(node, items, () -> {
 						//noinspection unchecked,rawtypes
-						Statement parsed = (Statement) SkriptParser.parse(input, (Iterator) Skript.getStatements().iterator(), defaultError);
+						Statement parsed = (Statement) SkriptParser.parse(input, (Iterator) iterator, defaultError);
 						if (parsed != null && !sectionContext.claimed()) {
 							Skript.error("The line '" + input + "' is a valid statement but cannot function as a section (:) because there is no syntax in the line to manage it.");
 							return null;
@@ -61,7 +62,7 @@ public abstract class Statement extends TriggerItem implements SyntaxElement {
 				});
 			} else {
 				//noinspection unchecked,rawtypes
-				statement = (Statement) SkriptParser.parse(input, (Iterator) Skript.getStatements().iterator(), defaultError);
+				statement = (Statement) SkriptParser.parse(input, (Iterator) iterator, defaultError);
 			}
 
 			if (statement != null) {

--- a/src/main/java/org/skriptlang/skript/registration/SyntaxRegister.java
+++ b/src/main/java/org/skriptlang/skript/registration/SyntaxRegister.java
@@ -1,6 +1,7 @@
 package org.skriptlang.skript.registration;
 
 import com.google.common.collect.ImmutableSet;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.Comparator;
@@ -23,19 +24,23 @@ final class SyntaxRegister<I extends SyntaxInfo<?>> {
 	};
 
 	final Set<I> syntaxes = new ConcurrentSkipListSet<>(SET_COMPARATOR);
+	private volatile @Nullable Set<I> cache = null;
 
 	public Collection<I> syntaxes() {
-		synchronized (syntaxes) {
-			return ImmutableSet.copyOf(syntaxes);
+		if (cache == null) {
+			cache = ImmutableSet.copyOf(syntaxes);
 		}
+		return cache;
 	}
 
 	public void add(I info) {
 		syntaxes.add(info);
+		cache = null;
 	}
 
 	public void remove(I info) {
 		syntaxes.remove(info);
+		cache = null;
 	}
 
 }


### PR DESCRIPTION
### Description
This PR aims to improve parsing performance by directly using the new Syntax Registration API in SkriptParser.

For compatibility, I have updated SyntaxElementInfo to implement SyntaxInfo. I avoided direct imports, but that may not be necessary and can be changed if desired. Initial testing indicates this works fine, but further testing would not hurt.

The SkriptParser changes are not as significant as they appear. I was able to reduce a lot of the loop/conditional nesting that was present.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
