### PR TITLE
Add experience point support to ExprTotalExperience

### DIFF
--- a/src/main/java/ch/njol/skript/util/Experience.java
+++ b/src/main/java/ch/njol/skript/util/Experience.java
@@ -9,18 +9,22 @@ import ch.njol.yggdrasil.YggdrasilSerializable;
  */
 public class Experience implements YggdrasilSerializable {
 	
-	private final int xp;
+	private int xp;
 	
 	public Experience() {
 		xp = -1;
 	}
 	
-	public Experience(final int xp) {
+	public Experience(int xp) {
 		this.xp = xp;
 	}
 	
 	public int getXP() {
 		return xp == -1 ? 1 : xp;
+	}
+
+	public void setXP(int xp) {
+		this.xp = xp;
 	}
 	
 	public int getInternalXP() {
@@ -41,17 +45,14 @@ public class Experience implements YggdrasilSerializable {
 	}
 	
 	@Override
-	public boolean equals(final @Nullable Object obj) {
+	public boolean equals(@Nullable Object obj) {
 		if (this == obj)
 			return true;
 		if (obj == null)
 			return false;
-		if (!(obj instanceof Experience))
+		if (!(obj instanceof Experience other))
 			return false;
-		final Experience other = (Experience) obj;
-		if (xp != other.xp)
-			return false;
-		return true;
+		return xp == other.xp;
 	}
 	
 }

--- a/src/test/skript/tests/syntaxes/expressions/ExprTotalExperience.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprTotalExperience.sk
@@ -13,3 +13,15 @@ test "total experience":
 		assert experience of entity is 0 with "remove too much experience from entity did not work"
 	assert experience of last spawned entity is 0 with "entity should have 0 experience after section"
 	delete last spawned entity
+
+	set {_xp} to 5 xp
+	assert experience of {_xp} is 5 with "getting xp of Experience doesn't work"
+	subtract 1 from experience of {_xp}
+	assert experience of {_xp} is 4 with "removing from xp of Experience doesn't work"
+	add 3 to experience of {_xp}
+	assert experience of {_xp} is 7 with "adding to xp of Experience doesn't work"
+	clear experience of {_xp}
+	assert experience of {_xp} is 0 with "clearing xp of Experience doesn't work"
+	set {_xp} to 5 xp
+	reset experience of {_xp}
+	assert experience of {_xp} is 0 with "resetting xp of Experience doesn't work"


### PR DESCRIPTION
### Description
This PR adds 'experience point' support to the total experience expression, cleans up the Experience and the syntax class and adds some tests.
I made this PR for the "on level progress change:" event. It did not let you get how much experience was changed as a number.
```
on level progress change:
  set {_xp} to event-experience     <--- what can you even do with this besides giving it to a player
```

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
