### PR TITLE
Fix event-itemstack for ComplexRecipe

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -486,7 +486,12 @@ public final class BukkitEventValues {
 			return null;
 		});
 		// CraftItemEvent
-		EventValues.registerEventValue(CraftItemEvent.class, ItemStack.class, event -> event.getRecipe().getResult());
+		EventValues.registerEventValue(CraftItemEvent.class, ItemStack.class, event -> {
+			Recipe recipe = event.getRecipe();
+			if (recipe instanceof ComplexRecipe)
+				return event.getCurrentItem();
+			return recipe.getResult();
+		});
 		//InventoryOpenEvent
 		EventValues.registerEventValue(InventoryOpenEvent.class, Player.class, event -> (Player) event.getPlayer());
 		EventValues.registerEventValue(InventoryOpenEvent.class, Inventory.class, InventoryEvent::getInventory);

--- a/src/main/java/ch/njol/skript/events/EvtItem.java
+++ b/src/main/java/ch/njol/skript/events/EvtItem.java
@@ -15,6 +15,7 @@ import org.bukkit.event.inventory.PrepareItemCraftEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.event.player.PlayerPickupItemEvent;
+import org.bukkit.inventory.ComplexRecipe;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
 import org.jetbrains.annotations.Nullable;
@@ -173,7 +174,12 @@ public class EvtItem extends SkriptEvent {
 		} else if (event instanceof EntityDropItemEvent) {
 			itemStack = ((EntityDropItemEvent) event).getItemDrop().getItemStack();
 		} else if (event instanceof CraftItemEvent) {
-			itemStack = ((CraftItemEvent) event).getRecipe().getResult();
+			Recipe recipe = ((CraftItemEvent) event).getRecipe();
+			if (recipe instanceof ComplexRecipe) {
+				itemStack = ((CraftItemEvent) event).getCurrentItem();
+			} else {
+				itemStack = ((CraftItemEvent) event).getRecipe().getResult();
+			}
 		} else if (hasPrepareCraftEvent && event instanceof PrepareItemCraftEvent) {
 			Recipe recipe = ((PrepareItemCraftEvent) event).getRecipe();
 			if (recipe != null) {


### PR DESCRIPTION
### Description
With _CraftEvent_, the item stack is obtained through looking at the recipe's result. However, in the majority of cases, when the recipe is a _ComplexRecipe_, this result is air.
This PR adds a check to instead use the _currentItem_ method in such cases, which solves the issue without altering the behaviour with 'normal' crafts.

This would potentially be an issue, as scripts relying on this bug would stop working.
However, it would eliminate some confusion, and allow to tell the items in question apart (as far as I know, there was no way to previously do so in such cases).

---
**Target Minecraft Versions:** any
**Requirements:** none
**Related Issues:** #5762
