### PR TITLE
Fix StackOverflow in variable parsing

### DIFF
--- a/src/main/java/ch/njol/skript/variables/FlatFileStorage.java
+++ b/src/main/java/ch/njol/skript/variables/FlatFileStorage.java
@@ -531,7 +531,7 @@ public class FlatFileStorage extends VariablesStorage {
 	/**
 	 * A regex pattern of a line in a CSV file.
 	 */
-	private static final Pattern CSV_LINE_PATTERN = Pattern.compile("(?<=^|,)\\s*([^\",]*|\"([^\"]|\"\")*\")\\s*(,|$)");
+	private static final Pattern CSV_LINE_PATTERN = Pattern.compile("(?<=^|,)\\s*([^\",]*|\"([^\"]+|\"\")*\")\\s*(,|$)");
 
 	/**
 	 * Splits the given CSV line into its values.

--- a/src/main/java/ch/njol/skript/variables/FlatFileStorage.java
+++ b/src/main/java/ch/njol/skript/variables/FlatFileStorage.java
@@ -530,8 +530,17 @@ public class FlatFileStorage extends VariablesStorage {
 
 	/**
 	 * A regex pattern of a line in a CSV file.
+	 * <ul>
+	 * <li>{@code (?<=^|,)}: assert that the match is preceded by the start of the line or a comma</li>
+	 * <li>{@code (?:([^",]*)|"((?:[^"]+|"")*)")}: match either a quoted or unquoted value</li>
+	 * <ul>
+	 * 	<li>- {@code ([^",]*)}: match an unquoted value</li>
+	 * 	<li>- {@code "((?:[^"]+|"")*)"}: match a quoted value</li>
+	 * </ul>
+	 * <li>{@code (?:,|$)}: match either a comma or the end of the line</li>
+	 * </ul>
 	 */
-	private static final Pattern CSV_LINE_PATTERN = Pattern.compile("(?<=^|,)\\s*([^\",]*|\"([^\"]+|\"\")*\")\\s*(,|$)");
+	private static final Pattern CSV_LINE_PATTERN = Pattern.compile("(?<=^|,)\\s*(?:([^\",]*)|\"((?:[^\"]+|\"\")*)\")\\s*(?:,|$)");
 
 	/**
 	 * Splits the given CSV line into its values.
@@ -550,14 +559,15 @@ public class FlatFileStorage extends VariablesStorage {
 
 		while (matcher.find()) {
 			if (lastEnd != matcher.start())
-				return null; // other stuff inbetween finds
+				return null; // other stuff in between finds
 
-			String value = matcher.group(1);
-			if (value.startsWith("\""))
-				// Unescape value
-				result.add(value.substring(1, value.length() - 1).replace("\"\"", "\""));
-			else
-				result.add(value.trim());
+			if (matcher.group(1) != null) {
+				// unquoted, leave as is
+				result.add(matcher.group(1).trim());
+			} else {
+				// quoted, remove quotes
+				result.add(matcher.group(2).replace("\"\"", "\""));
+			}
 
 			lastEnd = matcher.end();
 		}


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

The CSV parsing regex is extraordinarily slow at matching quoted variable names, to the point it causes StackOverflows that prevent variables from being loaded at all. This is due to the regex matching checking for "", then matching "" or a single character, and repeat for the next character, until it recurses too far. This PR fixes that by allowing the matching of multiple non-" characters between each "" check.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
