### PR TITLE
make the max target block value 1000

### DIFF
--- a/src/main/resources/config.sk
+++ b/src/main/resources/config.sk
@@ -142,10 +142,8 @@ number accuracy: 2
 # Money bypasses this setting and is displayed as configured in your economy plugin if you have one.
 
 
-maximum target block distance: 100
+maximum target block distance: 1000
 # How far to search for a player's targeted block in blocks/meters.
-# Lower values improve performance, but might reduce the usability of your scripts.
-# This value is limited by the server (e.g. by 'view-distance' in the server.properties), but is guaranteed to work up to 100 meters.
 
 
 case sensitive: false

--- a/src/test/skript/tests/syntaxes/expressions/ExprBlocks.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprBlocks.sk
@@ -9,7 +9,7 @@ test "blocks void":
 test "blocks vector direction":
 	set {_loc} to location(0.5, 20.5, 0.5)
 	set {_blocks::*} to blocks vector(1,0,0) {_loc}
-	assert size of {_blocks::*} is 100 with "Blocks vector(1,0,0) loc is not 100"
+	assert size of {_blocks::*} is 1000 with "Blocks vector(1,0,0) loc is not 1000"
 	set blocks at {_blocks::*} to stone
 	assert blocks at {_blocks::*} is stone with "1 or more blocks were not set to stone"
 	set blocks at {_blocks::*} to air


### PR DESCRIPTION
Makes the max target block config value 1000 instead of 100. I'm always needing to change this value, with builders and players having high render distance now with modded clients.

Code is more optimized than it was back in Java 6. The target block now uses ray tracing, and is not looping over blocks in the way it used to.

Cleaned up the description, it doesn't really impact performance, the value just has to exist so it doesn't run away if the player is looking at air.

32 render distance is about 1000 blocks, excluding if using any cache mods like Nvidium, Distant Horizons or Bobby.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
