### PR TITLE
Make ERS use names of events instead of class names 

### DIFF
--- a/src/main/java/ch/njol/skript/lang/EventRestrictedSyntax.java
+++ b/src/main/java/ch/njol/skript/lang/EventRestrictedSyntax.java
@@ -7,6 +7,7 @@ import org.bukkit.event.Event;
 /**
  * A syntax element that restricts the events it can be used in.
  */
+@FunctionalInterface
 public interface EventRestrictedSyntax {
 
 	/**

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -224,16 +224,7 @@ public class SkriptParser {
 							if (element instanceof EventRestrictedSyntax eventRestrictedSyntax) {
 								Class<? extends Event>[] supportedEvents = eventRestrictedSyntax.supportedEvents();
 								if (!getParser().isCurrentEvent(supportedEvents)) {
-									Iterator<String> iterator = Arrays.stream(supportedEvents)
-										.map(it -> "the " + it.getSimpleName()
-											.replaceAll("([A-Z])", " $1")
-											.toLowerCase()
-											.trim())
-										.iterator();
-
-									String events = StringUtils.join(iterator, ", ", " or ");
-
-									Skript.error("'" + parseResult.expr + "' can only be used in " + events);
+									Skript.error("'" + parseResult.expr + "' can only be used in " + supportedEventsNames(supportedEvents));
 									continue;
 								}
 							}
@@ -252,6 +243,22 @@ public class SkriptParser {
 			log.printError();
 			return null;
 		}
+	}
+
+	private static String supportedEventsNames(Class<? extends Event>[] supportedEvents) {
+		List<String> names = new ArrayList<>();
+
+		for (SkriptEventInfo<?> eventInfo : Skript.getEvents()) {
+			for (Class<? extends Event> eventClass : supportedEvents) {
+				for (Class<? extends Event> event : eventInfo.events) {
+					if (event.isAssignableFrom(eventClass)) {
+						names.add("the %s event".formatted(eventInfo.getName().toLowerCase()));
+					}
+				}
+			}
+		}
+
+		return StringUtils.join(names, ", ", " or ");
 	}
 
 	private static @NotNull DefaultExpression<?> getDefaultExpression(ExprInfo exprInfo, String pattern) {

--- a/src/test/skript/tests/misc/supported events.sk
+++ b/src/test/skript/tests/misc/supported events.sk
@@ -2,4 +2,4 @@ test "supported events":
 	parse:
 		set {_x} to the exploded blocks
 
-	assert last parse logs contain "'the exploded blocks' can only be used in the entity explode event" with "supported events message did not get sent correctly"
+	assert last parse logs contain "'the exploded blocks' can only be used in the on explode event" with "supported events message did not get sent correctly"


### PR DESCRIPTION
### Description
As title.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
