### PR TITLE
Prevent crash when loading bad blockdata

### DIFF
--- a/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/block/NewBlockCompat.java
@@ -1,8 +1,6 @@
 package ch.njol.skript.bukkitutil.block;
 
 import ch.njol.skript.Skript;
-import ch.njol.skript.aliases.Aliases;
-import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.aliases.MatchQuality;
 import ch.njol.skript.bukkitutil.ItemUtils;
 import ch.njol.skript.variables.Variables;
@@ -119,7 +117,11 @@ public class NewBlockCompat implements BlockCompat {
 			if (data == null)
 				throw new StreamCorruptedException("'data' is missing.");
 
-			this.data = Bukkit.createBlockData(data);
+			try {
+				this.data = Bukkit.createBlockData(data);
+			} catch (IllegalArgumentException e) {
+				throw new StreamCorruptedException("Invalid block data: " + data);
+			}
 			this.type = this.data.getMaterial();
 			this.isDefault = isDefault;
 		}


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Prevents crash when loading blockdata that's no longer valid (see changes to creaking heart blockdata between 1.21.3 and 1.21.4).
Previously, Skript would hard crash if it encountered this. Now, it fails to load just that variable and everything else is normal.
![image](https://github.com/user-attachments/assets/60b911a3-0552-4afc-85da-7516a2e77dc3)

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
