### PR TITLE
Fix non-single functions being parsed for single-only expression infos

### DIFF
--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -458,9 +458,9 @@ public class SkriptParser {
 
 						// Plural/singular sanity check
 						if (hasSingular && !parsedVariable.isSingle()) {
-							Skript.error("This expression can only accept a single "
+							Skript.error("'" + expr + "' can only be a single "
 								+ Classes.toString(Stream.of(exprInfo.classes).map(classInfo -> classInfo.getName().toString()).toArray(), false)
-								+ ", not more");
+								+ ", not more.");
 							log.printError();
 							return null;
 						}
@@ -494,7 +494,7 @@ public class SkriptParser {
 						// improper use in a script would result in an exception
 						if (((exprInfo.classes.length == 1 && !exprInfo.isPlural[0]) || Booleans.contains(exprInfo.isPlural, true))
 								&& !parsedVariable.isSingle()) {
-							Skript.error("This expression can only accept a single "
+							Skript.error("'" + expr + "' can only be a single "
 									+ Classes.toString(Stream.of(exprInfo.classes).map(classInfo -> classInfo.getName().toString()).toArray(), false)
 									+ ", not more.");
 							log.printError();
@@ -514,9 +514,9 @@ public class SkriptParser {
 				if (functionReference != null) {
 
 					if (onlySingular && !functionReference.isSingle()) {
-						Skript.error("This expression can only accept a single "
+						Skript.error("'" + expr + "' can only be a single "
 							+ Classes.toString(Stream.of(exprInfo.classes).map(classInfo -> classInfo.getName().toString()).toArray(), false)
-							+ ", not more");
+							+ ", not more.");
 						log.printError();
 						return null;
 					}
@@ -544,8 +544,11 @@ public class SkriptParser {
 								if (context == ParseContext.COMMAND) {
 									Skript.error(Commands.m_too_many_arguments.toString(exprInfo.classes[i].getName().getIndefiniteArticle(), exprInfo.classes[i].getName().toString()), ErrorQuality.SEMANTIC_ERROR);
 								} else {
-									Skript.error("'" + expr + "' can only accept a single " + exprInfo.classes[i].getName() + ", not more", ErrorQuality.SEMANTIC_ERROR);
+									Skript.error("'" + expr + "' can only be a single "
+										+ Classes.toString(Stream.of(exprInfo.classes).map(classInfo -> classInfo.getName().toString()).toArray(), false)
+										+ ", not more.");
 								}
+								log.printError();
 								return null;
 							}
 
@@ -555,7 +558,10 @@ public class SkriptParser {
 					}
 
 					if (onlySingular && !parsedExpression.isSingle()) {
-						Skript.error("'" + expr + "' can only accept singular expressions, not plural", ErrorQuality.SEMANTIC_ERROR);
+						Skript.error("'" + expr + "' can only be a single "
+							+ Classes.toString(Stream.of(exprInfo.classes).map(classInfo -> classInfo.getName().toString()).toArray(), false)
+							+ ", not more.");
+						log.printError();
 						return null;
 					}
 

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -458,7 +458,10 @@ public class SkriptParser {
 
 						// Plural/singular sanity check
 						if (hasSingular && !parsedVariable.isSingle()) {
-							Skript.error("'" + expr + "' can only accept a single value of any type, not more", ErrorQuality.SEMANTIC_ERROR);
+							Skript.error("This expression can only accept a single "
+								+ Classes.toString(Stream.of(exprInfo.classes).map(classInfo -> classInfo.getName().toString()).toArray(), false)
+								+ ", not more");
+							log.printError();
 							return null;
 						}
 
@@ -491,9 +494,10 @@ public class SkriptParser {
 						// improper use in a script would result in an exception
 						if (((exprInfo.classes.length == 1 && !exprInfo.isPlural[0]) || Booleans.contains(exprInfo.isPlural, true))
 								&& !parsedVariable.isSingle()) {
-							Skript.error("'" + expr + "' can only accept a single "
+							Skript.error("This expression can only accept a single "
 									+ Classes.toString(Stream.of(exprInfo.classes).map(classInfo -> classInfo.getName().toString()).toArray(), false)
-									+ ", not more", ErrorQuality.SEMANTIC_ERROR);
+									+ ", not more.");
+							log.printError();
 							return null;
 						}
 
@@ -508,6 +512,15 @@ public class SkriptParser {
 				// If it wasn't variable, do same for function call
 				FunctionReference<?> functionReference = parseFunction(types);
 				if (functionReference != null) {
+
+					if (onlySingular && !functionReference.isSingle()) {
+						Skript.error("This expression can only accept a single "
+							+ Classes.toString(Stream.of(exprInfo.classes).map(classInfo -> classInfo.getName().toString()).toArray(), false)
+							+ ", not more");
+						log.printError();
+						return null;
+					}
+
 					log.printLog();
 					return new ExprFunctionCall<>(functionReference);
 				} else if (log.hasError()) {


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Forces the parser to check the plurality of a function before returning it as a valid expression for a given exprInfo.
Also updates the other errors related to plural/single values that weren't being printed and were poorly written.

Before:
![image](https://github.com/user-attachments/assets/22194a40-50e7-45ee-a610-8e4ec2f5d971)
Note that the matched pattern only accepts a single number, but since the implementation uses getArray, no issue occurs.
This causes exceptions when used with implementations that use getSingle().

After:
![image](https://github.com/user-attachments/assets/d0de0988-0c6a-4447-a236-286d5bb66ba8)

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
