### PR TITLE
Remove Redundant "The"s

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprExperienceCooldown.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprExperienceCooldown.java
@@ -29,7 +29,7 @@ import org.jetbrains.annotations.Nullable;
 public class ExprExperienceCooldown extends SimplePropertyExpression<Player, Timespan> {
 
 	static {
-		register(ExprExperienceCooldown.class, Timespan.class, "[the] (experience|[e]xp) [pickup|collection] cooldown", "players");
+		register(ExprExperienceCooldown.class, Timespan.class, "(experience|[e]xp) [pickup|collection] cooldown", "players");
 	}
 
 	private static final int maxTicks = Integer.MAX_VALUE;

--- a/src/main/java/ch/njol/skript/expressions/ExprExperienceCooldownChangeReason.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprExperienceCooldownChangeReason.java
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.Nullable;
 public class ExprExperienceCooldownChangeReason extends EventValueExpression<ChangeReason> {
 
 	static {
-		register(ExprExperienceCooldownChangeReason.class, ChangeReason.class, "[the] (experience|[e]xp) cooldown change (reason|cause|type)");
+		register(ExprExperienceCooldownChangeReason.class, ChangeReason.class, "(experience|[e]xp) cooldown change (reason|cause|type)");
 	}
 
 	public ExprExperienceCooldownChangeReason() {


### PR DESCRIPTION
### Description
This PR removes redundant/duplicate "the"s from 2 elements. (It was me, and was before I knew `#register` added it by default)
😁 

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
