### PR TITLE
Fix array store exception in ExprAngle

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprAngle.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAngle.java
@@ -52,9 +52,12 @@ public class ExprAngle extends SimpleExpression<Number> {
 	protected Number @Nullable [] get(Event event) {
 		Number[] numbers = angle.getArray(event);
 
-		if (isRadians)
+		if (isRadians) {
+			Double[] degrees = new Double[numbers.length];
 			for (int i = 0; i < numbers.length; i++)
-            	numbers[i] = Math.toDegrees(numbers[i].doubleValue());
+				degrees[i] = Math.toDegrees(numbers[i].doubleValue());
+			return degrees;
+		}
 
 		return numbers;
 	}

--- a/src/test/skript/tests/regressions/7717-expr angle array store.sk
+++ b/src/test/skript/tests/regressions/7717-expr angle array store.sk
@@ -1,0 +1,2 @@
+test "expr angle array store exception":
+	set {_a::*} to (integers from 1 to 5) in radians


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Fixes an ArrayStoreException in ExprArray when integers are input. The array from getArray can be a Integer[] array and does not accept Doubles. (the ide doesn't catch this because the variable is a Number[] array).

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
