### PR TITLE
Expand Custom Model Data syntaxes to support new CMD component

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondHasCustomModelData.java
+++ b/src/main/java/ch/njol/skript/conditions/CondHasCustomModelData.java
@@ -1,32 +1,64 @@
 package ch.njol.skript.conditions;
 
-import org.bukkit.inventory.meta.ItemMeta;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.conditions.base.PropertyCondition;
-import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
-import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.RequiredPlugins;
-import ch.njol.skript.doc.Since;
+import ch.njol.skript.doc.*;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.components.CustomModelDataComponent;
+
+import java.util.Locale;
 
 @Name("Has Custom Model Data")
 @Description("Check if an item has a custom model data tag")
 @Examples("player's tool has custom model data")
-@RequiredPlugins("1.14+")
-@Since("2.5")
+@Since("2.5, INSERT VERSION (expanded data types)")
+@RequiredPlugins("1.21.4+ (floats/flags/strings/colours)")
 public class CondHasCustomModelData extends PropertyCondition<ItemType> {
 	
 	static {
-		if (Skript.methodExists(ItemMeta.class, "hasCustomModelData")) {
+		if (Skript.methodExists(ItemMeta.class, "getCustomModelDataComponent")) {
+			// new style
+			register(CondHasCustomModelData.class, PropertyType.HAVE, "[custom] model data [1:floats|2:flags|3:strings|4:colo[u]rs]", "itemtypes");
+		} else {
+			// old style
 			register(CondHasCustomModelData.class, PropertyType.HAVE, "[custom] model data", "itemtypes");
 		}
 	}
-	
+
+	private enum CMDType {
+		ANY,
+		FLOATS,
+		FLAGS,
+		STRINGS,
+		COLORS
+	}
+
+	private CMDType dataType;
+
 	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		dataType = CMDType.values()[parseResult.mark];
+		return super.init(expressions, matchedPattern, isDelayed, parseResult);
+	}
+
+	@Override
+	@SuppressWarnings("UnstableApiUsage")
 	public boolean check(ItemType item) {
-		return item.getItemMeta().hasCustomModelData();
+		ItemMeta meta = item.getItemMeta();
+		if (dataType == CMDType.ANY)
+			return meta.hasCustomModelData();
+		CustomModelDataComponent component = meta.getCustomModelDataComponent();
+		return switch (dataType) {
+			case FLOATS -> !component.getFloats().isEmpty();
+			case FLAGS -> !component.getFlags().isEmpty();
+			case STRINGS -> !component.getStrings().isEmpty();
+			case COLORS -> !component.getColors().isEmpty();
+			case ANY -> throw new IllegalStateException("Wrong path for CMDType.ANY.");
+		};
 	}
 
 	@Override
@@ -36,7 +68,7 @@ public class CondHasCustomModelData extends PropertyCondition<ItemType> {
 
 	@Override
 	protected String getPropertyName() {
-		return "custom model data";
+		return "custom model data" + (dataType != CMDType.ANY ? " " + dataType.name().toLowerCase(Locale.ENGLISH) : "");
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprCustomModelData.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCustomModelData.java
@@ -1,88 +1,321 @@
 package ch.njol.skript.expressions;
 
-import org.bukkit.event.Event;
-import org.bukkit.inventory.meta.ItemMeta;
-import org.jetbrains.annotations.Nullable;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
-import ch.njol.skript.classes.Changer;
+import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.RequiredPlugins;
 import ch.njol.skript.doc.Since;
-import ch.njol.skript.expressions.base.SimplePropertyExpression;
-import ch.njol.util.coll.CollectionUtils;
+import ch.njol.skript.expressions.base.PropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.util.Color;
+import ch.njol.skript.util.ColorRGB;
+import ch.njol.skript.util.Utils;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.components.CustomModelDataComponent;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 @Name("Custom Model Data")
-@Description("Get/set the CustomModelData tag for an item. (Value is an integer between 0 and 99999999)")
-@Examples({"set custom model data of player's tool to 3",
-	"set {_model} to custom model data of player's tool"})
-@RequiredPlugins("1.14+")
-@Since("2.5")
-public class ExprCustomModelData extends SimplePropertyExpression<ItemType, Long> {
-	
+@Description({
+	"Get/set the custom model data of an item. Using just `custom model data` will return an integer. Items without model data will return 0.",
+	"In 1.21.4+, though, custom model data is extended to include a list of numbers (floats), a list of booleans (flags), a list of strings, and a list of colours. " +
+	"Accessing and modifying these lists can be done type-by-type, or all at once with `complete custom model data`. " +
+	"This is the more accurate and recommended method of using custom model data."
+})
+@Example("""
+	set custom model data of player's tool to 3
+	set {_model} to custom model data of player's tool
+	""")
+@Example("""
+	set custom model data colours of {_flag} to red, white, and blue
+	add 10.5 to the model data floats of {_flag}
+	""")
+@Example("""
+	set the full custom model data of {_item} to 10, "sword", and rgb(100, 200, 30)
+	""")
+@Since({"2.5","INSERT VERSION (component support)"})
+public class ExprCustomModelData extends PropertyExpression<ItemType, Object> {
+
+	private static final boolean USE_NEW_CMD = Skript.classExists("org.bukkit.inventory.meta.components.CustomModelDataComponent");
+
 	static {
-		if (Skript.methodExists(ItemMeta.class, "hasCustomModelData")) {
-			register(ExprCustomModelData.class, Long.class, "[custom] model data", "itemtypes");
+		if (USE_NEW_CMD) {
+			List<String> patterns = new ArrayList<>();
+			patterns.addAll(Arrays.asList(PropertyExpression.getPatterns("[custom] model data", "itemtypes")));
+			patterns.addAll(Arrays.asList(PropertyExpression.getPatterns("[custom] model data (1:floats|2:flags|3:strings|4:colo[u]rs)", "itemtype")));
+			patterns.addAll(Arrays.asList(PropertyExpression.getPatterns("(5:(complete|full)) [custom] model data", "itemtype")));
+			Skript.registerExpression(ExprCustomModelData.class, Object.class, ExpressionType.PROPERTY, patterns.toArray(String[]::new));
+		} else {
+			register(ExprCustomModelData.class, Object.class, "[custom] model data", "itemtypes");
 		}
 	}
-	
-	@Override
-	public Long convert(ItemType item) {
-		ItemMeta meta = item.getItemMeta();
-		assert meta != null;
-		if (meta.hasCustomModelData())
-			return (long) meta.getCustomModelData();
-		else
-			return 0L;
+
+	private enum CMDType {
+		SINGLE_INT(Integer.class),
+		FLOATS(Float.class),
+		FLAGS(Boolean.class),
+		STRINGS(String.class),
+		COLORS(Color.class),
+		ALL(Float.class, Boolean.class, String.class, Color.class);
+
+		private final Class<?> supertype;
+		private final Class<?>[] types;
+
+		CMDType(Class<?>... returns) {
+			this.types = returns;
+			this.supertype = Utils.getSuperType(returns);
+		}
 	}
-	
+
+	private CMDType dataType;
+
 	@Override
-	public Class<? extends Long> getReturnType() {
-		return Long.class;
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		dataType = CMDType.values()[parseResult.mark];
+		//noinspection unchecked
+		setExpr((Expression<? extends ItemType>) expressions[0]);
+		return true;
 	}
-	
+
+
 	@Override
-	public Class<?>[] acceptChange(Changer.ChangeMode mode) {
-		return CollectionUtils.array(Number.class);
-	}
-	
-	@Override
-	protected String getPropertyName() {
-		return "custom model data";
-	}
-	
-	@Override
-	public void change(Event e, @Nullable Object[] delta, Changer.ChangeMode mode) {
-		long data = delta == null ? 0 : ((Number) delta[0]).intValue();
-		if (data > 99999999 || data < 0) data = 0;
-		for (ItemType item : getExpr().getArray(e)) {
-			long oldData = 0;
-			ItemMeta meta = item.getItemMeta();
-			if (meta.hasCustomModelData())
-				oldData = meta.getCustomModelData();
-			switch (mode) {
-				case ADD:
-					data = oldData + data;
-					break;
-				case REMOVE:
-					data = oldData - data;
-					break;
-				case DELETE:
-				case RESET:
-				case REMOVE_ALL:
-					data = 0;
+	@SuppressWarnings("UnstableApiUsage")
+	protected Object[] get(Event event, ItemType[] source) {
+		for (ItemType from : source) {
+			ItemMeta meta = from.getItemMeta();
+			if (dataType == CMDType.SINGLE_INT) {
+				if (meta.hasCustomModelData() && (!USE_NEW_CMD || !meta.getCustomModelDataComponent().getFloats().isEmpty()))
+					return new Integer[]{meta.getCustomModelData()};
+				return new Integer[]{0};
 			}
-			meta.setCustomModelData((int) data);
+
+			CustomModelDataComponent component = meta.getCustomModelDataComponent();
+			return switch (dataType) {
+				case SINGLE_INT -> throw new IllegalStateException("unreachable state for SINGLE_INT!");
+				case FLOATS -> component.getFloats().toArray(Float[]::new);
+				case FLAGS -> component.getFlags().toArray(Boolean[]::new);
+				case STRINGS -> component.getStrings().toArray(String[]::new);
+				case COLORS ->
+					component.getColors().stream().map(ColorRGB::fromBukkitColor).toList().toArray(ColorRGB[]::new);
+				case ALL -> {
+					List<Object> data = new ArrayList<>();
+					data.addAll(component.getFloats());
+					data.addAll(component.getFlags());
+					data.addAll(component.getStrings());
+					data.addAll(component.getColors().stream().map(ColorRGB::fromBukkitColor).toList());
+					yield data.toArray(Object[]::new);
+				}
+			};
+		}
+		throw new IllegalStateException("Unreachable state! Either source was an empty array or something horrible happened.");
+	}
+
+	@Override
+	public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
+		return switch (mode) {
+			case ADD, REMOVE, REMOVE_ALL, SET, DELETE, RESET -> {
+				// convert to array types to allow plural changes.
+				Class<?>[] arrayClasses = new Class[dataType.types.length];
+				for (int i = 0; i < dataType.types.length; i++) {
+					arrayClasses[i] = dataType.types[i].arrayType();
+				}
+				yield arrayClasses;
+			}
+			default -> null;
+		};
+	}
+
+	@Override
+	public void change(Event event, Object @Nullable [] delta, ChangeMode mode) {
+		for (ItemType item : getExpr().getArray(event)) {
+			ItemMeta meta = item.getItemMeta();
+			switch (dataType) {
+				case SINGLE_INT -> {
+					long deltaValue = delta == null ? 0 : ((Number) delta[0]).intValue();
+					changeOld(meta, mode, deltaValue);
+				}
+				case FLAGS, COLORS, STRINGS, FLOATS -> changeSingleType(meta, mode, delta);
+				case ALL -> changeAll(meta, mode, delta);
+			}
 			item.setItemMeta(meta);
 		}
 	}
-	
-	@Override
-	public String toString(@Nullable Event e, boolean d) {
-		return "custom model data of " + getExpr().toString(e, d);
+
+	/**
+	 * Changes the custom model data of an ItemMeta using <=1.21.3 methods.
+	 * @param meta The meta to change
+	 * @param mode The mode to change with
+	 * @param delta The delta value
+	 */
+	private void changeOld(ItemMeta meta, ChangeMode mode, long delta) {
+		// shortcut for delete/reset
+		if (mode == ChangeMode.DELETE || mode == ChangeMode.RESET) {
+			meta.setCustomModelData(null);
+			return;
+		}
+		long oldData = 0;
+		if (meta.hasCustomModelData()) {
+			//noinspection UnstableApiUsage
+			if (!USE_NEW_CMD || !meta.getCustomModelDataComponent().getFloats().isEmpty())
+				oldData = meta.getCustomModelData();
+		}
+
+		switch (mode) {
+			case REMOVE, REMOVE_ALL:
+				delta = -delta;
+			case ADD:
+				delta = oldData + delta;
+				meta.setCustomModelData((int) delta);
+				break;
+			case SET:
+				meta.setCustomModelData((int) delta);
+				break;
+		}
 	}
-	
+
+	/**
+	 * Changes a single type of custom model data of an ItemMeta.
+	 * @param meta The meta to change
+	 * @param mode The mode to change with
+	 * @param delta The values to add/remove/set
+	 */
+	@SuppressWarnings("UnstableApiUsage")
+	private <T> void changeSingleType(ItemMeta meta, ChangeMode mode, T @Nullable [] delta) {
+		if (delta == null && mode != ChangeMode.DELETE && mode != ChangeMode.RESET)
+			return;
+
+		CustomModelDataComponent component = meta.getCustomModelDataComponent();
+		// create the list from existing data
+		// we can be sure the values are of the proper types
+		//noinspection unchecked
+		List<T> data = new ArrayList<>((List<T>) switch (dataType) {
+			case FLOATS -> component.getFloats();
+			case FLAGS -> component.getFlags();
+			case STRINGS -> component.getStrings();
+			case COLORS -> component.getColors().stream().map(ColorRGB::fromBukkitColor).toList();
+			default -> throw new IllegalStateException("Wrong changemode for changeSingleType");
+		});
+
+		// edit the list
+		switch (mode) {
+			case REMOVE -> data.removeAll(Arrays.asList(delta));
+			case ADD -> data.addAll(Arrays.asList(delta));
+			case SET -> data = Arrays.asList(delta);
+			case RESET, DELETE -> data.clear();
+		}
+
+		// edit the component
+		switch (dataType) {
+			case FLOATS -> //noinspection unchecked
+				component.setFloats((List<Float>) data);
+			case FLAGS -> //noinspection unchecked
+				component.setFlags((List<Boolean>) data);
+			case STRINGS -> //noinspection unchecked
+				component.setStrings((List<String>) data);
+			case COLORS -> component.setColors(data.stream().map(colorRGB -> ((ColorRGB) colorRGB).asBukkitColor()).toList());
+		}
+		meta.setCustomModelDataComponent(component);
+	}
+
+	/**
+	 * Changes all the types of custom model data of an ItemMeta.
+	 * @param meta The meta to change
+	 * @param mode The mode to change with
+	 * @param delta The values to add/remove/set
+	 */
+	@SuppressWarnings("UnstableApiUsage")
+	private void changeAll(ItemMeta meta, ChangeMode mode, Object @Nullable [] delta) {
+		// shortcut for delete/reset
+		if (mode == ChangeMode.DELETE || mode == ChangeMode.RESET) {
+			meta.setCustomModelDataComponent(null);
+			return;
+		}
+
+		if (delta == null)
+			return;
+
+		CustomModelDataComponent component = meta.getCustomModelDataComponent();
+		List<Float> floats = new ArrayList<>(component.getFloats());
+		List<Boolean> flags = new ArrayList<>(component.getFlags());
+		List<String> strings = new ArrayList<>(component.getStrings());
+		List<Color> colors = new ArrayList<>(component.getColors().stream().map(ColorRGB::fromBukkitColor).toList());
+
+		// sort delta into the necessary lists
+		switch (mode) {
+			case REMOVE:
+				for (Object deltaValue : delta) {
+					if (deltaValue instanceof Float) {
+						floats.remove(deltaValue);
+					} else if (deltaValue instanceof Boolean) {
+						flags.remove(deltaValue);
+					} else if (deltaValue instanceof String) {
+						strings.remove(deltaValue);
+					} else if (deltaValue instanceof Color) {
+						colors.remove(deltaValue);
+					}
+				}
+				break;
+			case SET:
+				floats.clear();
+				flags.clear();
+				strings.clear();
+				colors.clear();
+			case ADD:
+				for (Object deltaValue : delta) {
+					if (deltaValue instanceof Float aFloat) {
+						floats.addLast(aFloat);
+					} else if (deltaValue instanceof Boolean aBoolean) {
+						flags.addLast(aBoolean);
+					} else if (deltaValue instanceof String string) {
+						strings.addLast(string);
+					} else if (deltaValue instanceof Color color) {
+						colors.addLast(color);
+					}
+				}
+				break;
+		}
+		// reconstruct the component
+		component.setFloats(floats);
+		component.setFlags(flags);
+		component.setStrings(strings);
+		component.setColors(colors.stream().map(Color::asBukkitColor).toList());
+		meta.setCustomModelDataComponent(component);
+	}
+
+	@Override
+	public boolean isSingle() {
+		return dataType == CMDType.SINGLE_INT && getExpr().isSingle();
+	}
+
+	@Override
+	public Class<?> getReturnType() {
+		return dataType.supertype;
+	}
+
+	@Override
+	public Class<?>[] possibleReturnTypes() {
+		return dataType.types;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return switch (dataType) {
+			case ALL -> "complete custom model data";
+			case FLOATS -> "custom model data floats";
+			case FLAGS -> "custom model data flags";
+			case STRINGS -> "custom model data strings";
+			case COLORS -> "custom model data colors";
+			case SINGLE_INT -> "custom model data";
+		} + " of " + getExpr().toString(event, debug);
+	}
+
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprItemWithCustomModelData.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprItemWithCustomModelData.java
@@ -1,58 +1,98 @@
 package ch.njol.skript.expressions;
 
-import org.bukkit.event.Event;
-import org.bukkit.inventory.meta.ItemMeta;
-import org.jetbrains.annotations.Nullable;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
-import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
-import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.RequiredPlugins;
-import ch.njol.skript.doc.Since;
+import ch.njol.skript.doc.*;
 import ch.njol.skript.expressions.base.PropertyExpression;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.util.Color;
 import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.Nullable;
 
-@Name("Item with CustomModelData")
-@Description("Get an item with a CustomModelData tag. (Value is an integer between 0 and 99999999)")
-@Examples({"give player a diamond sword with custom model data 2",
-	"set slot 1 of inventory of player to wooden hoe with custom model data 357"})
-@RequiredPlugins("1.14+")
-@Since("2.5")
+import java.util.ArrayList;
+import java.util.List;
+
+@Name("Item with Custom Model Data")
+@Description("Get an item with custom model data.")
+@Example("give player a diamond sword with custom model data 2")
+@Example("set slot 1 of inventory of player to wooden hoe with custom model data 357")
+@Example("give player a diamond hoe with custom model data 2, true, true, \"scythe\", and rgb(0,0,100)")
+@RequiredPlugins("1.21.4+ (boolean/string/color support)")
+@Since({"2.5", "INSERT VERSION (boolean/string/color support)"})
 public class ExprItemWithCustomModelData extends PropertyExpression<ItemType, ItemType> {
-	
+
+	private static final boolean USE_NEW_CMD = Skript.classExists("org.bukkit.inventory.meta.components.CustomModelDataComponent");
+
 	static {
-		if (Skript.methodExists(ItemMeta.class, "hasCustomModelData")) {
+		if (USE_NEW_CMD) {
+			Skript.registerExpression(ExprItemWithCustomModelData.class, ItemType.class, ExpressionType.PROPERTY,
+				"%itemtype% with [custom] model data %numbers/booleans/strings/colors%");
+		} else {
 			Skript.registerExpression(ExprItemWithCustomModelData.class, ItemType.class, ExpressionType.PROPERTY,
 				"%itemtype% with [custom] model data %number%");
 		}
 	}
 	
 	@SuppressWarnings("null")
-	private Expression<Number> data;
+	private Expression<?> data;
 	
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
-	public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, ParseResult parseResult) {
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean kleenean, ParseResult parseResult) {
 		setExpr((Expression<ItemType>) exprs[0]);
-		data = (Expression<Number>) exprs[1];
+		data = exprs[1];
 		return true;
 	}
-	
+
 	@Override
-	protected ItemType[] get(Event e, ItemType[] source) {
-		Number data = this.data.getSingle(e);
-		if (data == null)
+	@SuppressWarnings("UnstableApiUsage")
+	protected ItemType[] get(Event event, ItemType[] source) {
+		Object[] data = this.data.getArray(event);
+		if (data.length == 0)
 			return source;
-		return get(source.clone(), item -> {
-			ItemMeta meta = item.getItemMeta();
-			meta.setCustomModelData(data.intValue());
-			item.setItemMeta(meta);
-			return item;
+		if (!USE_NEW_CMD) {
+			return get(source, item -> {
+				ItemType clone = item.clone();
+				ItemMeta meta = clone.getItemMeta();
+				meta.setCustomModelData(((Number) data[0]).intValue());
+				clone.setItemMeta(meta);
+				return clone;
+			});
+		}
+		//create lists
+		List<Float> floats = new ArrayList<>();
+		List<Boolean> flags = new ArrayList<>();
+		List<String> strings = new ArrayList<>();
+		List<Color> colors = new ArrayList<>();
+		// populate lists
+		//noinspection DuplicatedCode
+		for (Object dataValue : data) {
+			if (dataValue instanceof Number number) {
+				floats.addLast(number.floatValue());
+			} else if (dataValue instanceof Boolean aBoolean) {
+				flags.addLast(aBoolean);
+			} else if (dataValue instanceof String string) {
+				strings.addLast(string);
+			} else if (dataValue instanceof Color color) {
+				colors.addLast(color);
+			}
+		}
+		// edit items
+		return get(source, item -> {
+			ItemType clone = item.clone();
+			ItemMeta meta = clone.getItemMeta();
+			var component = meta.getCustomModelDataComponent();
+			component.setFloats(floats);
+			component.setFlags(flags);
+			component.setStrings(strings);
+			component.setColors(colors.stream().map(Color::asBukkitColor).toList());
+			meta.setCustomModelDataComponent(component);
+			clone.setItemMeta(meta);
+			return clone;
 		});
 	}
 	
@@ -62,8 +102,8 @@ public class ExprItemWithCustomModelData extends PropertyExpression<ItemType, It
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean d) {
-		return getExpr().toString(e, d) + " with custom model data " + data.toString(e, d);
+	public String toString(@Nullable Event event, boolean debug) {
+		return getExpr().toString(event, debug) + " with custom model data " + data.toString(event, debug);
 	}
 	
 }

--- a/src/test/skript/tests/syntaxes/conditions/CondHasCustomModelData.sk
+++ b/src/test/skript/tests/syntaxes/conditions/CondHasCustomModelData.sk
@@ -1,0 +1,28 @@
+test "old custom model data":
+	set {_item} to a diamond sword with model data 1
+	assert {_item} has custom model data with "false negative for model data"
+	clear custom model data of {_item}
+	assert {_item} doesn't have custom model data with "false positive for model data"
+
+test "new custom model data" when running minecraft "1.21.4":
+	set {_item} to a diamond sword
+
+	set full model data of {_item} to 1
+	assert {_item} has custom model data with "false negative for float model data"
+	clear full model data of {_item}
+	assert {_item} doesn't have custom model data with "false positive for float model data"
+
+	set full model data of {_item} to "1"
+	assert {_item} has custom model data with "false negative for string model data"
+	clear full model data of {_item}
+	assert {_item} doesn't have custom model data with "false positive for string model data"
+
+	set full model data of {_item} to true
+	assert {_item} has custom model data with "false negative for boolean model data"
+	clear full model data of {_item}
+	assert {_item} doesn't have custom model data with "false positive for boolean model data"
+
+	set full model data of {_item} to rgb(1,1,1)
+	assert {_item} has custom model data with "false negative for color model data"
+	clear full model data of {_item}
+	assert {_item} doesn't have custom model data with "false positive for color model data"

--- a/src/test/skript/tests/syntaxes/expressions/ExprCustomModelData.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprCustomModelData.sk
@@ -1,7 +1,65 @@
-test "custom model data expressions/condition":
+test "old custom model data expression":
 	set {_item} to a diamond sword with custom model data 456
 	assert {_item} has custom model data with "{_item} does not have custom model data"
-	if {_item} has custom model data:
-		assert custom model data of {_item} = 456 with "{_item}'s custom model data != 456: %custom model data of {_item}%"
-		set custom model data of {_item} to 987
-		assert custom model data of {_item} = 987 with "{_item}'s custom model data != 987: %custom model data of {_item}%"
+	assert custom model data of {_item} = 456 with "{_item}'s custom model data != 456: %custom model data of {_item}%"
+	set custom model data of {_item} to 987
+	assert custom model data of {_item} = 987 with "{_item}'s custom model data != 987: %custom model data of {_item}%"
+
+test "new custom model data expression" when running minecraft "1.21.4":
+	set {_item} to a diamond sword with custom model data 456 and 52
+
+	assert model data of {_item} is 456 with "wrong model data"
+	assert full model data of {_item} is 456 and 52 with "wrong full model data"
+	assert model data floats of {_item} is 456 and 52 with "wrong model data floats"
+	assert model data flags of {_item} is not set with "wrong model data flags"
+	assert model data strings of {_item} is not set with "wrong model data strings"
+	assert model data colours of {_item} is not set with "wrong model data colours"
+
+	set model data strings of {_item} to "hello" and "world"
+	assert model data of {_item} is 456 with "wrong model data"
+	broadcast full model data of {_item}
+	assert full model data of {_item} is 456, 52, "hello", and "world" with "wrong full model data"
+	assert model data floats of {_item} is 456 and 52 with "wrong model data floats"
+	assert model data flags of {_item} is not set with "wrong model data flags"
+	assert model data strings of {_item} is "hello" and "world" with "wrong model data strings"
+	assert model data colours of {_item} is not set with "wrong model data colours"
+
+	add true to model data flags of {_item}
+	assert model data of {_item} is 456 with "wrong model data"
+	assert full model data of {_item} is 456, 52, true, "hello" and "world" with "wrong full model data"
+	assert model data floats of {_item} is 456 and 52 with "wrong model data floats"
+	assert model data flags of {_item} is true with "wrong model data flags"
+	assert model data strings of {_item} is "hello" and "world" with "wrong model data strings"
+	assert model data colours of {_item} is not set with "wrong model data colours"
+
+	remove "hello" from model data strings of {_item}
+	assert model data of {_item} is 456 with "wrong model data"
+	assert full model data of {_item} is 456, 52, true, and "world" with "wrong full model data"
+	assert model data floats of {_item} is 456 and 52 with "wrong model data floats"
+	assert model data flags of {_item} is true with "wrong model data flags"
+	assert model data strings of {_item} is "world" with "wrong model data strings"
+	assert model data colours of {_item} is not set with "wrong model data colours"
+
+	clear model data strings of {_item}
+	assert model data of {_item} is 456 with "wrong model data"
+	assert full model data of {_item} is 456, 52, and true with "wrong full model data"
+	assert model data floats of {_item} is 456 and 52 with "wrong model data floats"
+	assert model data flags of {_item} is true with "wrong model data flags"
+	assert model data strings of {_item} is not set with "wrong model data strings"
+	assert model data colours of {_item} is not set with "wrong model data colours"
+
+	set full model data of {_item} to true, false, 1.0, -5.4, "yes", no, rgb(1,0,1), and white
+	assert model data of {_item} is 1 with "wrong model data"
+	assert full model data of {_item} is 1.0, -5.4, true, false, false, "yes", rgb(1,0,1), and white with "wrong full model data"
+	assert model data floats of {_item} is 1.0 and -5.4 with "wrong model data floats"
+	assert model data flags of {_item} is true, false and false with "wrong model data flags"
+	assert model data strings of {_item} is "yes" with "wrong model data strings"
+	assert model data colours of {_item} is rgb(1,0,1) and white with "wrong model data colours"
+
+	reset full model data of {_item}
+	assert model data of {_item} is 0 with "wrong model data"
+	assert full model data of {_item} is not set with "wrong full model data"
+	assert model data floats of {_item} is not set with "wrong model data floats"
+	assert model data flags of {_item} is not set with "wrong model data flags"
+	assert model data strings of {_item} is not set with "wrong model data strings"
+	assert model data colours of {_item} is not set with "wrong model data colours"


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

All previous behavior should remain the same. 
In 1.21.4+:
-  `with model data %...%` now supports numbers, strings, booleans, and colors. 
- ExprCustomModelData has 3 modes
  - back compat: `custom model data of {_x}`. This remains the same as previous versions, a single int value. Setting this will remove any other CMD data on the item.
  - single type: `custom model data (floats|flags|strings|colors) of {_x}`. This returns a list of the given type from the custom model data and supports all changers.
  - all types: `(full|complete) custom model data of {_x}`. This returns a list of all the values in the CMD, in float-flag-string-color order. This supports all changers.
- CondHasCustomModelData allows checking for any custom model data, or for specific types of custom model data.
---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7782 <!-- Links to related issues -->
