### PR TITLE
Any Item Literal

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/Aliases.java
+++ b/src/main/java/ch/njol/skript/aliases/Aliases.java
@@ -64,9 +64,7 @@ public abstract class Aliases {
 
 	static {
 		everything.setAll(true);
-		ItemData all = new ItemData(Material.AIR);
-		all.isAnything = true;
-		everything.add(all);
+		everything.add(ItemData.wildcard());
 	}
 
 	@Nullable

--- a/src/main/java/ch/njol/skript/aliases/ItemData.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemData.java
@@ -118,7 +118,13 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 	 * Some properties about this item.
 	 */
 	int itemFlags;
-	
+
+	public static ItemData wildcard() {
+		ItemData data = new ItemData(Material.AIR);
+		data.isAnything = true;
+		return data;
+	}
+
 	public ItemData(Material type, @Nullable String tags) {
 		this.type = type;
 
@@ -148,6 +154,8 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 		this.isAlias = data.isAlias;
 		this.plain = data.plain;
 		this.itemFlags = data.itemFlags;
+		this.isAnything = data.isAnything;
+		this.itemForm = data.itemForm;
 	}
 
 	public ItemData(Material material, @Nullable BlockValues values) {

--- a/src/main/java/org/skriptlang/skript/bukkit/tags/elements/LitAnyItem.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/tags/elements/LitAnyItem.java
@@ -1,0 +1,54 @@
+package org.skriptlang.skript.bukkit.tags.elements;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.aliases.ItemData;
+import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.Literal;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleLiteral;
+import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.Material;
+import org.bukkit.Tag;
+
+import java.util.Objects;
+
+public class LitAnyItem extends SimpleLiteral<ItemType> {
+
+	static {
+		Skript.registerExpression(LitAnyItem.class, ItemType.class, ExpressionType.SIMPLE,
+				"[an[y]] item [tagged as %-minecrafttag%]",
+				"all items [tagged as %-minecrafttag%]");
+	}
+
+	public LitAnyItem() {
+		super(CollectionUtils.array(new ItemType(ItemData.wildcard())), ItemType.class, true);
+	}
+
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		Expression<?> tagExpression = expressions[0];
+		if (tagExpression !=  null) {
+			if (!(tagExpression.simplify() instanceof Literal)) {
+				Skript.error("The tag in an any/all item expression must be a literal.");
+				return false;
+			}
+			// filter by tag
+			Tag<?> tag = (Tag<?>) ((Literal<?>) tagExpression.simplify()).getSingle();
+			Material[] values = tag.getValues().stream()
+				.filter(Objects::nonNull)
+				.filter(Material.class::isInstance)
+				.toArray(Material[]::new);
+			if (values.length == 0) {
+				Skript.error("The tag in an any/all item expression must be a tag of materials.");
+				return false;
+			}
+			this.data[0] = new ItemType(values);
+		}
+		if (matchedPattern == 1)
+			this.data[0].setAll(true);
+		return true;
+	}
+}

--- a/src/test/skript/tests/syntaxes/expressions/LitAnyItem.sk
+++ b/src/test/skript/tests/syntaxes/expressions/LitAnyItem.sk
@@ -1,0 +1,22 @@
+test "any item literal":
+	assert a diamond sword is any item with "diamond sword should be in any item"
+	assert a diamond sword is an item with "diamond sword should be an item"
+	assert a diamond sword is an item type with "diamond sword should be an item type"
+	assert a diamond sword is an item tagged as (tag "swords") with "diamond sword should be an item tagged as 'swords'"
+
+parse:
+	results: {LitAnyItem::parse-a::*}
+	code:
+		on right click with any item tagged as tag "pickaxes":
+			broadcast "test"
+
+parse:
+	results: {LitAnyItem::parse-b::*}
+	code:
+		on right click with any item tagged as tag {_tag}:
+			broadcast "test"
+
+
+test "any item literal parse check":
+	assert {LitAnyItem::parse-a::*} is not set with "Any item literal failed to parse"
+	assert {LitAnyItem::parse-b::*} is "The tag in an any/all item expression must be a literal." with "Any item literal didn't fail properly when given a non-literal tag"


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Adds a literal for itemtypes representing any item, all items, and any item in a tag.
The literal uses `simplify()` on ExprTag to allow tag expressions with literal strings to be interpreted as literals. This allows the use in events, like:
```
on right click with any item tagged as tag "pig_food":
    broadcast "test"
```

This literal also allows things like `if player's tool is any item named "test" with lore "hello world"`, which makes item comparisons easier.

In the process of implementing this, I discovered that the parser doesn't attempt to parse Literals that are registered as expressions when only the PARSE_LITERALS flag is active. I've included a basic fix in this draft but will be improving it (so as to not duplicate code)

I also have concerns about evaluating the tag contents at parse time, since the tag contents may change after that. This may require storing the key to the tag instead and evaluating it when the itemtype itself is evaluated. This isn't ideal but may be necessary.

TODO:
- [ ] Fix the `any item` return value so it doesn't show as simply `air`?
  - [ ] Allow `give any item to me` to work properly.
- [ ] Fix the `any item` itemtype so it compares against any amount of item if not specified.
- [ ] Clean up parser literals fix

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
