### PR TITLE
Add entity size expression

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprEntitySize.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntitySize.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.Nullable;
 @Description({
 	"Changes the entity size of slimes and phantoms, this is not the same as changing the scale attribute of an entity.",
 	"When changing the size of a slime, its health is fully resorted and will have changes done to the MAX_HEALTH, MOVEMENT_SPEED and ATTACK_DAMAGE attributes",
-	"The minimum size of a slime is one and the minimum size of a phantom is 0"
+	"The maximum size of a slime is 126 and the maximum size of a phantom is 64"
 })
 @Example("""
 	spawn a slime at player:

--- a/src/main/java/ch/njol/skript/expressions/ExprEntitySize.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntitySize.java
@@ -61,7 +61,10 @@ public class ExprEntitySize extends SimplePropertyExpression<LivingEntity, Integ
 		if (delta == null && mode != ChangeMode.RESET)
 			return;
 
-		int deltaValue = delta != null ? ((Number) delta[0]).intValue() : -1;
+		double deltaValueDouble = delta != null ? ((Number) delta[0]).doubleValue() : -1;
+		if (Double.isNaN(deltaValueDouble) || Double.isInfinite(deltaValueDouble))
+			return;
+		int  deltaValue = (int) deltaValueDouble;
 		if (mode == ChangeMode.REMOVE)
 			deltaValue = -deltaValue;
 

--- a/src/main/java/ch/njol/skript/expressions/ExprEntitySize.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntitySize.java
@@ -1,0 +1,110 @@
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Example;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.util.Math2;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Phantom;
+import org.bukkit.entity.Slime;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Entity Size")
+@Description({
+	"Changes the entity size of slimes and phantoms, this is not the same as changing the scale attribute of an entity.",
+	"When changing the size of a slime, its health is fully resorted and will have changes done to the MAX_HEALTH, MOVEMENT_SPEED and ATTACK_DAMAGE attributes",
+	"The minimum size of a slime is one and the minimum size of a phantom is 0"
+})
+@Example("""
+	spawn a slime at player:
+		set entity size of event-entity to 5
+		set name of event-entity to "King Slime Jorg"
+	""")
+@Since("INSERT VERSION")
+public class ExprEntitySize extends SimplePropertyExpression<LivingEntity, Integer> {
+
+	// The minimum size of a slime is one, whereas phantoms' are 0
+	// Setting a slime size to 1 is the same as 0, however 2 is not the same as 1
+	private static final int MINIMUM_SLIME_SIZE = 1;
+	private static final int MINIMUM_PHANTOM_SIZE = 0;
+
+	static {
+		register(ExprEntitySize.class, Integer.class, "entity size", "livingentities");
+	}
+
+	@Override
+	public @Nullable Integer convert(LivingEntity from) {
+		if (from instanceof Phantom phantom) {
+			return phantom.getSize();
+		} else if (from instanceof Slime slime) {
+			return slime.getSize();
+		}
+		return null;
+	}
+
+	@Override
+	public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
+		return switch (mode) {
+			case ADD, REMOVE, SET -> CollectionUtils.array(Number.class);
+			case RESET -> CollectionUtils.array();
+			default -> null;
+		};
+	}
+
+	@Override
+	public void change(Event event, Object @Nullable [] delta, ChangeMode mode) {
+		if (delta == null && mode != ChangeMode.RESET)
+			return;
+
+		int deltaValue = delta != null ? ((Number) delta[0]).intValue() : -1;
+		if (mode == ChangeMode.REMOVE)
+			deltaValue = -deltaValue;
+
+		switch (mode) {
+			case ADD, REMOVE -> {
+				for (LivingEntity entity : getExpr().getArray(event)) {
+					if (entity instanceof Phantom phantom) {
+						int newSize = Math2.fit(MINIMUM_PHANTOM_SIZE, (phantom.getSize() + deltaValue), Integer.MAX_VALUE);
+						phantom.setSize(newSize);
+					} else if (entity instanceof Slime slime) {
+						int newSize = Math2.fit(MINIMUM_SLIME_SIZE, (slime.getSize() + deltaValue), Integer.MAX_VALUE);
+						slime.setSize(newSize);
+					}
+				}
+			}
+			case SET -> {
+				for (LivingEntity entity : getExpr().getArray(event)) {
+					if (entity instanceof Phantom phantom) {
+						phantom.setSize(Math2.fit(MINIMUM_PHANTOM_SIZE, deltaValue, Integer.MAX_VALUE));
+					} else if (entity instanceof Slime slime) {
+						slime.setSize(Math2.fit(MINIMUM_SLIME_SIZE, deltaValue, Integer.MAX_VALUE));
+					}
+				}
+			}
+			case RESET -> {
+				for (LivingEntity entity : getExpr().getArray(event)) {
+					if (entity instanceof Phantom phantom) {
+						phantom.setSize(MINIMUM_PHANTOM_SIZE);
+					} else if (entity instanceof Slime slime) {
+						slime.setSize(MINIMUM_SLIME_SIZE);
+					}
+				}
+			}
+		}
+	}
+
+	@Override
+	public Class<? extends Integer> getReturnType() {
+		return Integer.class;
+	}
+
+	@Override
+	protected String getPropertyName() {
+		return "entity size";
+	}
+}

--- a/src/test/skript/tests/syntaxes/expressions/ExprEntitySize.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprEntitySize.sk
@@ -1,0 +1,27 @@
+
+test "ExprEntitySize - Slimes & Phantoms":
+	spawn a slime at test location:
+		set entity size of entity to 5
+		set {_entity} to entity
+	assert entity size of {_entity} is 5
+	remove 3 from entity size of {_entity}
+	assert entity size of {_entity} is 2
+	add 10 to entity size of {_entity}
+	assert entity size of {_entity} is 12
+	reset entity size of {_entity}
+	assert entity size of {_entity} is 1
+
+	delete entity within {_entity}
+
+	spawn a phantom at test location:
+		set entity size of entity to 5
+		set {_entity} to entity
+	assert entity size of {_entity} is 5
+	remove 3 from entity size of {_entity}
+	assert entity size of {_entity} is 2
+	add 10 to entity size of {_entity}
+	assert entity size of {_entity} is 12
+	reset entity size of {_entity}
+	assert entity size of {_entity} is 0
+
+	delete entity within {_entity}

--- a/src/test/skript/tests/syntaxes/expressions/ExprEntitySize.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprEntitySize.sk
@@ -17,11 +17,11 @@ test "ExprEntitySize - Slimes":
 	set entity size of {_entity} to nan value
 	assert entity size of {_entity} is 12
 
-	reset entity size of {_entity}
-	assert entity size of {_entity} is 1
-
 	set entity size of {_entity} to {_blank}
-	assert entity size of {_entity} is 1
+	assert entity size of {_entity} is 12
+
+	reset entity size of {_entity}
+	assert entity size of {_entity} is 0
 
 	delete entity within {_entity}
 
@@ -43,10 +43,10 @@ test "ExprEntitySize - Phantoms":
 	set entity size of {_entity} to nan value
 	assert entity size of {_entity} is 12
 
-	reset entity size of {_entity}
-	assert entity size of {_entity} is 0
-
 	set entity size of {_entity} to {_blank}
+	assert entity size of {_entity} is 12
+
+	reset entity size of {_entity}
 	assert entity size of {_entity} is 0
 
 	delete entity within {_entity}

--- a/src/test/skript/tests/syntaxes/expressions/ExprEntitySize.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprEntitySize.sk
@@ -1,27 +1,52 @@
 
-test "ExprEntitySize - Slimes & Phantoms":
+test "ExprEntitySize - Slimes":
 	spawn a slime at test location:
 		set entity size of entity to 5
 		set {_entity} to entity
 	assert entity size of {_entity} is 5
+
 	remove 3 from entity size of {_entity}
 	assert entity size of {_entity} is 2
+
 	add 10 to entity size of {_entity}
 	assert entity size of {_entity} is 12
+
+	remove {_blank} from entity size of {_entity}
+	assert entity size of {_entity} is 12
+
+	set entity size of {_entity} to nan value
+	assert entity size of {_entity} is 12
+
 	reset entity size of {_entity}
+	assert entity size of {_entity} is 1
+
+	set entity size of {_entity} to {_blank}
 	assert entity size of {_entity} is 1
 
 	delete entity within {_entity}
 
+test "ExprEntitySize - Phantoms":
 	spawn a phantom at test location:
 		set entity size of entity to 5
 		set {_entity} to entity
 	assert entity size of {_entity} is 5
+
 	remove 3 from entity size of {_entity}
 	assert entity size of {_entity} is 2
+
 	add 10 to entity size of {_entity}
 	assert entity size of {_entity} is 12
+
+	remove {_blank} from entity size of {_entity}
+	assert entity size of {_entity} is 12
+
+	set entity size of {_entity} to nan value
+	assert entity size of {_entity} is 12
+
 	reset entity size of {_entity}
+	assert entity size of {_entity} is 0
+
+	set entity size of {_entity} to {_blank}
 	assert entity size of {_entity} is 0
 
 	delete entity within {_entity}


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
This PR aims to add a new expression for changing and getting the sizes of slimes and phantoms, this is not the same as changing attribute scale, slimes when changed will have changes done to their attributes for health, attack damage, and movement speed.

I've decided to fully prevent infinity and NaN values due to poorly defined behavior. When setting a value to NaN before would cause the value to be reset compared to setting it to null will do nothing, as a means to retain parity this was decided upon.

Any feedback regarding the description or test is welcomed they all seem to run fine and the same goes for ingame. As for why I didn't use `with ""` or whatever it was is to keep messages readable if errors appear, this relies more on the expected but got error.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
