### PR TITLE
Adds a preinit() method to SyntaxElement

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/base/SimplePropertyExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/SimplePropertyExpression.java
@@ -1,13 +1,11 @@
 package ch.njol.skript.expressions.base;
 
-import ch.njol.skript.config.Node;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.LiteralUtils;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
-import org.skriptlang.skript.log.runtime.SyntaxRuntimeErrorProducer;
 import org.skriptlang.skript.lang.converter.Converter;
 
 /**
@@ -16,9 +14,8 @@ import org.skriptlang.skript.lang.converter.Converter;
  * @see PropertyExpression
  * @see PropertyExpression#register(Class, Class, String, String)
  */
-public abstract class SimplePropertyExpression<F, T> extends PropertyExpression<F, T> implements Converter<F, T>, SyntaxRuntimeErrorProducer {
+public abstract class SimplePropertyExpression<F, T> extends PropertyExpression<F, T> implements Converter<F, T> {
 
-	private Node node;
 	protected String rawExpr;
   
 	@Override
@@ -29,7 +26,6 @@ public abstract class SimplePropertyExpression<F, T> extends PropertyExpression<
 			return LiteralUtils.canInitSafely(getExpr());
 		}
 		setExpr((Expression<? extends F>) expressions[0]);
-		node = getParser().getNode();
 		rawExpr = parseResult.expr;
 		return true;
 	}
@@ -41,11 +37,6 @@ public abstract class SimplePropertyExpression<F, T> extends PropertyExpression<
 	@Override
 	protected T[] get(Event event, F[] source) {
 		return super.get(source, this);
-	}
-
-	@Override
-	public Node getNode() {
-		return node;
 	}
 
 	/**

--- a/src/main/java/ch/njol/skript/lang/SyntaxElement.java
+++ b/src/main/java/ch/njol/skript/lang/SyntaxElement.java
@@ -12,7 +12,19 @@ import org.jetbrains.annotations.NotNull;
 public interface SyntaxElement {
 
 	/**
-	 * Called just after the constructor.
+	 * Called immediately after the constructor. This should be used to do any work that need to be done prior to
+	 * downstream initialization. This is not intended to be used by syntaxes directly, but by parent classes to do
+	 * work prior to the initialization of the child classes.
+	 *
+	 * @return Whether this expression was pre-initialised successfully.
+	 * 			An error should be printed prior to returning false to specify the cause.
+	 */
+	default boolean preInit() {
+		return true;
+	}
+
+	/**
+	 * Called just after the constructor and {@link #preInit}.
 	 * 
 	 * @param expressions all %expr%s included in the matching pattern in the order they appear in the pattern. If an optional value was left out, it will still be included in this list
 	 *            holding the default value of the desired type, which usually depends on the event.

--- a/src/main/java/ch/njol/skript/lang/util/SimpleExpression.java
+++ b/src/main/java/ch/njol/skript/lang/util/SimpleExpression.java
@@ -5,6 +5,7 @@ import ch.njol.skript.SkriptAPIException;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.config.Node;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.Loopable;
@@ -18,11 +19,11 @@ import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.converter.Converter;
+import org.skriptlang.skript.log.runtime.SyntaxRuntimeErrorProducer;
 
 import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.List;
 import java.util.function.Predicate;
 
 /**
@@ -30,11 +31,18 @@ import java.util.function.Predicate;
  *
  * @see Skript#registerExpression(Class, Class, ExpressionType, String...)
  */
-public abstract class SimpleExpression<T> implements Expression<T> {
+public abstract class SimpleExpression<T> implements Expression<T>, SyntaxRuntimeErrorProducer {
 
 	private int time = 0;
+	private Node node;
 
 	protected SimpleExpression() {}
+
+	@Override
+	public boolean preInit() {
+		node = getParser().getNode();
+		return Expression.super.preInit();
+	}
 
 	@Override
 	public final @Nullable T getSingle(Event event) {
@@ -331,6 +339,11 @@ public abstract class SimpleExpression<T> implements Expression<T> {
 	}
 
 	@Override
+	public Node getNode() {
+		return node;
+	}
+
+	@Override
 	public Expression<? extends T> simplify() {
 		return this;
 	}
@@ -344,4 +357,5 @@ public abstract class SimpleExpression<T> implements Expression<T> {
 	public boolean supportsLoopPeeking() {
 		return true;
 	}
+
 }

--- a/src/main/java/org/skriptlang/skript/bukkit/tags/elements/ExprTag.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/tags/elements/ExprTag.java
@@ -1,13 +1,7 @@
 package org.skriptlang.skript.bukkit.tags.elements;
 
 import ch.njol.skript.Skript;
-import ch.njol.skript.config.Node;
-import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
-import ch.njol.skript.doc.Keywords;
-import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.RequiredPlugins;
-import ch.njol.skript.doc.Since;
+import ch.njol.skript.doc.*;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.Literal;
@@ -23,7 +17,6 @@ import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.bukkit.tags.TagModule;
 import org.skriptlang.skript.bukkit.tags.TagType;
 import org.skriptlang.skript.bukkit.tags.sources.TagOrigin;
-import org.skriptlang.skript.log.runtime.SyntaxRuntimeErrorProducer;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -53,7 +46,7 @@ import java.util.List;
 @Since("2.10")
 @RequiredPlugins("Paper (paper tags)")
 @Keywords({"blocks", "minecraft tag", "type", "category"})
-public class ExprTag extends SimpleExpression<Tag> implements SyntaxRuntimeErrorProducer {
+public class ExprTag extends SimpleExpression<Tag> {
 
 	static {
 		Skript.registerExpression(ExprTag.class, Tag.class, ExpressionType.COMBINED,
@@ -65,8 +58,6 @@ public class ExprTag extends SimpleExpression<Tag> implements SyntaxRuntimeError
 	private TagOrigin origin;
 	private boolean datapackOnly;
 
-	private Node node;
-
 	@Override
 	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		//noinspection unchecked
@@ -74,7 +65,6 @@ public class ExprTag extends SimpleExpression<Tag> implements SyntaxRuntimeError
 		types = TagType.fromParseMark(parseResult.mark);
 		origin = TagOrigin.fromParseTags(parseResult.tags);
 		datapackOnly = origin == TagOrigin.BUKKIT && parseResult.hasTag("datapack");
-		node = getParser().getNode();
 		return true;
 	}
 
@@ -140,11 +130,6 @@ public class ExprTag extends SimpleExpression<Tag> implements SyntaxRuntimeError
 	@SuppressWarnings("rawtypes")
 	public Class<? extends Tag> getReturnType() {
 		return Tag.class;
-	}
-
-	@Override
-	public Node getNode() {
-		return node;
 	}
 
 	@Override


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

I first ran into this issue with runtime errors, where I wanted code to run in init for all expressions. This was not possible for any class but SimplePropertyExpression, as it was the only one that used a separate init method for children and therefore could run code for all children.

This adds a preinit() method to SyntaxElement that is called just before init() and is intended to allow any syntax element the chance to do checks or work that should be consistent across children, without needing to change the signature of init() for the children or force all implementations to call super.init().

I also took the opportunity to separate ERS and ExprimentalSyntax's logic in SkriptParser into helper methods for clarity.

This PR includes changes to runtime errors to showcase the utility of preinit. It's not ideal, as I'd like to get the node in Expression, but state isn't allowed in interfaces so SimpleExpression it is.

I welcome feedback about whether this is necessary or if there are better ways to implement this kind of feature.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
