### PR TITLE
Adds an isSingle check to EffSort's mapping expression

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffSort.java
+++ b/src/main/java/ch/njol/skript/effects/EffSort.java
@@ -65,11 +65,11 @@ public class EffSort extends Effect implements InputSource {
 
 	@Override
 	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		if (expressions[0].isSingle() || !(expressions[0] instanceof Variable)) {
+		if (expressions[0].isSingle() || !(expressions[0] instanceof Variable<?> variable)) {
 			Skript.error("You can only sort list variables!");
 			return false;
 		}
-		unsortedObjects = (Variable<?>) expressions[0];
+		unsortedObjects = variable;
 		descendingOrder = parseResult.hasTag("descending");
 
 		//noinspection DuplicatedCode
@@ -77,7 +77,12 @@ public class EffSort extends Effect implements InputSource {
 			@Nullable String unparsedExpression = parseResult.regexes.get(0).group();
 			assert unparsedExpression != null;
 			mappingExpr = parseExpression(unparsedExpression, getParser(), SkriptParser.PARSE_EXPRESSIONS);
-			return mappingExpr != null;
+			if (mappingExpr == null)
+				return false;
+			if (!mappingExpr.isSingle()) {
+				Skript.error("The mapping expression in the sort effect must only return a single value for a single input.");
+				return false;
+			}
 		}
 		return true;
 	}


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Makes sure the mapping expression only returns a single value, rather than simply assuming it.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
