### PR TITLE
Improve API for tracking delayed execution at runtime.

### DIFF
--- a/src/main/java/ch/njol/skript/command/ScriptCommandEvent.java
+++ b/src/main/java/ch/njol/skript/command/ScriptCommandEvent.java
@@ -56,15 +56,26 @@ public class ScriptCommandEvent extends CommandEvent {
 		return cooldownCancelled;
 	}
 
+	/**
+	 * @deprecated Use {@link #setCooldownCancelled(boolean, boolean)} instead.
+	 */
+	@Deprecated(since = "INSERT VERSION", forRemoval = true)
 	public void setCooldownCancelled(boolean cooldownCancelled) {
-		if (Delay.isDelayed(this)) {
-			CommandSender sender = getSender();
-			if (sender instanceof Player) {
-				Date date = cooldownCancelled ? null : executionDate;
-				scriptCommand.setLastUsage(((Player) sender).getUniqueId(), this, date);
-			}
-		} else {
-			this.cooldownCancelled = cooldownCancelled;
+		//noinspection removal
+		setCooldownCancelled(cooldownCancelled, Delay.isDelayed(this));
+	}
+
+	/**
+	 * Sets whether the cooldown should be cancelled.
+	 *
+	 * @param cooldownCancelled Whether the cooldown should be cancelled.
+	 * @param delayed Whether this event is delayed. If true, the sender's cooldown will be retroactively set.
+	 */
+	public void setCooldownCancelled(boolean cooldownCancelled, boolean delayed) {
+		this.cooldownCancelled = cooldownCancelled;
+		if (delayed && getSender() instanceof Player player) {
+			Date date = cooldownCancelled ? null : executionDate;
+			scriptCommand.setLastUsage(player.getUniqueId(), this, date);
 		}
 	}
 

--- a/src/main/java/ch/njol/skript/effects/Delay.java
+++ b/src/main/java/ch/njol/skript/effects/Delay.java
@@ -5,12 +5,8 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
-import ch.njol.skript.lang.Effect;
-import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.Literal;
+import ch.njol.skript.lang.*;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.skript.lang.Trigger;
-import ch.njol.skript.lang.TriggerItem;
 import ch.njol.skript.timings.SkriptTimings;
 import ch.njol.skript.util.Timespan;
 import ch.njol.skript.variables.Variables;
@@ -112,7 +108,9 @@ public class Delay extends Effect {
 	 * The main method for checking if the execution of {@link TriggerItem}s has been delayed.
 	 * @param event The event to check for a delay.
 	 * @return Whether {@link TriggerItem} execution has been delayed.
+	 * @deprecated Use {@link Trigger#isExecutionDelayed(Event)} or {@link TriggerItem#isExecutionDelayed(Event)} instead.
 	 */
+	@Deprecated(since = "INSERT VERSION", forRemoval = true)
 	public static boolean isDelayed(Event event) {
 		return DELAYED.contains(event);
 	}
@@ -120,7 +118,9 @@ public class Delay extends Effect {
 	/**
 	 * The main method for marking the execution of {@link TriggerItem}s as delayed.
 	 * @param event The event to mark as delayed.
+	 * @deprecated Use {@link Trigger#markExecutionAsDelayed(Event)} or {@link TriggerItem#markExecutionAsDelayed(Event)} instead.
 	 */
+	@Deprecated(since = "INSERT VERSION", forRemoval = true)
 	public static void addDelayedEvent(Event event) {
 		DELAYED.add(event);
 	}

--- a/src/main/java/ch/njol/skript/effects/EffCancelCooldown.java
+++ b/src/main/java/ch/njol/skript/effects/EffCancelCooldown.java
@@ -1,12 +1,9 @@
 package ch.njol.skript.effects;
 
-import org.bukkit.event.Event;
-import org.jetbrains.annotations.Nullable;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.command.ScriptCommandEvent;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
@@ -14,20 +11,23 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.log.ErrorQuality;
 import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
 
 @Name("Cancel Command Cooldown")
 @Description({"Only usable in commands. Makes it so the current command usage isn't counted towards the cooldown."})
-@Examples({
-		"command /nick &lt;text&gt;:",
-		"\texecutable by: players",
-		"\tcooldown: 10 seconds",
-		"\ttrigger:",
-		"\t\tif length of arg-1 is more than 16:",
-		"\t\t\t# Makes it so that invalid arguments don't make you wait for the cooldown again",
-		"\t\t\tcancel the cooldown",
-		"\t\t\tsend \"Your nickname may be at most 16 characters.\"",
-		"\t\t\tstop",
-		"\t\tset the player's display name to arg-1"})
+@Example("""
+	command /nick &lt;text&gt;:
+		executable by: players
+		cooldown: 10 seconds
+		trigger:
+			if length of arg-1 is more than 16:
+				# Makes it so that invalid arguments don't make you wait for the cooldown again
+				cancel the cooldown
+				send "Your nickname may be at most 16 characters."
+				stop
+			set the player's display name to arg-1
+	""")
 @Since("2.2-dev34")
 public class EffCancelCooldown extends Effect {
 
@@ -50,15 +50,15 @@ public class EffCancelCooldown extends Effect {
 	}
 
 	@Override
-	protected void execute(Event e) {
-		if (!(e instanceof ScriptCommandEvent))
+	protected void execute(Event event) {
+		if (!(event instanceof ScriptCommandEvent scriptCommandEvent))
 			return;
 
-		((ScriptCommandEvent) e).setCooldownCancelled(cancel);
+		scriptCommandEvent.setCooldownCancelled(cancel, isExecutionDelayed(event));
 	}
 
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
+	public String toString(@Nullable Event event, boolean debug) {
 		return (cancel ? "" : "un") + "cancel the command cooldown";
 	}
 

--- a/src/main/java/ch/njol/skript/effects/EffIgnite.java
+++ b/src/main/java/ch/njol/skript/effects/EffIgnite.java
@@ -63,16 +63,11 @@ public class EffIgnite extends Effect {
 			duration = (int) timespan.getAs(Timespan.TimePeriod.TICK);
 		}
 		for (Entity entity : entities.getArray(event)) {
-			if (event instanceof EntityDamageEvent && ((EntityDamageEvent) event).getEntity() == entity && !Delay.isDelayed(event)) {
-				Bukkit.getScheduler().scheduleSyncDelayedTask(Skript.getInstance(), new Runnable() {
-					@Override
-					public void run() {
-						entity.setFireTicks(duration);
-					}
-				});
+			if (event instanceof EntityDamageEvent entityDamageEvent && entityDamageEvent.getEntity() == entity && !isExecutionDelayed(event)) {
+				Bukkit.getScheduler().scheduleSyncDelayedTask(Skript.getInstance(), () -> entity.setFireTicks(duration));
 			} else {
-				if (event instanceof EntityCombustEvent && ((EntityCombustEvent) event).getEntity() == entity && !Delay.isDelayed(event))
-					((EntityCombustEvent) event).setCancelled(true);// can't change the duration, thus simply cancel the event (and create a new one)
+				if (event instanceof EntityCombustEvent entityCombustEvent && entityCombustEvent.getEntity() == entity && !isExecutionDelayed(event))
+					entityCombustEvent.setCancelled(true);// can't change the duration, thus simply cancel the event (and create a new one)
 				entity.setFireTicks(duration);
 			}
 		}

--- a/src/main/java/ch/njol/skript/effects/EffKick.java
+++ b/src/main/java/ch/njol/skript/effects/EffKick.java
@@ -1,5 +1,14 @@
 package ch.njol.skript.effects;
 
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Example;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.player.PlayerKickEvent;
@@ -7,62 +16,50 @@ import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.event.player.PlayerLoginEvent.Result;
 import org.jetbrains.annotations.Nullable;
 
-import ch.njol.skript.Skript;
-import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
-import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.Since;
-import ch.njol.skript.lang.Effect;
-import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.util.Kleenean;
-
-/**
- * @author Peter Güttinger
- */
 @Name("Kick")
 @Description("Kicks a player from the server.")
-@Examples({"on place of TNT, lava, or obsidian:",
-		"	kick the player due to \"You may not place %block%!\"",
-		"	cancel the event"})
+@Example("""
+	on place of TNT, lava, or obsidian:
+		kick the player due to "You may not place %block%!"
+		cancel the event
+	""")
 @Since("1.0")
 public class EffKick extends Effect {
 	static {
 		Skript.registerEffect(EffKick.class, "kick %players% [(by reason of|because [of]|on account of|due to) %-string%]");
 	}
-	
-	@SuppressWarnings("null")
+
 	private Expression<Player> players;
-	@Nullable
-	private Expression<String> reason;
-	
-	@SuppressWarnings({"unchecked", "null"})
+	private @Nullable Expression<String> reason;
+
 	@Override
-	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
+	@SuppressWarnings("unchecked")
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		players = (Expression<Player>) exprs[0];
 		reason = (Expression<String>) exprs[1];
 		return true;
 	}
-	
+
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "kick " + players.toString(e, debug) + (reason != null ? " on account of " + reason.toString(e, debug) : "");
+	protected void execute(Event event) {
+		final String reasonString = reason != null ? reason.getSingle(event) : "";
+		if (reasonString == null)
+			return;
+		for (final Player player : players.getArray(event)) {
+			if (event instanceof PlayerLoginEvent playerLoginEvent && player.equals(playerLoginEvent.getPlayer()) && !isExecutionDelayed(event)) {
+				playerLoginEvent.disallow(Result.KICK_OTHER, reasonString);
+			} else if (event instanceof PlayerKickEvent playerKickEvent && player.equals(playerKickEvent.getPlayer()) && !isExecutionDelayed(event)) {
+				playerKickEvent.setLeaveMessage(reasonString);
+			} else {
+				player.kickPlayer(reasonString);
+			}
+		}
 	}
 	
 	@Override
-	protected void execute(final Event e) {
-		final String r = reason != null ? reason.getSingle(e) : "";
-		if (r == null)
-			return;
-		for (final Player p : players.getArray(e)) {
-			if (e instanceof PlayerLoginEvent && p.equals(((PlayerLoginEvent) e).getPlayer()) && !Delay.isDelayed(e)) {
-				((PlayerLoginEvent) e).disallow(Result.KICK_OTHER, r);
-			} else if (e instanceof PlayerKickEvent && p.equals(((PlayerKickEvent) e).getPlayer()) && !Delay.isDelayed(e)) {
-				((PlayerKickEvent) e).setLeaveMessage(r);
-			} else {
-				p.kickPlayer(r);
-			}
-		}
+	public String toString(@Nullable Event event, boolean debug) {
+		return "kick " + players.toString(event, debug)
+				+ (reason != null ? " on account of " + reason.toString(event, debug) : "");
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffTeleport.java
+++ b/src/main/java/ch/njol/skript/effects/EffTeleport.java
@@ -84,7 +84,7 @@ public class EffTeleport extends Effect {
 		debug(event, true);
 		TriggerItem next = getNext();
 
-		boolean delayed = Delay.isDelayed(event);
+		boolean delayed = isExecutionDelayed(event);
 		Location location = this.location.getSingle(event);
 		if (location == null)
 			return next;

--- a/src/main/java/ch/njol/skript/expressions/ExprFoodLevel.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFoodLevel.java
@@ -43,7 +43,7 @@ public class ExprFoodLevel extends PropertyExpression<Player, Number> {
 	protected Number[] get(Event event, Player[] source) {
 		return get(source, player -> {
 			if (getTime() >= 0 && event instanceof FoodLevelChangeEvent foodLevelChangeEvent
-				&& player.equals(foodLevelChangeEvent.getEntity()) && !Delay.isDelayed(event)) {
+				&& player.equals(foodLevelChangeEvent.getEntity()) && !isExecutionDelayed(event)) {
 				return 0.5f * foodLevelChangeEvent.getFoodLevel();
 			}
 			return 0.5f * player.getFoodLevel();

--- a/src/main/java/ch/njol/skript/lang/Trigger.java
+++ b/src/main/java/ch/njol/skript/lang/Trigger.java
@@ -1,11 +1,15 @@
 package ch.njol.skript.lang;
 
+import ch.njol.skript.effects.Delay;
 import ch.njol.skript.variables.Variables;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.script.Script;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.WeakHashMap;
 
 public class Trigger extends TriggerSection {
 
@@ -15,6 +19,9 @@ public class Trigger extends TriggerSection {
 	private final @Nullable Script script;
 	private int line = -1; // -1 is default: it means there is no line number available
 	private String debugLabel;
+
+	private final Set<Event> delayedEvents =
+		Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
 
 	public Trigger(@Nullable Script script, String name, SkriptEvent event, List<TriggerItem> items) {
 		super(items);
@@ -100,6 +107,23 @@ public class Trigger extends TriggerSection {
 
 	public String getDebugLabel() {
 		return debugLabel;
+	}
+
+	/**
+	 * @return Whether the execution of this trigger for this specific event has been delayed.
+	 */
+	public boolean isExecutionDelayed(Event event) {
+		return delayedEvents.contains(event);
+	}
+
+	/**
+	 * Marks the execution of this trigger for this specific event as delayed.
+	 */
+	public void markExecutionAsDelayed(Event event) {
+		delayedEvents.add(event);
+		// for backwards compatibility
+		//noinspection removal
+		Delay.addDelayedEvent(event);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/lang/TriggerItem.java
+++ b/src/main/java/ch/njol/skript/lang/TriggerItem.java
@@ -174,4 +174,28 @@ public abstract class TriggerItem implements Debuggable {
 		return next;
 	}
 
+	/**
+	 * Whether there has been a delay between the event being fired and this item being executed.
+	 * {@link TriggerItem}s without enclosing {@link Trigger}s will always return false.
+	 *
+	 * @see Trigger#isExecutionDelayed(Event)
+	 */
+	public boolean isExecutionDelayed(Event event) {
+		Trigger trigger = getTrigger();
+		if (trigger == null)
+			return false;
+		return trigger.isExecutionDelayed(event);
+	}
+
+	/**
+	 * Marks this trigger's execution for this specific event as delayed.
+	 *
+	 * @see Trigger#markExecutionAsDelayed(Event)
+	 */
+	public void markExecutionAsDelayed(Event event) {
+		Trigger trigger = getTrigger();
+		if (trigger != null)
+			trigger.markExecutionAsDelayed(event);
+	}
+
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

The current method of checking if the current execution has been delayed utilises Delay.isDelayed(Event), which returns whether a delay has been run in that event before. If the event only corresponds to a single trigger, this is ok. However, as soon as 2 triggers enter the picture, problems arise:

```
on jump:
  send isDelayed # sends false
  wait 1 tick # adds to DELAYED
  send isDelayed # sends true

on jump:
  send isDelayed # uh oh, this ran after the first event, so the event's already in DELAYED! returns TRUE
  wait 1 tick
  send isDelayed # sends true
```

This PR attempts to resolve that by moving this logic to Trigger, so each trigger tracks whether it has been delayed for an Event or not. The old methods are deprecated and marked for removal, but are still functional.

Current issues/concerns:
- Grabbing a Trigger from an Expression context
- Is getTrigger reliable when working with sections that completely overwrite context, like EffSecSpawn?

Some simple cleanup was done to classes affected by the deprecation. Anything more is out of scope.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7393 (not a fix) <!-- Links to related issues -->
