### PR TITLE
Copy item inventories when setting blocks.

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/ItemType.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemType.java
@@ -408,16 +408,18 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 	 * @param itemMeta The item meta to copy the state from
 	 */
 	private void copyContainerState(@NotNull Block block, @NotNull ItemMeta itemMeta) {
-		if (itemMeta instanceof BlockStateMeta blockStateMeta && blockStateMeta.hasBlockState()) {
-			if (blockStateMeta.getBlockState() instanceof org.bukkit.block.Container itemContainer) {
-				// copy inventory from item to block
-				BlockState blockState = block.getState();
-				if (blockState instanceof org.bukkit.block.Container blockContainer) {
-					copyInventories(itemContainer.getSnapshotInventory(), blockContainer.getSnapshotInventory());
-					blockContainer.update();
-				}
-			}
-		}
+		// ensure the item has a block state
+		if (!(itemMeta instanceof BlockStateMeta blockStateMeta) || !blockStateMeta.hasBlockState())
+			return;
+
+		// only care about container -> container copying
+		if (!(blockStateMeta.getBlockState() instanceof org.bukkit.block.Container itemContainer)
+				|| !(block.getState() instanceof org.bukkit.block.Container blockContainer))
+			return;
+
+		// copy inventory from item to block
+		copyInventories(itemContainer.getSnapshotInventory(), blockContainer.getSnapshotInventory());
+		blockContainer.update();
 	}
 
 	/**

--- a/src/main/java/ch/njol/skript/aliases/ItemType.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemType.java
@@ -42,7 +42,6 @@ import java.io.StreamCorruptedException;
 import java.lang.reflect.Field;
 import java.util.*;
 import java.util.Map.Entry;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 @ContainerType(ItemStack.class)
@@ -561,30 +560,6 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 				return containerIterator();
 			}
 		};
-	}
-
-	/**
-	 * Determines whether this ItemType satisfies the given predicate.
-	 * If {@link #isAll()} is true, this will return true if the predicate is satisfied by all ItemDatas.
-	 * If {@link #isAll()} is false, this will return true if the predicate is satisfied by any ItemData.
- 	 * @param predicate A predicate to test items against
-	 * @return Whether this ItemType satisfies the predicate
-	 */
-	public boolean satisfies(Predicate<ItemStack> predicate) {
-		if (isAll()) {
-			for (Iterator<ItemStack> it = containerIterator(); it.hasNext(); ) {
-				ItemStack stack = it.next();
-				if (!predicate.test(stack))
-					return false;
-			}
-			return true;
-		}
-		for (Iterator<ItemStack> it = containerIterator(); it.hasNext(); ) {
-			ItemStack stack = it.next();
-			if (predicate.test(stack))
-				return true;
-		}
-		return false;
 	}
 
 	@Nullable


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

BlockStateMeta information is not copied to the placed block when settting blocks based on ItemTypes. 
I could not find any general method to do this, though BlockState#copy(Location) is experimental, so it may be viable in the future. For now, I resorted to manually copying inventory information over for Container BlockStates.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7735 <!-- Links to related issues -->
