### PR TITLE
Fix double-claiming behavior with Secspressions that have no section.

### DIFF
--- a/src/main/java/ch/njol/skript/lang/Statement.java
+++ b/src/main/java/ch/njol/skript/lang/Statement.java
@@ -48,8 +48,8 @@ public abstract class Statement extends TriggerItem implements SyntaxElement {
 			log.clear();
 
 			Statement statement;
+			Section.SectionContext sectionContext = ParserInstance.get().getData(Section.SectionContext.class);
 			if (node != null) {
-				Section.SectionContext sectionContext = ParserInstance.get().getData(Section.SectionContext.class);
 				statement = sectionContext.modify(node, items, () -> {
 						//noinspection unchecked,rawtypes
 						Statement parsed = (Statement) SkriptParser.parse(input, (Iterator) Skript.getStatements().iterator(), defaultError);
@@ -60,8 +60,10 @@ public abstract class Statement extends TriggerItem implements SyntaxElement {
 						return parsed;
 				});
 			} else {
-				//noinspection unchecked,rawtypes
-				statement = (Statement) SkriptParser.parse(input, (Iterator) Skript.getStatements().iterator(), defaultError);
+				statement = sectionContext.modify(null, null, () -> {
+					//noinspection unchecked,rawtypes
+					return (Statement) SkriptParser.parse(input, (Iterator) Skript.getStatements().iterator(), defaultError);
+				});
 			}
 
 			if (statement != null) {


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

The sectioncontext was not being cleared when attempting to parse sectionless statements, which resulted in sectionless Secspressions being given their parent section to claim, leading to shenanigans like the secspression parsing itself multiple times.

This ensures the section context is cleared before attempting to parse sectionless statements.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7721 <!-- Links to related issues -->
