### PR TITLE
Add since tag onto ExprWithItemFlags for "all itemflags"

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprWithItemFlags.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprWithItemFlags.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.Nullable;
 	"give player torch with hide placed on item flag",
 	"set {_item} to diamond sword with all item flags"
 })
-@Since("2.10")
+@Since("2.10, 2.11 (all itemflags)")
 public class ExprWithItemFlags extends SimpleExpression<ItemType> {
 
 	static {


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

This PR aims to add a since value for "all item flags" onto the `ExprWithItemFlags` class, I've applied 2.11 since it was merged in this release. The decision to change this was to prevent further confusion between users on older versions

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
