### PR TITLE
Add fishing state change event

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
@@ -27,6 +27,8 @@ import ch.njol.skript.util.visual.VisualEffects;
 import ch.njol.yggdrasil.Fields;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.script.Script;
@@ -966,6 +968,15 @@ public class SkriptClasses {
 				.examples("{a} contains {b}")
 				.since("2.10")
 		);
+
+		Classes.registerClass(new EnumClassInfo<>(PlayerFishEvent.State.class, "fishingstate", "fishing states")
+				.user("fish(ing)? ?states?")
+				.name("Fishing Event State")
+				.description("The state of a fishing event. Mainly useful when listening to fishing state change")
+				.examples("")
+				.since("INSERT VERSION")
+		);
+
 	}
 
 }

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/EvtFish.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/EvtFish.java
@@ -7,6 +7,7 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.registrations.EventValues;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
+import org.bukkit.event.player.PlayerEvent;
 import org.bukkit.event.player.PlayerFishEvent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -75,6 +76,7 @@ public class EvtFish extends SkriptEvent {
 			.since("2.10, INSERT VERSION (state change)");
 
 		EventValues.registerEventValue(PlayerFishEvent.class, Entity.class, PlayerFishEvent::getCaught);
+		EventValues.registerEventValue(PlayerFishEvent.class, PlayerFishEvent.State.class, PlayerFishEvent::getState);
 	}
 
 	private State state;

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/EvtFish.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/EvtFish.java
@@ -25,7 +25,8 @@ public class EvtFish extends SkriptEvent {
 		FISH_ESCAPE(PlayerFishEvent.State.FAILED_ATTEMPT, "fish (escape|get away)", "fish escape"),
 		REEL_IN(PlayerFishEvent.State.REEL_IN, "[fishing] (rod|line) reel in", "fishing rod reel in"),
 		BITE(PlayerFishEvent.State.BITE, "fish bit(e|ing)", "fish bite"),
-		LURED(getOptional("LURED"), "(fish approach[ing]|(bobber|hook) lure[d])", "fish approaching");
+		LURED(getOptional("LURED"), "(fish approach[ing]|(bobber|hook) lure[d])", "fish approaching"),
+		ALL(null, "fish[ing] [state change]", "fishing state change");
 
 		private final @Nullable PlayerFishEvent.State state;
 		private final String pattern;
@@ -54,22 +55,24 @@ public class EvtFish extends SkriptEvent {
 
 			patterns.add(state.pattern);
 		}
+		patterns.add(State.ALL.pattern);
 
 		Skript.registerEvent("Fishing", EvtFish.class, PlayerFishEvent.class, patterns.toArray(new String[0]))
 			.description(
 				"Called when a player triggers a fishing event.",
 				"An entity hooked event is triggered when an entity gets caught by a fishing rod.",
 				"A fish escape event is called when the player fails to click on time, and the fish escapes.",
-				"A fish approaching event is when the bobber is waiting to be hooked, and a fish is approaching."
+				"A fish approaching event is when the bobber is waiting to be hooked, and a fish is approaching.",
+				""
 			)
 			.examples(
 				"on fishing line cast:",
 					"\tsend \"You caught a fish!\" to player",
-				"on fishing state of caught entity:",
+				"on fishing state change:",
 					"\tpush event-entity vector from entity to player"
 			)
 			.requiredPlugins("Paper (bobber lured)")
-			.since("2.10");
+			.since("2.10, INSERT VERSION (state change)");
 
 		EventValues.registerEventValue(PlayerFishEvent.class, Entity.class, PlayerFishEvent::getCaught);
 	}
@@ -86,6 +89,8 @@ public class EvtFish extends SkriptEvent {
 	public boolean check(Event event) {
 		if (!(event instanceof PlayerFishEvent fishEvent))
 			return false;
+		if (state == State.ALL)
+			return true;
 
 		return state.state == fishEvent.getState();
 	}

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -2695,3 +2695,14 @@ types:
 
 	# Other
 	quaternion: quaternion¦s @a
+
+# -- Fishing Event State Types --
+fishing states:
+	fishing: fishing, cast
+	caught_fish: caught fish
+	caught_entity: caught entity
+	in_ground: hook in ground, bobber in ground
+	failed_attempt: fish escape
+	reel_in: [rod] reel in
+	bite: fish bite
+	lured: fish approaching, bobber lured, hook lured


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

The old fishing event used to trigger for any fishing related activity which could still be useful behavior. With the fishing revamp in 2.10 this was lost when the event was broken into its individual states. This PR attempts to create a new syntax withing the event that triggers no matter which fishing state is called. Also adds an event value for the fishing state although I would love to have more feedback on this since I had no clue what I was doing

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7671  <!-- Links to related issues -->
