### PR TITLE
Adds missing lang entries for bundle inventory actions and bucket spawn reason

### DIFF
--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -2085,6 +2085,12 @@ inventory actions:
 	clone_stack: clone stack
 	collect_to_cursor: collect to cursor, collect items to cursor
 	unknown: unknown, unsupported, custom
+	pickup_from_bundle: pickup from bundle, pickup items from bundle
+	pickup_all_into_bundle: pickup all into bundle, pickup all items into bundle
+	pickup_some_into_bundle: pickup some into bundle, pickup some items into bundle
+	place_from_bundle: place from bundle, place items from bundle
+	place_all_into_bundle: place all into bundle, place all items into bundle
+	place_some_into_bundle: place some into bundle, place some items into bundle
 
 # -- Inventory Click Types --
 click types:
@@ -2144,6 +2150,7 @@ spawn reasons:
 	bed: bed
 	beehive: beehive
 	breeding: breed, breeding
+	bucket: release from bucket # 'bucket' alone is problematic
 	build_irongolem: built iron golem, build iron golem
 	build_snowman: built snowman, build snowman
 	build_wither: built wither, build wither


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Adds lang entries for 1.21.4+ bundle inventory actions ~~(These actions appear to be unused as of Paper 1.21.4-222)~~.
Adds entry for `bucket` spawn reason. Due to conflicts, I chose `release from bucket` as the full entry. Suggestions welcome.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7772 <!-- Links to related issues -->
