### PR TITLE
Expose EntryValidator within ContainerEntryData 😊

### DIFF
--- a/src/main/java/org/skriptlang/skript/lang/entry/ContainerEntryData.java
+++ b/src/main/java/org/skriptlang/skript/lang/entry/ContainerEntryData.java
@@ -25,6 +25,10 @@ public class ContainerEntryData extends EntryData<EntryContainer> {
 		this.entryValidator = validatorBuilder.build();
 	}
 
+	public EntryValidator getEntryValidator() {
+		return entryValidator;
+	}
+
 	@Override
 	public @Nullable EntryContainer getValue(Node node) {
 		return entryContainer;


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

This PR aims to expose the entry validator within container entry data, main goal of this decision was to offer documentation sites easier access to this without further reflection than already needed.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7783 <!-- Links to related issues -->
