### PR TITLE
Sub Entity Data Fix

### DIFF
--- a/src/main/java/ch/njol/skript/entity/EntityData.java
+++ b/src/main/java/ch/njol/skript/entity/EntityData.java
@@ -489,9 +489,10 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		assert worlds != null && worlds.length > 0 : Arrays.toString(worlds);
 		List<E> list = new ArrayList<>();
 		for (World world : worlds) {
-			for (E entity : world.getEntitiesByClass(getType()))
+			for (E entity : world.getEntitiesByClass(getType())) {
 				if (match(entity))
 					list.add(entity);
+			}
 		}
 		return list.toArray((E[]) Array.newInstance(getType(), list.size()));
 	}

--- a/src/main/java/ch/njol/skript/entity/EntityData.java
+++ b/src/main/java/ch/njol/skript/entity/EntityData.java
@@ -29,10 +29,7 @@ import java.io.StreamCorruptedException;
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -54,24 +51,24 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		} catch (NoSuchMethodException | SecurityException ignored) { /* We already checked if the method exists */ }
 	}
 
-	private static boolean HAS_ENABLED_BY_FEATURE = Skript.methodExists(EntityType.class, "isEnabledByFeature", World.class);
-	public static String LANGUAGE_NODE = "entities";
+	private static final boolean HAS_ENABLED_BY_FEATURE = Skript.methodExists(EntityType.class, "isEnabledByFeature", World.class);
+	public final static String LANGUAGE_NODE = "entities";
 
-	public static Message m_age_pattern = new Message(LANGUAGE_NODE + ".age pattern");
-	public static Adjective m_baby = new Adjective(LANGUAGE_NODE + ".age adjectives.baby"),
+	public final static Message m_age_pattern = new Message(LANGUAGE_NODE + ".age pattern");
+	public final static Adjective m_baby = new Adjective(LANGUAGE_NODE + ".age adjectives.baby"),
 			m_adult = new Adjective(LANGUAGE_NODE + ".age adjectives.adult");
 
 	// must be here to be initialised before 'new SimpleLiteral' is called in the register block below
-	private static List<EntityDataInfo<EntityData<?>>> infos = new ArrayList<>();
+	private final static List<EntityDataInfo<EntityData<?>>> infos = new ArrayList<>();
 
-	private static List<EntityData> ALL_ENTITY_DATAS = new ArrayList<>();
+	private static final List<EntityData> ALL_ENTITY_DATAS = new ArrayList<>();
 
 	public static Serializer<EntityData> serializer = new Serializer<EntityData>() {
 		@Override
 		public Fields serialize(EntityData entityData) throws NotSerializableException {
-			Fields f = entityData.serialize();
-			f.putObject("codeName", entityData.info.codeName);
-			return f;
+			Fields fields = entityData.serialize();
+			fields.putObject("codeName", entityData.info.codeName);
+			return fields;
 		}
 
 		@Override
@@ -174,7 +171,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		});
 	}
 
-	private static class EntityDataInfo<T extends EntityData<?>> extends SyntaxElementInfo<T>
+	private final static class EntityDataInfo<T extends EntityData<?>> extends SyntaxElementInfo<T>
 		implements LanguageChangeListener {
 
 		final String codeName;
@@ -207,10 +204,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 
 		@Override
 		public int hashCode() {
-			int prime = 31;
-			int result = 1;
-			result = prime * result + codeName.hashCode();
-			return result;
+			return Objects.hashCode(codeName);
 		}
 
 		@Override
@@ -276,7 +270,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 
 	@SuppressWarnings("null")
 	@Override
-	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+	public final boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		this.matchedPattern = matchedPattern;
 		// plural bits (0x3): 0 = singular, 1 = plural, 2 = unknown
 		int pluralBits = parseResult.mark & 0x3;
@@ -310,7 +304,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	public abstract EntityData getSuperType();
 
 	@Override
-	public String toString() {
+	public final String toString() {
 		return toString(0);
 	}
 
@@ -340,7 +334,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	protected abstract int hashCode_i();
 
 	@Override
-	public int hashCode() {
+	public final int hashCode() {
 		int prime = 31;
 		int result = 1;
 		result = prime * result + baby.hashCode();
@@ -354,7 +348,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	protected abstract boolean equals_i(EntityData<?> obj);
 
 	@Override
-	public boolean equals(@Nullable Object obj) {
+	public final boolean equals(@Nullable Object obj) {
 		if (this == obj)
 			return true;
 		if (obj == null)
@@ -449,7 +443,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	 * @param location The {@link Location} to spawn the entity at.
 	 * @return The Entity object that is spawned.
 	 */
-	public @Nullable E spawn(Location location) {
+	public final @Nullable E spawn(Location location) {
 		return spawn(location, (Consumer<E>) null);
 	}
 
@@ -609,7 +603,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	}
 
 	@SuppressWarnings("unchecked")
-	public boolean isInstance(@Nullable Entity entity) {
+	public final boolean isInstance(@Nullable Entity entity) {
 		if (entity == null)
 			return false;
 		if (!baby.isUnknown() && EntityUtils.isAgeable(entity) && EntityUtils.isAdult(entity) != baby.isFalse())

--- a/src/main/java/ch/njol/skript/entity/EntityData.java
+++ b/src/main/java/ch/njol/skript/entity/EntityData.java
@@ -44,42 +44,33 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	 * From the class header: "API methods which use this consumer will be remapped to Java's consumer at runtime, resulting in an error."
 	 * But in 1.13-1.16 the only way to use a consumer was World#spawn(Location, Class, org.bukkit.util.Consumer).
 	 */
-	@Nullable
-	protected static Method WORLD_1_13_CONSUMER_METHOD;
-	protected static final boolean WORLD_1_13_CONSUMER = Skript.methodExists(World.class, "spawn", Location.class, Class.class, org.bukkit.util.Consumer.class);
-
-	@Nullable
-	protected static Method WORLD_1_17_CONSUMER_METHOD;
+	protected static @Nullable Method WORLD_1_17_CONSUMER_METHOD;
 	protected static boolean WORLD_1_17_CONSUMER;
 
 	static {
 		try {
-			if (WORLD_1_13_CONSUMER) {
-				WORLD_1_13_CONSUMER_METHOD = World.class.getDeclaredMethod("spawn", Location.class, Class.class, org.bukkit.util.Consumer.class);
-			} else if (Skript.classExists("org.bukkit.RegionAccessor")) {
-				if (WORLD_1_17_CONSUMER = Skript.methodExists(RegionAccessor.class, "spawn", Location.class, Class.class, org.bukkit.util.Consumer.class))
-					WORLD_1_17_CONSUMER_METHOD = RegionAccessor.class.getDeclaredMethod("spawn", Location.class, Class.class, org.bukkit.util.Consumer.class);
-			}
+			if (WORLD_1_17_CONSUMER = Skript.methodExists(RegionAccessor.class, "spawn", Location.class, Class.class, org.bukkit.util.Consumer.class))
+				WORLD_1_17_CONSUMER_METHOD = RegionAccessor.class.getDeclaredMethod("spawn", Location.class, Class.class, org.bukkit.util.Consumer.class);
 		} catch (NoSuchMethodException | SecurityException ignored) { /* We already checked if the method exists */ }
 	}
 
-	private static final boolean HAS_ENABLED_BY_FEATURE = Skript.methodExists(EntityType.class, "isEnabledByFeature", World.class);
-	public final static String LANGUAGE_NODE = "entities";
+	private static boolean HAS_ENABLED_BY_FEATURE = Skript.methodExists(EntityType.class, "isEnabledByFeature", World.class);
+	public static String LANGUAGE_NODE = "entities";
 
-	public final static Message m_age_pattern = new Message(LANGUAGE_NODE + ".age pattern");
-	public final static Adjective m_baby = new Adjective(LANGUAGE_NODE + ".age adjectives.baby"),
+	public static Message m_age_pattern = new Message(LANGUAGE_NODE + ".age pattern");
+	public static Adjective m_baby = new Adjective(LANGUAGE_NODE + ".age adjectives.baby"),
 			m_adult = new Adjective(LANGUAGE_NODE + ".age adjectives.adult");
 
 	// must be here to be initialised before 'new SimpleLiteral' is called in the register block below
-	private final static List<EntityDataInfo<EntityData<?>>> infos = new ArrayList<>();
+	private static List<EntityDataInfo<EntityData<?>>> infos = new ArrayList<>();
 
-	private static final List<EntityData> ALL_ENTITY_DATAS = new ArrayList<>();
+	private static List<EntityData> ALL_ENTITY_DATAS = new ArrayList<>();
 
 	public static Serializer<EntityData> serializer = new Serializer<EntityData>() {
 		@Override
-		public Fields serialize(final EntityData o) throws NotSerializableException {
-			final Fields f = o.serialize();
-			f.putObject("codeName", o.info.codeName);
+		public Fields serialize(EntityData entityData) throws NotSerializableException {
+			Fields f = entityData.serialize();
+			f.putObject("codeName", entityData.info.codeName);
 			return f;
 		}
 
@@ -89,25 +80,23 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		}
 
 		@Override
-		public void deserialize(final EntityData o, final Fields f) throws StreamCorruptedException {
+		public void deserialize(EntityData entityData, Fields fields) throws StreamCorruptedException {
 			assert false;
 		}
 
 		@Override
-		protected EntityData deserialize(final Fields fields) throws StreamCorruptedException, NotSerializableException {
-			final String codeName = fields.getAndRemoveObject("codeName", String.class);
+		protected EntityData deserialize(Fields fields) throws StreamCorruptedException, NotSerializableException {
+			String codeName = fields.getAndRemoveObject("codeName", String.class);
 			if (codeName == null)
 				throw new StreamCorruptedException();
-			final EntityDataInfo<?> info = getInfo(codeName);
+			EntityDataInfo<?> info = getInfo(codeName);
 			if (info == null)
 				throw new StreamCorruptedException("Invalid EntityData code name " + codeName);
 			try {
-				final EntityData<?> d = info.getElementClass().newInstance();
-				d.deserialize(fields);
-				return d;
-			} catch (final InstantiationException e) {
-				Skript.exception(e);
-			} catch (final IllegalAccessException e) {
+				EntityData<?> entityData = info.getElementClass().newInstance();
+				entityData.deserialize(fields);
+				return entityData;
+			} catch (InstantiationException | IllegalAccessException e) {
 				Skript.exception(e);
 			}
 			throw new StreamCorruptedException();
@@ -117,24 +106,23 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		@SuppressWarnings("null")
 		@Override
 		@Deprecated
-		@Nullable
-		public EntityData deserialize(final String s) {
-			final String[] split = s.split(":", 2);
+		public @Nullable EntityData deserialize(String string) {
+			String[] split = string.split(":", 2);
 			if (split.length != 2)
 				return null;
-			final EntityDataInfo<?> i = getInfo(split[0]);
-			if (i == null)
+			EntityDataInfo<?> entityDataInfo = getInfo(split[0]);
+			if (entityDataInfo == null)
 				return null;
-			EntityData<?> d;
+			EntityData<?> entityData;
 			try {
-				d = i.getElementClass().newInstance();
-			} catch (final Exception e) {
-				Skript.exception(e, "Can't create an instance of " + i.getElementClass().getCanonicalName());
+				entityData = entityDataInfo.getElementClass().newInstance();
+			} catch (Exception e) {
+				Skript.exception(e, "Can't create an instance of " + entityDataInfo.getElementClass().getCanonicalName());
 				return null;
 			}
-			if (!d.deserialize(split[1]))
+			if (!entityData.deserialize(split[1]))
 				return null;
-			return d;
+			return entityData;
 		}
 
 		@Override
@@ -157,21 +145,20 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 				.supplier(ALL_ENTITY_DATAS::iterator)
 				.parser(new Parser<EntityData>() {
 					@Override
-					public String toString(final EntityData d, final int flags) {
-						return d.toString(flags);
+					public String toString(EntityData entityData, int flags) {
+						return entityData.toString(flags);
 					}
 
 					@Override
-					@Nullable
-					public EntityData parse(final String s, final ParseContext context) {
-						return EntityData.parse(s);
+					public @Nullable EntityData parse(String string, ParseContext context) {
+						return EntityData.parse(string);
 					}
 
 					@Override
-					public String toVariableNameString(final EntityData o) {
-						return "entitydata:" + o.toString();
+					public String toVariableNameString(EntityData entityData) {
+						return "entitydata:" + entityData.toString();
 					}
-                }).serializer(serializer));
+				}).serializer(serializer));
 	}
 
 	public static void onRegistrationStop() {
@@ -187,16 +174,16 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		});
 	}
 
-	private final static class EntityDataInfo<T extends EntityData<?>> extends SyntaxElementInfo<T>
+	private static class EntityDataInfo<T extends EntityData<?>> extends SyntaxElementInfo<T>
 		implements LanguageChangeListener {
 
-		final String codeName;
-		final String[] codeNames;
-		final int defaultName;
-		final Class<? extends Entity> entityClass;
-		final Noun[] names;
+		String codeName;
+		String[] codeNames;
+		int defaultName;
+		Class<? extends Entity> entityClass;
+		Noun[] names;
 
-		public EntityDataInfo(final Class<T> dataClass, final String codeName, final String[] codeNames, final int defaultName, final Class<? extends Entity> entityClass) throws IllegalArgumentException {
+		public EntityDataInfo(Class<T> dataClass, String codeName, String[] codeNames, int defaultName, Class<? extends Entity> entityClass) throws IllegalArgumentException {
 			super(new String[codeNames.length], dataClass, dataClass.getName());
 			assert codeName != null && entityClass != null && codeNames.length > 0;
 			this.codeName = codeName;
@@ -220,21 +207,20 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 
 		@Override
 		public int hashCode() {
-			final int prime = 31;
+			int prime = 31;
 			int result = 1;
 			result = prime * result + codeName.hashCode();
 			return result;
 		}
 
 		@Override
-		public boolean equals(final @Nullable Object obj) {
+		public boolean equals(@Nullable Object obj) {
 			if (this == obj)
 				return true;
 			if (obj == null)
 				return false;
-			if (!(obj instanceof EntityDataInfo))
+			if (!(obj instanceof EntityDataInfo other))
 				return false;
-			final EntityDataInfo other = (EntityDataInfo) obj;
 			if (!codeName.equals(other.codeName))
 				return false;
 			assert Arrays.equals(codeNames, other.codeNames);
@@ -245,13 +231,24 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 
 	}
 
-	public static <E extends Entity, T extends EntityData<E>> void register(final Class<T> dataClass, final String name, final Class<E> entityClass, final String codeName) throws IllegalArgumentException {
+	public static <E extends Entity, T extends EntityData<E>> void register(
+		Class<T> dataClass,
+		String name,
+		Class<E> entityClass,
+		String codeName
+	) throws IllegalArgumentException {
 		register(dataClass, name, entityClass, 0, codeName);
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <E extends Entity, T extends EntityData<E>> void register(final Class<T> dataClass, final String name, final Class<E> entityClass, final int defaultName, final String... codeNames) throws IllegalArgumentException {
-		final EntityDataInfo<T> info = new EntityDataInfo<>(dataClass, name, codeNames, defaultName, entityClass);
+	public static <E extends Entity, T extends EntityData<E>> void register(
+		Class<T> dataClass,
+		String name,
+		Class<E> entityClass,
+		int defaultName,
+		String... codeNames
+	) throws IllegalArgumentException {
+		EntityDataInfo<T> info = new EntityDataInfo<>(dataClass, name, codeNames, defaultName, entityClass);
 		for (int i = 0; i < infos.size(); i++) {
 			if (infos.get(i).entityClass.isAssignableFrom(entityClass)) {
 				infos.add(i, (EntityDataInfo<EntityData<?>>) info);
@@ -267,10 +264,10 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	private Kleenean baby = Kleenean.UNKNOWN;
 
 	public EntityData() {
-		for (final EntityDataInfo<?> i : infos) {
-			if (getClass() == i.getElementClass()) {
-				info = i;
-				matchedPattern = i.defaultName;
+		for (EntityDataInfo<?> info : infos) {
+			if (getClass() == info.getElementClass()) {
+				this.info = info;
+				matchedPattern = info.defaultName;
 				return;
 			}
 		}
@@ -279,25 +276,25 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 
 	@SuppressWarnings("null")
 	@Override
-	public final boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		this.matchedPattern = matchedPattern;
 		// plural bits (0x3): 0 = singular, 1 = plural, 2 = unknown
-		final int pluralBits = parseResult.mark & 0x3;
+		int pluralBits = parseResult.mark & 0x3;
 		this.plural = pluralBits == 1 ? Kleenean.TRUE : pluralBits == 0 ? Kleenean.FALSE : Kleenean.UNKNOWN;
 		// age bits (0xC): 0 = unknown, 4 = baby, 8 = adult
-		final int ageBits = parseResult.mark & 0xC;
+		int ageBits = parseResult.mark & 0xC;
 		this.baby = ageBits == 4 ? Kleenean.TRUE : ageBits == 8 ? Kleenean.FALSE : Kleenean.UNKNOWN;
 		return init(Arrays.copyOf(exprs, exprs.length, Literal[].class), matchedPattern, parseResult);
 	}
 
-	protected abstract boolean init(final Literal<?>[] exprs, final int matchedPattern, final ParseResult parseResult);
+	protected abstract boolean init(Literal<?>[] exprs, int matchedPattern, ParseResult parseResult);
 
 	/**
-	 * @param c An entity's class, e.g. Player
-	 * @param e An actual entity, or null to get an entity data for an entity class
+	 * @param entityClass An entity's class, e.g. Player
+	 * @param entity An actual entity, or null to get an entity data for an entity class
 	 * @return Whether initialisation was successful
 	 */
-	protected abstract boolean init(@Nullable Class<? extends E> c, @Nullable E e);
+	protected abstract boolean init(@Nullable Class<? extends E> entityClass, @Nullable E entity);
 
 	public abstract void set(E entity);
 
@@ -313,7 +310,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	public abstract EntityData getSuperType();
 
 	@Override
-	public final String toString() {
+	public String toString() {
 		return toString(0);
 	}
 
@@ -322,14 +319,13 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		return info.names[matchedPattern];
 	}
 
-	@Nullable
-	protected Adjective getAgeAdjective() {
+	protected @Nullable Adjective getAgeAdjective() {
 		return baby.isTrue() ? m_baby : baby.isFalse() ? m_adult : null;
 	}
 
 	@SuppressWarnings("null")
-	public String toString(final int flags) {
-		final Noun name = info.names[matchedPattern];
+	public String toString(int flags) {
+		Noun name = info.names[matchedPattern];
 		return baby.isTrue() ? m_baby.toString(name, flags) : baby.isFalse() ? m_adult.toString(name, flags) : name.toString(flags);
 	}
 
@@ -344,8 +340,8 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	protected abstract int hashCode_i();
 
 	@Override
-	public final int hashCode() {
-		final int prime = 31;
+	public int hashCode() {
+		int prime = 31;
 		int result = 1;
 		result = prime * result + baby.hashCode();
 		result = prime * result + plural.hashCode();
@@ -358,14 +354,13 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	protected abstract boolean equals_i(EntityData<?> obj);
 
 	@Override
-	public final boolean equals(final @Nullable Object obj) {
+	public boolean equals(@Nullable Object obj) {
 		if (this == obj)
 			return true;
 		if (obj == null)
 			return false;
-		if (!(obj instanceof EntityData))
+		if (!(obj instanceof EntityData other))
 			return false;
-		final EntityData other = (EntityData) obj;
 		if (baby != other.baby)
 			return false;
 		if (plural != other.plural)
@@ -377,19 +372,18 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		return equals_i(other);
 	}
 
-	public static EntityDataInfo<?> getInfo(final Class<? extends EntityData<?>> c) {
-		for (final EntityDataInfo<?> i : infos) {
-			if (i.getElementClass() == c)
-				return i;
+	public static EntityDataInfo<?> getInfo(Class<? extends EntityData<?>> entityDataClass) {
+		for (EntityDataInfo<?> info : infos) {
+			if (info.getElementClass() == entityDataClass)
+				return info;
 		}
-		throw new SkriptAPIException("Unregistered EntityData class " + c.getName());
+		throw new SkriptAPIException("Unregistered EntityData class " + entityDataClass.getName());
 	}
 
-	@Nullable
-	public static EntityDataInfo<?> getInfo(final String codeName) {
-		for (final EntityDataInfo<?> i : infos) {
-			if (i.codeName.equals(codeName))
-				return i;
+	public static @Nullable EntityDataInfo<?> getInfo(String codeName) {
+		for (EntityDataInfo<?> info : infos) {
+			if (info.codeName.equals(codeName))
+				return info;
 		}
 		return null;
 	}
@@ -397,26 +391,24 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	/**
 	 * Prints errors.
 	 *
-	 * @param s String with optional indefinite article at the beginning
+	 * @param string String with optional indefinite article at the beginning
 	 * @return The parsed entity data
 	 */
 	@SuppressWarnings("null")
-	@Nullable
-	public static EntityData<?> parse(String s) {
+	public static @Nullable EntityData<?> parse(String string) {
 		Iterator<EntityDataInfo<EntityData<?>>> it = new ArrayList<>(infos).iterator();
-		return SkriptParser.parseStatic(Noun.stripIndefiniteArticle(s), it, null);
+		return SkriptParser.parseStatic(Noun.stripIndefiniteArticle(string), it, null);
 	}
 
 	/**
 	 * Prints errors.
 	 *
-	 * @param s
+	 * @param string
 	 * @return The parsed entity data
 	 */
-	@Nullable
-	public static EntityData<?> parseWithoutIndefiniteArticle(String s) {
+	public static @Nullable EntityData<?> parseWithoutIndefiniteArticle(String string) {
 		Iterator<EntityDataInfo<EntityData<?>>> it = new ArrayList<>(infos).iterator();
-		return SkriptParser.parseStatic(s, it, null);
+		return SkriptParser.parseStatic(string, it, null);
 	}
 
 	private E apply(E entity) {
@@ -446,7 +438,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		if (HAS_ENABLED_BY_FEATURE) {
 			// Check if the entity can actually be spawned
 			// Some entity types may be restricted by experimental datapacks
-            return bukkitEntityType.isEnabledByFeature(world) && bukkitEntityType.isSpawnable();
+			return bukkitEntityType.isEnabledByFeature(world) && bukkitEntityType.isSpawnable();
 		}
 		return bukkitEntityType.isSpawnable();
 	}
@@ -457,8 +449,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	 * @param location The {@link Location} to spawn the entity at.
 	 * @return The Entity object that is spawned.
 	 */
-	@Nullable
-	public final E spawn(Location location) {
+	public @Nullable E spawn(Location location) {
 		return spawn(location, (Consumer<E>) null);
 	}
 
@@ -473,10 +464,9 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	 * @param consumer A {@link Consumer} to apply the entity changes to.
 	 * @return The Entity object that is spawned.
 	 */
-	@Nullable
 	@Deprecated
 	@SuppressWarnings("deprecation")
-	public E spawn(Location location, org.bukkit.util.@Nullable Consumer<E> consumer) {
+	public @Nullable E spawn(Location location, org.bukkit.util.@Nullable Consumer<E> consumer) {
 		return spawn(location, (Consumer<E>) e -> consumer.accept(e));
 	}
 
@@ -488,8 +478,7 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	 * @param consumer A {@link Consumer} to apply the entity changes to.
 	 * @return The Entity object that is spawned.
 	 */
-	@Nullable
-	public E spawn(Location location, @Nullable Consumer<E> consumer) {
+	public @Nullable E spawn(Location location, @Nullable Consumer<E> consumer) {
 		assert location != null;
 		World world = location.getWorld();
 		if (!canSpawn(world))
@@ -502,13 +491,13 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	}
 
 	@SuppressWarnings("unchecked")
-	public E[] getAll(final World... worlds) {
+	public E[] getAll(World... worlds) {
 		assert worlds != null && worlds.length > 0 : Arrays.toString(worlds);
-		final List<E> list = new ArrayList<>();
-		for (final World w : worlds) {
-			for (final E e : w.getEntitiesByClass(getType()))
-				if (match(e))
-					list.add(e);
+		List<E> list = new ArrayList<>();
+		for (World world : worlds) {
+			for (E entity : world.getEntitiesByClass(getType()))
+				if (match(entity))
+					list.add(entity);
 		}
 		return list.toArray((E[]) Array.newInstance(getType(), list.size()));
 	}
@@ -520,26 +509,26 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	 * @return All entities of this type in the given worlds
 	 */
 	@SuppressWarnings({"null", "unchecked"})
-	public static <E extends Entity> E[] getAll(final EntityData<?>[] types, final Class<E> type, @Nullable World[] worlds) {
+	public static <E extends Entity> E[] getAll(EntityData<?>[] types, Class<E> type, World @Nullable [] worlds) {
 		assert types.length > 0;
 		if (type == Player.class) {
 			if (worlds == null)
 				return (E[]) Bukkit.getOnlinePlayers().toArray(new Player[0]);
 			List<Player> list = new ArrayList<>();
-			for (Player p : Bukkit.getOnlinePlayers()) {
-				if (CollectionUtils.contains(worlds, p.getWorld()))
-					list.add(p);
+			for (Player player : Bukkit.getOnlinePlayers()) {
+				if (CollectionUtils.contains(worlds, player.getWorld()))
+					list.add(player);
 			}
 			return (E[]) list.toArray(new Player[list.size()]);
 		}
-		final List<E> list = new ArrayList<>();
+		List<E> list = new ArrayList<>();
 		if (worlds == null)
 			worlds = Bukkit.getWorlds().toArray(new World[0]);
-		for (final World w : worlds) {
-			for (final E e : w.getEntitiesByClass(type)) {
-				for (final EntityData<?> t : types) {
-					if (t.isInstance(e)) {
-						list.add(e);
+		for (World world : worlds) {
+			for (E entity : world.getEntitiesByClass(type)) {
+				for (EntityData<?> entityData : types) {
+					if (entityData.isInstance(entity)) {
+						list.add(entity);
 						break;
 					}
 				}
@@ -549,13 +538,13 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <E extends Entity> E[] getAll(final EntityData<?>[] types, final Class<E> type, Chunk[] chunks) {
+	public static <E extends Entity> E[] getAll(EntityData<?>[] types, Class<E> type, Chunk[] chunks) {
 		assert types.length > 0;
-		final List<E> list = new ArrayList<>();
+		List<E> list = new ArrayList<>();
 		for (Chunk chunk : chunks) {
 			for (Entity entity : chunk.getEntities()) {
-				for (EntityData<?> t : types) {
-					if (t.isInstance(entity)) {
+				for (EntityData<?> entityData : types) {
+					if (entityData.isInstance(entity)) {
 						list.add(((E) entity));
 						break;
 					}
@@ -565,63 +554,70 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		return list.toArray((E[]) Array.newInstance(type, list.size()));
 	}
 
-	private static <E extends Entity> EntityData<? super E> getData(final @Nullable Class<E> c, final @Nullable E e) {
-		assert c == null ^ e == null;
-		assert c == null || c.isInterface();
-		for (final EntityDataInfo<?> info : infos) {
-			if (info.entityClass != Entity.class && (e == null ? info.entityClass.isAssignableFrom(c) : info.entityClass.isInstance(e))) {
+	private static <E extends Entity> EntityData<? super E> getData(@Nullable Class<E> entityClass, @Nullable E entity) {
+		assert entityClass == null ^ entity == null;
+		assert entityClass == null || entityClass.isInterface();
+		EntityDataInfo<?> closestInfo = null;
+		EntityData<E> closestData = null;
+		for (EntityDataInfo<?> info : infos) {
+			if (info.entityClass == Entity.class)
+				continue;
+			if (entity == null ? info.entityClass.isAssignableFrom(entityClass) : info.entityClass.isInstance(entity)) {
+				EntityData<E> entityData = null;
 				try {
-					@SuppressWarnings("unchecked")
-					final EntityData<E> d = (EntityData<E>) info.getElementClass().newInstance();
-					if (d.init(c, e))
-						return d;
-				} catch (final Exception ex) {
-					throw Skript.exception(ex);
+					//noinspection unchecked
+					entityData = (EntityData<E>) info.getElementClass().newInstance();
+				} catch (Exception ignored) {}
+				if (entityData != null && entityData.init(entityClass, entity)) {
+					if (closestInfo == null || closestInfo.entityClass.isAssignableFrom(info.entityClass)) {
+						closestInfo = info;
+						closestData = entityData;
+					}
 				}
 			}
 		}
-		if (e != null) {
-			return new SimpleEntityData(e);
-		} else {
-			assert c != null;
-			return new SimpleEntityData(c);
+		if (closestInfo == null) {
+			if (entity != null)
+				return new SimpleEntityData(entity);
+			return new SimpleEntityData(entityClass);
 		}
+		return closestData;
+	};
+
+	public static <E extends Entity> EntityData<? super E> fromClass(Class<E> entityClass) {
+		return getData(entityClass, null);
 	}
 
-	public static <E extends Entity> EntityData<? super E> fromClass(final Class<E> c) {
-		return getData(c, null);
+	public static <E extends Entity> EntityData<? super E> fromEntity(E entity) {
+		return getData(null, entity);
 	}
 
-	public static <E extends Entity> EntityData<? super E> fromEntity(final E e) {
-		return getData(null, e);
+	public static String toString(Entity entity) {
+		return fromEntity(entity).getSuperType().toString();
 	}
 
-	public static String toString(final Entity e) {
-		return fromEntity(e).getSuperType().toString();
+	public static String toString(Class<? extends Entity> entityClass) {
+		return fromClass(entityClass).getSuperType().toString();
 	}
 
-	public static String toString(final Class<? extends Entity> c) {
-		return fromClass(c).getSuperType().toString();
+	public static String toString(Entity entity, int flags) {
+		return fromEntity(entity).getSuperType().toString(flags);
 	}
 
-	public static String toString(final Entity e, final int flags) {
-		return fromEntity(e).getSuperType().toString(flags);
-	}
-
-	public static String toString(final Class<? extends Entity> c, final int flags) {
-		return fromClass(c).getSuperType().toString(flags);
+	public static String toString(Class<? extends Entity> entityClass, int flags) {
+		return fromClass(entityClass).getSuperType().toString(flags);
 	}
 
 	@SuppressWarnings("unchecked")
-	public final boolean isInstance(final @Nullable Entity e) {
-		if (e == null)
+	public boolean isInstance(@Nullable Entity entity) {
+		if (entity == null)
 			return false;
-		if (!baby.isUnknown() && EntityUtils.isAgeable(e) && EntityUtils.isAdult(e) != baby.isFalse())
+		if (!baby.isUnknown() && EntityUtils.isAgeable(entity) && EntityUtils.isAdult(entity) != baby.isFalse())
 			return false;
-		return getType().isInstance(e) && match((E) e);
+		return getType().isInstance(entity) && match((E) entity);
 	}
 
-	public abstract boolean isSupertypeOf(EntityData<?> e);
+	public abstract boolean isSupertypeOf(EntityData<?> entityData);
 
 	@Override
 	public Fields serialize() throws NotSerializableException {
@@ -629,12 +625,12 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	}
 
 	@Override
-	public void deserialize(final Fields fields) throws StreamCorruptedException, NotSerializableException {
+	public void deserialize(Fields fields) throws StreamCorruptedException, NotSerializableException {
 		fields.setFields(this);
 	}
 
 	@Deprecated
-	protected boolean deserialize(final String s) {
+	protected boolean deserialize(String string) {
 		return false;
 	}
 
@@ -652,16 +648,13 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 			if (WORLD_1_17_CONSUMER) {
 				return (@Nullable E) WORLD_1_17_CONSUMER_METHOD.invoke(world, location, type,
 					(org.bukkit.util.Consumer<E>) consumer::accept);
-			} else if (WORLD_1_13_CONSUMER) {
-				return (@Nullable E) WORLD_1_13_CONSUMER_METHOD.invoke(world, location, type,
-					(org.bukkit.util.Consumer<E>) consumer::accept);
 			}
 		} catch (InvocationTargetException | IllegalAccessException e) {
 			if (Skript.testing())
 				Skript.exception(e, "Can't spawn " + type.getName());
 			return null;
-        }
-        return world.spawn(location, type, consumer);
+		}
+		return world.spawn(location, type, consumer);
 	}
 
 	/**

--- a/src/main/java/ch/njol/skript/entity/EntityData.java
+++ b/src/main/java/ch/njol/skript/entity/EntityData.java
@@ -177,11 +177,11 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	private static class EntityDataInfo<T extends EntityData<?>> extends SyntaxElementInfo<T>
 		implements LanguageChangeListener {
 
-		String codeName;
-		String[] codeNames;
-		int defaultName;
-		Class<? extends Entity> entityClass;
-		Noun[] names;
+		final String codeName;
+		final String[] codeNames;
+		final int defaultName;
+		final Class<? extends Entity> entityClass;
+		final Noun[] names;
 
 		public EntityDataInfo(Class<T> dataClass, String codeName, String[] codeNames, int defaultName, Class<? extends Entity> entityClass) throws IllegalArgumentException {
 			super(new String[codeNames.length], dataClass, dataClass.getName());

--- a/src/main/java/ch/njol/skript/entity/SimpleEntityData.java
+++ b/src/main/java/ch/njol/skript/entity/SimpleEntityData.java
@@ -65,8 +65,13 @@ public class SimpleEntityData extends EntityData<Entity> {
 	}
 
 	private static void addSuperEntity(String codeName, Class<? extends Entity> entityClass) {
-		types.add(new SimpleEntityDataInfo(codeName, entityClass, true, Kleenean.UNKNOWN));
+		addSuperEntity(codeName, entityClass, Kleenean.UNKNOWN);
 	}
+
+	private static void addSuperEntity(String codeName, Class<? extends Entity> entityClass, Kleenean allowSpawning) {
+		types.add(new SimpleEntityDataInfo(codeName, entityClass, true, allowSpawning));
+	}
+
 	static {
 		// Simple Entities
 		addSimpleEntity("arrow", Arrow.class);
@@ -85,7 +90,7 @@ public class SimpleEntityData extends EntityData<Entity> {
 		addSimpleEntity("ender eye", EnderSignal.class);
 		addSimpleEntity("small fireball", SmallFireball.class);
 		addSimpleEntity("large fireball", LargeFireball.class);
-		addSuperEntity("fireball", Fireball.class);
+		addSuperEntity("fireball", Fireball.class, Kleenean.TRUE);
 		addSimpleEntity("fish hook", FishHook.class);
 		addSimpleEntity("ghast", Ghast.class);
 		addSimpleEntity("giant", Giant.class);

--- a/src/main/java/ch/njol/skript/entity/SimpleEntityData.java
+++ b/src/main/java/ch/njol/skript/entity/SimpleEntityData.java
@@ -18,10 +18,10 @@ import java.util.List;
 public class SimpleEntityData extends EntityData<Entity> {
 	
 	public static class SimpleEntityDataInfo {
-		String codeName;
-		Class<? extends Entity> c;
-		boolean isSupertype;
-		Kleenean allowSpawning;
+		final String codeName;
+		final Class<? extends Entity> c;
+		final boolean isSupertype;
+		final Kleenean allowSpawning;
 		
 		SimpleEntityDataInfo(String codeName, Class<? extends Entity> c, boolean isSupertype, Kleenean allowSpawning) {
 			this.codeName = codeName;

--- a/src/main/java/ch/njol/skript/entity/SimpleEntityData.java
+++ b/src/main/java/ch/njol/skript/entity/SimpleEntityData.java
@@ -17,11 +17,11 @@ import java.util.List;
 
 public class SimpleEntityData extends EntityData<Entity> {
 	
-	public final static class SimpleEntityDataInfo {
-		final String codeName;
-		final Class<? extends Entity> c;
-		final boolean isSupertype;
-		final Kleenean allowSpawning;
+	public static class SimpleEntityDataInfo {
+		String codeName;
+		Class<? extends Entity> c;
+		boolean isSupertype;
+		Kleenean allowSpawning;
 		
 		SimpleEntityDataInfo(String codeName, Class<? extends Entity> c, boolean isSupertype, Kleenean allowSpawning) {
 			this.codeName = codeName;
@@ -36,14 +36,13 @@ public class SimpleEntityData extends EntityData<Entity> {
 		}
 		
 		@Override
-		public boolean equals(final @Nullable Object obj) {
+		public boolean equals(@Nullable Object obj) {
 			if (this == obj)
 				return true;
 			if (obj == null)
 				return false;
-			if (!(obj instanceof SimpleEntityDataInfo))
+			if (!(obj instanceof SimpleEntityDataInfo other))
 				return false;
-			final SimpleEntityDataInfo other = (SimpleEntityDataInfo) obj;
 			if (c != other.c)
 				return false;
 			assert codeName.equals(other.codeName);
@@ -52,7 +51,7 @@ public class SimpleEntityData extends EntityData<Entity> {
 		}
 	}
 	
-	private final static List<SimpleEntityDataInfo> types = new ArrayList<>();
+	private static List<SimpleEntityDataInfo> types = new ArrayList<>();
 
 	private static void addSimpleEntity(String codeName, Class<? extends Entity> entityClass) {
 		addSimpleEntity(codeName, entityClass, Kleenean.UNKNOWN);
@@ -86,7 +85,7 @@ public class SimpleEntityData extends EntityData<Entity> {
 		addSimpleEntity("ender eye", EnderSignal.class);
 		addSimpleEntity("small fireball", SmallFireball.class);
 		addSimpleEntity("large fireball", LargeFireball.class);
-		addSimpleEntity("fireball", Fireball.class);
+		addSuperEntity("fireball", Fireball.class);
 		addSimpleEntity("fish hook", FishHook.class);
 		addSimpleEntity("ghast", Ghast.class);
 		addSimpleEntity("giant", Giant.class);
@@ -146,41 +145,36 @@ public class SimpleEntityData extends EntityData<Entity> {
 
 		addSimpleEntity("illusioner", Illusioner.class);
 
-		if (Skript.isRunningMinecraft(1, 14)) {
-			addSimpleEntity("pillager", Pillager.class);
-			addSimpleEntity("ravager", Ravager.class);
-			addSimpleEntity("wandering trader", WanderingTrader.class);
-		}
+		// 1.14
+		addSimpleEntity("pillager", Pillager.class);
+		addSimpleEntity("ravager", Ravager.class);
+		addSimpleEntity("wandering trader", WanderingTrader.class);
 
-		if (Skript.isRunningMinecraft(1, 16)) {
-			addSimpleEntity("piglin", Piglin.class);
-			addSimpleEntity("hoglin", Hoglin.class);
-			addSimpleEntity("zoglin", Zoglin.class);
-			addSimpleEntity("strider", Strider.class);
-		}
+		// 1.16
+		addSimpleEntity("piglin", Piglin.class);
+		addSimpleEntity("hoglin", Hoglin.class);
+		addSimpleEntity("zoglin", Zoglin.class);
+		addSimpleEntity("strider", Strider.class);
 
-		if (Skript.classExists("org.bukkit.entity.PiglinBrute")) // Added in 1.16.2
-			addSimpleEntity("piglin brute", PiglinBrute.class);
+		// 1.16.2
+		addSimpleEntity("piglin brute", PiglinBrute.class);
 
-		if (Skript.isRunningMinecraft(1, 17)) {
-			addSimpleEntity("glow squid", GlowSquid.class);
-			addSimpleEntity("marker", Marker.class);
-			addSimpleEntity("glow item frame", GlowItemFrame.class);
-		}
+		// 1.17
+		addSimpleEntity("glow squid", GlowSquid.class);
+		addSimpleEntity("marker", Marker.class);
+		addSimpleEntity("glow item frame", GlowItemFrame.class);
 
-		if (Skript.isRunningMinecraft(1, 19)) {
-			addSimpleEntity("allay", Allay.class);
-			addSimpleEntity("tadpole", Tadpole.class);
-			addSimpleEntity("warden", Warden.class);
-		}
+		// 1.19
+		addSimpleEntity("allay", Allay.class);
+		addSimpleEntity("tadpole", Tadpole.class);
+		addSimpleEntity("warden", Warden.class);
 
-		if (Skript.isRunningMinecraft(1, 19, 3))
-			addSimpleEntity("camel", Camel.class);
+		// 1.19.3
+		addSimpleEntity("camel", Camel.class);
 
-		if (Skript.isRunningMinecraft(1, 19, 4)) {
-			addSimpleEntity("sniffer", Sniffer.class);
-			addSimpleEntity("interaction", Interaction.class);
-		}
+		// 1.19.4
+		addSimpleEntity("sniffer", Sniffer.class);
+		addSimpleEntity("interaction", Interaction.class);
 
 		if (Skript.isRunningMinecraft(1, 20, 3)) {
 			addSimpleEntity("breeze", Breeze.class);
@@ -258,9 +252,9 @@ public class SimpleEntityData extends EntityData<Entity> {
 	}
 
 	static {
-		final String[] codeNames = new String[types.size()];
+		String[] codeNames = new String[types.size()];
 		int i = 0;
-		for (final SimpleEntityDataInfo info : types) {
+		for (SimpleEntityDataInfo info : types) {
 			codeNames[i++] = info.codeName;
 		}
 		EntityData.register(SimpleEntityData.class, "simple", Entity.class, 0, codeNames);
@@ -272,64 +266,84 @@ public class SimpleEntityData extends EntityData<Entity> {
 		this(Entity.class);
 	}
 	
-	private SimpleEntityData(final SimpleEntityDataInfo info) {
+	private SimpleEntityData(SimpleEntityDataInfo info) {
 		assert info != null;
 		this.info = info;
 		matchedPattern = types.indexOf(info);
 	}
 	
-	public SimpleEntityData(final Class<? extends Entity> c) {
-		assert c != null && c.isInterface() : c;
+	public SimpleEntityData(Class<? extends Entity> entityClass) {
+		assert entityClass != null && entityClass.isInterface() : entityClass;
 		int i = 0;
-		for (final SimpleEntityDataInfo info : types) {
-			if (info.c.isAssignableFrom(c)) {
-				this.info = info;
-				matchedPattern = i;
-				return;
+		SimpleEntityDataInfo closestInfo = null;
+		int closestPattern = 0;
+		for (SimpleEntityDataInfo info : types) {
+			if (info.c.isAssignableFrom(entityClass)) {
+				if (closestInfo == null || closestInfo.c.isAssignableFrom(info.c)) {
+					closestInfo = info;
+					closestPattern = i;
+				}
 			}
 			i++;
+		}
+		if (closestInfo != null) {
+			this.info = closestInfo;
+			this.matchedPattern = closestPattern;
+			return;
 		}
 		throw new IllegalStateException();
 	}
 	
-	public SimpleEntityData(final Entity e) {
+	public SimpleEntityData(Entity entity) {
 		int i = 0;
-		for (final SimpleEntityDataInfo info : types) {
-			if (info.c.isInstance(e)) {
-				this.info = info;
-				matchedPattern = i;
-				return;
+		SimpleEntityDataInfo closestInfo = null;
+		int closestPattern = 0;
+		for (SimpleEntityDataInfo info : types) {
+			if (info.c.isInstance(entity)) {
+				if (closestInfo == null || closestInfo.c.isAssignableFrom(info.c)) {
+					closestInfo = info;
+					closestPattern = i;
+				}
 			}
 			i++;
 		}
+		if (closestInfo != null) {
+			this.info = closestInfo;
+			this.matchedPattern = closestPattern;
+			return;
+		}
 		throw new IllegalStateException();
 	}
-	
-	@SuppressWarnings("null")
+
 	@Override
-	protected boolean init(final Literal<?>[] exprs, final int matchedPattern, final ParseResult parseResult) {
+	protected boolean init(Literal<?>[] exprs, int matchedPattern, ParseResult parseResult) {
 		info = types.get(matchedPattern);
 		assert info != null : matchedPattern;
 		return true;
 	}
 	
 	@Override
-	protected boolean init(final @Nullable Class<? extends Entity> c, final @Nullable Entity e) {
+	protected boolean init(@Nullable Class<? extends Entity> entityClass, @Nullable Entity entity) {
 		assert false;
 		return false;
 	}
 	
 	@Override
-	public void set(final Entity entity) {}
+	public void set(Entity entity) {}
 	
 	@Override
-	public boolean match(final Entity e) {
+	public boolean match(Entity entity) {
 		if (info.isSupertype)
-			return info.c.isInstance(e);
-		for (final SimpleEntityDataInfo info : types) {
-			if (info.c.isInstance(e))
-				return this.info.c == info.c;
+			return info.c.isInstance(entity);
+		SimpleEntityDataInfo closest = null;
+		for (SimpleEntityDataInfo info : types) {
+			if (info.c.isInstance(entity)) {
+				if (closest == null || closest.c.isAssignableFrom(info.c))
+					closest = info;
+			}
 		}
+		if (closest != null)
+			return this.info.c == closest.c;
 		assert false;
 		return false;
 	}
@@ -345,10 +359,9 @@ public class SimpleEntityData extends EntityData<Entity> {
 	}
 	
 	@Override
-	protected boolean equals_i(final EntityData<?> obj) {
-		if (!(obj instanceof SimpleEntityData))
+	protected boolean equals_i(EntityData<?> obj) {
+		if (!(obj instanceof SimpleEntityData other))
 			return false;
-		final SimpleEntityData other = (SimpleEntityData) obj;
 		return info.equals(other.info);
 	}
 
@@ -363,17 +376,17 @@ public class SimpleEntityData extends EntityData<Entity> {
 
 	@Override
 	public Fields serialize() throws NotSerializableException {
-		final Fields f = super.serialize();
-		f.putObject("info.codeName", info.codeName);
-		return f;
+		Fields fields = super.serialize();
+		fields.putObject("info.codeName", info.codeName);
+		return fields;
 	}
 	
 	@Override
-	public void deserialize(final Fields fields) throws StreamCorruptedException, NotSerializableException {
-		final String codeName = fields.getAndRemoveObject("info.codeName", String.class);
-		for (final SimpleEntityDataInfo i : types) {
-			if (i.codeName.equals(codeName)) {
-				info = i;
+	public void deserialize(Fields fields) throws StreamCorruptedException, NotSerializableException {
+		String codeName = fields.getAndRemoveObject("info.codeName", String.class);
+		for (SimpleEntityDataInfo info : types) {
+			if (info.codeName.equals(codeName)) {
+				this.info = info;
 				super.deserialize(fields);
 				return;
 			}
@@ -381,27 +394,27 @@ public class SimpleEntityData extends EntityData<Entity> {
 		throw new StreamCorruptedException("Invalid SimpleEntityDataInfo code name " + codeName);
 	}
 	
-//		return info.c.getName();
+
 	@Override
 	@Deprecated
-	protected boolean deserialize(final String s) {
+	protected boolean deserialize(String string) {
 		try {
-			final Class<?> c = Class.forName(s);
-			for (final SimpleEntityDataInfo i : types) {
-				if (i.c == c) {
-					info = i;
+			Class<?> c = Class.forName(string);
+			for (SimpleEntityDataInfo info : types) {
+				if (info.c == c) {
+					this.info = info;
 					return true;
 				}
 			}
 			return false;
-		} catch (final ClassNotFoundException e) {
+		} catch (ClassNotFoundException e) {
 			return false;
 		}
 	}
 	
 	@Override
-	public boolean isSupertypeOf(final EntityData<?> e) {
-		return info.c == e.getType() || info.isSupertype && info.c.isAssignableFrom(e.getType());
+	public boolean isSupertypeOf(EntityData<?> entityData) {
+		return info.c == entityData.getType() || info.isSupertype && info.c.isAssignableFrom(entityData.getType());
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/entity/SimpleEntityData.java
+++ b/src/main/java/ch/njol/skript/entity/SimpleEntityData.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 public class SimpleEntityData extends EntityData<Entity> {
 	
-	public static class SimpleEntityDataInfo {
+	public final static class SimpleEntityDataInfo {
 		final String codeName;
 		final Class<? extends Entity> c;
 		final boolean isSupertype;
@@ -51,7 +51,7 @@ public class SimpleEntityData extends EntityData<Entity> {
 		}
 	}
 	
-	private static List<SimpleEntityDataInfo> types = new ArrayList<>();
+	private final static List<SimpleEntityDataInfo> types = new ArrayList<>();
 
 	private static void addSimpleEntity(String codeName, Class<? extends Entity> entityClass) {
 		addSimpleEntity(codeName, entityClass, Kleenean.UNKNOWN);

--- a/src/main/java/org/skriptlang/skript/bukkit/displays/text/ExprTextDisplayAlignment.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/displays/text/ExprTextDisplayAlignment.java
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("Text Display Alignment")
 @Description("Returns or changes the <a href='classes.html#textalignment'>alignment</a> setting of <a href='classes.html#display'>text displays</a>.")
-@Examples("set text alignment of the last spawned text display to left")
+@Examples("set text alignment of the last spawned text display to left aligned")
 @Since("2.10")
 public class ExprTextDisplayAlignment extends SimplePropertyExpression<Display, TextAlignment> {
 

--- a/src/test/skript/tests/misc/sub entity datas.sk
+++ b/src/test/skript/tests/misc/sub entity datas.sk
@@ -1,0 +1,39 @@
+
+test "fireball":
+	spawn a fireball at test-location:
+		set {_entity} to entity
+	assert {_entity} is a fireball with "Entity should be a fireball"
+	clear entity within {_entity}
+
+test "small fireball":
+	spawn a small fireball at test-location:
+		set {_entity} to entity
+	assert {_entity} is a fireball with "Entity should be a fireball"
+	assert {_entity} is a small fireball with "Entity should be a small fireball"
+	clear entity within {_entity}
+
+test "large fireball":
+	spawn a large fireball at test-location:
+		set {_entity} to entity
+	assert {_entity} is a fireball with "Entity should be a fireball"
+	assert {_entity} is a large fireball with "Entity should be a large fireball"
+	clear entity within {_entity}
+
+test "dragon fireball":
+	spawn a dragon fireball at test-location:
+		set {_entity} to entity
+	assert {_entity} is a fireball with "Entity should be a fireball"
+	assert {_entity} is a dragon fireball with "Entity should be a dragon fireball"
+	clear entity within {_entity}
+
+test "wither skull":
+	spawn a wither skull at test-location:
+		set {_entity} to entity
+	assert {_entity} is a wither skull with "Entity should be a wither skull"
+	clear entity within {_entity}
+
+test "wind charge" when running minecraft "1.20.3":
+	spawn a wind charge at test-location:
+		set {_entity} to entity
+	assert {_entity} is a wind charge with "Entity should be a wind charge"
+	clear entity within {_entity}

--- a/src/test/skript/tests/misc/sub entity datas.sk
+++ b/src/test/skript/tests/misc/sub entity datas.sk
@@ -32,7 +32,7 @@ test "wither skull":
 	assert {_entity} is a wither skull with "Entity should be a wither skull"
 	clear entity within {_entity}
 
-test "wind charge" when running minecraft "1.20.3":
+test "wind charge" when running minecraft "1.20.5":
 	spawn a wind charge at test-location:
 		set {_entity} to entity
 	assert {_entity} is a wind charge with "Entity should be a wind charge"

--- a/src/test/skript/tests/misc/sub entity datas.sk
+++ b/src/test/skript/tests/misc/sub entity datas.sk
@@ -32,7 +32,7 @@ test "wither skull":
 	assert {_entity} is a wither skull with "Entity should be a wither skull"
 	clear entity within {_entity}
 
-test "wind charge" when running minecraft "1.20.5":
+test "wind charge" when running minecraft "1.21.0":
 	spawn a wind charge at test-location:
 		set {_entity} to entity
 	assert {_entity} is a wind charge with "Entity should be a wind charge"

--- a/src/test/skript/tests/syntaxes/sections/EffSecSpawn.sk
+++ b/src/test/skript/tests/syntaxes/sections/EffSecSpawn.sk
@@ -85,7 +85,7 @@ test "spawn entities":
 	add "ender dragon" and "wither" to {_entities::*}
 	add "oak boat", "oak chest boat", "armor stand", "primed tnt", "firework", "arrow", "trident" and "egg" to {_entities::*}
 	add "snowball", "end crystal", "eye of ender", "regular minecart", "falling sand" and "falling gravel" to {_entities::*}
-	add "falling powder snow" and "fireball" to {_entities::*}
+	add "falling powder snow", "fireball" and "wither skull" to {_entities::*}
 
 	if running minecraft "1.20.0":
 		add "camel" and "sniffer" to {_entities::*}

--- a/src/test/skript/tests/syntaxes/sections/EffSecSpawn.sk
+++ b/src/test/skript/tests/syntaxes/sections/EffSecSpawn.sk
@@ -89,7 +89,7 @@ test "spawn entities":
 
 	if running minecraft "1.20.0":
 		add "camel" and "sniffer" to {_entities::*}
-	if running minecraft "1.20.3":
+	if running minecraft "1.20.5":
 		add "wind charge" to {_entities::*}
 	if running minecraft "1.20.6":
 		add "armadillo" to {_entities::*}

--- a/src/test/skript/tests/syntaxes/sections/EffSecSpawn.sk
+++ b/src/test/skript/tests/syntaxes/sections/EffSecSpawn.sk
@@ -85,10 +85,12 @@ test "spawn entities":
 	add "ender dragon" and "wither" to {_entities::*}
 	add "oak boat", "oak chest boat", "armor stand", "primed tnt", "firework", "arrow", "trident" and "egg" to {_entities::*}
 	add "snowball", "end crystal", "eye of ender", "regular minecart", "falling sand" and "falling gravel" to {_entities::*}
-	add "falling powder snow" to {_entities::*}
+	add "falling powder snow" and "fireball" to {_entities::*}
 
 	if running minecraft "1.20.0":
 		add "camel" and "sniffer" to {_entities::*}
+	if running minecraft "1.20.3":
+		add "wind charge" to {_entities::*}
 	if running minecraft "1.20.6":
 		add "armadillo" to {_entities::*}
 	if running minecraft "1.21":

--- a/src/test/skript/tests/syntaxes/sections/EffSecSpawn.sk
+++ b/src/test/skript/tests/syntaxes/sections/EffSecSpawn.sk
@@ -89,12 +89,10 @@ test "spawn entities":
 
 	if running minecraft "1.20.0":
 		add "camel" and "sniffer" to {_entities::*}
-	if running minecraft "1.20.5":
-		add "wind charge" to {_entities::*}
 	if running minecraft "1.20.6":
 		add "armadillo" to {_entities::*}
-	if running minecraft "1.21":
-		add "bogged" and "breeze" to {_entities::*}
+	if running minecraft "1.21.0":
+		add "bogged", "breeze" and "wind charge" to {_entities::*}
 
 	# Note: Had to remove 'fireball' and 'wind charge'
 


### PR DESCRIPTION
### Description
This PR aims to:
- Fix #7491 allowing users to detect if a projectile is a wind charge or wither skull
- Future proofing for any other entities that extend another entity
- Adds tests for entities extending another entity, such as: small fireball, large fireball, dragon fireball, wind charge and wither skull
- Adds fireball, wind charge and wither skull to the all entities test within `EffSecSpawn.sk`

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7491 <!-- Links to related issues -->
