### PR TITLE
ExprExcept

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprExcept.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprExcept.java
@@ -1,0 +1,81 @@
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.skript.util.LiteralUtils;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Except")
+@Description("Filter a list by providing objects to be excluded.")
+@Examples({
+	"spawn zombie at location(0, 0, 0):",
+		"\thide entity from all players except {_player}",
+	"",
+	"set {_items::*} to a copper ingot, an iron ingot and a gold ingot",
+	"set {_except::*} to {_items::*} excluding copper ingot"
+})
+@Since("INSERT VERSION")
+public class ExprExcept extends SimpleExpression<Object> {
+
+	static {
+		Skript.registerExpression(ExprExcept.class, Object.class, ExpressionType.COMBINED,
+			"%objects% (except|excluding|not including) %objects%");
+	}
+
+	private Expression<?> source;
+	private Expression<?> exclude;
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		source = LiteralUtils.defendExpression(exprs[0]);
+		if (source.isSingle() || !LiteralUtils.canInitSafely(source))
+			return false;
+
+		exclude = LiteralUtils.defendExpression(exprs[1]);
+		if (!LiteralUtils.canInitSafely(exclude))
+			return false;
+
+		return true;
+	}
+
+	@Override
+	protected Object @Nullable [] get(Event event) {
+		Object[] exclude = this.exclude.getArray(event);
+		if (exclude == null || exclude.length == 0)
+			return source.getArray(event);
+
+		return source.stream(event)
+			.filter(sourceObject -> {
+				for (Object excludeObject : exclude)
+					if (sourceObject.equals(excludeObject))
+						return false;
+				return true;
+			})
+			.toArray();
+	}
+
+	@Override
+	public boolean isSingle() {
+		return false;
+	}
+
+	@Override
+	public Class<?> getReturnType() {
+		return Object.class;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return source.toString(event, debug) + " except " + exclude.toString(event, debug);
+	}
+
+}

--- a/src/test/skript/tests/syntaxes/expressions/ExprExcept.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprExcept.sk
@@ -1,0 +1,37 @@
+test "except items":
+	set {_base::*} to a copper ingot, an iron ingot, a gold ingot, a diamond and a netherite ingot
+	set {_except::*} to {_base::*} except a copper ingot
+	assert {_except::*} is an iron ingot, a gold ingot, a diamond and a netherite ingot with "Failed to exclude a copper ingot"
+
+	set {_except::*} to {_base::*} except a copper ingot and an iron ingot
+	assert {_except::*} is a gold ingot, a diamond and a netherite ingot with "Failed to exclude a copper ingot and an iron ingot"
+
+	set {_except::*} to {_base::*} excluding a copper ingot, an iron ingot, a gold ingot and a diamond
+	assert {_except::*} is a netherite ingot with "Failed to exclude all but netherite ingot"
+
+	set {_except::*} to {_base::*} not including {_base::*}
+	assert {_except::*} is not set with "Failed to exclude all"
+
+test "except entities":
+	spawn 5 zombies at test-location
+	set {_zombie} to last spawned zombie
+	add {_zombie} to {_exclude::*}
+
+	assert size of all zombies except {_zombie} is 4 with "Failed to exclude zombie"
+	assert size of all entities except {_exclude::*} is 4 with "Failed to exclude list"
+
+	spawn 5 skeletons at test-location
+	set {_skeleton} to last spawned skeleton
+	add {_skeleton} to {_exclude::*}
+
+	assert size of all skeletons excluding {_skeleton} is 4 with "Failed to exclude skeleton"
+	assert size of all entities excluding {_exclude::*} is 8 with "Failed to exclude list"
+
+	spawn 5 villagers at test-location
+	set {_villager} to last spawned villager
+	add {_villager} to {_exclude::*}
+
+	assert size of all villagers not including {_villager} is 4 with "Failed to exclude villager"
+	assert size of all entities not including {_exclude::*} is 12 with "Failed to exclude list"
+
+	clear all entities


### PR DESCRIPTION
### Description
This PR aims to add a new expression that returns a list excluding the options provided.

If there is no need for this, since SecFilter now exists, that's ok. Just saw the issue and it wasn't closed nor any other comment.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #5710 <!-- Links to related issues -->
