### PR TITLE
Fix BlockLineIterator error due to floating point error near edges of blocks.

### DIFF
--- a/src/main/java/ch/njol/skript/util/BlockLineIterator.java
+++ b/src/main/java/ch/njol/skript/util/BlockLineIterator.java
@@ -73,7 +73,7 @@ public class BlockLineIterator implements Iterator<Block> {
 	public Block next() {
 		if (!hasNext()) throw new NoSuchElementException("Reached the final block destination");
 		// sanity check (is the current->end vector pointing away from step)
-		if (end.sub(current, new Vector3d()).dot(step) < 0) throw new NoSuchElementException("Overshot the final block!");
+		if (end.sub(current, new Vector3d()).dot(step) < 1) throw new NoSuchElementException("Overshot the final block!");
 		// get block and check end
 		Vector3d center = centered(current);
 		Block block = getBlock(center, world);

--- a/src/main/java/ch/njol/skript/util/BlockLineIterator.java
+++ b/src/main/java/ch/njol/skript/util/BlockLineIterator.java
@@ -73,7 +73,7 @@ public class BlockLineIterator implements Iterator<Block> {
 	public Block next() {
 		if (!hasNext()) throw new NoSuchElementException("Reached the final block destination");
 		// sanity check (is the current->end vector pointing away from step)
-		if (end.sub(current, new Vector3d()).dot(step) < 1) throw new NoSuchElementException("Overshot the final block!");
+		if (end.sub(current, new Vector3d()).dot(step) < -1) throw new NoSuchElementException("Overshot the final block!");
 		// get block and check end
 		Vector3d center = centered(current);
 		Block block = getBlock(center, world);

--- a/src/test/skript/tests/regressions/7768-block line iterator overshoot.sk
+++ b/src/test/skript/tests/regressions/7768-block line iterator overshoot.sk
@@ -1,0 +1,6 @@
+test "block line overshoot too aggressive":
+	set {_loc} to location(0,-0.9,0,world "world")
+	set {_step} to vector(0,0.001,0)
+	loop 200 times:
+		assert (size of blocks above {_loc}) is 100 with "failed to get blocks above %{_loc}%"
+		set {_loc} to {_loc} ~ {_step}


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Changes overshoot check to ensure it's significantly behind the end point (1+ meter) instead of behind at all.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7768 <!-- Links to related issues -->
