### PR TITLE
Remove s01 sonatype maven repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ allprojects {
 		maven { url 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/' }
 		maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
 		maven { url 'https://repo.papermc.io/repository/maven-public/' }
-//		maven { url = 'https://s01.oss.sonatype.org/content/repositories/snapshots/' } // needed for paper adventure snapshot
 		maven { url 'https://ci.emc.gs/nexus/content/groups/aikar/' }
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ allprojects {
 		maven { url 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/' }
 		maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
 		maven { url 'https://repo.papermc.io/repository/maven-public/' }
-		maven { url = 'https://s01.oss.sonatype.org/content/repositories/snapshots/' } // needed for paper adventure snapshot
+//		maven { url = 'https://s01.oss.sonatype.org/content/repositories/snapshots/' } // needed for paper adventure snapshot
 		maven { url 'https://ci.emc.gs/nexus/content/groups/aikar/' }
 	}
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

s01.oss.sonatype.org seems to be responding with 503s, while the main sonatype website and repo seems to be fine. It also appears that we do not need this repo, as the adventure text serializer is obtainable without it. This PR removes the repo to fix the tests failing from 503 responses.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
