### PR TITLE
Fix Date Serialization

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
@@ -354,15 +354,19 @@ public class SkriptClasses {
 					@Override
 					public Fields serialize(Date date) {
 						Fields fields = new Fields();
-						fields.putPrimitive("time", date.getTime());
+						fields.putPrimitive("timestamp", date.getTime());
 						return fields;
 					}
 
 
 					@Override
-					protected Date deserialize(Fields fields)
-						throws StreamCorruptedException {
-						long time = fields.getPrimitive("time", long.class);
+					protected Date deserialize(Fields fields) throws StreamCorruptedException {
+						long time;
+						if (fields.hasField("time")) { // compatibility for 2.10.0 (#7542)
+							time = fields.getPrimitive("time", long.class);
+						} else {
+							time = fields.getPrimitive("timestamp", long.class);
+						}
 						return new Date(time);
 					}
 


### PR DESCRIPTION
### Description
This PR aims to fix the date serialization issue on 2.10. Before 2.9, dates were serialized with the primitive field being represented as `timestamp` (the name of the old field). However, when serialization was updated in 2.10, the serializer was created using "time" as the Fields name, which is why old variables could not be deserialized.

I resolve this issue by changing the name _back_ to `timestamp` and adding a compatibility check for the `time` field name.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:**
- https://github.com/SkriptLang/Skript/issues/7542
