### PR TITLE
Fix SectionExpression errors not appearing in the final log.

### DIFF
--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -1005,11 +1005,6 @@ public class ScriptLoader {
 					// restore the failure log
 					if (errors.isEmpty()) {
 						handler.restore(backup);
-					} else { // We specifically want these two errors in preference to the section error!
-						String firstError = errors.iterator().next().getMessage();
-						if (!firstError.contains("is a valid statement but cannot function as a section (:)")
-							&& !firstError.contains("You cannot have two section-starters in the same line"))
-							handler.restore(backup);
 					}
 					continue;
 				} finally {

--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -1003,7 +1003,7 @@ public class ScriptLoader {
 					Collection<LogEntry> errors = handler.getErrors();
 
 					// restore the failure log
-					if (errors.isEmpty()) {
+					if (errors.isEmpty() || errors.iterator().next().getMessage().contains("Can't understand this condition/effect:")) {
 						handler.restore(backup);
 					}
 					continue;

--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -1002,8 +1002,14 @@ public class ScriptLoader {
 						break find_section;
 					Collection<LogEntry> errors = handler.getErrors();
 
-					// restore the failure log
-					if (errors.isEmpty() || errors.iterator().next().getMessage().contains("Can't understand this condition/effect:")) {
+					// restore the failure log if:
+					// 1. there are no errors from the statement parse
+					// 2. the error message is the default one from the statement parse
+					// 3. the backup log contains a message about the section being claimed
+					if (errors.isEmpty()
+						|| errors.iterator().next().getMessage().contains("Can't understand this condition/effect:")
+						|| backup.getErrors().iterator().next().getMessage().contains("tried to claim the current section, but it was already claimed by")
+					) {
 						handler.restore(backup);
 					}
 					continue;

--- a/src/test/skript/tests/misc/expression sections.sk
+++ b/src/test/skript/tests/misc/expression sections.sk
@@ -50,4 +50,4 @@ test "expression sections that don't work":
 	parse:
 		if {_var} is a new runnable:
 			broadcast "NO BAD"
-	assert last parse logs contain {_expected} with "section was allowed with multiple headers"
+	assert last parse logs contain {_expected} with "section was allowed with multiple headers: %last parse logs%"


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Failed SE parses would have their errors overwritten by the errors from a previous Section parse. 
This was likely to avoid errors like:
![image](https://github.com/user-attachments/assets/7baa6bdb-c23d-4743-bc25-8101a0197938)
However, this meant that all errors produced intentionally by SectionExpressions would never see the light of day.
This PR reverses that policy by only overwriting the "Can't understand this condition/effect" error:
![image](https://github.com/user-attachments/assets/a79c7797-ef3e-4b62-9b37-84fb516ad82e)


---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7792 <!-- Links to related issues -->
