### PR TITLE
Use NamespacedKeys instead of Material ordinals for ItemData serialization

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/ItemData.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemData.java
@@ -11,7 +11,6 @@ import ch.njol.yggdrasil.Fields;
 import ch.njol.yggdrasil.YggdrasilSerializable.YggdrasilExtendedSerializable;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.data.BlockData;
@@ -565,7 +564,7 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 	@Override
 	public Fields serialize() throws NotSerializableException {
 		Fields fields = new Fields(this); // ItemStack is transient, will be ignored
-		fields.putObject("key", type.getKey());
+		fields.putObject("key", type.getKey().toString());
 		fields.putObject("meta", stack != null ? stack.getItemMeta() : null);
 		return fields;
 	}
@@ -575,10 +574,10 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 	@Override
 	public void deserialize(Fields fields) throws StreamCorruptedException, NotSerializableException {
 		if (fields.hasField("key")) {
-			NamespacedKey key = fields.getAndRemoveObject("key", NamespacedKey.class);
+			String key = fields.getAndRemoveObject("key", String.class);
 			if (key == null)
 				throw new StreamCorruptedException("Material key is null");
-			this.type = Material.matchMaterial(key.toString());
+			this.type = Material.matchMaterial(key);
 		} else {
 			// attempt back compat deserialization, though using ordinals is not reliable
 			this.type = materials[fields.getAndRemovePrimitive("id", int.class)];


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Material ordinals change between versions and cannot be relied upon for serialization.
This uses getKey to serialize and matchMaterial to deserialize.

We should recommend users upgrade to 2.11 without changing their minecraft version and run the server at least once before changing versions.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7789 <!-- Links to related issues -->
