### PR TITLE
Panda Support

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondIsEating.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsEating.java
@@ -1,0 +1,41 @@
+package ch.njol.skript.conditions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.doc.*;
+import org.bukkit.entity.AbstractHorse;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Panda;
+
+@Name("Is Eating")
+@Description("Whether a panda or horse type (horse, camel, donkey, llama, mule) is eating.")
+@Example("""
+	if last spawned panda is eating:
+		force last spawned panda to stop eating
+	""")
+@Since("INSERT VERSION")
+@RequiredPlugins("Paper (horse type)")
+public class CondIsEating extends PropertyCondition<LivingEntity> {
+
+	private static final boolean SUPPORTS_HORSES = Skript.methodExists(AbstractHorse.class, "isEating");
+
+	static {
+		register(CondIsEating.class, "eating", "livingentities");
+	}
+
+	@Override
+	public boolean check(LivingEntity entity) {
+		if (entity instanceof Panda panda) {
+			return panda.isEating();
+		} else if (SUPPORTS_HORSES && entity instanceof AbstractHorse horse) {
+			return horse.isEating();
+		}
+		return false;
+	}
+
+	@Override
+	protected String getPropertyName() {
+		return "eating";
+	}
+
+}

--- a/src/main/java/ch/njol/skript/conditions/CondPandaIsOnBack.java
+++ b/src/main/java/ch/njol/skript/conditions/CondPandaIsOnBack.java
@@ -1,0 +1,34 @@
+package ch.njol.skript.conditions;
+
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Panda;
+
+@Name("Panda Is On Its Back")
+@Description("Whether a panda is on its back.")
+@Examples("""
+	if last spawned panda is on its back:
+		make last spawned panda get off its back
+	""")
+@Since("INSERT VERSION")
+public class CondPandaIsOnBack extends PropertyCondition<LivingEntity> {
+
+	static {
+		register(CondPandaIsOnBack.class, "on (its|their) back[s]", "livingentities");
+	}
+
+	@Override
+	public boolean check(LivingEntity entity) {
+		return entity instanceof Panda panda && panda.isOnBack();
+	}
+
+	@Override
+	protected String getPropertyName() {
+		return "on their back";
+	}
+
+}

--- a/src/main/java/ch/njol/skript/conditions/CondPandaIsRolling.java
+++ b/src/main/java/ch/njol/skript/conditions/CondPandaIsRolling.java
@@ -1,0 +1,34 @@
+package ch.njol.skript.conditions;
+
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Example;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Panda;
+
+@Name("Panda Is Rolling")
+@Description("Whether a panda is rolling.")
+@Example("""
+	if last spawned panda is rolling:
+		make last spawned panda stop rolling
+	""")
+@Since("INSERT VERSION")
+public class CondPandaIsRolling extends PropertyCondition<LivingEntity> {
+
+	static {
+		register(CondPandaIsRolling.class, "rolling", "livingentities");
+	}
+
+	@Override
+	public boolean check(LivingEntity entity) {
+		return entity instanceof Panda panda && panda.isRolling();
+	}
+
+	@Override
+	protected String getPropertyName() {
+		return "rolling";
+	}
+
+}

--- a/src/main/java/ch/njol/skript/conditions/CondPandaIsScared.java
+++ b/src/main/java/ch/njol/skript/conditions/CondPandaIsScared.java
@@ -1,0 +1,31 @@
+package ch.njol.skript.conditions;
+
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Example;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Panda;
+
+@Name("Panda Is Scared")
+@Description("Whether a panda is scared.")
+@Example("if last spawned panda is scared:")
+@Since("INSERT VERSION")
+public class CondPandaIsScared extends PropertyCondition<LivingEntity> {
+
+	static {
+		register(CondPandaIsScared.class, "scared", "livingentities");
+	}
+
+	@Override
+	public boolean check(LivingEntity entity) {
+		return entity instanceof Panda panda && panda.isScared();
+	}
+
+	@Override
+	protected String getPropertyName() {
+		return "scared";
+	}
+
+}

--- a/src/main/java/ch/njol/skript/conditions/CondPandaIsSneezing.java
+++ b/src/main/java/ch/njol/skript/conditions/CondPandaIsSneezing.java
@@ -1,0 +1,34 @@
+package ch.njol.skript.conditions;
+
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Example;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Panda;
+
+@Name("Panda Is Sneezing")
+@Description("Whether a panda is sneezing.")
+@Example("""
+	if last spawned panda is sneezing:
+		make last spawned panda stop sneezing
+	""")
+@Since("INSERT VERSION")
+public class CondPandaIsSneezing extends PropertyCondition<LivingEntity> {
+
+	static {
+		register(CondPandaIsSneezing.class, "sneezing", "livingentities");
+	}
+
+	@Override
+	public boolean check(LivingEntity entity) {
+		return entity instanceof Panda panda && panda.isSneezing();
+	}
+
+	@Override
+	protected String getPropertyName() {
+		return "sneezing";
+	}
+
+}

--- a/src/main/java/ch/njol/skript/effects/EffEating.java
+++ b/src/main/java/ch/njol/skript/effects/EffEating.java
@@ -1,0 +1,71 @@
+package ch.njol.skript.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.*;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.SyntaxStringBuilder;
+import ch.njol.util.Kleenean;
+import org.bukkit.entity.AbstractHorse;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Panda;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Force Eating")
+@Description("Make a panda or horse type (horse, camel, donkey, llama, mule) start/stop eating.")
+@Example("""
+	if last spawned panda is eating:
+		make last spawned panda stop eating
+	""")
+@Since("INSERT VERSION")
+@RequiredPlugins("Paper (horse type)")
+public class EffEating extends Effect {
+
+	private static final boolean SUPPORTS_HORSES = Skript.methodExists(AbstractHorse.class, "isEating");
+
+	static {
+		Skript.registerEffect(EffEating.class,
+			"make %livingentities% start eating",
+			"force %livingentities% to start eating",
+			"make %livingentities% stop eating",
+			"force %livingentities% to stop eating");
+	}
+
+	private Expression<LivingEntity> entities;
+	private boolean start;
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		//noinspection unchecked
+		entities = (Expression<LivingEntity>) exprs[0];
+		start = matchedPattern <= 1;
+		return true;
+	}
+
+	@Override
+	protected void execute(Event event) {
+		for (LivingEntity entity : entities.getArray(event)) {
+			if (entity instanceof Panda panda) {
+				panda.setEating(start);
+			} else if (SUPPORTS_HORSES && entity instanceof AbstractHorse horse) {
+				horse.setEating(start);
+			}
+		}
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		SyntaxStringBuilder builder = new SyntaxStringBuilder(event, debug);
+		builder.append("make", entities);
+		if (start) {
+			builder.append("start");
+		} else {
+			builder.append("stop");
+		}
+		builder.append("eating");
+		return builder.toString();
+	}
+
+}

--- a/src/main/java/ch/njol/skript/effects/EffEating.java
+++ b/src/main/java/ch/njol/skript/effects/EffEating.java
@@ -27,10 +27,8 @@ public class EffEating extends Effect {
 
 	static {
 		Skript.registerEffect(EffEating.class,
-			"make %livingentities% start eating",
-			"force %livingentities% to start eating",
-			"make %livingentities% stop eating",
-			"force %livingentities% to stop eating");
+			"make %livingentities% (:start|stop) eating",
+			"force %livingentities% to (:start|stop) eating");
 	}
 
 	private Expression<LivingEntity> entities;
@@ -40,7 +38,7 @@ public class EffEating extends Effect {
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		//noinspection unchecked
 		entities = (Expression<LivingEntity>) exprs[0];
-		start = matchedPattern <= 1;
+		start = parseResult.hasTag("start");
 		return true;
 	}
 

--- a/src/main/java/ch/njol/skript/effects/EffPandaOnBack.java
+++ b/src/main/java/ch/njol/skript/effects/EffPandaOnBack.java
@@ -1,0 +1,66 @@
+package ch.njol.skript.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.SyntaxStringBuilder;
+import ch.njol.util.Kleenean;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Panda;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Force Panda On Back")
+@Description("Make a panda get on/off its back.")
+@Examples("""
+	if last spawned panda is on its back:
+		make last spawned panda get off its back
+	""")
+@Since("INSERT VERSION")
+public class EffPandaOnBack extends Effect {
+
+	static {
+		Skript.registerEffect(EffPandaOnBack.class,
+			"make %livingentities% get (:on|off) (its|their) back[s]",
+			"force %livingentities% to get (:on|off) (its|their) back[s]");
+	}
+
+	private Expression<LivingEntity> entities;
+	private boolean getOn;
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		//noinspection unchecked
+		entities = (Expression<LivingEntity>) exprs[0];
+		getOn = parseResult.hasTag("on");
+		return true;
+	}
+
+	@Override
+	protected void execute(Event event) {
+		for (LivingEntity entity : entities.getArray(event)) {
+			if (entity instanceof Panda panda) {
+				panda.setOnBack(getOn);
+			}
+		}
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		SyntaxStringBuilder builder = new SyntaxStringBuilder(event, debug);
+		builder.append("make", entities, "get");
+		if (getOn) {
+			builder.append("on");
+		} else {
+			builder.append("off");
+		}
+		builder.append("their backs");
+		return builder.toString();
+	}
+
+}

--- a/src/main/java/ch/njol/skript/effects/EffPandaRolling.java
+++ b/src/main/java/ch/njol/skript/effects/EffPandaRolling.java
@@ -1,0 +1,68 @@
+package ch.njol.skript.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Example;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.SyntaxStringBuilder;
+import ch.njol.util.Kleenean;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Panda;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Make Panda Roll")
+@Description("Make a panda start/stop rolling.")
+@Example("""
+	if last spawned panda is not rolling:
+		make last spawned panda start rolling
+	""")
+@Since("INSERT VERSION")
+public class EffPandaRolling extends Effect {
+
+	static {
+		Skript.registerEffect(EffPandaRolling.class,
+			"make %livingentities% start rolling",
+			"force %livingentities% to start rolling",
+			"make %livingentities% stop rolling",
+			"fore %livingentities% to stop rolling");
+	}
+
+	private Expression<LivingEntity> entities;
+	private boolean start;
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		//noinspection unchecked
+		entities = (Expression<LivingEntity>) exprs[0];
+		start = matchedPattern <= 1;
+		return true;
+	}
+
+	@Override
+	protected void execute(Event event) {
+		for (LivingEntity entity : entities.getArray(event)) {
+			if (entity instanceof Panda panda) {
+				panda.setRolling(start);
+			}
+		}
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		SyntaxStringBuilder builder = new SyntaxStringBuilder(event, debug);
+		builder.append("make", entities);
+		if (start) {
+			builder.append("start");
+		} else {
+			builder.append("stop");
+		}
+		builder.append("rolling");
+		return builder.toString();
+	}
+
+}

--- a/src/main/java/ch/njol/skript/effects/EffPandaRolling.java
+++ b/src/main/java/ch/njol/skript/effects/EffPandaRolling.java
@@ -26,7 +26,7 @@ public class EffPandaRolling extends Effect {
 
 	static {
 		Skript.registerEffect(EffPandaRolling.class,
-			"make %livingentities% start rolling",
+			"make %livingentities% (start rolling|roll)",
 			"force %livingentities% to start rolling",
 			"make %livingentities% stop rolling",
 			"fore %livingentities% to stop rolling");

--- a/src/main/java/ch/njol/skript/effects/EffPandaRolling.java
+++ b/src/main/java/ch/njol/skript/effects/EffPandaRolling.java
@@ -26,10 +26,8 @@ public class EffPandaRolling extends Effect {
 
 	static {
 		Skript.registerEffect(EffPandaRolling.class,
-			"make %livingentities% (start rolling|roll)",
-			"force %livingentities% to start rolling",
-			"make %livingentities% stop rolling",
-			"fore %livingentities% to stop rolling");
+			"make %livingentities% (start:(start rolling|roll)|stop rolling)",
+			"force %livingentities% to (:start|stop) rolling");
 	}
 
 	private Expression<LivingEntity> entities;
@@ -39,7 +37,7 @@ public class EffPandaRolling extends Effect {
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		//noinspection unchecked
 		entities = (Expression<LivingEntity>) exprs[0];
-		start = matchedPattern <= 1;
+		start = parseResult.hasTag("start");
 		return true;
 	}
 

--- a/src/main/java/ch/njol/skript/effects/EffPandaSneezing.java
+++ b/src/main/java/ch/njol/skript/effects/EffPandaSneezing.java
@@ -26,10 +26,8 @@ public class EffPandaSneezing extends Effect {
 
 	static {
 		Skript.registerEffect(EffPandaSneezing.class,
-			"make %livingentities% (start sneezing|sneeze)",
-			"force %livingentities% to start sneezing",
-			"make %livingentities% stop sneezing",
-			"fore %livingentities% to stop sneezing");
+			"make %livingentities% (start:(start sneezing|sneeze)|stop sneezing)",
+			"force %livingentities% to (:start|stop) sneezing");
 	}
 
 	private Expression<LivingEntity> entities;
@@ -39,7 +37,7 @@ public class EffPandaSneezing extends Effect {
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		//noinspection unchecked
 		entities = (Expression<LivingEntity>) exprs[0];
-		start = matchedPattern <= 1;
+		start = parseResult.hasTag("start");
 		return true;
 	}
 

--- a/src/main/java/ch/njol/skript/effects/EffPandaSneezing.java
+++ b/src/main/java/ch/njol/skript/effects/EffPandaSneezing.java
@@ -1,0 +1,68 @@
+package ch.njol.skript.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Example;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.SyntaxStringBuilder;
+import ch.njol.util.Kleenean;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Panda;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Make Panda Sneeze")
+@Description("Make a panda start/stop sneezing.")
+@Example("""
+	if last spawned panda is not sneezing:
+		make last spawned panda start sneezing
+	""")
+@Since("INSERT VERSION")
+public class EffPandaSneezing extends Effect {
+
+	static {
+		Skript.registerEffect(EffPandaSneezing.class,
+			"make %livingentities% start sneezing",
+			"force %livingentities% to start sneezing",
+			"make %livingentities% stop sneezing",
+			"fore %livingentities% to stop sneezing");
+	}
+
+	private Expression<LivingEntity> entities;
+	private boolean start;
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		//noinspection unchecked
+		entities = (Expression<LivingEntity>) exprs[0];
+		start = matchedPattern <= 1;
+		return true;
+	}
+
+	@Override
+	protected void execute(Event event) {
+		for (LivingEntity entity : entities.getArray(event)) {
+			if (entity instanceof Panda panda) {
+				panda.setSneezing(start);
+			}
+		}
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		SyntaxStringBuilder builder = new SyntaxStringBuilder(event, debug);
+		builder.append("make", entities);
+		if (start) {
+			builder.append("start");
+		} else {
+			builder.append("stop");
+		}
+		builder.append("sneezing");
+		return builder.toString();
+	}
+
+}

--- a/src/main/java/ch/njol/skript/effects/EffPandaSneezing.java
+++ b/src/main/java/ch/njol/skript/effects/EffPandaSneezing.java
@@ -26,7 +26,7 @@ public class EffPandaSneezing extends Effect {
 
 	static {
 		Skript.registerEffect(EffPandaSneezing.class,
-			"make %livingentities% start sneezing",
+			"make %livingentities% (start sneezing|sneeze)",
 			"force %livingentities% to start sneezing",
 			"make %livingentities% stop sneezing",
 			"fore %livingentities% to stop sneezing");

--- a/src/main/java/ch/njol/skript/expressions/ExprPandaGene.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPandaGene.java
@@ -1,0 +1,79 @@
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Example;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Panda;
+import org.bukkit.entity.Panda.Gene;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Panda Gene")
+@Description("The main or hidden gene of a panda.")
+@Example("""
+	if the main gene of last spawned panda is lazy:
+		set the main gene of last spawned panda to playful
+	""")
+@Since("INSERT VERSION")
+public class ExprPandaGene extends SimplePropertyExpression<LivingEntity, Gene> {
+
+	static {
+		register(ExprPandaGene.class, Gene.class, "(:main|hidden) gene[s]", "livingentities");
+	}
+
+	private boolean mainGene;
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		mainGene = parseResult.hasTag("main");
+		return super.init(exprs, matchedPattern, isDelayed, parseResult);
+	}
+
+	@Override
+	public @Nullable Gene convert(LivingEntity entity) {
+		if (!(entity instanceof Panda panda))
+			return null;
+		return mainGene ? panda.getMainGene() : panda.getHiddenGene();
+	}
+
+	@Override
+	public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
+		if (mode == ChangeMode.SET)
+			return CollectionUtils.array(Gene.class);
+		return null;
+	}
+
+	@Override
+	public void change(Event event, Object @Nullable [] delta, ChangeMode mode) {
+		assert delta != null;
+		Gene gene = (Gene) delta[0];
+		for (LivingEntity entity : getExpr().getArray(event)) {
+			if (!(entity instanceof Panda panda))
+				continue;
+			if (mainGene) {
+				panda.setMainGene(gene);
+			} else {
+				panda.setHiddenGene(gene);
+			}
+		}
+	}
+
+	@Override
+	public Class<? extends Gene> getReturnType() {
+		return Gene.class;
+	}
+
+	@Override
+	protected String getPropertyName() {
+		return (mainGene ? "main" : "hidden") + "gene";
+	}
+
+}

--- a/src/test/skript/tests/syntaxes/effects/EffEating.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffEating.sk
@@ -1,0 +1,15 @@
+test "panda eating":
+	spawn a panda at test-location:
+		set {_entity} to entity
+	assert {_entity} is not eating with "Panda should not be eating"
+	make {_entity} start eating
+	assert {_entity} is eating with "Panda should be eating"
+	clear entity within {_entity}
+
+test "horse eating":
+	spawn a horse at test-location:
+		set {_entity} to entity
+	assert {_entity} is not eating with "Horse should not be eating"
+	make {_entity} start eating
+	assert {_entity} is eating with "Horse should be eating"
+	clear entity within {_entity}

--- a/src/test/skript/tests/syntaxes/effects/EffPandaOnBack.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffPandaOnBack.sk
@@ -1,0 +1,7 @@
+test "panda on back":
+	spawn a panda at test-location:
+		set {_entity} to entity
+	assert {_entity} is not on its back with "Panda should not be on its back"
+	make {_entity} get on its back
+	assert {_entity} is on its back with "Panda should be on its back"
+	clear entity within {_entity}

--- a/src/test/skript/tests/syntaxes/effects/EffPandaRolling.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffPandaRolling.sk
@@ -1,0 +1,7 @@
+test "panda rolling":
+	spawn a panda at test-location:
+		set {_entity} to entity
+	assert {_entity} is not rolling with "Panda should not be rolling"
+	make {_entity} start rolling
+	assert {_entity} is rolling with "Panda should be rolling"
+	clear entity within {_entity}

--- a/src/test/skript/tests/syntaxes/effects/EffPandaSneezing.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffPandaSneezing.sk
@@ -1,0 +1,7 @@
+test "panda sneezing":
+	spawn a panda at test-location:
+		set {_entity} to entity
+	assert {_entity} is not sneezing with "Panda should not be sneezing"
+	make {_entity} start sneezing
+	assert {_entity} is sneezing with "Panda should be sneezing"
+	clear entity within {_entity}

--- a/src/test/skript/tests/syntaxes/expressions/ExprPandaGene.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprPandaGene.sk
@@ -1,0 +1,10 @@
+test "panda genes":
+	spawn a brown playful panda at test-location:
+		set {_entity} to entity
+	assert the main gene of {_entity} is brown with "Panda main gene should be brown"
+	assert the hidden gene of {_entity} is playful with "Panda hidden gene should be playful"
+	set the main gene of {_entity} to lazy
+	assert the main gene of {_entity} is lazy with "Panda's mina gene should be set to lazy"
+	set the hidden gene of {_entity} to normal
+	assert the hidden gene of {_entity} is normal with "Panda's hidden gene should be set to normal"
+	clear entity within {_entity}


### PR DESCRIPTION
### Description
This PR aims to add panda support by:
- Check if a panda is eating, with an effect (including horse types)
- Check if a panda is rolling, with an effect
- Check if a panda is scared
- Check if a panda is sneezing, with an effect
- Check if a panda is on its back, with an effect
- Expression for the main and hidden genes of a panda, with a changer

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
