### PR TITLE
Enforce NotNull on EquipmentSlot constructors.

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -641,6 +641,8 @@ public final class BukkitEventValues {
 		EventValues.registerEventValue(EntityResurrectEvent.class, Slot.class, event -> {
 			EquipmentSlot hand = event.getHand();
 			EntityEquipment equipment = event.getEntity().getEquipment();
+			if (equipment == null || hand == null)
+				return null;
 			return new ch.njol.skript.util.slot.EquipmentSlot(equipment, hand);
 		});
 

--- a/src/main/java/ch/njol/skript/util/slot/EquipmentSlot.java
+++ b/src/main/java/ch/njol/skript/util/slot/EquipmentSlot.java
@@ -2,6 +2,7 @@ package ch.njol.skript.util.slot;
 
 import ch.njol.skript.bukkitutil.PlayerUtils;
 import ch.njol.skript.registrations.Classes;
+import com.google.common.base.Preconditions;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
@@ -128,8 +129,7 @@ public class EquipmentSlot extends SlotWithIndex {
 		public abstract void set(EntityEquipment e, @Nullable ItemStack item);
 		
 	}
-	
-	private static final EquipSlot[] SKRIPT_VALUES = EquipSlot.values();
+
 	private static final org.bukkit.inventory.EquipmentSlot[] BUKKIT_VALUES = org.bukkit.inventory.EquipmentSlot.values();
 
 	private static final Map<org.bukkit.inventory.EquipmentSlot, Integer> BUKKIT_SLOT_INDICES = new HashMap<>();
@@ -153,12 +153,14 @@ public class EquipmentSlot extends SlotWithIndex {
 	 */
 	@Deprecated
 	public EquipmentSlot(@NotNull EntityEquipment entityEquipment, @NotNull EquipSlot skriptSlot, boolean slotToString) {
+		Preconditions.checkNotNull(entityEquipment, "entityEquipment cannot be null");
+		Preconditions.checkNotNull(skriptSlot, "skriptSlot cannot be null");
 		this.entityEquipment = entityEquipment;
 		int slotIndex = -1;
 		if (skriptSlot == EquipSlot.TOOL) {
 			Entity holder = entityEquipment.getHolder();
-			if (holder instanceof Player)
-				slotIndex = ((Player) holder).getInventory().getHeldItemSlot();
+			if (holder instanceof Player player)
+				slotIndex = player.getInventory().getHeldItemSlot();
 		}
 		this.slotIndex = slotIndex;
 		this.skriptSlot = skriptSlot;
@@ -173,11 +175,13 @@ public class EquipmentSlot extends SlotWithIndex {
 		this(entityEquipment, skriptSlot, false);
 	}
 
-	public EquipmentSlot(@NotNull EntityEquipment equipment, @NotNull org.bukkit.inventory.EquipmentSlot bukkitSlot, boolean slotToString) {
-		this.entityEquipment = equipment;
+	public EquipmentSlot(@NotNull EntityEquipment entityEquipment, @NotNull org.bukkit.inventory.EquipmentSlot bukkitSlot, boolean slotToString) {
+		Preconditions.checkNotNull(entityEquipment, "entityEquipment cannot be null");
+		Preconditions.checkNotNull(bukkitSlot, "bukkitSlot cannot be null");
+		this.entityEquipment = entityEquipment;
 		int slotIndex = -1;
 		if (bukkitSlot == org.bukkit.inventory.EquipmentSlot.HAND) {
-			Entity holder = equipment.getHolder();
+			Entity holder = entityEquipment.getHolder();
 			if (holder instanceof Player player)
 				slotIndex = player.getInventory().getHeldItemSlot();
 		}

--- a/src/main/java/ch/njol/skript/util/slot/EquipmentSlot.java
+++ b/src/main/java/ch/njol/skript/util/slot/EquipmentSlot.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
@@ -151,7 +152,7 @@ public class EquipmentSlot extends SlotWithIndex {
 	 * @deprecated Use {@link EquipmentSlot#EquipmentSlot(EntityEquipment, org.bukkit.inventory.EquipmentSlot, boolean)} instead
 	 */
 	@Deprecated
-	public EquipmentSlot(EntityEquipment entityEquipment, EquipSlot skriptSlot, boolean slotToString) {
+	public EquipmentSlot(@NotNull EntityEquipment entityEquipment, @NotNull EquipSlot skriptSlot, boolean slotToString) {
 		this.entityEquipment = entityEquipment;
 		int slotIndex = -1;
 		if (skriptSlot == EquipSlot.TOOL) {
@@ -168,11 +169,11 @@ public class EquipmentSlot extends SlotWithIndex {
 	 * @deprecated Use {@link EquipmentSlot#EquipmentSlot(EntityEquipment, org.bukkit.inventory.EquipmentSlot)} instead
 	 */
 	@Deprecated
-	public EquipmentSlot(EntityEquipment entityEquipment, EquipSlot skriptSlot) {
+	public EquipmentSlot(@NotNull EntityEquipment entityEquipment, @NotNull EquipSlot skriptSlot) {
 		this(entityEquipment, skriptSlot, false);
 	}
 
-	public EquipmentSlot(EntityEquipment equipment, org.bukkit.inventory.EquipmentSlot bukkitSlot, boolean slotToString) {
+	public EquipmentSlot(@NotNull EntityEquipment equipment, @NotNull org.bukkit.inventory.EquipmentSlot bukkitSlot, boolean slotToString) {
 		this.entityEquipment = equipment;
 		int slotIndex = -1;
 		if (bukkitSlot == org.bukkit.inventory.EquipmentSlot.HAND) {
@@ -185,17 +186,17 @@ public class EquipmentSlot extends SlotWithIndex {
 		this.slotToString = slotToString;
 	}
 
-	public EquipmentSlot(EntityEquipment equipment, org.bukkit.inventory.EquipmentSlot bukkitSlot) {
+	public EquipmentSlot(@NotNull EntityEquipment equipment, @NotNull org.bukkit.inventory.EquipmentSlot bukkitSlot) {
 		this(equipment, bukkitSlot, false);
 	}
-	
-	@SuppressWarnings("null")
-	public EquipmentSlot(HumanEntity holder, int index) {
+
+	public EquipmentSlot(@NotNull HumanEntity holder, int index) {
 		/*
 		 * slot: 6 entries in EquipSlot, indices descending
 		 *  So this math trick gets us the EquipSlot from inventory slot index
 		 * slotToString: Referring to numeric slot id, right?
 		 */
+		//noinspection DataFlowIssue
 		this(holder.getEquipment(), BUKKIT_VALUES[41 - index], true);
 	}
 


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

EquipmentSlot was being called with an null value for equipment/slot, which resulted in NPE. This reinstates the null check and annotates the inputs as NotNull, so this can be caught more easily in the future.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
