### PR TITLE
Add comparator exists check to Enum and Registry ClassInfo

### DIFF
--- a/src/main/java/ch/njol/skript/classes/EnumClassInfo.java
+++ b/src/main/java/ch/njol/skript/classes/EnumClassInfo.java
@@ -25,7 +25,7 @@ public class EnumClassInfo<T extends Enum<T>> extends ClassInfo<T> {
 	 * @param languageNode The language node of the type
 	 */
 	public EnumClassInfo(Class<T> enumClass, String codeName, String languageNode) {
-		this(enumClass, codeName, languageNode, new EventValueExpression<>(enumClass), Comparators.exactComparatorExists(enumClass, enumClass));
+		this(enumClass, codeName, languageNode, new EventValueExpression<>(enumClass), true);
 	}
 
 	/**
@@ -45,7 +45,7 @@ public class EnumClassInfo<T extends Enum<T>> extends ClassInfo<T> {
 	 * @param defaultExpression The default expression of the type
 	 */
 	public EnumClassInfo(Class<T> enumClass, String codeName, String languageNode, DefaultExpression<T> defaultExpression) {
-		this(enumClass, codeName, languageNode, defaultExpression, Comparators.exactComparatorExists(enumClass, enumClass));
+		this(enumClass, codeName, languageNode, defaultExpression, true);
 	}
 
 	/**
@@ -78,7 +78,7 @@ public class EnumClassInfo<T extends Enum<T>> extends ClassInfo<T> {
 					return enumUtils.toString(constant, StringMode.VARIABLE_NAME);
 				}
 			});
-		if (registerComparator)
+		if (registerComparator && !Comparators.exactComparatorExists(enumClass, enumClass))
 			Comparators.registerComparator(enumClass, enumClass, (o1, o2) -> Relation.get(o1.ordinal() - o2.ordinal()));
 	}
 

--- a/src/main/java/ch/njol/skript/classes/EnumClassInfo.java
+++ b/src/main/java/ch/njol/skript/classes/EnumClassInfo.java
@@ -25,7 +25,7 @@ public class EnumClassInfo<T extends Enum<T>> extends ClassInfo<T> {
 	 * @param languageNode The language node of the type
 	 */
 	public EnumClassInfo(Class<T> enumClass, String codeName, String languageNode) {
-		this(enumClass, codeName, languageNode, new EventValueExpression<>(enumClass), true);
+		this(enumClass, codeName, languageNode, new EventValueExpression<>(enumClass), Comparators.exactComparatorExists(enumClass, enumClass));
 	}
 
 	/**
@@ -45,7 +45,7 @@ public class EnumClassInfo<T extends Enum<T>> extends ClassInfo<T> {
 	 * @param defaultExpression The default expression of the type
 	 */
 	public EnumClassInfo(Class<T> enumClass, String codeName, String languageNode, DefaultExpression<T> defaultExpression) {
-		this(enumClass, codeName, languageNode, defaultExpression, true);
+		this(enumClass, codeName, languageNode, defaultExpression, Comparators.exactComparatorExists(enumClass, enumClass));
 	}
 
 	/**

--- a/src/main/java/ch/njol/skript/classes/registry/RegistryClassInfo.java
+++ b/src/main/java/ch/njol/skript/classes/registry/RegistryClassInfo.java
@@ -23,7 +23,7 @@ public class RegistryClassInfo<R extends Keyed> extends ClassInfo<R> {
 	 * @param languageNode The language node of the type
 	 */
 	public RegistryClassInfo(Class<R> registryClass, Registry<R> registry, String codeName, String languageNode) {
-		this(registryClass, registry, codeName, languageNode, new EventValueExpression<>(registryClass), Comparators.exactComparatorExists(registryClass, registryClass));
+		this(registryClass, registry, codeName, languageNode, new EventValueExpression<>(registryClass), true);
 	}
 
 	/**
@@ -45,7 +45,7 @@ public class RegistryClassInfo<R extends Keyed> extends ClassInfo<R> {
 	 * @param defaultExpression The default expression of the type
 	 */
 	public RegistryClassInfo(Class<R> registryClass, Registry<R> registry, String codeName, String languageNode, DefaultExpression<R> defaultExpression) {
-		this(registryClass, registry, codeName, languageNode,  defaultExpression, Comparators.exactComparatorExists(registryClass, registryClass));
+		this(registryClass, registry, codeName, languageNode,  defaultExpression, true);
 	}
 
 	/**
@@ -65,7 +65,7 @@ public class RegistryClassInfo<R extends Keyed> extends ClassInfo<R> {
 			.defaultExpression(defaultExpression)
 			.parser(registryParser);
 
-		if (registerComparator)
+		if (registerComparator && !Comparators.exactComparatorExists(registryClass, registryClass))
 			Comparators.registerComparator(registryClass, registryClass, (o1, o2) -> Relation.get(o1.getKey().equals(o2.getKey())));
 	}
 

--- a/src/main/java/ch/njol/skript/classes/registry/RegistryClassInfo.java
+++ b/src/main/java/ch/njol/skript/classes/registry/RegistryClassInfo.java
@@ -23,7 +23,7 @@ public class RegistryClassInfo<R extends Keyed> extends ClassInfo<R> {
 	 * @param languageNode The language node of the type
 	 */
 	public RegistryClassInfo(Class<R> registryClass, Registry<R> registry, String codeName, String languageNode) {
-		this(registryClass, registry, codeName, languageNode, new EventValueExpression<>(registryClass), true);
+		this(registryClass, registry, codeName, languageNode, new EventValueExpression<>(registryClass), Comparators.exactComparatorExists(registryClass, registryClass));
 	}
 
 	/**
@@ -45,7 +45,7 @@ public class RegistryClassInfo<R extends Keyed> extends ClassInfo<R> {
 	 * @param defaultExpression The default expression of the type
 	 */
 	public RegistryClassInfo(Class<R> registryClass, Registry<R> registry, String codeName, String languageNode, DefaultExpression<R> defaultExpression) {
-		this(registryClass, registry, codeName, languageNode,  defaultExpression, true);
+		this(registryClass, registry, codeName, languageNode,  defaultExpression, Comparators.exactComparatorExists(registryClass, registryClass));
 	}
 
 	/**


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

This PR aims to add a condition check for ensuring a registry and enum classinfo does not attempt to register a comparator if one already exists.

As I said in the issue, this has no affect on skript, and is done for addons

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7607 <!-- Links to related issues -->
