### PR TITLE
ExprHash cleanup

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprHash.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHash.java
@@ -1,107 +1,68 @@
 package ch.njol.skript.expressions;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
 
+import ch.njol.skript.doc.*;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 
 import ch.njol.skript.Skript;
-import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
-import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.PropertyExpression;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
+import org.skriptlang.skript.lang.script.ScriptWarning;
 
 
 @Name("Hash")
-@Description({"Hashes the given text using the MD5 or SHA-256 algorithms. Each algorithm is suitable for different use cases.<p>",
-		"MD5 is provided mostly for backwards compatibility, as it is outdated and not secure. ",
-		"SHA-256 is more secure, and can used to hash somewhat confidental data like IP addresses and even passwords. ",
-		"It is not <i>that</i> secure out of the box, so please consider using salt when dealing with passwords! ",
+@Description({"Hashes the given text using the MD5 or SHA algorithms. Each algorithm is suitable for different use cases.<p>",
+		"These hashing algorithms are not suitable for hashing passwords.",
+		"If handling passwords, use a <a href='https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#password-hashing-algorithms'>hashing algorithm specifically designed for passwords</a>.",
+		"<p>MD5 is provided mostly for backwards compatibility, as it is outdated and not secure. ",
+		"SHA is more secure, but is not suitable for hashing passwords (even with salting). ",
 		"When hashing data, you <strong>must</strong> specify algorithms that will be used for security reasons! ",
-		"<p>Please note that a hash cannot be reversed under normal circumstanses. You will not be able to get original value from a hash with Skript."})
-@Examples({
-		"command /setpass &lt;text&gt;:",
-		"\ttrigger:",
-		"\t\tset {password::%uuid of player%} to text-argument hashed with SHA-256",
-		"command /login &lt;text&gt;:",
-		"\ttrigger:",
-		"\t\tif text-argument hashed with SHA-256 is {password::%uuid of player%}:",
-		"\t\t\tmessage \"Login successful.\"",
-		"\t\telse:",
-		"\t\t\tmessage \"Wrong password!\""})
-@Since("2.0, 2.2-dev32 (SHA-256 algorithm)")
+		"<p>Please note that a hash cannot be reversed under normal circumstances. You will not be able to get original value from a hash with Skript."})
+@Example("set {_hash} to \"hello world\" hashed with SHA-256")
+@Since("2.0, 2.2-dev32 (SHA-256 algorithm), INSERT VERSION (SHA-384, SHA-512)")
 public class ExprHash extends PropertyExpression<String, String> {
 	static {
 		Skript.registerExpression(ExprHash.class, String.class, ExpressionType.SIMPLE,
-				"%strings% hash[ed] with (0¦MD5|1¦SHA-256)");
+				"%strings% hash[ed] with (:MD5|:SHA-256|:SHA-384|:SHA-512)");
 	}
-	
-	@SuppressWarnings("null")
-	private final static Charset UTF_8 = Charset.forName("UTF-8");
-	
-	@Nullable
-	static MessageDigest md5;
-	@Nullable
-	static MessageDigest sha256;
-	
-	static {
-		try {
-			md5 = MessageDigest.getInstance("MD5");
-			sha256 = MessageDigest.getInstance("SHA-256");
-		} catch (final NoSuchAlgorithmException e) {
-			throw new InternalError("JVM does not adhere to Java specifications");
-		}
-	}
-	
-	private int algorithm;
+
+	private static final HexFormat hexFormat = HexFormat.of().withLowerCase();
+	private MessageDigest digest;
 	
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
 	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
 		setExpr((Expression<? extends String>) exprs[0]);
-		algorithm = parseResult.mark;
-		return true;
+		String algorithm = parseResult.tags.get(0).toUpperCase();
+		try {
+			digest = MessageDigest.getInstance(algorithm);
+			if (algorithm.equals("MD5") && !getParser().getCurrentScript().suppressesWarning(ScriptWarning.MD5_HASH)) {
+				Skript.warning("MD5 is not secure and shouldn't be used if a cryptographically secure hashing algorithm is required.");
+			}
+			return true;
+		} catch (NoSuchAlgorithmException e) {
+			Skript.error("Unsupported hashing algorithm: " + algorithm);
+			return false;
+		}
 	}
 	
 	@SuppressWarnings("null")
 	@Override
 	protected String[] get(final Event e, final String[] source) {
-		// These can't be null
-		assert md5 != null;
-		assert sha256 != null;
-		
-		// Get correct digest
-		MessageDigest digest = null;
-		if (algorithm == 0)
-			digest = md5;
-		else if (algorithm == 1)
-			digest = sha256;
-		else
-			assert false;
-
 		// Apply it to all strings
 		final String[] r = new String[source.length];
 		for (int i = 0; i < r.length; i++)
-			r[i] = toHex(digest.digest(source[i].getBytes(UTF_8)));
-		
-		
+			r[i] = hexFormat.formatHex(digest.digest(source[i].getBytes(StandardCharsets.UTF_8)));
+
 		return r;
-	}
-	
-	private static String toHex(final byte[] b) {
-		final char[] r = new char[2 * b.length];
-		for (int i = 0; i < b.length; i++) {
-			r[2 * i] = Character.forDigit((b[i] & 0xF0) >> 4, 16);
-			r[2 * i + 1] = Character.forDigit(b[i] & 0x0F, 16);
-		}
-		return new String(r);
 	}
 	
 	@Override

--- a/src/main/java/org/skriptlang/skript/lang/script/ScriptWarning.java
+++ b/src/main/java/org/skriptlang/skript/lang/script/ScriptWarning.java
@@ -41,7 +41,12 @@ public enum ScriptWarning {
 	/**
 	 * The code cannot be reached due to a previous statement stopping further execution
 	 */
-	UNREACHABLE_CODE("unreachable code");
+	UNREACHABLE_CODE("unreachable code"),
+
+	/**
+	 * MD5 used for hashing
+	 */
+	MD5_HASH("MD5", "MD5 [hash[ing]] [algorithm]");
 
 	private final String warningName;
 	private final String pattern;

--- a/src/test/skript/tests/syntaxes/expressions/ExprHash.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprHash.sk
@@ -1,0 +1,11 @@
+test "MD5 hash":
+	assert "hello world" hashed with MD5 is "5eb63bbbe01eeed093cb22bb8f5acdc3" with "incorrect hash"
+
+test "SHA-256 hash":
+	assert "hello world" hashed with SHA-256 is "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9" with "incorrect hash"
+
+test "SHA-384 hash":
+	assert "hello world" hashed with SHA-384 is "fdbd8e75a67f29f701a4e040385e2e23986303ea10239211af907fcbb83578b3e417cb71ce646efd0819dd8c088de1bd" with "incorrect hash"
+
+test "SHA-512 hash":
+	assert "hello world" hashed with SHA-512 is "309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f" with "incorrect hash"


### PR DESCRIPTION
### Description
- Don't recommend SHA for passwords in the documentation
- Added SHA-384 and SHA-512
- Added suppressible warning when MD5 is used
- Added tests

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** https://github.com/SkriptLang/Skript/issues/5836 <!-- Links to related issues -->
