### PR TITLE
ExprAnyOf's acceptChange returning an empty array instead of null.

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprAnyOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAnyOf.java
@@ -36,7 +36,7 @@ public class ExprAnyOf extends WrapperExpression<Object> {
 
 	@Override
 	public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
-		return new Class[0];
+		return null;
 	}
 
 	@Override


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Switches to returning null to avoid assertion errors when trying to add/remove/set ExprAnyOf.
I believe the issue breaks testing for some addons that use skript-test-action

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
