### PR TITLE
ExprCompassTarget - update docs

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprCompassTarget.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCompassTarget.java
@@ -16,7 +16,9 @@ import ch.njol.skript.expressions.base.SimplePropertyExpression;
  * @author Peter Güttinger
  */
 @Name("Compass Target")
-@Description("The location a player's compass is pointing at.")
+@Description({"The location a player's compass is pointing at.",
+	"As of Minecraft 1.21.4, the compass is controlled by the resource pack and by default will not point to " +
+		"this compass target when used outside of the overworld dimension."})
 @Examples({"# make all player's compasses target a player stored in {compass::target::%player%}",
 		"every 5 seconds:",
 		"\tloop all players:",


### PR DESCRIPTION
### Description
This PR aims to update docs for the compass target expression.
As of Minecraft 1.21.4, the compass has been changed to no longer point to spawn of dimensions other than the vanilla overworld dimension.
This is now handled by the resource pack and can be modified in the pack.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
