### PR TITLE
Event Values Fix

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -286,6 +286,7 @@ public final class BukkitEventValues {
 		EventValues.registerEventValue(PlayerDropItemEvent.class, Player.class, PlayerEvent::getPlayer);
 		EventValues.registerEventValue(PlayerDropItemEvent.class, Item.class, PlayerDropItemEvent::getItemDrop);
 		EventValues.registerEventValue(PlayerDropItemEvent.class, ItemStack.class, event -> event.getItemDrop().getItemStack());
+		EventValues.registerEventValue(PlayerDropItemEvent.class, Entity.class, PlayerEvent::getPlayer);
 		// EntityDropItemEvent
 		EventValues.registerEventValue(EntityDropItemEvent.class, Item.class, EntityDropItemEvent::getItemDrop);
 		EventValues.registerEventValue(EntityDropItemEvent.class, ItemStack.class, event -> event.getItemDrop().getItemStack());
@@ -293,6 +294,7 @@ public final class BukkitEventValues {
 		EventValues.registerEventValue(PlayerPickupItemEvent.class, Player.class, PlayerEvent::getPlayer);
 		EventValues.registerEventValue(PlayerPickupItemEvent.class, Item.class, PlayerPickupItemEvent::getItem);
 		EventValues.registerEventValue(PlayerPickupItemEvent.class, ItemStack.class, event -> event.getItem().getItemStack());
+		EventValues.registerEventValue(PlayerPickupItemEvent.class, Entity.class, PlayerEvent::getPlayer);
 		// EntityPickupItemEvent
 		EventValues.registerEventValue(EntityPickupItemEvent.class, Entity.class, EntityPickupItemEvent::getEntity);
 		EventValues.registerEventValue(EntityPickupItemEvent.class, Item.class, EntityPickupItemEvent::getItem);

--- a/src/main/java/ch/njol/skript/doc/JSONGenerator.java
+++ b/src/main/java/ch/njol/skript/doc/JSONGenerator.java
@@ -176,7 +176,7 @@ public class JSONGenerator extends DocumentationGenerator {
 						continue;
 					}
 
-					ClassInfo<?> exactClassInfo = Classes.getExactClassInfo(eventValueInfo.c());
+					ClassInfo<?> exactClassInfo = Classes.getExactClassInfo(eventValueInfo.valueClass());
 					if (exactClassInfo == null) {
 						continue;
 					}

--- a/src/main/java/ch/njol/skript/expressions/ExprEntity.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntity.java
@@ -108,7 +108,13 @@ public class ExprEntity extends SimpleExpression<Entity> {
 		}
 		return super.getConvertedExpression(to);
 	}
-	
+
+	@Override
+	public boolean setTime(int time) {
+		// Allows using 'past' / 'future' event-entitydata if they're registered
+		return entity.setTime(time);
+	}
+
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
 		return "the " + type;

--- a/src/main/java/ch/njol/skript/registrations/EventValues.java
+++ b/src/main/java/ch/njol/skript/registrations/EventValues.java
@@ -21,17 +21,17 @@ public class EventValues {
 	private EventValues() {}
 
 	/**
-	 * The past value of an eventClass value. Represented by "past" or "former".
+	 * The past value of an event value. Represented by "past" or "former".
 	 */
 	public static final int TIME_PAST = -1;
 
 	/**
-	 * The current time of an eventClass value.
+	 * The current time of an event value.
 	 */
 	public static final int TIME_NOW = 0;
 
 	/**
-	 * The future time of an eventClass value.
+	 * The future time of an event value.
 	 */
 	public static final int TIME_FUTURE = 1;
 
@@ -41,9 +41,9 @@ public class EventValues {
 
 	/**
 	 * Get Event Values list for the specified time
-	 * @param time The time of the eventClass values. One of
+	 * @param time The time of the event values. One of
 	 * {@link EventValues#TIME_PAST}, {@link EventValues#TIME_NOW} or {@link EventValues#TIME_FUTURE}.
-	 * @return An immutable copy of the eventClass values list for the specified time
+	 * @return An immutable copy of the event values list for the specified time
 	 */
 	public static List<EventValueInfo<?, ?>> getEventValuesListForTime(int time) {
 		return ImmutableList.copyOf(getEventValuesList(time));
@@ -60,7 +60,7 @@ public class EventValues {
 	}
 
 	/**
-	 * Registers an eventClass value, specified by the provided {@link Converter}, with excluded events.
+	 * Registers an event value, specified by the provided {@link Converter}, with excluded events.
 	 * Uses the default time, {@link #TIME_NOW}.
 	 *
 	 * @see #registerEventValue(Class, Class, Converter, int)
@@ -73,10 +73,10 @@ public class EventValues {
 	}
 
 	/**
-	 * Registers an eventClass value.
+	 * Registers an event value.
 	 *
-	 * @param eventClass the eventClass valueClass class.
-	 * @param valueClass the return valueClass of the converter for the eventClass value.
+	 * @param eventClass the event valueClass class.
+	 * @param valueClass the return valueClass of the converter for the event value.
 	 * @param converter the converter to get the value with the provided eventClass.
 	 * @param time value of TIME_PAST if this is the value before the eventClass, TIME_FUTURE if after, and TIME_NOW if it's the default or this value doesn't have distinct states.
 	 *            <b>Always register a default state!</b> You can leave out one of the other states instead, e.g. only register a default and a past state. The future state will
@@ -90,17 +90,17 @@ public class EventValues {
 	}
 
 	/**
-	 * Registers an eventClass value and with excluded events.
-	 * Excluded events are events that this eventClass value can't operate in.
+	 * Registers an event value and with excluded events.
+	 * Excluded events are events that this event value can't operate in.
 	 *
 	 * @param eventClass the eventClass type class.
-	 * @param valueClass the return type of the converter for the eventClass value.
+	 * @param valueClass the return type of the converter for the event value.
 	 * @param converter the converter to get the value with the provided eventClass.
 	 * @param time value of TIME_PAST if this is the value before the eventClass, TIME_FUTURE if after, and TIME_NOW if it's the default or this value doesn't have distinct states.
 	 *            <b>Always register a default state!</b> You can leave out one of the other states instead, e.g. only register a default and a past state. The future state will
 	 *            default to the default state in this case.
 	 * @param excludeErrorMessage The error message to display when used in the excluded events.
-	 * @param excludes subclasses of the eventClass for which this eventClass value should not be registered for
+	 * @param excludes subclasses of the eventClass for which this event value should not be registered for
 	 */
 	@SafeVarargs
 	public static <T, E extends Event> void registerEventValue(
@@ -192,7 +192,7 @@ public class EventValues {
 	 *
 	 * @param eventClass the eventClass class the getter will be getting from
 	 * @param valueClass type of {@link Converter}
-	 * @param time the eventClass-value's time
+	 * @param time the event-value's time
 	 * @return A getter to get values for a given type of events
 	 * @see #registerEventValue(Class, Class, Converter, int)
 	 * @see EventValueExpression#EventValueExpression(Class)
@@ -228,7 +228,7 @@ public class EventValues {
 	 *
 	 * @param eventClass the eventClass class the {@link Converter} will be getting from.
 	 * @param valueClass type of {@link Converter}.
-	 * @param time the eventClass-value's time.
+	 * @param time the event-value's time.
 	 * @return true or false if the eventClass and type have multiple {@link Converter}s.
 	 */
 	public static <T, E extends Event> Kleenean hasMultipleConverters(Class<E> eventClass, Class<T> valueClass, int time) {
@@ -251,11 +251,11 @@ public class EventValues {
 	/**
 	 * Returns a {@link Converter} to get a value from in an eventClass.
 	 * <p>
-	 * Can print an error if the eventClass value is blocked for the given eventClass.
+	 * Can print an error if the event value is blocked for the given eventClass.
 	 *
 	 * @param eventClass the eventClass class the {@link Converter} will be getting from.
 	 * @param valueClass type of {@link Converter}.
-	 * @param time the eventClass-value's time.
+	 * @param time the event-value's time.
 	 * @return A getter to get values for a given type of events.
 	 * @see #registerEventValue(Class, Class, Converter, int)
 	 * @see EventValueExpression#EventValueExpression(Class)
@@ -284,7 +284,7 @@ public class EventValues {
 	}
 
 	/*
-	 * We need to be able to collect all possible eventClass-values to a list for determining problematic collisions.
+	 * We need to be able to collect all possible event-values to a list for determining problematic collisions.
 	 * Always return after the loop check if the list is not empty.
 	 */
 	@Nullable
@@ -352,7 +352,7 @@ public class EventValues {
 		}
 		if (!list.isEmpty())
 			return delegateConverters(eventClass, valueClass, infoConverterMap, list);
-		// Fourth check will attempt to convert the eventClass value to the requesting type.
+		// Fourth check will attempt to convert the event value to the requesting type.
 		// This first for loop will check that the events are exact. See issue #5016
 		for (EventValueInfo<?, ?> eventValueInfo : eventValues) {
 			if (!eventClass.equals(eventValueInfo.eventClass))
@@ -372,7 +372,7 @@ public class EventValues {
 			return list;
 		// This loop will attempt to look for converters assignable to the class of the provided eventClass.
 		for (EventValueInfo<?, ?> eventValueInfo : eventValues) {
-			// The requesting eventClass must be assignable to the eventClass value's eventClass. Otherwise it'll throw an error.
+			// The requesting eventClass must be assignable to the event value's eventClass. Otherwise it'll throw an error.
 			if (!eventClass.isAssignableFrom(eventValueInfo.eventClass))
 				continue;
 
@@ -388,7 +388,7 @@ public class EventValues {
 		}
 		if (!list.isEmpty())
 			return list;
-		// If the check should try again matching eventClass values with a 0 time (most eventClass values).
+		// If the check should try again matching event values with a 0 time (most event values).
 		if (allowDefault && time != 0)
 			return getEventValueConverters(eventClass, valueClass, 0, false);
 		return null;
@@ -424,12 +424,12 @@ public class EventValues {
 	}
 
 	/**
-	 * Check if the eventClass value states to exclude events.
+	 * Check if the event value states to exclude events.
 	 * False if the current EventValueInfo cannot operate in the provided eventClass.
 	 *
-	 * @param info The eventClass value info that will be used to grab the value from
+	 * @param info The event value info that will be used to grab the value from
 	 * @param eventClass The eventClass class to check the excludes against.
-	 * @return boolean if true the eventClass value passes for the events.
+	 * @return boolean if true the event value passes for the events.
 	 */
 	private static boolean checkExcludes(EventValueInfo<?, ?> info, Class<? extends Event> eventClass) {
 		if (info.excludes == null)
@@ -444,11 +444,11 @@ public class EventValues {
 	}
 
 	/**
-	 * Return a converter wrapped in a getter that will grab the requested value by converting from the given eventClass value info.
+	 * Return a converter wrapped in a getter that will grab the requested value by converting from the given event value info.
 	 *
-	 * @param info The eventClass value info that will be used to grab the value from
-	 * @param valueClass The class that the converter will look for to convert the type from the eventClass value to
-	 * @param checkInstanceOf If the eventClass must be an exact instance of the eventClass value info's eventClass or not.
+	 * @param info The event value info that will be used to grab the value from
+	 * @param valueClass The class that the converter will look for to convert the type from the event value to
+	 * @param checkInstanceOf If the eventClass must be an exact instance of the event value info's eventClass or not.
 	 * @return The found Converter wrapped in a Getter object, or null if no Converter was found.
 	 */
 	@Nullable

--- a/src/main/java/ch/njol/skript/registrations/EventValues.java
+++ b/src/main/java/ch/njol/skript/registrations/EventValues.java
@@ -1,6 +1,7 @@
 package ch.njol.skript.registrations;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.expressions.base.EventValueExpression;
 import ch.njol.skript.util.Getter;
 import ch.njol.util.Kleenean;
@@ -11,24 +12,26 @@ import org.skriptlang.skript.lang.converter.Converter;
 import org.skriptlang.skript.lang.converter.Converters;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class EventValues {
 
 	private EventValues() {}
 
 	/**
-	 * The past value of an event value. Represented by "past" or "former".
+	 * The past value of an eventClass value. Represented by "past" or "former".
 	 */
 	public static final int TIME_PAST = -1;
 
 	/**
-	 * The current time of an event value.
+	 * The current time of an eventClass value.
 	 */
 	public static final int TIME_NOW = 0;
 
 	/**
-	 * The future time of an event value.
+	 * The future time of an eventClass value.
 	 */
 	public static final int TIME_FUTURE = 1;
 
@@ -38,9 +41,9 @@ public class EventValues {
 
 	/**
 	 * Get Event Values list for the specified time
-	 * @param time The time of the event values. One of
+	 * @param time The time of the eventClass values. One of
 	 * {@link EventValues#TIME_PAST}, {@link EventValues#TIME_NOW} or {@link EventValues#TIME_FUTURE}.
-	 * @return An immutable copy of the event values list for the specified time
+	 * @return An immutable copy of the eventClass values list for the specified time
 	 */
 	public static List<EventValueInfo<?, ?>> getEventValuesListForTime(int time) {
 		return ImmutableList.copyOf(getEventValuesList(time));
@@ -57,67 +60,67 @@ public class EventValues {
 	}
 
 	/**
-	 * Registers an event value, specified by the provided {@link Converter}, with excluded events.
+	 * Registers an eventClass value, specified by the provided {@link Converter}, with excluded events.
 	 * Uses the default time, {@link #TIME_NOW}.
 	 *
 	 * @see #registerEventValue(Class, Class, Converter, int)
 	 */
 	public static <T, E extends Event> void registerEventValue(
-		Class<E> event, Class<T> type,
+		Class<E> eventClass, Class<T> valueClass,
 		Converter<E, T> converter
 	) {
-		registerEventValue(event, type, converter, TIME_NOW);
+		registerEventValue(eventClass, valueClass, converter, TIME_NOW);
 	}
 
 	/**
-	 * Registers an event value.
+	 * Registers an eventClass value.
 	 *
-	 * @param event the event type class.
-	 * @param type the return type of the converter for the event value.
-	 * @param converter the converter to get the value with the provided event.
-	 * @param time value of TIME_PAST if this is the value before the event, TIME_FUTURE if after, and TIME_NOW if it's the default or this value doesn't have distinct states.
+	 * @param eventClass the eventClass valueClass class.
+	 * @param valueClass the return valueClass of the converter for the eventClass value.
+	 * @param converter the converter to get the value with the provided eventClass.
+	 * @param time value of TIME_PAST if this is the value before the eventClass, TIME_FUTURE if after, and TIME_NOW if it's the default or this value doesn't have distinct states.
 	 *            <b>Always register a default state!</b> You can leave out one of the other states instead, e.g. only register a default and a past state. The future state will
 	 *            default to the default state in this case.
 	 */
 	public static <T, E extends Event> void registerEventValue(
-		Class<E> event, Class<T> type,
+		Class<E> eventClass, Class<T> valueClass,
 		Converter<E, T> converter, int time
 	) {
-		registerEventValue(event, type, converter, time, null, (Class<? extends E>[]) null);
+		registerEventValue(eventClass, valueClass, converter, time, null, (Class<? extends E>[]) null);
 	}
 
 	/**
-	 * Registers an event value and with excluded events.
-	 * Excluded events are events that this event value can't operate in.
+	 * Registers an eventClass value and with excluded events.
+	 * Excluded events are events that this eventClass value can't operate in.
 	 *
-	 * @param event the event type class.
-	 * @param type the return type of the converter for the event value.
-	 * @param converter the converter to get the value with the provided event.
-	 * @param time value of TIME_PAST if this is the value before the event, TIME_FUTURE if after, and TIME_NOW if it's the default or this value doesn't have distinct states.
+	 * @param eventClass the eventClass type class.
+	 * @param valueClass the return type of the converter for the eventClass value.
+	 * @param converter the converter to get the value with the provided eventClass.
+	 * @param time value of TIME_PAST if this is the value before the eventClass, TIME_FUTURE if after, and TIME_NOW if it's the default or this value doesn't have distinct states.
 	 *            <b>Always register a default state!</b> You can leave out one of the other states instead, e.g. only register a default and a past state. The future state will
 	 *            default to the default state in this case.
 	 * @param excludeErrorMessage The error message to display when used in the excluded events.
-	 * @param excludes subclasses of the event for which this event value should not be registered for
+	 * @param excludes subclasses of the eventClass for which this eventClass value should not be registered for
 	 */
 	@SafeVarargs
 	public static <T, E extends Event> void registerEventValue(
-		Class<E> event, Class<T> type,
+		Class<E> eventClass, Class<T> valueClass,
 		Converter<E, T> converter, int time,
 		@Nullable String excludeErrorMessage,
 		@Nullable Class<? extends E>... excludes
 	) {
 		Skript.checkAcceptRegistrations();
 		List<EventValueInfo<?, ?>> eventValues = getEventValuesList(time);
-		EventValueInfo<E, T> element = new EventValueInfo<>(event, type, converter, excludeErrorMessage, excludes);
+		EventValueInfo<E, T> element = new EventValueInfo<>(eventClass, valueClass, converter, excludeErrorMessage, excludes);
 
 		for (int i = 0; i < eventValues.size(); i++) {
 			EventValueInfo<?, ?> info = eventValues.get(i);
 			// We don't care for exact duplicates. Prefer Skript's over any addon.
-			if (info.event.equals(event) && info.c.equals(type))
+			if (info.eventClass.equals(eventClass) && info.valueClass.equals(valueClass))
 				return;
-			// If the events don't match, we prefer the highest subclass event.
+			// If the events don't match, we prefer the highest subclass eventClass.
 			// If the events match, we prefer the highest subclass type.
-			if (!info.event.equals(event) ? info.event.isAssignableFrom(event) : info.c.isAssignableFrom(type)) {
+			if (!info.eventClass.equals(eventClass) ? info.eventClass.isAssignableFrom(eventClass) : info.valueClass.isAssignableFrom(valueClass)) {
 				eventValues.add(i, element);
 				return;
 			}
@@ -132,12 +135,12 @@ public class EventValues {
 	@SafeVarargs
 	@SuppressWarnings({"removal"})
 	public static <T, E extends Event> void registerEventValue(
-		Class<E> event, Class<T> type,
+		Class<E> eventClass, Class<T> valueClass,
 		Getter<T, E> getter, int time,
 		@Nullable String excludeErrorMessage,
 		@Nullable Class<? extends E>... excludes
 	) {
-		registerEventValue(event, type, (Converter<E, T>) getter, time, excludeErrorMessage, excludes);
+		registerEventValue(eventClass, valueClass, (Converter<E, T>) getter, time, excludeErrorMessage, excludes);
 	}
 
 	/**
@@ -146,32 +149,32 @@ public class EventValues {
 	@Deprecated(forRemoval = true)
 	@SuppressWarnings({"removal"})
 	public static <T, E extends Event> void registerEventValue(
-		Class<E> event, Class<T> type,
+		Class<E> eventClass, Class<T> valueClass,
 		Getter<T, E> getter, int time
 	) {
-		registerEventValue(event, type, (Converter<E, T>) getter, time);
+		registerEventValue(eventClass, valueClass, (Converter<E, T>) getter, time);
 	}
 
 	/**
-	 * Gets a specific value from an event. Returns null if the event doesn't have such a value (conversions are done to try and get the desired value).
+	 * Gets a specific value from an eventClass. Returns null if the eventClass doesn't have such a value (conversions are done to try and get the desired value).
 	 * <p>
 	 * It is recommended to use {@link EventValues#getEventValueGetter(Class, Class, int)} or {@link EventValueExpression#EventValueExpression(Class)} instead of invoking this
 	 * method repeatedly.
 	 *
-	 * @param e event
-	 * @param c return type of getter
-	 * @param time -1 if this is the value before the event, 1 if after, and 0 if it's the default or this value doesn't have distinct states.
+	 * @param event eventClass
+	 * @param valueClass return type of getter
+	 * @param time -1 if this is the value before the eventClass, 1 if after, and 0 if it's the default or this value doesn't have distinct states.
 	 *            <b>Always register a default state!</b> You can leave out one of the other states instead, e.g. only register a default and a past state. The future state will
 	 *            default to the default state in this case.
-	 * @return The event's value
+	 * @return The eventClass's value
 	 * @see #registerEventValue(Class, Class, Converter, int)
 	 */
-	public static <T, E extends Event> @Nullable T getEventValue(E e, Class<T> c, int time) {
+	public static <T, E extends Event> @Nullable T getEventValue(E event, Class<T> valueClass, int time) {
 		//noinspection unchecked
-		Converter<? super E, ? extends T> converter = getEventValueConverter((Class<E>) e.getClass(), c, time);
+		Converter<? super E, ? extends T> converter = getEventValueConverter((Class<E>) event.getClass(), valueClass, time);
 		if (converter == null)
 			return null;
-		return converter.convert(e);
+		return converter.convert(event);
 	}
 
 	/**
@@ -180,32 +183,32 @@ public class EventValues {
 	@Nullable
 	@Deprecated(forRemoval = true)
 	@SuppressWarnings({"removal"})
-	public static <T, E extends Event> Getter<? extends T, ? super E> getExactEventValueGetter(Class<E> event, Class<T> c, int time) {
-		return toGetter(getExactEventValueConverter(event, c, time));
+	public static <T, E extends Event> Getter<? extends T, ? super E> getExactEventValueGetter(Class<E> eventClass, Class<T> valueClass, int time) {
+		return toGetter(getExactEventValueConverter(eventClass, valueClass, time));
 	}
 
 	/**
 	 * Checks that a {@link Converter} exists for the exact type. No converting or subclass checking.
 	 *
-	 * @param event the event class the getter will be getting from
-	 * @param c type of {@link Converter}
-	 * @param time the event-value's time
+	 * @param eventClass the eventClass class the getter will be getting from
+	 * @param valueClass type of {@link Converter}
+	 * @param time the eventClass-value's time
 	 * @return A getter to get values for a given type of events
 	 * @see #registerEventValue(Class, Class, Converter, int)
 	 * @see EventValueExpression#EventValueExpression(Class)
 	 */
 	@Nullable
 	public static <E extends Event, T> Converter<? super E, ? extends T> getExactEventValueConverter(
-		Class<E> event, Class<T> c, int time
+		Class<E> eventClass, Class<T> valueClass, int time
 	) {
 		List<EventValueInfo<?, ?>> eventValues = getEventValuesList(time);
 		// First check for exact classes matching the parameters.
 		for (EventValueInfo<?, ?> eventValueInfo : eventValues) {
-			if (!c.equals(eventValueInfo.c))
+			if (!valueClass.equals(eventValueInfo.valueClass))
 				continue;
-			if (!checkExcludes(eventValueInfo, event))
+			if (!checkExcludes(eventValueInfo, eventClass))
 				return null;
-			if (eventValueInfo.event.isAssignableFrom(event))
+			if (eventValueInfo.eventClass.isAssignableFrom(eventClass))
 				//noinspection unchecked
 				return (Converter<? super E, ? extends T>) eventValueInfo.converter;
 		}
@@ -216,20 +219,20 @@ public class EventValues {
 	 * @deprecated Use {@link #hasMultipleConverters(Class, Class, int)} instead.
 	 */
 	@Deprecated(forRemoval = true)
-	public static <T, E extends Event> Kleenean hasMultipleGetters(Class<E> event, Class<T> type, int time) {
-		return hasMultipleConverters(event, type, time);
+	public static <T, E extends Event> Kleenean hasMultipleGetters(Class<E> eventClass, Class<T> valueClass, int time) {
+		return hasMultipleConverters(eventClass, valueClass, time);
 	}
 
 	/**
-	 * Checks if an event has multiple {@link Converter}s, including default ones.
+	 * Checks if an eventClass has multiple {@link Converter}s, including default ones.
 	 *
-	 * @param event the event class the {@link Converter} will be getting from.
-	 * @param type type of {@link Converter}.
-	 * @param time the event-value's time.
-	 * @return true or false if the event and type have multiple {@link Converter}s.
+	 * @param eventClass the eventClass class the {@link Converter} will be getting from.
+	 * @param valueClass type of {@link Converter}.
+	 * @param time the eventClass-value's time.
+	 * @return true or false if the eventClass and type have multiple {@link Converter}s.
 	 */
-	public static <T, E extends Event> Kleenean hasMultipleConverters(Class<E> event, Class<T> type, int time) {
-		List<Converter<? super E, ? extends T>> getters = getEventValueConverters(event, type, time, true, false);
+	public static <T, E extends Event> Kleenean hasMultipleConverters(Class<E> eventClass, Class<T> valueClass, int time) {
+		List<Converter<? super E, ? extends T>> getters = getEventValueConverters(eventClass, valueClass, time, true, false);
 		if (getters == null)
 			return Kleenean.UNKNOWN;
 		return Kleenean.get(getters.size() > 1);
@@ -241,33 +244,33 @@ public class EventValues {
 	@Nullable
 	@Deprecated(forRemoval = true)
 	@SuppressWarnings({"removal"})
-	public static <T, E extends Event> Getter<? extends T, ? super E> getEventValueGetter(Class<E> event, Class<T> type, int time) {
-		return toGetter(getEventValueConverter(event, type, time, true));
+	public static <T, E extends Event> Getter<? extends T, ? super E> getEventValueGetter(Class<E> eventClass, Class<T> valueClass, int time) {
+		return toGetter(getEventValueConverter(eventClass, valueClass, time, true));
 	}
 
 	/**
-	 * Returns a {@link Converter} to get a value from in an event.
+	 * Returns a {@link Converter} to get a value from in an eventClass.
 	 * <p>
-	 * Can print an error if the event value is blocked for the given event.
+	 * Can print an error if the eventClass value is blocked for the given eventClass.
 	 *
-	 * @param event the event class the {@link Converter} will be getting from.
-	 * @param type type of {@link Converter}.
-	 * @param time the event-value's time.
+	 * @param eventClass the eventClass class the {@link Converter} will be getting from.
+	 * @param valueClass type of {@link Converter}.
+	 * @param time the eventClass-value's time.
 	 * @return A getter to get values for a given type of events.
 	 * @see #registerEventValue(Class, Class, Converter, int)
 	 * @see EventValueExpression#EventValueExpression(Class)
 	 */
 	public static <T, E extends Event> @Nullable Converter<? super E, ? extends T> getEventValueConverter(
-		Class<E> event, Class<T> type, int time
+		Class<E> eventClass, Class<T> valueClass, int time
 	) {
-		return getEventValueConverter(event, type, time, true);
+		return getEventValueConverter(eventClass, valueClass, time, true);
 	}
 
 	@Nullable
 	private static <T, E extends Event> Converter<? super E, ? extends T> getEventValueConverter(
-		Class<E> event, Class<T> type, int time, boolean allowDefault
+		Class<E> eventClass, Class<T> valueClass, int time, boolean allowDefault
 	) {
-		List<Converter<? super E, ? extends T>> list = getEventValueConverters(event, type, time, allowDefault);
+		List<Converter<? super E, ? extends T>> list = getEventValueConverters(eventClass, valueClass, time, allowDefault);
 		if (list == null || list.isEmpty())
 			return null;
 		return list.get(0);
@@ -275,82 +278,88 @@ public class EventValues {
 
 	@Nullable
 	private static <T, E extends Event> List<Converter<? super E, ? extends T>> getEventValueConverters(
-		Class<E> event, Class<T> type, int time, boolean allowDefault
+		Class<E> eventClass, Class<T> valueClass, int time, boolean allowDefault
 	) {
-		return getEventValueConverters(event, type, time, allowDefault, true);
+		return getEventValueConverters(eventClass, valueClass, time, allowDefault, true);
 	}
 
 	/*
-	 * We need to be able to collect all possible event-values to a list for determining problematic collisions.
+	 * We need to be able to collect all possible eventClass-values to a list for determining problematic collisions.
 	 * Always return after the loop check if the list is not empty.
 	 */
 	@Nullable
 	@SuppressWarnings("unchecked")
 	private static <T, E extends Event> List<Converter<? super E, ? extends T>> getEventValueConverters(
-		Class<E> event, Class<T> type, int time,
+		Class<E> event, Class<T> valueClass, int time,
 		boolean allowDefault, boolean allowConverting
 	) {
 		List<EventValueInfo<?, ?>> eventValues = getEventValuesList(time);
 		List<Converter<? super E, ? extends T>> list = new ArrayList<>();
 		// First check for exact classes matching the parameters.
-		Converter<? super E, ? extends T> exact = getExactEventValueConverter(event, type, time);
+		Converter<? super E, ? extends T> exact = getExactEventValueConverter(event, valueClass, time);
 		if (exact != null) {
 			list.add(exact);
 			return list;
 		}
+		Map<EventValueInfo<?, ?>, Converter<? super E, ? extends T>> infoConverterMap = new HashMap<>();
 		// Second check for assignable subclasses.
 		for (EventValueInfo<?, ?> eventValueInfo : eventValues) {
-			if (!type.isAssignableFrom(eventValueInfo.c))
+			if (!valueClass.isAssignableFrom(eventValueInfo.valueClass))
 				continue;
 			if (!checkExcludes(eventValueInfo, event))
 				return null;
-			if (eventValueInfo.event.isAssignableFrom(event)) {
+			if (eventValueInfo.eventClass.isAssignableFrom(event)) {
 				list.add((Converter<? super E, ? extends T>) eventValueInfo.converter);
+				infoConverterMap.put(eventValueInfo, (Converter<? super E, ? extends T>) eventValueInfo.converter);
 				continue;
 			}
-			if (!event.isAssignableFrom(eventValueInfo.event))
+			if (!event.isAssignableFrom(eventValueInfo.eventClass))
 				continue;
-			list.add(e -> {
-				if (!eventValueInfo.event.isInstance(e))
+			Converter<? super E, ? extends T> converter = e -> {
+				if (!eventValueInfo.eventClass.isInstance(e))
 					return null;
 				return ((Converter<? super E, ? extends T>) eventValueInfo.converter).convert(e);
-			});
+			};
+			list.add(converter);
+			infoConverterMap.put(eventValueInfo, converter);
 		}
 		if (!list.isEmpty())
-			return list;
+			return delegateConverters(event, valueClass, infoConverterMap, list);
 		if (!allowConverting)
 			return null;
 		// Most checks have returned before this below is called, but Skript will attempt to convert or find an alternative.
 		// Third check is if the returned object matches the class.
 		for (EventValueInfo<?, ?> eventValueInfo : eventValues) {
-			if (!eventValueInfo.c.isAssignableFrom(type))
+			if (!eventValueInfo.valueClass.isAssignableFrom(valueClass))
 				continue;
-			boolean checkInstanceOf = !eventValueInfo.event.isAssignableFrom(event);
-			if (checkInstanceOf && !event.isAssignableFrom(eventValueInfo.event))
+			boolean checkInstanceOf = !eventValueInfo.eventClass.isAssignableFrom(event);
+			if (checkInstanceOf && !event.isAssignableFrom(eventValueInfo.eventClass))
 				continue;
 
 			if (!checkExcludes(eventValueInfo, event))
 				return null;
 
-			list.add(e -> {
-				if (checkInstanceOf && !eventValueInfo.event.isInstance(e))
+			Converter<? super E, ? extends T> converter = e -> {
+				if (checkInstanceOf && !eventValueInfo.eventClass.isInstance(e))
 					return null;
 				T object = ((Converter<? super E, ? extends T>) eventValueInfo.converter).convert(e);
-				if (type.isInstance(object))
+				if (valueClass.isInstance(object))
 					return object;
 				return null;
-			});
+			};
+			list.add(converter);
+			infoConverterMap.put(eventValueInfo, converter);
 		}
 		if (!list.isEmpty())
-			return list;
-		// Fourth check will attempt to convert the event value to the requesting type.
+			return delegateConverters(event, valueClass, infoConverterMap, list);
+		// Fourth check will attempt to convert the eventClass value to the requesting type.
 		// This first for loop will check that the events are exact. See issue #5016
 		for (EventValueInfo<?, ?> eventValueInfo : eventValues) {
-			if (!event.equals(eventValueInfo.event))
+			if (!event.equals(eventValueInfo.eventClass))
 				continue;
 
 			Converter<? super E, ? extends T> converter = (Converter<? super E, ? extends T>)
-				getConvertedConverter(eventValueInfo, type, false);
+				getConvertedConverter(eventValueInfo, valueClass, false);
 			if (converter == null)
 				continue;
 
@@ -361,14 +370,14 @@ public class EventValues {
 		}
 		if (!list.isEmpty())
 			return list;
-		// This loop will attempt to look for converters assignable to the class of the provided event.
+		// This loop will attempt to look for converters assignable to the class of the provided eventClass.
 		for (EventValueInfo<?, ?> eventValueInfo : eventValues) {
-			// The requesting event must be assignable to the event value's event. Otherwise it'll throw an error.
-			if (!event.isAssignableFrom(eventValueInfo.event))
+			// The requesting eventClass must be assignable to the eventClass value's eventClass. Otherwise it'll throw an error.
+			if (!event.isAssignableFrom(eventValueInfo.eventClass))
 				continue;
 
 			Converter<? super E, ? extends T> converter = (Converter<? super E, ? extends T>)
-				getConvertedConverter(eventValueInfo, type, true);
+				getConvertedConverter(eventValueInfo, valueClass, true);
 			if (converter == null)
 				continue;
 
@@ -379,25 +388,54 @@ public class EventValues {
 		}
 		if (!list.isEmpty())
 			return list;
-		// If the check should try again matching event values with a 0 time (most event values).
+		// If the check should try again matching eventClass values with a 0 time (most eventClass values).
 		if (allowDefault && time != 0)
-			return getEventValueConverters(event, type, 0, false);
+			return getEventValueConverters(event, valueClass, 0, false);
 		return null;
 	}
 
-	/**
-	 * Check if the event value states to exclude events.
-	 * False if the current EventValueInfo cannot operate in the provided event.
-	 *
-	 * @param info The event value info that will be used to grab the value from
-	 * @param event The event class to check the excludes against.
-	 * @return boolean if true the event value passes for the events.
+	/*
+		In this method we can delegate/strip converters that are able to be obtainable through their own 'event-classinfo'.
+		For example, PlayerTradeEvent has a player value (player who traded) and an AbstractVillager value (villager traded from).
+		Beforehand, since there is no Entity value, it was then grabbing both values as they both can be casted as an Entity
+			resulting in a parse error of "multiple entities"
+		Now, we filter out the ones that can be obtained using their own classinfo, such as 'event-player'
+			which leaves us only the AbstractVillager for 'event-entity'
 	 */
-	private static boolean checkExcludes(EventValueInfo<?, ?> info, Class<? extends Event> event) {
+	private static <E extends Event, T> List<Converter<? super E, ? extends T>> delegateConverters(
+		Class<E> eventClass,
+		Class<T> valueClass,
+		Map<EventValueInfo<?, ?>, Converter<? super E, ? extends T>> converterMap,
+		List<Converter<? super E, ? extends T>> converters
+	) {
+		if (converters.size() == 1)
+			return converters;
+		ClassInfo<T> valueClassInfo = Classes.getExactClassInfo(valueClass);
+		List<Converter<? super E, ? extends T>> delegated = new ArrayList<>();
+		for (EventValueInfo<?, ?> eventValueInfo : converterMap.keySet()) {
+			ClassInfo<?> thisClassInfo = Classes.getExactClassInfo(eventValueInfo.valueClass);
+			if (thisClassInfo != null && !thisClassInfo.equals(valueClassInfo))
+				continue;
+			delegated.add(converterMap.get(eventValueInfo));
+		}
+		if (delegated.isEmpty())
+			return converters;
+		return delegated;
+	}
+
+	/**
+	 * Check if the eventClass value states to exclude events.
+	 * False if the current EventValueInfo cannot operate in the provided eventClass.
+	 *
+	 * @param info The eventClass value info that will be used to grab the value from
+	 * @param eventClass The eventClass class to check the excludes against.
+	 * @return boolean if true the eventClass value passes for the events.
+	 */
+	private static boolean checkExcludes(EventValueInfo<?, ?> info, Class<? extends Event> eventClass) {
 		if (info.excludes == null)
 			return true;
 		for (Class<? extends Event> ex : (Class<? extends Event>[]) info.excludes) {
-			if (ex.isAssignableFrom(event)) {
+			if (ex.isAssignableFrom(eventClass)) {
 				Skript.error(info.excludeErrorMessage);
 				return false;
 			}
@@ -406,24 +444,24 @@ public class EventValues {
 	}
 
 	/**
-	 * Return a converter wrapped in a getter that will grab the requested value by converting from the given event value info.
+	 * Return a converter wrapped in a getter that will grab the requested value by converting from the given eventClass value info.
 	 *
-	 * @param info The event value info that will be used to grab the value from
-	 * @param to The class that the converter will look for to convert the type from the event value to
-	 * @param checkInstanceOf If the event must be an exact instance of the event value info's event or not.
+	 * @param info The eventClass value info that will be used to grab the value from
+	 * @param valueClass The class that the converter will look for to convert the type from the eventClass value to
+	 * @param checkInstanceOf If the eventClass must be an exact instance of the eventClass value info's eventClass or not.
 	 * @return The found Converter wrapped in a Getter object, or null if no Converter was found.
 	 */
 	@Nullable
 	private static <E extends Event, F, T> Converter<? super E, ? extends T> getConvertedConverter(
-		EventValueInfo<E, F> info, Class<T> to, boolean checkInstanceOf
+		EventValueInfo<E, F> info, Class<T> valueClass, boolean checkInstanceOf
 	) {
-		Converter<? super F, ? extends T> converter = Converters.getConverter(info.c, to);
+		Converter<? super F, ? extends T> converter = Converters.getConverter(info.valueClass, valueClass);
 
 		if (converter == null)
 			return null;
 
 		return event -> {
-			if (checkInstanceOf && !info.event.isInstance(event))
+			if (checkInstanceOf && !info.eventClass.isInstance(event))
 				return null;
 			F f = info.converter.convert(event);
 			if (f == null)
@@ -446,22 +484,24 @@ public class EventValues {
 		};
 	}
 
-	public static boolean doesExactEventValueHaveTimeStates(Class<? extends Event> event, Class<?> c) {
-		return getExactEventValueConverter(event, c, TIME_PAST) != null || getExactEventValueConverter(event, c, TIME_FUTURE) != null;
+	public static boolean doesExactEventValueHaveTimeStates(Class<? extends Event> eventClass, Class<?> valueClass) {
+		return getExactEventValueConverter(eventClass, valueClass, TIME_PAST) != null
+			|| getExactEventValueConverter(eventClass, valueClass, TIME_FUTURE) != null;
 	}
 
-	public static boolean doesEventValueHaveTimeStates(Class<? extends Event> event, Class<?> c) {
-		return getEventValueConverter(event, c, TIME_PAST, false) != null || getEventValueConverter(event, c, TIME_FUTURE, false) != null;
+	public static boolean doesEventValueHaveTimeStates(Class<? extends Event> eventClass, Class<?> valueClass) {
+		return getEventValueConverter(eventClass, valueClass, TIME_PAST, false) != null
+			|| getEventValueConverter(eventClass, valueClass, TIME_FUTURE, false) != null;
 	}
 
 	private record EventValueInfo<E extends Event, T>(
-		Class<E> event, Class<T> c, Converter<E, T> converter,
+		Class<E> eventClass, Class<T> valueClass, Converter<E, T> converter,
 		@Nullable String excludeErrorMessage,
 		@Nullable Class<? extends E>[] excludes
 	) {
 		private EventValueInfo {
-			assert event != null;
-			assert c != null;
+			assert eventClass != null;
+			assert valueClass != null;
 			assert converter != null;
 		}
 

--- a/src/main/java/ch/njol/skript/registrations/EventValues.java
+++ b/src/main/java/ch/njol/skript/registrations/EventValues.java
@@ -8,16 +8,16 @@ import ch.njol.util.Kleenean;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
+import io.papermc.paper.event.player.PlayerTradeEvent;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.AbstractVillager;
+import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.converter.Converter;
 import org.skriptlang.skript.lang.converter.Converters;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class EventValues {
 
@@ -400,11 +400,12 @@ public class EventValues {
 	/**
 	 * <p>
 	 *  In this method we can strip converters that are able to be obtainable through their own 'event-classinfo'.
-	 *  For example, PlayerTradeEvent has a player value (player who traded) and an AbstractVillager value (villager traded from).
-	 *  Beforehand, since there is no Entity value, it was then grabbing both values as they both can be casted as an Entity
-	 *  	resulting in a parse error of "multiple entities"
-	 * 	Now, we filter out the ones that can be obtained using their own classinfo, such as 'event-player'
-	 * 		which leaves us only the AbstractVillager for 'event-entity'
+	 *  For example, {@link PlayerTradeEvent} has a {@link Player} value (player who traded)
+	 *  	and an {@link AbstractVillager} value (villager traded from).
+	 *  Beforehand, since there is no {@link Entity} value, it was grabbing both values as they both can be casted as an {@link Entity},
+	 *  	resulting in a parse error of "multiple entities".
+	 * 	Now, we filter out the values that can be obtained using their own classinfo, such as 'event-player'
+	 * 		which leaves us only the {@link AbstractVillager} for 'event-entity'.
 	 * </p>
 	 */
 	private static <E extends Event, T> List<Converter<? super E, ? extends T>> stripConverters(
@@ -416,16 +417,16 @@ public class EventValues {
 		if (converters.size() == 1)
 			return converters;
 		ClassInfo<T> valueClassInfo = Classes.getExactClassInfo(valueClass);
-		List<Converter<? super E, ? extends T>> delegated = new ArrayList<>();
+		List<Converter<? super E, ? extends T>> stripped = new ArrayList<>();
 		for (EventValueInfo<?, ?> eventValueInfo : infoConverterMap.keySet()) {
 			ClassInfo<?> thisClassInfo = Classes.getExactClassInfo(eventValueInfo.valueClass);
 			if (thisClassInfo != null && !thisClassInfo.equals(valueClassInfo))
 				continue;
-			delegated.add(infoConverterMap.get(eventValueInfo));
+			stripped.add(infoConverterMap.get(eventValueInfo));
 		}
-		if (delegated.isEmpty())
+		if (stripped.isEmpty())
 			return converters;
-		return delegated;
+		return stripped;
 	}
 
 	/**

--- a/src/test/skript/tests/misc/EventValues.sk
+++ b/src/test/skript/tests/misc/EventValues.sk
@@ -97,16 +97,10 @@ on craft:
 	set {_values::*} to event-string and event-item
 
 on entity pickup:
-	add event-entity to {_values::*}
-	add event-dropped item to {_values::*}
-	add event-itemtype to {_values::*}
-	#set {_values::*} to event-entity, event-dropped item and event-itemtype
+	set {_values::*} to event-entity, event-dropped item and event-itemtype
 
 on player pickup:
-	add event-player to {_values::*}
-	add event-dropped item to {_values::*}
-	add event-itemtype to {_values::*}
-	#set {_values::*} to event-player, event-dropped item and event-itemtype
+	set {_values::*} to event-player, event-dropped item and event-itemtype
 
 on consume:
 	set {_values::*} to event-player and event-item
@@ -136,7 +130,7 @@ on player unleash:
 	set {_values::*} to event-player and event-unleash reason
 
 on level change:
-	set {_values::*} to event-player
+	set {_values::*} to event-player and event-entity
 
 on entity move:
 	set {_values::*} to event-entity
@@ -145,10 +139,10 @@ on step on dirt:
 	set {_values::*} to event-player, event-block, past event-location, event-location, past event-chunk and event-chunk
 
 on send command list:
-	set {_values::*} to event-player
+	set {_values::*} to event-player and event-entity
 
 on resource pack response:
-	set {_values::*} to event-player
+	set {_values::*} to event-player and event-entity
 
 on load:
 	set {_values::*} to event-sender
@@ -163,7 +157,7 @@ on skript unload:
 	set {_values::*} to event-sender
 
 on start spectating:
-	set {_values::*} to event-player
+	set {_values::*} to event-player and event-entity
 
 on entity teleport:
 	set {_values::*} to event-entity, past event-location and event-location
@@ -283,13 +277,13 @@ on tool change:
 	set {_values::*} to event-player, past event-slot and event-slot
 
 on join:
-	set {_values::*} to event-player
+	set {_values::*} to event-player and event-entity
 
 on connect:
-	set {_values::*} to event-player
+	set {_values::*} to event-player and event-entity
 
 on kick:
-	set {_values::*} to event-player
+	set {_values::*} to event-player and event-entity
 
 on entity portal:
 	set {_values::*} to event-entity, past event-location and event-location
@@ -301,13 +295,13 @@ on leave:
 	set {_values::*} to event-player and event-quit reason
 
 on respawn:
-	set {_values::*} to event-player
+	set {_values::*} to event-player and event-entity
 
 on toggle sneak:
-	set {_values::*} to event-player
+	set {_values::*} to event-player and event-entity
 
 on toggle sprint:
-	set {_values::*} to event-player
+	set {_values::*} to event-player and event-entity
 
 on portal create:
 	set {_values::*} to event-world, event-blocks and event-entity

--- a/src/test/skript/tests/misc/EventValues.sk
+++ b/src/test/skript/tests/misc/EventValues.sk
@@ -1,487 +1,966 @@
-options:
-	test: "EventValuesTest"
 
 # This is to test parsing of event-value expressions
 
-on beacon effect:
-	set {_values::*} to event-player and event-block
-
-on beacon toggle:
-	set {_values::*} to event-block
-
-on break:
-	set {_values::*} to event-player, event-block and past event-block
-
-on burn:
-	set {_value::*} to event-block
-
-on place:
-	set {_values::*} to event-player, event-block, past event-block, past event-item, event-item and future event-item
-
-on fade:
-	set {_values::*} to past event-block, event-block and future event-block
-
-on form:
-	set {_values::*} to past event-block and event-block
-
-on block drop:
-	set {_values::*} to past event-block, event-block, event-player, event-items and event-entities
-
-on book edit:
-	set {_values::*} to event-player, past event-item, event-item, past event-strings and event-strings
-
-on click:
-	set {_values::*} to event-item, event-block, event-direction, event-player and event-entity
-
-on command:
-	set {_values::*} to event-player, event-sender, event-world and event-block
-
-on damage:
-	set {_values::*} to event-world, event-location, event-damage cause and event-projectile
-
-on death:
-	set {_values::*} to event-world, event-location, event-damage cause, event-items and event-projectile
-
-on spawn:
-	set {_values::*} to event-entity
-
-on entity change block:
-	set {_values::*} to past event-block, event-block, past event-block data and event-block data
-
-on entity potion effect:
-	set {_values::*} to past event-potion effect, event-potion effect and event-potion effect type
-
-on target:
-	set {_values::*} to event-entity
-
-on entity transform:
-	set {_values::*} to event-entities and event-transform reason
-
-on xp change:
-	set {_values::*} to event-player and event-experience
-
-on xp spawn:
-	set {_values::*} to event-location and event-experience
-
-on firework explode:
-	set {_values::*} to event-firework, event-firework effect and event-colors
-
-on first join:
-	set {_values::*} to event-player
-
-on gamemode change:
-	set {_values::*} to event-player
-
-on grow:
-	set {_values::*} to past event-block and event-block
-
-on heal:
-	set {_values::*} to event-entity and event-heal reason
-
-on dispense:
-	set {_values::*} to event-block and event-item
-
-on item spawn:
-	set {_values::*} to event-item
-
-on entity drop:
-	set {_values::*} to event-entity, event-dropped item and event-item
-
-on player drop:
-	set {_values::*} to event-player, event-dropped item and event-item
-
-on preparing craft:
-	set {_values::*} to event-slot, event-item, event-inventory, event-player and event-string
-
-on craft:
-	set {_values::*} to event-string and event-item
-
-on entity pickup:
-	set {_values::*} to event-entity, event-dropped item and event-itemtype
-
-on player pickup:
-	set {_values::*} to event-player, event-dropped item and event-itemtype
-
-on consume:
-	set {_values::*} to event-player and event-item
-
-on inventory click:
-	set {_values::*} to event-player, event-world, event-item, event-slot, event-inventory action, event-click type and event-inventory
-
-on item despawn:
-	set {_values::*} to event-dropped item and event-item
-
-on item merge:
-	set {_values::*} to event-dropped item and event-item and future event-dropped item
-
-on inventory item move:
-	set {_values::*} to event-inventory, future event-inventory, event-block, event-item and future event-block
-
-on stonecutting:
-	set {_values::*} to event-player and event-item
-
-on leash:
-	set {_values::*} to event-player and event-entity
-
-on unleash:
-	set {_values::*} to event-entity and event-unleash reason
-
-on player unleash:
-	set {_values::*} to event-player and event-unleash reason
-
-on level change:
-	set {_values::*} to event-player and event-entity
-
-on entity move:
-	set {_values::*} to event-entity
-
-on step on dirt:
-	set {_values::*} to event-player, event-block, past event-location, event-location, past event-chunk and event-chunk
-
-on send command list:
-	set {_values::*} to event-player and event-entity
-
-on resource pack response:
-	set {_values::*} to event-player and event-entity
-
-on load:
-	set {_values::*} to event-sender
-
-on unload:
-	set {_values::*} to event-sender
-
-on skript load:
-	set {_values::*} to event-sender
-
-on skript unload:
-	set {_values::*} to event-sender
-
-on start spectating:
-	set {_values::*} to event-player and event-entity
-
-on entity teleport:
-	set {_values::*} to event-entity, past event-location and event-location
-
-on player teleport:
-	set {_values::*} to event-player, past event-location and event-location
-
-on vehicle collision:
-	set {_values::*} to event-world, event-entity and event-block
-
-on weather change:
-	set {_values::*} to event-world
-
-on world save:
-	set {_values::*} to event-world
-
-on world init:
-	set {_values::*} to event-world
-
-on world load:
-	set {_values::*} to event-world
-
-on world unload:
-	set {_values::*} to event-world
-
-on can build check:
-	set {_values::*} to past event-block, event-block and event-player
-
-on block damage:
-	set {_values::*} to event-block and event-player
-
-on flow:
-	set {_values::*} to event-block and future event-block
-
-on ignite:
-	set {_values::*} to event-block and event-player
-
-on physics:
-	set {_values::*} to event-block
-
-on piston extend:
-	set {_values::*} to event-block
-
-on piston retract:
-	set {_values::*} to event-block
-
-on redstone:
-	set {_values::*} to event-block
-
-on spread:
-	set {_values::*} to event-block
-
-on chunk load:
-	set {_values::*} to event-world and event-chunk
-
-on chunk generate:
-	set {_values::*} to event-world and event-chunk
-
-on chunk unload:
-	set {_values::*} to event-world and event-chunk
-
-on creeper power:
-	set {_values::*} to event-entity
-
-on zombie break door:
-	set {_values::*} to event-entity, past event-block, event-block, event-block data and future event-block data
-
-on combust:
-	set {_values::*} to event-entity
-
-on explode:
-	set {_values::*} to event-entity
-
-on portal enter:
-	set {_values::*} to event-entity
-
-on tame:
-	set {_values::*} to event-entity
-
-on explosion prime:
-	set {_values::*} to event-entity
-
-on hunger level change:
-	set {_values::*} to event-entity
-
-on leaves decay:
-	set {_values::*} to event-block
-
-on lightning:
-	set {_values::*} to event-entity
-
-on pig zap:
-	set {_values::*} to event-entity, event-entities and event-transform reason
-
-on bed enter:
-	set {_values::*} to event-player and event-block
-
-on leave bed:
-	set {_values::*} to event-player and event-block
-
-on bucket empty:
-	set {_values::*} to event-player, past event-block and event-block
-
-on bucket fill:
-	set {_values::*} to event-player, event-block and future event-block
-
-on throw egg:
-	set {_values::*} to event-player and event-projectile
-
-on tool break:
-	set {_values::*} to event-player and event-item
-
-on item damage:
-	set {_values::*} to event-player and event-item
-
-on tool change:
-	set {_values::*} to event-player, past event-slot and event-slot
-
-on join:
-	set {_values::*} to event-player and event-entity
-
-on connect:
-	set {_values::*} to event-player and event-entity
-
-on kick:
-	set {_values::*} to event-player and event-entity
-
-on entity portal:
-	set {_values::*} to event-entity, past event-location and event-location
-
-on portal:
-	set {_values::*} to event-player, event-teleport cause, event-block, past event-location, event-location, past event-chunk and event-chunk
-
-on leave:
-	set {_values::*} to event-player and event-quit reason
-
-on respawn:
-	set {_values::*} to event-player and event-entity
-
-on toggle sneak:
-	set {_values::*} to event-player and event-entity
-
-on toggle sprint:
-	set {_values::*} to event-player and event-entity
-
-on portal create:
-	set {_values::*} to event-world, event-blocks and event-entity
-
-on projectile collide:
-	set {_values::*} to event-projectile and event-entity
-
-on shoot:
-	set {_values::*} to event-projectile
-
-on sign change:
-	set {_values::*} to event-player, event-strings and event-block
-
-on spawn change:
-	set {_values::*} to event-world
-
-on vehicle create:
-	#set {_values::*} to event-vehicle, event-world and event-entity
-	set {_values::*} to event-world and event-entity
-
-on vehicle damage:
-	#set {_values::*} to event-vehicle, event-world and event-entity
-	set {_values::*} to event-world and event-entity
-
-on vehicle enter:
-	#set {_values::*} to event-vehicle, event-world and event-entity
-	set {_values::*} to event-world and event-entity
-
-on vehicle destroy:
-	#set {_values::*} to event-vehicle, event-world and event-entity
-	set {_values::*} to event-world and event-entity
-
-on vehicle exit:
-	#set {_values::*} to event-vehicle, event-world and event-entity
-	set {_values::*} to event-world and event-entity
-
-on mount:
-	set {_values::*} to event-entity
-
-on dismount:
-	set {_values::*} to event-entity
-
-on toggle gliding:
-	set {_values::*} to event-entity
-
-on area effect:
-	set {_values::*} to event-living entities and event-potion effect type
-
-on sheep grow wool:
-	set {_values::*} to event-entity
-
-on inventory open:
-	set {_values::*} to event-player and event-inventory
-
-on inventory close:
-	set {_values::*} to event-player, event-inventory and event-inventory close reason
-
-on slime split:
-	set {_values::*} to event-entity
-
-on resurrect:
-	set {_values::*} to event-entity and event-slot
-
-on world change:
-	set {_values::*} to event-player and past event-world
-
-on toggle flight:
-	set {_values::*} to event-player
-
-on locale change:
-	set {_values::*} to event-player
-
-on jump:
-	set {_values::*} to event-player
-
-on swap item:
-	set {_values::*} to event-player
-
-on toggle swim:
-	set {_values::*} to event-entity
-
-on riptide:
-	set {_values::*} to event-player and event-item
-
-on armor change:
-	set {_values::*} to event-player
-
-on sponge absorb:
-	set {_values::*} to event-block, event-world and event-location
-
-on enchant prepare:
-	set {_values::*} to event-player, event-item, event-block and event-inventory
-
-on enchant:
-	set {_values::*} to event-player, event-item, event-enchantment types and event-block
-
-on inventory pickup:
-	set {_values::*} to event-inventory, event-dropped item and event-item
-
-on horse jump:
-	set {_values::*} to event-entity
-
-on fertilize:
-	set {_values::*} to event-player and event-blocks
-
-on arm swing:
-	set {_values::*} to event-player
-
-on anvil prepare:
-	set {_values::*} to event-item and event-inventory
-
-on player trade:
-	set {_values::*} to event-player and event-entity
-
-on entity jump:
-	set {_values::*} to event-entity
-
-on anvil damage:
-	set {_values::*} to event-inventory
-
-on stop item use:
-	set {_values::*} to event-player, event-timespan and event-item
-
-on ready arrow:
-	set {_values::*} to event-player
-
-on inventory slot change:
-	set {_values::*} to event-player, past event-item, event-item and event-slot
-
-on chat:
-	set {_values::*} to event-player
-
-on deep sleep:
-	set {_values::*} to event-player
-
-on arrow pickup:
-	set {_values::*} to event-player, event-projectile and event-item
-
-on inventory drag:
-	set {_values::*} to event-player, event-world, past event-item, event-item, event-items, event-slots, event-click type and event-inventories
-
-on piglin barter:
-	set {_values::*} to event-entity
-
-on bell ring:
-	set {_values::*} to event-block, event-entity and event-direction
-
-on bell resonate:
-	set {_values::*} to event-block and event-entities
-
-on enderman anger:
-	set {_values::*} to event-entity and event-player
-
-on player change beacon effect:
-	set {_values::*} to event-player and event-block
-
-on player xp cooldown change:
-	set {_values::*} to event-player, event-experience cooldown change reason, past event-timespan and event-timespan
-
-on vehicle move:
-	#set {_values::*} to event-vehicle, past event-location and event-location
-	set {_values::*} to past event-location and event-location
-
-on elytra boost:
-	set {_values::*} to event-player, event-item and event-entity
-
-on breed:
-	set {_values::*} to event-entity and event-item
-
-on fish caught:
-	set {_values::*} to event-player
-
-on smelt:
-	set {_values::*} to event-block
-
-on fuel burn:
-	set {_values::*} to event-block
-
-on furnace extract:
-	set {_values::*} to event-block, event-player and event-items
-
-on smelt start:
-	set {_values::*} to event-block
+parse:
+	results: {EventValues::on beacon effect}
+	code:
+		on beacon effect:
+			set {_values::*} to event-player and event-block
+
+parse:
+	results: {EventValues::on beacon toggle}
+	code:
+		on beacon toggle:
+			set {_values::*} to event-block
+
+parse:
+	results: {EventValues::on break}
+	code:
+		on break:
+			set {_values::*} to event-player, event-block and past event-block
+
+parse:
+	results: {EventValues::on burn}
+	code:
+		on burn:
+			set {_value::*} to event-block
+
+parse:
+	results: {EventValues::on place}
+	code:
+		on place:
+			set {_values::*} to event-player, event-block, past event-block, past event-item, event-item and future event-item
+
+parse:
+	results: {EventValues::on fade}
+	code:
+		on fade:
+			set {_values::*} to past event-block, event-block and future event-block
+
+parse:
+	results: {EventValues::on form}
+	code:
+		on form:
+			set {_values::*} to past event-block and event-block
+
+parse:
+	results: {EventValues::on block drop}
+	code:
+		on block drop:
+			set {_values::*} to past event-block, event-block, event-player, event-items and event-entities
+
+parse:
+	results: {EventValues::on book edit}
+	code:
+		on book edit:
+			set {_values::*} to event-player, past event-item, event-item, past event-strings and event-strings
+
+parse:
+	results: {EventValues::on click}
+	code:
+		on click:
+			set {_values::*} to event-item, event-block, event-direction, event-player and event-entity
+
+parse:
+	results: {EventValues::on command}
+	code:
+		on command:
+			set {_values::*} to event-player, event-sender, event-world and event-block
+
+parse:
+	results: {EventValues::on damage}
+	code:
+		on damage:
+			set {_values::*} to event-world, event-location, event-damage cause and event-projectile
+
+parse:
+	results: {EventValues::on death}
+	code:
+		on death:
+			set {_values::*} to event-world, event-location, event-damage cause, event-items and event-projectile
+
+parse:
+	results: {EventValues::on spawn}
+	code:
+		on spawn:
+			set {_values::*} to event-entity
+
+parse:
+	results: {EventValues::on entity change block}
+	code:
+		on entity change block:
+			set {_values::*} to past event-block, event-block, past event-block data and event-block data
+
+parse:
+	results: {EventValues::on entity potion effect}
+	code:
+		on entity potion effect:
+			set {_values::*} to past event-potion effect, event-potion effect and event-potion effect type
+
+parse:
+	results: {EventValues::on target}
+	code:
+		on target:
+			set {_values::*} to event-entity
+
+parse:
+	results: {EventValues::on entity transform}
+	code:
+		on entity transform:
+			set {_values::*} to event-entities and event-transform reason
+
+parse:
+	results: {EventValues::on xp change}
+	code:
+		on xp change:
+			set {_values::*} to event-player and event-experience
+
+parse:
+	results: {EventValues::on xp spawn}
+	code:
+		on xp spawn:
+			set {_values::*} to event-location and event-experience
+
+parse:
+	results: {EventValues::on firework explode}
+	code:
+		on firework explode:
+			set {_values::*} to event-firework, event-firework effect and event-colors
+
+parse:
+    results: {EventValues::on first join}
+    code:
+        on first join:
+            set {_values::*} to event-player
+
+parse:
+    results: {EventValues::on gamemode change}
+    code:
+        on gamemode change:
+            set {_values::*} to event-player
+
+parse:
+    results: {EventValues::on grow}
+    code:
+        on grow:
+            set {_values::*} to past event-block and event-block
+
+parse:
+    results: {EventValues::on heal}
+    code:
+        on heal:
+            set {_values::*} to event-entity and event-heal reason
+
+parse:
+    results: {EventValues::on dispense}
+    code:
+        on dispense:
+            set {_values::*} to event-block and event-item
+
+parse:
+    results: {EventValues::on item spawn}
+    code:
+        on item spawn:
+            set {_values::*} to event-item
+
+parse:
+    results: {EventValues::on entity drop}
+    code:
+        on entity drop:
+            set {_values::*} to event-entity, event-dropped item and event-item
+
+parse:
+    results: {EventValues::on player drop}
+    code:
+        on player drop:
+            set {_values::*} to event-player, event-dropped item and event-item
+
+parse:
+    results: {EventValues::on preparing craft}
+    code:
+        on preparing craft:
+            set {_values::*} to event-slot, event-item, event-inventory, event-player and event-string
+
+parse:
+    results: {EventValues::on craft}
+    code:
+        on craft:
+            set {_values::*} to event-string and event-item
+
+parse:
+    results: {EventValues::on entity pickup}
+    code:
+        on entity pickup:
+            set {_values::*} to event-entity, event-dropped item and event-itemtype
+
+parse:
+    results: {EventValues::on player pickup}
+    code:
+        on player pickup:
+            set {_values::*} to event-player, event-dropped item and event-itemtype
+
+parse:
+    results: {EventValues::on consume}
+    code:
+        on consume:
+            set {_values::*} to event-player and event-item
+
+parse:
+    results: {EventValues::on inventory click}
+    code:
+        on inventory click:
+            set {_values::*} to event-player, event-world, event-item, event-slot, event-inventory action, event-click type and event-inventory
+
+parse:
+    results: {EventValues::on item despawn}
+    code:
+        on item despawn:
+            set {_values::*} to event-dropped item and event-item
+
+parse:
+    results: {EventValues::on item merge}
+    code:
+        on item merge:
+            set {_values::*} to event-dropped item and event-item and future event-dropped item
+
+parse:
+    results: {EventValues::on inventory item move}
+    code:
+        on inventory item move:
+            set {_values::*} to event-inventory, future event-inventory, event-block, event-item and future event-block
+
+parse:
+    results: {EventValues::on stonecutting}
+    code:
+        on stonecutting:
+            set {_values::*} to event-player and event-item
+
+parse:
+    results: {EventValues::on leash}
+    code:
+        on leash:
+            set {_values::*} to event-player and event-entity
+
+parse:
+    results: {EventValues::on unleash}
+    code:
+        on unleash:
+            set {_values::*} to event-entity and event-unleash reason
+
+parse:
+    results: {EventValues::on player unleash}
+    code:
+        on player unleash:
+            set {_values::*} to event-player and event-unleash reason
+
+parse:
+    results: {EventValues::on level change}
+    code:
+        on level change:
+            set {_values::*} to event-player and event-entity
+
+parse:
+    results: {EventValues::on entity move}
+    code:
+        on entity move:
+            set {_values::*} to event-entity
+
+parse:
+    results: {EventValues::on step on dirt}
+    code:
+        on step on dirt:
+            set {_values::*} to event-player, event-block, past event-location, event-location, past event-chunk and event-chunk
+
+parse:
+    results: {EventValues::on send command list}
+    code:
+        on send command list:
+            set {_values::*} to event-player and event-entity
+
+parse:
+    results: {EventValues::on resource pack response}
+    code:
+        on resource pack response:
+            set {_values::*} to event-player and event-entity
+
+parse:
+    results: {EventValues::on load}
+    code:
+        on load:
+            set {_values::*} to event-sender
+
+parse:
+    results: {EventValues::on unload}
+    code:
+        on unload:
+            set {_values::*} to event-sender
+
+parse:
+    results: {EventValues::on skript load}
+    code:
+        on skript load:
+            set {_values::*} to event-sender
+
+parse:
+    results: {EventValues::on skript unload}
+    code:
+        on skript unload:
+            set {_values::*} to event-sender
+
+parse:
+	results: {EventValues::on start spectating}
+	code:
+		on start spectating:
+			set {_values::*} to event-player and event-entity
+
+parse:
+	results: {EventValues::on entity teleport}
+	code:
+		on entity teleport:
+			set {_values::*} to event-entity, past event-location and event-location
+
+parse:
+	results: {EventValues::on player teleport}
+	code:
+		on player teleport:
+			set {_values::*} to event-player, past event-location and event-location
+
+parse:
+	results: {EventValues::on vehicle collision}
+	code:
+		on vehicle collision:
+			set {_values::*} to event-world, event-entity and event-block
+
+parse:
+	results: {EventValues::on weather change}
+	code:
+		on weather change:
+			set {_values::*} to event-world
+
+parse:
+	results: {EventValues::on world save}
+	code:
+		on world save:
+			set {_values::*} to event-world
+
+parse:
+	results: {EventValues::on world init}
+	code:
+		on world init:
+			set {_values::*} to event-world
+
+parse:
+	results: {EventValues::on world load}
+	code:
+		on world load:
+			set {_values::*} to event-world
+
+parse:
+	results: {EventValues::on world unload}
+	code:
+		on world unload:
+			set {_values::*} to event-world
+
+parse:
+	results: {EventValues::on can build check}
+	code:
+		on can build check:
+			set {_values::*} to past event-block, event-block and event-player
+
+parse:
+	results: {EventValues::on block damage}
+	code:
+		on block damage:
+			set {_values::*} to event-block and event-player
+
+parse:
+	results: {EventValues::on flow}
+	code:
+		on flow:
+			set {_values::*} to event-block and future event-block
+
+parse:
+	results: {EventValues::on ignite}
+	code:
+		on ignite:
+			set {_values::*} to event-block and event-player
+
+parse:
+	results: {EventValues::on physics}
+	code:
+		on physics:
+			set {_values::*} to event-block
+
+parse:
+	results: {EventValues::on piston extend}
+	code:
+		on piston extend:
+			set {_values::*} to event-block
+
+parse:
+	results: {EventValues::on piston retract}
+	code:
+		on piston retract:
+			set {_values::*} to event-block
+
+parse:
+	results: {EventValues::on redstone}
+	code:
+		on redstone:
+			set {_values::*} to event-block
+
+parse:
+	results: {EventValues::on spread}
+	code:
+		on spread:
+			set {_values::*} to event-block
+
+parse:
+	results: {EventValues::on chunk load}
+	code:
+		on chunk load:
+			set {_values::*} to event-world and event-chunk
+
+parse:
+	results: {EventValues::on chunk generate}
+	code:
+		on chunk generate:
+			set {_values::*} to event-world and event-chunk
+
+parse:
+	results: {EventValues::on chunk unload}
+	code:
+		on chunk unload:
+			set {_values::*} to event-world and event-chunk
+
+parse:
+	results: {EventValues::on creeper power}
+	code:
+		on creeper power:
+			set {_values::*} to event-entity
+
+parse:
+	results: {EventValues::on zombie break door}
+	code:
+		on zombie break door:
+			set {_values::*} to event-entity, past event-block, event-block, event-block data and future event-block data
+
+parse:
+	results: {EventValues::on combust}
+	code:
+		on combust:
+			set {_values::*} to event-entity
+
+parse:
+	results: {EventValues::on explode}
+	code:
+		on explode:
+			set {_values::*} to event-entity
+
+parse:
+	results: {EventValues::on portal enter}
+	code:
+		on portal enter:
+			set {_values::*} to event-entity
+
+parse:
+	results: {EventValues::on tame}
+	code:
+		on tame:
+			set {_values::*} to event-entity
+
+parse:
+	results: {EventValues::on explosion prime}
+	code:
+		on explosion prime:
+			set {_values::*} to event-entity
+
+parse:
+	results: {EventValues::on hunger level change}
+	code:
+		on hunger level change:
+			set {_values::*} to event-entity
+
+parse:
+	results: {EventValues::on leaves decay}
+	code:
+		on leaves decay:
+			set {_values::*} to event-block
+
+parse:
+	results: {EventValues::on lightning}
+	code:
+		on lightning:
+			set {_values::*} to event-entity
+
+parse:
+	results: {EventValues::on pig zap}
+	code:
+		on pig zap:
+			set {_values::*} to event-entity, event-entities and event-transform reason
+
+parse:
+	results: {EventValues::on bed enter}
+	code:
+		on bed enter:
+			set {_values::*} to event-player and event-block
+
+parse:
+	results: {EventValues::on leave bed}
+	code:
+		on leave bed:
+			set {_values::*} to event-player and event-block
+
+parse:
+	results: {EventValues::on bucket empty}
+	code:
+		on bucket empty:
+			set {_values::*} to event-player, past event-block and event-block
+
+parse:
+	results: {EventValues::on bucket fill}
+	code:
+		on bucket fill:
+			set {_values::*} to event-player, event-block and future event-block
+
+parse:
+	results: {EventValues::on throw egg}
+	code:
+		on throw egg:
+			set {_values::*} to event-player and event-projectile
+
+parse:
+	results: {EventValues::on tool break}
+	code:
+		on tool break:
+			set {_values::*} to event-player and event-item
+
+parse:
+	results: {EventValues::on item damage}
+	code:
+		on item damage:
+			set {_values::*} to event-player and event-item
+
+parse:
+	results: {EventValues::on tool change}
+	code:
+		on tool change:
+			set {_values::*} to event-player, past event-slot and event-slot
+
+parse:
+	results: {EventValues::on join}
+	code:
+		on join:
+			set {_values::*} to event-player and event-entity
+
+parse:
+	results: {EventValues::on connect}
+	code:
+		on connect:
+			set {_values::*} to event-player and event-entity
+
+parse:
+	results: {EventValues::on kick}
+	code:
+		on kick:
+			set {_values::*} to event-player and event-entity
+
+parse:
+	results: {EventValues::on entity portal}
+	code:
+		on entity portal:
+			set {_values::*} to event-entity, past event-location and event-location
+
+parse:
+	results: {EventValues::on portal}
+	code:
+		on portal:
+			set {_values::*} to event-player, event-teleport cause, event-block, past event-location, event-location, past event-chunk and event-chunk
+
+parse:
+	results: {EventValues::on leave}
+	code:
+		on leave:
+			set {_values::*} to event-player and event-quit reason
+
+parse:
+	results: {EventValues::on respawn}
+	code:
+		on respawn:
+			set {_values::*} to event-player and event-entity
+
+parse:
+	results: {EventValues::on toggle sneak}
+	code:
+		on toggle sneak:
+			set {_values::*} to event-player and event-entity
+
+parse:
+	results: {EventValues::on toggle sprint}
+	code:
+		on toggle sprint:
+			set {_values::*} to event-player and event-entity
+
+parse:
+	results: {EventValues::on portal create}
+	code:
+		on portal create:
+			set {_values::*} to event-world, event-blocks and event-entity
+
+parse:
+	results: {EventValues::on projectile collide}
+	code:
+		on projectile collide:
+			set {_values::*} to event-projectile and event-entity
+
+parse:
+	results: {EventValues::on shoot}
+	code:
+		on shoot:
+			set {_values::*} to event-projectile
+
+parse:
+	results: {EventValues::on sign change}
+	code:
+		on sign change:
+			set {_values::*} to event-player, event-strings and event-block
+
+parse:
+	results: {EventValues::on spawn change}
+	code:
+		on spawn change:
+			set {_values::*} to event-world
+
+parse:
+	results: {EventValues::on vehicle create}
+	code:
+		on vehicle create:
+			set {_values::*} to event-vehicle, event-world and event-entity
+
+parse:
+	results: {EventValues::on vehicle damage}
+	code:
+		on vehicle damage:
+			set {_values::*} to event-vehicle, event-world and event-entity
+
+parse:
+	results: {EventValues::on vehicle enter}
+	code:
+		on vehicle enter:
+			set {_values::*} to event-vehicle, event-world and event-entity
+
+parse:
+	results: {EventValues::on vehicle destroy}
+	code:
+		on vehicle destroy:
+			set {_values::*} to event-vehicle, event-world and event-entity
+
+parse:
+	results: {EventValues::on vehicle exit}
+	code:
+		on vehicle exit:
+			set {_values::*} to event-vehicle, event-world and event-entity
+
+parse:
+	results: {EventValues::on mount}
+	code:
+		on mount:
+			set {_values::*} to event-entity
+
+parse:
+	results: {EventValues::on dismount}
+	code:
+		on dismount:
+			set {_values::*} to event-entity
+
+parse:
+	results: {EventValues::on toggle gliding}
+	code:
+		on toggle gliding:
+			set {_values::*} to event-entity
+
+parse:
+	results: {EventValues::on area effect}
+	code:
+		on area effect:
+			set {_values::*} to event-living entities and event-potion effect type
+
+parse:
+	results: {EventValues::on sheep grow wool}
+	code:
+		on sheep grow wool:
+			set {_values::*} to event-entity
+
+parse:
+	results: {EventValues::on inventory open}
+	code:
+		on inventory open:
+			set {_values::*} to event-player and event-inventory
+
+parse:
+	results: {EventValues::on inventory close}
+	code:
+		on inventory close:
+			set {_values::*} to event-player, event-inventory and event-inventory close reason
+
+parse:
+	results: {EventValues::on slime split}
+	code:
+		on slime split:
+			set {_values::*} to event-entity
+
+parse:
+	results: {EventValues::on resurrect}
+	code:
+		on resurrect:
+			set {_values::*} to event-entity and event-slot
+
+parse:
+	results: {EventValues::on world change}
+	code:
+		on world change:
+			set {_values::*} to event-player and past event-world
+
+parse:
+	results: {EventValues::on toggle flight}
+	code:
+		on toggle flight:
+			set {_values::*} to event-player
+
+parse:
+	results: {EventValues::on locale change}
+	code:
+		on locale change:
+			set {_values::*} to event-player
+
+parse:
+	results: {EventValues::on jump}
+	code:
+		on jump:
+			set {_values::*} to event-player
+
+parse:
+	results: {EventValues::on swap item}
+	code:
+		on swap item:
+			set {_values::*} to event-player
+
+parse:
+	results: {EventValues::on toggle swim}
+	code:
+		on toggle swim:
+			set {_values::*} to event-entity
+
+parse:
+	results: {EventValues::on riptide}
+	code:
+		on riptide:
+			set {_values::*} to event-player and event-item
+
+parse:
+	results: {EventValues::on armor change}
+	code:
+		on armor change:
+			set {_values::*} to event-player
+
+parse:
+	results: {EventValues::on sponge absorb}
+	code:
+		on sponge absorb:
+			set {_values::*} to event-block, event-world and event-location
+
+parse:
+	results: {EventValues::on enchant prepare}
+	code:
+		on enchant prepare:
+			set {_values::*} to event-player, event-item, event-block and event-inventory
+
+parse:
+	results: {EventValues::on enchant}
+	code:
+		on enchant:
+			set {_values::*} to event-player, event-item, event-enchantment types and event-block
+
+parse:
+	results: {EventValues::on inventory pickup}
+	code:
+		on inventory pickup:
+			set {_values::*} to event-inventory, event-dropped item and event-item
+
+parse:
+	results: {EventValues::on horse jump}
+	code:
+		on horse jump:
+			set {_values::*} to event-entity
+
+parse:
+	results: {EventValues::on fertilize}
+	code:
+		on fertilize:
+			set {_values::*} to event-player and event-blocks
+
+parse:
+	results: {EventValues::on arm swing}
+	code:
+		on arm swing:
+			set {_values::*} to event-player
+
+parse:
+	results: {EventValues::on anvil prepare}
+	code:
+		on anvil prepare:
+			set {_values::*} to event-item and event-inventory
+
+parse:
+	results: {EventValues::on player trade}
+	code:
+		on player trade:
+			set {_values::*} to event-player and event-entity
+
+parse:
+	results: {EventValues::on entity jump}
+	code:
+		on entity jump:
+			set {_values::*} to event-entity
+
+parse:
+	results: {EventValues::on anvil damage}
+	code:
+		on anvil damage:
+			set {_values::*} to event-inventory
+
+parse:
+	results: {EventValues::on stop item use}
+	code:
+		on stop item use:
+			set {_values::*} to event-player, event-timespan and event-item
+
+parse:
+	results: {EventValues::on ready arrow}
+	code:
+		on ready arrow:
+			set {_values::*} to event-player
+
+parse:
+	results: {EventValues::on inventory slot change}
+	code:
+		on inventory slot change:
+			set {_values::*} to event-player, past event-item, event-item and event-slot
+
+parse:
+	results: {EventValues::on chat}
+	code:
+		on chat:
+			set {_values::*} to event-player
+
+parse:
+	results: {EventValues::on deep sleep}
+	code:
+		on deep sleep:
+			set {_values::*} to event-player
+
+parse:
+	results: {EventValues::on arrow pickup}
+	code:
+		on arrow pickup:
+			set {_values::*} to event-player, event-projectile and event-item
+
+parse:
+	results: {EventValues::on inventory drag}
+	code:
+		on inventory drag:
+			set {_values::*} to event-player, event-world, past event-item, event-item, event-items, event-slots, event-click type and event-inventories
+
+parse:
+	results: {EventValues::on piglin barter}
+	code:
+		on piglin barter:
+			set {_values::*} to event-entity
+
+parse:
+	results: {EventValues::on bell ring}
+	code:
+		on bell ring:
+			set {_values::*} to event-block, event-entity and event-direction
+
+parse:
+	results: {EventValues::on bell resonate}
+	code:
+		on bell resonate:
+			set {_values::*} to event-block and event-entities
+
+parse:
+	results: {EventValues::on enderman anger}
+	code:
+		on enderman anger:
+			set {_values::*} to event-entity and event-player
+
+parse:
+	results: {EventValues::on player change beacon effect}
+	code:
+		on player change beacon effect:
+			set {_values::*} to event-player and event-block
+
+parse:
+	results: {EventValues::on player xp cooldown change}
+	code:
+		on player xp cooldown change:
+			set {_values::*} to event-player, event-experience cooldown change reason, past event-timespan and event-timespan
+
+parse:
+	results: {EventValues::on vehicle move}
+	code:
+		on vehicle move:
+			set {_values::*} to event-vehicle, past event-location and event-location
+
+parse:
+	results: {EventValues::on elytra boost}
+	code:
+		on elytra boost:
+			set {_values::*} to event-player, event-item and event-entity
+
+parse:
+	results: {EventValues::on breed}
+	code:
+		on breed:
+			set {_values::*} to event-entity and event-item
+
+parse:
+	results: {EventValues::on fish caught}
+	code:
+		on fish caught:
+			set {_values::*} to event-player
+
+parse:
+	results: {EventValues::on smelt}
+	code:
+		on smelt:
+			set {_values::*} to event-block
+
+parse:
+	results: {EventValues::on fuel burn}
+	code:
+		on fuel burn:
+			set {_values::*} to event-block
+
+parse:
+	results: {EventValues::on furnace extract}
+	code:
+		on furnace extract:
+			set {_values::*} to event-block, event-player and event-items
+
+parse:
+	results: {EventValues::on smelt start}
+	code:
+		on smelt start:
+			set {_values::*} to event-block
+
+test "Event Values":
+	if size of {EventValues::*} > 0:
+		set {_string} to "Event value error(s) in:"
+		loop {EventValues::*}:
+			set {_string} to {_string} + newline + "		%loop-index%: %loop-value%"
+		clear {EventValues::*}
+		assert true is false with {_string}
+	else:
+		clear {EventValues::*}

--- a/src/test/skript/tests/misc/EventValues.sk
+++ b/src/test/skript/tests/misc/EventValues.sk
@@ -1,0 +1,493 @@
+options:
+	test: "EventValuesTest"
+
+# This is to test parsing of event-value expressions
+
+on beacon effect:
+	set {_values::*} to event-player and event-block
+
+on beacon toggle:
+	set {_values::*} to event-block
+
+on break:
+	set {_values::*} to event-player, event-block and past event-block
+
+on burn:
+	set {_value::*} to event-block
+
+on place:
+	set {_values::*} to event-player, event-block, past event-block, past event-item, event-item and future event-item
+
+on fade:
+	set {_values::*} to past event-block, event-block and future event-block
+
+on form:
+	set {_values::*} to past event-block and event-block
+
+on block drop:
+	set {_values::*} to past event-block, event-block, event-player, event-items and event-entities
+
+on book edit:
+	set {_values::*} to event-player, past event-item, event-item, past event-strings and event-strings
+
+on click:
+	set {_values::*} to event-item, event-block, event-direction, event-player and event-entity
+
+on command:
+	set {_values::*} to event-player, event-sender, event-world and event-block
+
+on damage:
+	set {_values::*} to event-world, event-location, event-damage cause and event-projectile
+
+on death:
+	set {_values::*} to event-world, event-location, event-damage cause, event-items and event-projectile
+
+on spawn:
+	set {_values::*} to event-entity
+
+on entity change block:
+	set {_values::*} to past event-block, event-block, past event-block data and event-block data
+
+on entity potion effect:
+	set {_values::*} to past event-potion effect, event-potion effect and event-potion effect type
+
+on target:
+	set {_values::*} to event-entity
+
+on entity transform:
+	set {_values::*} to event-entities and event-transform reason
+
+on xp change:
+	set {_values::*} to event-player and event-experience
+
+on xp spawn:
+	set {_values::*} to event-location and event-experience
+
+on firework explode:
+	set {_values::*} to event-firework, event-firework effect and event-colors
+
+on first join:
+	set {_values::*} to event-player
+
+on gamemode change:
+	set {_values::*} to event-player
+
+on grow:
+	set {_values::*} to past event-block and event-block
+
+on heal:
+	set {_values::*} to event-entity and event-heal reason
+
+on dispense:
+	set {_values::*} to event-block and event-item
+
+on item spawn:
+	set {_values::*} to event-item
+
+on entity drop:
+	set {_values::*} to event-entity, event-dropped item and event-item
+
+on player drop:
+	set {_values::*} to event-player, event-dropped item and event-item
+
+on preparing craft:
+	set {_values::*} to event-slot, event-item, event-inventory, event-player and event-string
+
+on craft:
+	set {_values::*} to event-string and event-item
+
+on entity pickup:
+	add event-entity to {_values::*}
+	add event-dropped item to {_values::*}
+	add event-itemtype to {_values::*}
+	#set {_values::*} to event-entity, event-dropped item and event-itemtype
+
+on player pickup:
+	add event-player to {_values::*}
+	add event-dropped item to {_values::*}
+	add event-itemtype to {_values::*}
+	#set {_values::*} to event-player, event-dropped item and event-itemtype
+
+on consume:
+	set {_values::*} to event-player and event-item
+
+on inventory click:
+	set {_values::*} to event-player, event-world, event-item, event-slot, event-inventory action, event-click type and event-inventory
+
+on item despawn:
+	set {_values::*} to event-dropped item and event-item
+
+on item merge:
+	set {_values::*} to event-dropped item and event-item and future event-dropped item
+
+on inventory item move:
+	set {_values::*} to event-inventory, future event-inventory, event-block, event-item and future event-block
+
+on stonecutting:
+	set {_values::*} to event-player and event-item
+
+on leash:
+	set {_values::*} to event-player and event-entity
+
+on unleash:
+	set {_values::*} to event-entity and event-unleash reason
+
+on player unleash:
+	set {_values::*} to event-player and event-unleash reason
+
+on level change:
+	set {_values::*} to event-player
+
+on entity move:
+	set {_values::*} to event-entity
+
+on step on dirt:
+	set {_values::*} to event-player, event-block, past event-location, event-location, past event-chunk and event-chunk
+
+on send command list:
+	set {_values::*} to event-player
+
+on resource pack response:
+	set {_values::*} to event-player
+
+on load:
+	set {_values::*} to event-sender
+
+on unload:
+	set {_values::*} to event-sender
+
+on skript load:
+	set {_values::*} to event-sender
+
+on skript unload:
+	set {_values::*} to event-sender
+
+on start spectating:
+	set {_values::*} to event-player
+
+on entity teleport:
+	set {_values::*} to event-entity, past event-location and event-location
+
+on player teleport:
+	set {_values::*} to event-player, past event-location and event-location
+
+on vehicle collision:
+	set {_values::*} to event-world, event-entity and event-block
+
+on weather change:
+	set {_values::*} to event-world
+
+on world save:
+	set {_values::*} to event-world
+
+on world init:
+	set {_values::*} to event-world
+
+on world load:
+	set {_values::*} to event-world
+
+on world unload:
+	set {_values::*} to event-world
+
+on can build check:
+	set {_values::*} to past event-block, event-block and event-player
+
+on block damage:
+	set {_values::*} to event-block and event-player
+
+on flow:
+	set {_values::*} to event-block and future event-block
+
+on ignite:
+	set {_values::*} to event-block and event-player
+
+on physics:
+	set {_values::*} to event-block
+
+on piston extend:
+	set {_values::*} to event-block
+
+on piston retract:
+	set {_values::*} to event-block
+
+on redstone:
+	set {_values::*} to event-block
+
+on spread:
+	set {_values::*} to event-block
+
+on chunk load:
+	set {_values::*} to event-world and event-chunk
+
+on chunk generate:
+	set {_values::*} to event-world and event-chunk
+
+on chunk unload:
+	set {_values::*} to event-world and event-chunk
+
+on creeper power:
+	set {_values::*} to event-entity
+
+on zombie break door:
+	set {_values::*} to event-entity, past event-block, event-block, event-block data and future event-block data
+
+on combust:
+	set {_values::*} to event-entity
+
+on explode:
+	set {_values::*} to event-entity
+
+on portal enter:
+	set {_values::*} to event-entity
+
+on tame:
+	set {_values::*} to event-entity
+
+on explosion prime:
+	set {_values::*} to event-entity
+
+on hunger level change:
+	set {_values::*} to event-entity
+
+on leaves decay:
+	set {_values::*} to event-block
+
+on lightning:
+	set {_values::*} to event-entity
+
+on pig zap:
+	set {_values::*} to event-entity, event-entities and event-transform reason
+
+on bed enter:
+	set {_values::*} to event-player and event-block
+
+on leave bed:
+	set {_values::*} to event-player and event-block
+
+on bucket empty:
+	set {_values::*} to event-player, past event-block and event-block
+
+on bucket fill:
+	set {_values::*} to event-player, event-block and future event-block
+
+on throw egg:
+	set {_values::*} to event-player and event-projectile
+
+on tool break:
+	set {_values::*} to event-player and event-item
+
+on item damage:
+	set {_values::*} to event-player and event-item
+
+on tool change:
+	set {_values::*} to event-player, past event-slot and event-slot
+
+on join:
+	set {_values::*} to event-player
+
+on connect:
+	set {_values::*} to event-player
+
+on kick:
+	set {_values::*} to event-player
+
+on entity portal:
+	set {_values::*} to event-entity, past event-location and event-location
+
+on portal:
+	set {_values::*} to event-player, event-teleport cause, event-block, past event-location, event-location, past event-chunk and event-chunk
+
+on leave:
+	set {_values::*} to event-player and event-quit reason
+
+on respawn:
+	set {_values::*} to event-player
+
+on toggle sneak:
+	set {_values::*} to event-player
+
+on toggle sprint:
+	set {_values::*} to event-player
+
+on portal create:
+	set {_values::*} to event-world, event-blocks and event-entity
+
+on projectile collide:
+	set {_values::*} to event-projectile and event-entity
+
+on shoot:
+	set {_values::*} to event-projectile
+
+on sign change:
+	set {_values::*} to event-player, event-strings and event-block
+
+on spawn change:
+	set {_values::*} to event-world
+
+on vehicle create:
+	#set {_values::*} to event-vehicle, event-world and event-entity
+	set {_values::*} to event-world and event-entity
+
+on vehicle damage:
+	#set {_values::*} to event-vehicle, event-world and event-entity
+	set {_values::*} to event-world and event-entity
+
+on vehicle enter:
+	#set {_values::*} to event-vehicle, event-world and event-entity
+	set {_values::*} to event-world and event-entity
+
+on vehicle destroy:
+	#set {_values::*} to event-vehicle, event-world and event-entity
+	set {_values::*} to event-world and event-entity
+
+on vehicle exit:
+	#set {_values::*} to event-vehicle, event-world and event-entity
+	set {_values::*} to event-world and event-entity
+
+on mount:
+	set {_values::*} to event-entity
+
+on dismount:
+	set {_values::*} to event-entity
+
+on toggle gliding:
+	set {_values::*} to event-entity
+
+on area effect:
+	set {_values::*} to event-living entities and event-potion effect type
+
+on sheep grow wool:
+	set {_values::*} to event-entity
+
+on inventory open:
+	set {_values::*} to event-player and event-inventory
+
+on inventory close:
+	set {_values::*} to event-player, event-inventory and event-inventory close reason
+
+on slime split:
+	set {_values::*} to event-entity
+
+on resurrect:
+	set {_values::*} to event-entity and event-slot
+
+on world change:
+	set {_values::*} to event-player and past event-world
+
+on toggle flight:
+	set {_values::*} to event-player
+
+on locale change:
+	set {_values::*} to event-player
+
+on jump:
+	set {_values::*} to event-player
+
+on swap item:
+	set {_values::*} to event-player
+
+on toggle swim:
+	set {_values::*} to event-entity
+
+on riptide:
+	set {_values::*} to event-player and event-item
+
+on armor change:
+	set {_values::*} to event-player
+
+on sponge absorb:
+	set {_values::*} to event-block, event-world and event-location
+
+on enchant prepare:
+	set {_values::*} to event-player, event-item, event-block and event-inventory
+
+on enchant:
+	set {_values::*} to event-player, event-item, event-enchantment types and event-block
+
+on inventory pickup:
+	set {_values::*} to event-inventory, event-dropped item and event-item
+
+on horse jump:
+	set {_values::*} to event-entity
+
+on fertilize:
+	set {_values::*} to event-player and event-blocks
+
+on arm swing:
+	set {_values::*} to event-player
+
+on anvil prepare:
+	set {_values::*} to event-item and event-inventory
+
+on player trade:
+	set {_values::*} to event-player and event-entity
+
+on entity jump:
+	set {_values::*} to event-entity
+
+on anvil damage:
+	set {_values::*} to event-inventory
+
+on stop item use:
+	set {_values::*} to event-player, event-timespan and event-item
+
+on ready arrow:
+	set {_values::*} to event-player
+
+on inventory slot change:
+	set {_values::*} to event-player, past event-item, event-item and event-slot
+
+on chat:
+	set {_values::*} to event-player
+
+on deep sleep:
+	set {_values::*} to event-player
+
+on arrow pickup:
+	set {_values::*} to event-player, event-projectile and event-item
+
+on inventory drag:
+	set {_values::*} to event-player, event-world, past event-item, event-item, event-items, event-slots, event-click type and event-inventories
+
+on piglin barter:
+	set {_values::*} to event-entity
+
+on bell ring:
+	set {_values::*} to event-block, event-entity and event-direction
+
+on bell resonate:
+	set {_values::*} to event-block and event-entities
+
+on enderman anger:
+	set {_values::*} to event-entity and event-player
+
+on player change beacon effect:
+	set {_values::*} to event-player and event-block
+
+on player xp cooldown change:
+	set {_values::*} to event-player, event-experience cooldown change reason, past event-timespan and event-timespan
+
+on vehicle move:
+	#set {_values::*} to event-vehicle, past event-location and event-location
+	set {_values::*} to past event-location and event-location
+
+on elytra boost:
+	set {_values::*} to event-player, event-item and event-entity
+
+on breed:
+	set {_values::*} to event-entity and event-item
+
+on fish caught:
+	set {_values::*} to event-player
+
+on smelt:
+	set {_values::*} to event-block
+
+on fuel burn:
+	set {_values::*} to event-block
+
+on furnace extract:
+	set {_values::*} to event-block, event-player and event-items
+
+on smelt start:
+	set {_values::*} to event-block

--- a/src/test/skript/tests/syntaxes/effects/EffDetonate.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffDetonate.sk
@@ -5,10 +5,11 @@ test "detonate entity effect":
 	assert last spawned entity isn't valid with "creepers should instantly detonate when spawned"
 
 test "detonate explosive minecart":
-	spawn a minecart with tnt at event-location
-	assert last spawned entity is valid with "minecarts with tnt should not detonate when they are first spawned"
-	detonate last spawned entity
-	assert last spawned entity isn't valid with "minecarts with tnt should instantly detonate when they are first spawned"
+	spawn a minecart with tnt at event-location:
+		set {_entity} to entity
+	assert {_entity} is valid with "minecarts with tnt should not detonate when they are first spawned"
+	detonate {_entity}
+	assert {_entity} isn't valid with "minecarts with tnt should instantly detonate when they are first spawned"
 
 test "detonate wind charge" when running minecraft "1.21":
 	spawn a wind charge at event-location ~ vector(0, 100, 0)


### PR DESCRIPTION
### Description
This PR aims to fix and update Event Values. (dev/patch branch)

- For the `PlayerDropItemEvent` and `PlayerPickupItemEvent` using `event-entity` was throwing a parse error of `multiple entities` which should not be the case. The easy solution to this was to register an `Entity` value directly to these classes. Though in their corresponding `SkriptEvent`s they are paired with their `Entity` counterparts, inside `EventValueExpression#init` only the Player event was being accessed.

- Adds the `#setTime` into `ExprEntity` which utilizes `EventValueExpression#setTime` allowing past and future `event-%entitydata%` resulting in the fix of not being able to grab the `future event-entity` in `ItemMergeEvent`

- Adds a new method within `EventValues`, `#stripConverters`
```
/*
In this method we can strip converters that are able to be obtainable through their own 'event-classinfo'.
For example, PlayerTradeEvent has a player value (player who traded) and an AbstractVillager value (villager traded from).
Beforehand, since there is no Entity value, it was then grabbing both values as they both can be casted as an Entity
	resulting in a parse error of "multiple entities"
Now, we filter out the ones that can be obtained using their own classinfo, such as 'event-player'
	which leaves us only the AbstractVillager for 'event-entity'
 */
```
Though the `PlayerTradeEvent` could have easily been fixed by changing the valueClass of the registered event value from `AbstractVillager` to `Entity` (dont know why it's like that in the first place, as we dont register a class info for abstract villager)
However, I believe this addition can be beneficial.

- Finally, adds an `EventValues.sk` test which sole purpose is to look for parse errors.
Had to fix `EffDetonate.sk` because `EffSecSpawn.lastSpawned` was being overwritten by the dropped items that spawned.

- Also changes variable names within `EventValues` to match what they are

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
