### PR TITLE
EvtVaultDisplayItem

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -769,6 +769,21 @@ public final class BukkitEventValues {
 			EventValues.registerEventValue(WorldBorderCenterChangeEvent.class, Location.class, WorldBorderCenterChangeEvent::getNewCenter);
 			EventValues.registerEventValue(WorldBorderCenterChangeEvent.class, Location.class, WorldBorderCenterChangeEvent::getOldCenter, EventValues.TIME_PAST);
 		}
+
+		if (Skript.classExists("org.bukkit.event.block.VaultDisplayItemEvent")) {
+			EventValues.registerEventValue(VaultDisplayItemEvent.class, ItemStack.class, new EventConverter<>() {
+				@Override
+				public void set(VaultDisplayItemEvent event, @Nullable ItemStack itemStack) {
+					event.setDisplayItem(itemStack);
+				}
+
+				@Override
+				public @Nullable ItemStack convert(VaultDisplayItemEvent event) {
+					return event.getDisplayItem();
+				}
+			});
+		}
+
 	}
 
 }

--- a/src/main/java/ch/njol/skript/events/SimpleEvents.java
+++ b/src/main/java/ch/njol/skript/events/SimpleEvents.java
@@ -804,6 +804,20 @@ public class SimpleEvents {
 				)
 				.since("INSERT VERSION");
 		}
+
+		if (Skript.classExists("org.bukkit.event.block.VaultDisplayItemEvent")) {
+			Skript.registerEvent("Vault Display Item", SimpleEvent.class, VaultDisplayItemEvent.class,
+					"vault display[ing] item")
+				.description("Called when a vault in a trial chamber is about to display an item.")
+				.examples(
+					"""
+						on vault display item:
+							set event-item to a netherite ingot	
+					"""
+				)
+				.since("INSERT VERSION")
+				.requiredPlugins("Minecraft 1.21.1+");
+		}
 	}
 
 }

--- a/src/test/java/org/skriptlang/skript/test/tests/syntaxes/events/EvtVaultDisplayItemTest.java
+++ b/src/test/java/org/skriptlang/skript/test/tests/syntaxes/events/EvtVaultDisplayItemTest.java
@@ -1,0 +1,34 @@
+package org.skriptlang.skript.test.tests.syntaxes.events;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.test.runner.SkriptJUnitTest;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.event.block.VaultDisplayItemEvent;
+import org.bukkit.inventory.ItemStack;
+import org.junit.Before;
+import org.junit.Test;
+
+public class EvtVaultDisplayItemTest extends SkriptJUnitTest {
+
+	private boolean VAULT_EVENT_EXISTS = Skript.classExists("org.bukkit.event.block.VaultDisplayItemEvent");
+	private Block vault;
+	private final ItemStack item = new ItemStack(Material.DIAMOND);
+
+	@Before
+	public void setup() {
+		if (!VAULT_EVENT_EXISTS)
+			return;
+		vault = setBlock(Material.VAULT);
+	}
+
+	@Test
+	public void test() {
+		if (!VAULT_EVENT_EXISTS)
+			return;
+		VaultDisplayItemEvent event = new VaultDisplayItemEvent(vault, item);
+		Bukkit.getPluginManager().callEvent(event);
+	}
+
+}

--- a/src/test/java/org/skriptlang/skript/test/tests/syntaxes/events/EvtVaultDisplayItemTest.java
+++ b/src/test/java/org/skriptlang/skript/test/tests/syntaxes/events/EvtVaultDisplayItemTest.java
@@ -5,14 +5,16 @@ import ch.njol.skript.test.runner.SkriptJUnitTest;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
-import org.bukkit.event.block.VaultDisplayItemEvent;
+import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemStack;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.lang.reflect.Constructor;
+
 public class EvtVaultDisplayItemTest extends SkriptJUnitTest {
 
-	private boolean VAULT_EVENT_EXISTS = Skript.classExists("org.bukkit.event.block.VaultDisplayItemEvent");
+	private final boolean VAULT_EVENT_EXISTS = Skript.classExists("org.bukkit.event.block.VaultDisplayItemEvent");
 	private Block vault;
 	private final ItemStack item = new ItemStack(Material.DIAMOND);
 
@@ -20,14 +22,20 @@ public class EvtVaultDisplayItemTest extends SkriptJUnitTest {
 	public void setup() {
 		if (!VAULT_EVENT_EXISTS)
 			return;
-		vault = setBlock(Material.VAULT);
+		vault = setBlock(Material.valueOf("VAULT"));
 	}
 
 	@Test
 	public void test() {
 		if (!VAULT_EVENT_EXISTS)
 			return;
-		VaultDisplayItemEvent event = new VaultDisplayItemEvent(vault, item);
+		Event event = null;
+        try {
+            Class<?> eventClass = Class.forName("org.bukkit.event.block.VaultDisplayItemEvent");
+			Constructor<?> constructor = eventClass.getConstructor(Block.class, ItemStack.class);
+			event = (Event) constructor.newInstance(vault, item);
+        } catch (Exception ignored) {}
+		assert event != null;
 		Bukkit.getPluginManager().callEvent(event);
 	}
 

--- a/src/test/skript/junit/EvtVaultDisplayItemTest.sk
+++ b/src/test/skript/junit/EvtVaultDisplayItemTest.sk
@@ -7,7 +7,7 @@ test "VaultDisplayItem" when running JUnit:
 	ensure {@test} completes {_tests::*}
 
 parse:
-	results: {EvtVaultDisplayItem::*}
+	results: {EvtVaultDisplayItem::parse::*}
 	code:
 		on vault display item:
 			junit test is {@test}
@@ -17,3 +17,9 @@ parse:
 			set event-item to a netherite ingot
 			if event-item is a netherite ingot:
 				complete "display changed" for {@test}
+
+test "VaultDisplayItemParse":
+	if running minecraft "1.21.1":
+		assert {EvtVaultDisplayItem::parse::*} is not set with "EvtVaultDisplayItem failed to parse on supported version"
+	else:
+		assert {EvtVaultDisplayItem::parse::*} is set with "EvtVaultDisplayItem should have failed to parse on unsupported version"

--- a/src/test/skript/junit/EvtVaultDisplayItemTest.sk
+++ b/src/test/skript/junit/EvtVaultDisplayItemTest.sk
@@ -1,0 +1,19 @@
+options:
+	test: "org.skriptlang.skript.test.tests.syntaxes.events.EvtVaultDisplayItemTest"
+
+test "VaultDisplayItem" when running JUnit:
+	running minecraft "1.21.1"
+	set {_tests::*} to "event called", "display is diamond" and "display changed"
+	ensure {@test} completes {_tests::*}
+
+parse:
+	results: {EvtVaultDisplayItem::*}
+	code:
+		on vault display item:
+			junit test is {@test}
+			complete "event called" for {@test}
+			if event-item is a diamond:
+				complete "display is diamond" for {@test}
+			set event-item to a netherite ingot
+			if event-item is a netherite ingot:
+				complete "display changed" for {@test}


### PR DESCRIPTION
### Description
This PR allows users to detect when a vault is about to display an item and gives them the ability to change the item that is going to be displayed.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
