### PR TITLE
Add Time states for ArmorChangeEvent (and add event-slot)

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -10,6 +10,7 @@ import ch.njol.skript.events.bukkit.SkriptStopEvent;
 import ch.njol.skript.registrations.EventValues;
 import ch.njol.skript.util.Color;
 import ch.njol.skript.util.*;
+import ch.njol.skript.util.slot.EquipmentSlot.EquipSlot;
 import ch.njol.skript.util.slot.InventorySlot;
 import ch.njol.skript.util.slot.Slot;
 import com.destroystokyo.paper.event.block.AnvilDamagedEvent;
@@ -570,6 +571,13 @@ public final class BukkitEventValues {
 		//PlayerArmorChangeEvent
 		if (Skript.classExists("com.destroystokyo.paper.event.player.PlayerArmorChangeEvent")) {
 			EventValues.registerEventValue(PlayerArmorChangeEvent.class, ItemStack.class, PlayerArmorChangeEvent::getNewItem);
+			EventValues.registerEventValue(PlayerArmorChangeEvent.class, ItemStack.class, PlayerArmorChangeEvent::getNewItem, TIME_FUTURE);
+			EventValues.registerEventValue(PlayerArmorChangeEvent.class, ItemStack.class, PlayerArmorChangeEvent::getOldItem, TIME_PAST);
+			EventValues.registerEventValue(PlayerArmorChangeEvent.class, Slot.class, event -> {
+				EntityEquipment equipment = event.getPlayer().getEquipment();
+				EquipSlot equipSlot = EquipSlot.fromBukkitEquipmentSlot(event.getSlot());
+				return new ch.njol.skript.util.slot.EquipmentSlot(equipment, equipSlot);
+			});
 		}
 		//PlayerInventorySlotChangeEvent
 		if (Skript.classExists("io.papermc.paper.event.player.PlayerInventorySlotChangeEvent")) {
@@ -630,8 +638,7 @@ public final class BukkitEventValues {
 			if (equipment == null || hand == null)
 				return null;
 			return new ch.njol.skript.util.slot.EquipmentSlot(equipment,
-				(hand == EquipmentSlot.HAND) ? ch.njol.skript.util.slot.EquipmentSlot.EquipSlot.TOOL
-					: ch.njol.skript.util.slot.EquipmentSlot.EquipSlot.OFF_HAND);
+				(hand == EquipmentSlot.HAND) ? EquipSlot.TOOL : EquipSlot.OFF_HAND);
 		});
 
 		// PlayerItemHeldEvent

--- a/src/main/java/ch/njol/skript/util/slot/EquipmentSlot.java
+++ b/src/main/java/ch/njol/skript/util/slot/EquipmentSlot.java
@@ -120,6 +120,18 @@ public class EquipmentSlot extends SlotWithIndex {
 		public abstract ItemStack get(EntityEquipment e);
 		
 		public abstract void set(EntityEquipment e, @Nullable ItemStack item);
+
+		public static EquipSlot fromBukkitEquipmentSlot(org.bukkit.inventory.EquipmentSlot equipmentSlot) {
+			return switch (equipmentSlot) {
+				case HEAD -> EquipSlot.HELMET;
+				case CHEST -> EquipSlot.CHESTPLATE;
+				case LEGS -> EquipSlot.LEGGINGS;
+				case FEET -> EquipSlot.BOOTS;
+				case HAND -> EquipSlot.TOOL;
+				case OFF_HAND -> EquipSlot.OFF_HAND;
+				case BODY -> EquipSlot.BODY;
+			};
+		}
 		
 	}
 	


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

This PR aims to add `past` and `future` timestates onto the ArmorChangeEvent giving developers that extra control they need.
In addition to that I've added `event-slot` to give developers some way to modify the resulting item.  the `ArmorChangeEvent#getSlot` when retrieved refences the `ArmorChangeEvent#getNewItem()`

Additionally a new helper method on EquipSlot has been added to make conversion between it and EquipmentSlot a little easier, this method is only temporary until skript changes EquipmentSlot to a better system.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** PaperMC <!-- Required plugins, server software... -->
**Related Issues:** #5973 <!-- Links to related issues -->
