### PR TITLE
AnyIdentifier

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/DefaultConverters.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultConverters.java
@@ -11,6 +11,7 @@ import ch.njol.skript.entity.EntityType;
 import ch.njol.skript.entity.XpOrbData;
 import ch.njol.skript.lang.util.common.AnyAmount;
 import ch.njol.skript.lang.util.common.AnyNamed;
+import ch.njol.skript.lang.util.common.AnyUUID;
 import ch.njol.skript.util.*;
 import ch.njol.skript.util.slot.Slot;
 import org.bukkit.*;
@@ -284,6 +285,27 @@ public class DefaultConverters {
 
 		// UUID -> String
 		Converters.registerConverter(UUID.class, String.class, UUID::toString);
+
+		// Entity - AnyUUID
+		Converters.registerConverter(Entity.class, AnyUUID.class, entity -> new AnyUUID() {
+			@Override
+			public UUID uuid() {
+				return entity.getUniqueId();
+			}
+
+			@Override
+			public boolean isOfflinePlayer() {
+				return entity instanceof OfflinePlayer;
+			}
+		}, Converter.NO_RIGHT_CHAINING);
+
+		// World - AnyUUID
+		Converters.registerConverter(World.class, AnyUUID.class, world -> new AnyUUID() {
+			@Override
+			public UUID uuid() {
+				return world.getUID();
+			}
+		}, Converter.NO_RIGHT_CHAINING);
 
 //		// Entity - String (UUID) // Very slow, thus disabled for now
 //		Converters.registerConverter(String.class, Entity.class, new Converter<String, Entity>() {

--- a/src/main/java/ch/njol/skript/classes/data/DefaultConverters.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultConverters.java
@@ -10,8 +10,8 @@ import ch.njol.skript.entity.EntityData;
 import ch.njol.skript.entity.EntityType;
 import ch.njol.skript.entity.XpOrbData;
 import ch.njol.skript.lang.util.common.AnyAmount;
+import ch.njol.skript.lang.util.common.AnyIdentifier;
 import ch.njol.skript.lang.util.common.AnyNamed;
-import ch.njol.skript.lang.util.common.AnyUUID;
 import ch.njol.skript.util.*;
 import ch.njol.skript.util.slot.Slot;
 import org.bukkit.*;
@@ -286,10 +286,10 @@ public class DefaultConverters {
 		// UUID -> String
 		Converters.registerConverter(UUID.class, String.class, UUID::toString);
 
-		// Entity - AnyUUID
-		Converters.registerConverter(Entity.class, AnyUUID.class, entity -> new AnyUUID() {
+		// Entity - AnyIdentifier
+		Converters.registerConverter(Entity.class, AnyIdentifier.class, entity -> new AnyIdentifier() {
 			@Override
-			public UUID uuid() {
+			public UUID identifier() {
 				return entity.getUniqueId();
 			}
 
@@ -299,13 +299,8 @@ public class DefaultConverters {
 			}
 		}, Converter.NO_RIGHT_CHAINING);
 
-		// World - AnyUUID
-		Converters.registerConverter(World.class, AnyUUID.class, world -> new AnyUUID() {
-			@Override
-			public UUID uuid() {
-				return world.getUID();
-			}
-		}, Converter.NO_RIGHT_CHAINING);
+		// World - AnyIdentifier
+		Converters.registerConverter(World.class, AnyIdentifier.class, world -> world::getUID, Converter.NO_RIGHT_CHAINING);
 
 //		// Entity - String (UUID) // Very slow, thus disabled for now
 //		Converters.registerConverter(String.class, Entity.class, new Converter<String, Entity>() {

--- a/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
@@ -964,10 +964,10 @@ public class SkriptClasses {
 				.since("2.10")
 		);
 
-		Classes.registerClass(new AnyInfo<>(AnyUUID.class, "identifiable")
+		Classes.registerClass(new AnyInfo<>(AnyIdentifier.class, "identifiable")
 				.user("any (identifiable|uuid)")
 				.name("Any Identifiable Thing")
-				.description("Anything thats has a unique identifier (uuid).")
+				.description("Something that has a unique identifier (uuid).")
 				.usage("")
 				.examples("the uuid of {thing}")
 				.since("INSERT VERSION")

--- a/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
@@ -13,10 +13,7 @@ import ch.njol.skript.expressions.base.EventValueExpression;
 import ch.njol.skript.lang.ParseContext;
 import ch.njol.skript.lang.function.DynamicFunctionReference;
 import ch.njol.skript.lang.util.SimpleLiteral;
-import ch.njol.skript.lang.util.common.AnyAmount;
-import ch.njol.skript.lang.util.common.AnyContains;
-import ch.njol.skript.lang.util.common.AnyNamed;
-import ch.njol.skript.lang.util.common.AnyValued;
+import ch.njol.skript.lang.util.common.*;
 import ch.njol.skript.localization.Noun;
 import ch.njol.skript.localization.RegexMessage;
 import ch.njol.skript.registrations.Classes;
@@ -966,6 +963,16 @@ public class SkriptClasses {
 				.examples("{a} contains {b}")
 				.since("2.10")
 		);
+
+		Classes.registerClass(new AnyInfo<>(AnyUUID.class, "identifiable")
+				.user("any (identifiable|uuid)")
+				.name("Any Identifiable Thing")
+				.description("Anything thats has a unique identifier (uuid).")
+				.usage("")
+				.examples("the uuid of {thing}")
+				.since("INSERT VERSION")
+		);
+
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprUUID.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprUUID.java
@@ -1,5 +1,6 @@
 package ch.njol.skript.expressions;
 
+import ch.njol.skript.lang.util.common.AnyUUID;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
@@ -32,17 +33,17 @@ import java.util.UUID;
 			"\t\tsend \"Your UUID is '%string within {_uuid}%'\"",
 })
 @Since("2.1.2, 2.2 (offline players' uuids), 2.2-dev24 (other entities' uuids)")
-public class ExprUUID extends SimplePropertyExpression<Object, UUID> {
+public class ExprUUID extends SimplePropertyExpression<AnyUUID, UUID> {
 
 	static {
-		register(ExprUUID.class, UUID.class, "UUID", "offlineplayers/worlds/entities");
+		register(ExprUUID.class, UUID.class, "UUID", "identifiable");
 	}
 
 	@Override
-	public @Nullable UUID convert(Object object) {
-		if (object instanceof OfflinePlayer player) {
+	public @Nullable UUID convert(AnyUUID anyUUID) {
+		if (anyUUID.isOfflinePlayer()) {
 			try {
-				return player.getUniqueId();
+				return anyUUID.uuid();
 			} catch (UnsupportedOperationException e) {
 				// Some plugins (ProtocolLib) try to emulate offline players, but fail miserably
 				// They will throw this exception... and somehow server may freeze when this happens
@@ -50,12 +51,9 @@ public class ExprUUID extends SimplePropertyExpression<Object, UUID> {
 				e.printStackTrace();
 				return null;
 			}
-		} else if (object instanceof Entity entity) {
-			return entity.getUniqueId();
-		} else if (object instanceof World world) {
-			return world.getUID();
 		}
-		return null;
+
+		return anyUUID.uuid();
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprUUID.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprUUID.java
@@ -1,6 +1,6 @@
 package ch.njol.skript.expressions;
 
-import ch.njol.skript.lang.util.common.AnyUUID;
+import ch.njol.skript.lang.util.common.AnyIdentifier;
 import org.jetbrains.annotations.Nullable;
 
 import ch.njol.skript.Skript;
@@ -30,17 +30,17 @@ import java.util.UUID;
 			"\t\tsend \"Your UUID is '%string within {_uuid}%'\"",
 })
 @Since("2.1.2, 2.2 (offline players' uuids), 2.2-dev24 (other entities' uuids)")
-public class ExprUUID extends SimplePropertyExpression<AnyUUID, UUID> {
+public class ExprUUID extends SimplePropertyExpression<AnyIdentifier, UUID> {
 
 	static {
 		register(ExprUUID.class, UUID.class, "UUID", "identifiable");
 	}
 
 	@Override
-	public @Nullable UUID convert(AnyUUID identifiable) {
+	public @Nullable UUID convert(AnyIdentifier identifiable) {
 		if (identifiable.isOfflinePlayer()) {
 			try {
-				return identifiable.uuid();
+				return identifiable.identifier();
 			} catch (UnsupportedOperationException e) {
 				// Some plugins (ProtocolLib) try to emulate offline players, but fail miserably
 				// They will throw this exception... and somehow server may freeze when this happens
@@ -50,7 +50,7 @@ public class ExprUUID extends SimplePropertyExpression<AnyUUID, UUID> {
 			}
 		}
 
-		return identifiable.uuid();
+		return identifiable.identifier();
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprUUID.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprUUID.java
@@ -1,6 +1,9 @@
 package ch.njol.skript.expressions;
 
+import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.lang.util.common.AnyIdentifier;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 
 import ch.njol.skript.Skript;
@@ -51,6 +54,31 @@ public class ExprUUID extends SimplePropertyExpression<AnyIdentifier, UUID> {
 		}
 
 		return identifiable.identifier();
+	}
+
+	@Override
+	public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
+		if (mode == ChangeMode.SET)
+			return CollectionUtils.array(UUID.class);
+		return null;
+	}
+
+	@Override
+	public void change(Event event, Object @Nullable [] delta, ChangeMode mode) {
+		assert delta != null;
+
+		UUID uuid = (UUID) delta[0];
+
+		AnyIdentifier identifiable = getExpr().getSingle(event);
+		if (identifiable == null)
+			return;
+
+		if (!identifiable.supportsChange()) {
+			error("'" + rawExpr + "' cannot be changed.");
+			return;
+		}
+
+		identifiable.setIdentifier(uuid);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprUUID.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprUUID.java
@@ -1,9 +1,6 @@
 package ch.njol.skript.expressions;
 
 import ch.njol.skript.lang.util.common.AnyUUID;
-import org.bukkit.OfflinePlayer;
-import org.bukkit.World;
-import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.Nullable;
 
 import ch.njol.skript.Skript;
@@ -40,10 +37,10 @@ public class ExprUUID extends SimplePropertyExpression<AnyUUID, UUID> {
 	}
 
 	@Override
-	public @Nullable UUID convert(AnyUUID anyUUID) {
-		if (anyUUID.isOfflinePlayer()) {
+	public @Nullable UUID convert(AnyUUID identifiable) {
+		if (identifiable.isOfflinePlayer()) {
 			try {
-				return anyUUID.uuid();
+				return identifiable.uuid();
 			} catch (UnsupportedOperationException e) {
 				// Some plugins (ProtocolLib) try to emulate offline players, but fail miserably
 				// They will throw this exception... and somehow server may freeze when this happens
@@ -53,7 +50,7 @@ public class ExprUUID extends SimplePropertyExpression<AnyUUID, UUID> {
 			}
 		}
 
-		return anyUUID.uuid();
+		return identifiable.uuid();
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/lang/util/common/AnyIdentifier.java
+++ b/src/main/java/ch/njol/skript/lang/util/common/AnyIdentifier.java
@@ -5,32 +5,32 @@ import org.jetbrains.annotations.UnknownNullability;
 
 import java.util.UUID;
 
-public interface AnyUUID extends AnyProvider {
+public interface AnyIdentifier extends AnyProvider {
 
 	/**
 	 * @return This thing's {@link UUID}
 	 */
-	@UnknownNullability UUID uuid();
+	@UnknownNullability UUID identifier();
 
 	/**
-	 * This is called before {@link #setUUID(UUID)}.
-	 * If the result is false, setting the uuid will never be attempted.
+	 * This is called before {@link #setIdentifier(UUID)}.
+	 * If the result is false, setting the identifier will never be attempted.
 	 *
 	 * @return Whether this supports being set
 	 */
-	default boolean supportsUUIDChange() {
+	default boolean supportsChange() {
 		return false;
 	}
 
 	/**
-	 * The behaviour for changing this thing's UUID, if possible.
-	 * If not possible, then {@link #supportsUUIDChange()} should return false and this
+	 * The behaviour for changing this thing's identifier, if possible.
+	 * If not possible, then {@link #supportsChange()} should return false and this
 	 * may throw an error.
 	 *
 	 * @param uuid The UUID to change
 	 * @throws UnsupportedOperationException If this is impossible
 	 */
-	default void setUUID(UUID uuid) throws UnsupportedOperationException {
+	default void setIdentifier(UUID uuid) throws UnsupportedOperationException {
 		throw new UnsupportedOperationException();
 	}
 

--- a/src/main/java/ch/njol/skript/lang/util/common/AnyUUID.java
+++ b/src/main/java/ch/njol/skript/lang/util/common/AnyUUID.java
@@ -1,0 +1,40 @@
+package ch.njol.skript.lang.util.common;
+
+import org.jetbrains.annotations.UnknownNullability;
+
+import java.util.UUID;
+
+public interface AnyUUID extends AnyProvider {
+
+	/**
+	 * @return This thing's uuid
+	 */
+	@UnknownNullability UUID uuid();
+
+	/**
+	 * This is called before {@link #setUUID(UUID)}.
+	 * If the result is false, setting the uuid will never be attempted.
+	 *
+	 * @return Whether this supports being set
+	 */
+	default boolean supportsUUIDChange() {
+		return false;
+	}
+
+	/**
+	 * The behaviour for changing this thing's UUID, if possible.
+	 * If not possible, then {@link #supportsUUIDChange()} should return false and this
+	 * may throw an error.
+	 *
+	 * @param uuid The UUID to change
+	 * @throws UnsupportedOperationException If this is impossible
+	 */
+	default void setUUID(UUID uuid) throws UnsupportedOperationException {
+		throw new UnsupportedOperationException();
+	}
+
+	default boolean isOfflinePlayer() {
+		return false;
+	}
+
+}

--- a/src/main/java/ch/njol/skript/lang/util/common/AnyUUID.java
+++ b/src/main/java/ch/njol/skript/lang/util/common/AnyUUID.java
@@ -1,5 +1,6 @@
 package ch.njol.skript.lang.util.common;
 
+import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.UnknownNullability;
 
 import java.util.UUID;
@@ -7,7 +8,7 @@ import java.util.UUID;
 public interface AnyUUID extends AnyProvider {
 
 	/**
-	 * @return This thing's uuid
+	 * @return This thing's {@link UUID}
 	 */
 	@UnknownNullability UUID uuid();
 
@@ -34,8 +35,9 @@ public interface AnyUUID extends AnyProvider {
 	}
 
 	/**
-	 * Whether this is an offline player. This is used to catch an UnsupportedOperationException
+	 * Whether this is an {@link OfflinePlayer}. This is used to catch an {@link UnsupportedOperationException}
 	 * when trying to access the UUID of an emulated offline player by plugins like ProtocolLib.
+	 *
 	 * @return whether this is an offline player
 	 */
 	default boolean isOfflinePlayer() {

--- a/src/main/java/ch/njol/skript/lang/util/common/AnyUUID.java
+++ b/src/main/java/ch/njol/skript/lang/util/common/AnyUUID.java
@@ -33,6 +33,11 @@ public interface AnyUUID extends AnyProvider {
 		throw new UnsupportedOperationException();
 	}
 
+	/**
+	 * Whether this is an offline player. This is used to catch an UnsupportedOperationException
+	 * when trying to access the UUID of an emulated offline player by plugins like ProtocolLib.
+	 * @return whether this is an offline player
+	 */
 	default boolean isOfflinePlayer() {
 		return false;
 	}

--- a/src/main/java/ch/njol/skript/lang/util/common/AnyUUID.java
+++ b/src/main/java/ch/njol/skript/lang/util/common/AnyUUID.java
@@ -35,8 +35,9 @@ public interface AnyUUID extends AnyProvider {
 	}
 
 	/**
-	 * Whether this is an {@link OfflinePlayer}. This is used to catch an {@link UnsupportedOperationException}
-	 * when trying to access the UUID of an emulated offline player by plugins like ProtocolLib.
+	 * Whether this is an {@link OfflinePlayer}. This is used to know whether to try and catch an
+	 * {@link UnsupportedOperationException} when trying to access the UUIDs of emulated
+	 * offline players by plugins like ProtocolLib.
 	 *
 	 * @return whether this is an offline player
 	 */


### PR DESCRIPTION
### Description
This PR adds an AnyIdentifier class, which holds a UUID and is used for `uuid of ...`
<!--- Describe your changes here. --->

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7675 <!-- Links to related issues -->
