### PR TITLE
Simple JUnits

### DIFF
--- a/src/main/java/ch/njol/skript/SkriptEventHandler.java
+++ b/src/main/java/ch/njol/skript/SkriptEventHandler.java
@@ -392,7 +392,6 @@ public final class SkriptEventHandler {
 
 	@Nullable
 	private static Method getHandlerListMethod_i(Class<? extends Event> eventClass) {
-		Method superMethod = null;
 		try {
 			return eventClass.getDeclaredMethod("getHandlerList");
 		} catch (NoSuchMethodException e) {
@@ -401,15 +400,10 @@ public final class SkriptEventHandler {
 				&& !eventClass.getSuperclass().equals(Event.class)
 				&& Event.class.isAssignableFrom(eventClass.getSuperclass())
 			) {
-				superMethod = getHandlerListMethod(eventClass.getSuperclass().asSubclass(Event.class));
+				return getHandlerListMethod(eventClass.getSuperclass().asSubclass(Event.class));
+			} else {
+				return null;
 			}
-		}
-		if (superMethod != null)
-			return superMethod;
-		try {
-			return eventClass.getDeclaredMethod("getHandlers");
-		} catch (NoSuchMethodException e) {
-			return null;
 		}
 	}
 

--- a/src/main/java/ch/njol/skript/SkriptEventHandler.java
+++ b/src/main/java/ch/njol/skript/SkriptEventHandler.java
@@ -392,6 +392,7 @@ public final class SkriptEventHandler {
 
 	@Nullable
 	private static Method getHandlerListMethod_i(Class<? extends Event> eventClass) {
+		Method superMethod = null;
 		try {
 			return eventClass.getDeclaredMethod("getHandlerList");
 		} catch (NoSuchMethodException e) {
@@ -400,10 +401,15 @@ public final class SkriptEventHandler {
 				&& !eventClass.getSuperclass().equals(Event.class)
 				&& Event.class.isAssignableFrom(eventClass.getSuperclass())
 			) {
-				return getHandlerListMethod(eventClass.getSuperclass().asSubclass(Event.class));
-			} else {
-				return null;
+				superMethod = getHandlerListMethod(eventClass.getSuperclass().asSubclass(Event.class));
 			}
+		}
+		if (superMethod != null)
+			return superMethod;
+		try {
+			return eventClass.getDeclaredMethod("getHandlers");
+		} catch (NoSuchMethodException e) {
+			return null;
 		}
 	}
 

--- a/src/main/java/ch/njol/skript/test/runner/EffObjectives.java
+++ b/src/main/java/ch/njol/skript/test/runner/EffObjectives.java
@@ -1,15 +1,5 @@
 package ch.njol.skript.test.runner;
 
-import java.util.Arrays;
-import java.util.List;
-
-import org.bukkit.event.Event;
-import org.jetbrains.annotations.Nullable;
-
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Multimap;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Name;
@@ -18,6 +8,14 @@ import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Name("Objectives")
 @Description("An effect to setup required objectives for JUnit tests to complete.")
@@ -27,8 +25,8 @@ public class EffObjectives extends Effect  {
 	static {
 		if (TestMode.ENABLED)
 			Skript.registerEffect(EffObjectives.class,
-					"ensure [[junit] test] %string% completes [(objective|trigger)[s]] %strings%",
-					"complete [(objective|trigger)[s]] %strings% (for|on) [[junit] test] %string%"
+					"ensure [:simple] [[junit] test] %string% completes [(objective|trigger)[s]] %strings%",
+					"complete [(objective|trigger)[s]] %strings% (for|on) [:simple] [[junit] test] %string%"
 			);
 	}
 
@@ -37,6 +35,7 @@ public class EffObjectives extends Effect  {
 
 	private Expression<String> junit, objectives;
 	private boolean setup;
+	private boolean simple;
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -44,6 +43,7 @@ public class EffObjectives extends Effect  {
 		objectives = (Expression<String>) exprs[matchedPattern ^ 1];
 		junit = (Expression<String>) exprs[matchedPattern];
 		setup = matchedPattern == 0;
+		simple = parseResult.hasTag("simple");
 		return true;
 	}
 
@@ -53,6 +53,8 @@ public class EffObjectives extends Effect  {
 		assert junit != null;
 		String[] objectives = this.objectives.getArray(event);
 		assert objectives.length > 0;
+		if (simple)
+			junit = "SimpleJUnits." + junit;
 		if (setup) {
 			requirements.putAll(junit, Lists.newArrayList(objectives));
 		} else {

--- a/src/main/java/ch/njol/skript/test/runner/EvtSimpleJUnit.java
+++ b/src/main/java/ch/njol/skript/test/runner/EvtSimpleJUnit.java
@@ -1,0 +1,73 @@
+package ch.njol.skript.test.runner;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.NoDoc;
+import ch.njol.skript.lang.Literal;
+import ch.njol.skript.lang.SkriptEvent;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@NoDoc
+public class EvtSimpleJUnit extends SkriptEvent {
+
+	public static class SimpleJUnitEvent extends Event {
+
+		private final static HandlerList handlers = new HandlerList();
+		private final String testName;
+
+		public SimpleJUnitEvent(String testName) {
+			this.testName = testName;
+		}
+
+		public String getTestName() {
+			return testName;
+		}
+
+		@Override
+		public @NotNull HandlerList getHandlers() {
+			return handlers;
+		}
+
+		public static HandlerList getHandlerList() {
+			return handlers;
+		}
+
+	}
+
+	static {
+		if (TestMode.ENABLED)
+			Skript.registerEvent("Simple JUnit Load", EvtSimpleJUnit.class, SimpleJUnitEvent.class,
+				"simple junit of %string%");
+	}
+
+	private Literal<String> literal;
+	private String testName;
+
+	@Override
+	public boolean init(Literal<?>[] args, int matchedPattern, ParseResult parseResult) {
+		//noinspection unchecked
+		literal = (Literal<String>) args[0];
+		testName = literal.getSingle();
+		return true;
+	}
+
+	@Override
+	public boolean check(Event event) {
+		if (!(event instanceof SimpleJUnitEvent simpleJUnitEvent))
+			return false;
+
+		if (simpleJUnitEvent.getTestName().equalsIgnoreCase(testName))
+			return true;
+
+		return false;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "simple junit of " + literal.toString(event, debug);
+	}
+
+}

--- a/src/test/java/org/skriptlang/skript/test/tests/syntaxes/SimpleJUnitsTest.java
+++ b/src/test/java/org/skriptlang/skript/test/tests/syntaxes/SimpleJUnitsTest.java
@@ -1,0 +1,36 @@
+package org.skriptlang.skript.test.tests.syntaxes;
+
+import ch.njol.skript.test.runner.EvtSimpleJUnit.SimpleJUnitEvent;
+import ch.njol.skript.test.runner.SkriptJUnitTest;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.PluginManager;
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SimpleJUnitsTest extends SkriptJUnitTest {
+
+	private static final List<String> tests = new ArrayList<>();
+
+	static {
+		tests.add("SimpleJUnits");
+
+		setShutdownDelay(tests.size());
+	}
+
+	@Test
+	public void runTests() {
+		PluginManager pluginManager = Bukkit.getPluginManager();
+		for (String currentTest : tests) {
+			pluginManager.callEvent(new SimpleJUnitEvent(currentTest));
+		}
+	}
+
+	@After
+	public void after() {
+		// Should be handled in the .sk files
+	}
+
+}

--- a/src/test/skript/junit/SimpleJUnits.sk
+++ b/src/test/skript/junit/SimpleJUnits.sk
@@ -1,6 +1,8 @@
-test "simple junits" when running JUnit:
-	ensure simple "SimpleJUnits" completes "simple junit event"
+options:
+	test: "SimpleJUnits"
 
-on simple junit of "SimpleJUnits":
-	broadcast "simple junit event called"
-	complete "simple junit event" for simple "SimpleJUnits"
+test {@test} when running JUnit:
+	ensure simple {@test} completes "simple junit event"
+
+on simple junit of {@test}:
+	complete "simple junit event" for simple {@test}

--- a/src/test/skript/junit/SimpleJUnits.sk
+++ b/src/test/skript/junit/SimpleJUnits.sk
@@ -1,0 +1,6 @@
+test "simple junits" when running JUnit:
+	ensure simple "SimpleJUnits" completes "simple junit event"
+
+on simple junit of "SimpleJUnits":
+	broadcast "simple junit event called"
+	complete "simple junit event" for simple "SimpleJUnits"


### PR DESCRIPTION
### Description
With the recent change of making a JUnit test for a test that would fail through the `skriptTest` environment due to failing an assertion because the change requires atleast a tick.
Instead of making a JUnit Java class for each of these tests, I propose this idea of simply adding the test to `SimpleJUnits` and whatever name is chosen should match between the list addition and usage within the `.sk` file.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
