### PR TITLE
Improve reliability of order of config nodes after update  

### DIFF
--- a/src/main/java/ch/njol/skript/config/Config.java
+++ b/src/main/java/ch/njol/skript/config/Config.java
@@ -223,6 +223,7 @@ public class Config implements Comparable<Config>, Validated, NodeNavigator, Any
 		if (nodesToUpdate.isEmpty())
 			return false;
 
+		Map<SectionNode, Integer> offsets = new HashMap<>();
 		for (Node node : nodesToUpdate) {
 			/*
 			 prevents nodes that are already in the config from being added again
@@ -270,9 +271,14 @@ public class Config implements Comparable<Config>, Validated, NodeNavigator, Any
 			Node existing = parent.getAt(index);
 			if (existing != null) {
 				// there's already something at the node we want to add the new node
+				int offset = offsets.getOrDefault(parent, 0);
 
-				Skript.debug("Adding node %s to %s at index %s", node, parent, index);
-				parent.add(index, node);
+				Skript.debug("Adding node %s to %s at index %s", node, parent, index + offset);
+				// for some reason, the node list isn't updated when adding a node at an index,
+				// so we have to manually shift the nodes after the index here
+				parent.add(Math.min(parent.size(), index + offset), node);
+
+				offsets.put(parent, offset + 1);
 			} else {
 				// there's nothing at the index we want to add the new node
 

--- a/src/main/java/ch/njol/skript/config/Node.java
+++ b/src/main/java/ch/njol/skript/config/Node.java
@@ -455,7 +455,7 @@ public abstract class Node implements AnyNamed, Validated, NodeNavigator {
 
 	/**
 	 * Returns the node names in the path to this node from the config root.
-	 * If this is not a section node, returns the path to its parent node.
+	 * For a node with no key, this will return the path from the root node to its parent.
 	 *
 	 * <p>
 	 * Getting the path of node {@code z} in the following example would
@@ -470,7 +470,7 @@ public abstract class Node implements AnyNamed, Validated, NodeNavigator {
 	 */
 	public @NotNull String[] getPathSteps() {
 		List<String> path = new ArrayList<>();
-		Node node = this;
+		Node node = parent;
 
 		while (node != null) {
 			if (node.getKey() == null || node.getKey().isEmpty())
@@ -480,8 +480,14 @@ public abstract class Node implements AnyNamed, Validated, NodeNavigator {
 			node = node.getParent();
 		}
 
-		if (path.isEmpty())
+		// allow getting the path steps of a node without key
+		if (getKey() != null) {
+			path.add(getKey());
+		}
+
+		if (path.isEmpty()) {
 			return new String[0];
+		}
 
 		return path.toArray(new String[0]);
 	}

--- a/src/main/java/ch/njol/skript/config/VoidNode.java
+++ b/src/main/java/ch/njol/skript/config/VoidNode.java
@@ -24,7 +24,6 @@ public class VoidNode extends Node {
 		return key;
 	}
 
-	@Deprecated
 	public void set(final String s) {
 		key = s;
 	}

--- a/src/main/java/ch/njol/skript/config/VoidNode.java
+++ b/src/main/java/ch/njol/skript/config/VoidNode.java
@@ -2,6 +2,9 @@ package ch.njol.skript.config;
 
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 /**
  * An empty line or a comment.
  * <p>
@@ -11,13 +14,8 @@ import org.jetbrains.annotations.Nullable;
  */
 public class VoidNode extends Node {
 
-//	private final int initialLevel;
-//	private final String initialIndentation;
-
 	VoidNode(final String line, final String comment, final SectionNode parent, final int lineNum) {
-		super("" + line.trim(), comment, parent, lineNum);
-//		initialLevel = getLevel();
-//		initialIndentation = "" + line.replaceFirst("\\S.*$", "");
+		super(line.trim(), comment, parent, lineNum);
 	}
 
 	@SuppressWarnings("null")
@@ -26,30 +24,14 @@ public class VoidNode extends Node {
 		return key;
 	}
 
+	@Deprecated
 	public void set(final String s) {
 		key = s;
 	}
 
-	// doesn't work reliably
-//	@Override
-//	protected String getIndentation() {
-//		int levelDiff = getLevel() - initialLevel;
-//		if (levelDiff >= 0) {
-//			return StringUtils.multiply(config.getIndentation(), levelDiff) + initialIndentation;
-//		} else {
-//			final String ci = config.getIndentation();
-//			String ind = initialIndentation;
-//			while (levelDiff < 0 && ind.startsWith(ci)) {
-//				levelDiff++;
-//				ind = "" + ind.substring(ci.length());
-//			}
-//			return ind;
-//		}
-//	}
-
 	@Override
 	String save_i() {
-		return "" + key;
+		return key;
 	}
 
 	@Override
@@ -57,4 +39,10 @@ public class VoidNode extends Node {
 		return null;
 	}
 
+	@Override
+	public int hashCode() {
+		// ensures that two void nodes can exist with the same parent as long as they are
+		// at a different position
+		return Objects.hash(Arrays.hashCode(getPathSteps()), comment, getIndex());
+	}
 }


### PR DESCRIPTION
### Description
Improves the reliability of the updating order of the config nodes

- Fixes `#getPathSteps()` for nodes with no key returning an empty path
- Makes void nodes differentiable by index of their parent instead of just their parent, allowing multiple void nodes to be added to a parent during an update

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
