### PR TITLE
Fix Text Display Alignment Example

### DIFF
--- a/src/main/java/org/skriptlang/skript/bukkit/displays/text/ExprTextDisplayAlignment.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/displays/text/ExprTextDisplayAlignment.java
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("Text Display Alignment")
 @Description("Returns or changes the <a href='classes.html#textalignment'>alignment</a> setting of <a href='classes.html#display'>text displays</a>.")
-@Examples("set text alignment of the last spawned text display to left")
+@Examples("set text alignment of the last spawned text display to left aligned")
 @Since("2.10")
 public class ExprTextDisplayAlignment extends SimplePropertyExpression<Display, TextAlignment> {
 


### PR DESCRIPTION
### Description
Fixes the incorrect example in text display alignment docs.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7587 <!-- Links to related issues -->
