### PR TITLE
RuntimeLogHandler + Runtime Testing Elements

### DIFF
--- a/src/main/java/ch/njol/skript/test/runner/ExprRuntimeErrors.java
+++ b/src/main/java/ch/njol/skript/test/runner/ExprRuntimeErrors.java
@@ -1,0 +1,49 @@
+package ch.njol.skript.test.runner;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.NoDoc;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+@NoDoc
+public class ExprRuntimeErrors extends SimpleExpression<String> {
+
+	static {
+		if (Skript.testing())
+			Skript.registerExpression(ExprRuntimeErrors.class, String.class, ExpressionType.SIMPLE,
+				"last [caught] run[ ]time errors");
+	}
+
+	public static String[] lastErrors;
+
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		return true;
+	}
+
+	@Override
+	protected String @Nullable [] get(Event event) {
+		return lastErrors;
+	}
+
+	@Override
+	public boolean isSingle() {
+		return false;
+	}
+
+	@Override
+	public Class<? extends String> getReturnType() {
+		return String.class;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "last runtime errors";
+	}
+
+}

--- a/src/main/java/ch/njol/skript/test/runner/SecRuntime.java
+++ b/src/main/java/ch/njol/skript/test/runner/SecRuntime.java
@@ -1,0 +1,65 @@
+package ch.njol.skript.test.runner;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.config.SectionNode;
+import ch.njol.skript.doc.NoDoc;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.Section;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.Trigger;
+import ch.njol.skript.lang.TriggerItem;
+import ch.njol.skript.variables.Variables;
+import ch.njol.util.Kleenean;
+import com.google.common.collect.Iterables;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.log.runtime.RuntimeError;
+import org.skriptlang.skript.log.runtime.RuntimeLogHandler;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@NoDoc
+public class SecRuntime extends Section {
+
+	static {
+		if (Skript.testing())
+			Skript.registerSection(SecRuntime.class, "runtime");
+	}
+
+	private Trigger trigger;
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
+		if (Iterables.size(sectionNode) == 0) {
+			Skript.error("A runtime section must contain code.");
+			return false;
+		}
+
+		AtomicBoolean delayed = new AtomicBoolean(false);
+		Runnable afterLoading = () -> delayed.set(!getParser().getHasDelayBefore().isFalse());
+		trigger = loadCode(sectionNode, "runtime", afterLoading, SkriptTestEvent.class);
+		if (delayed.get()) {
+			Skript.error("Delays can't be used within a testing environment.");
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	protected @Nullable TriggerItem walk(Event event) {
+		SkriptTestEvent testEvent = new SkriptTestEvent();
+		RuntimeLogHandler handler = new RuntimeLogHandler().start();
+		Variables.withLocalVariables(event, testEvent, () -> TriggerItem.walk(trigger, testEvent));
+        ExprRuntimeErrors.lastErrors = handler.getErrors().stream().map(RuntimeError::error).toArray(String[]::new);
+		handler.clear();
+		handler.stop();
+		return walk(event, false);
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "runtime";
+	}
+
+}

--- a/src/main/java/org/skriptlang/skript/log/runtime/RuntimeErrorManager.java
+++ b/src/main/java/org/skriptlang/skript/log/runtime/RuntimeErrorManager.java
@@ -161,7 +161,7 @@ public class RuntimeErrorManager implements Closeable {
 	 * @return {@code handler}
 	 */
 	public RuntimeLogHandler startLogHandler(RuntimeLogHandler handler) {
-		RUNTIME_HANDLERS.addFirst(handler);
+		RUNTIME_HANDLERS.add(0, handler);
 		return handler;
 	}
 

--- a/src/main/java/org/skriptlang/skript/log/runtime/RuntimeLogHandler.java
+++ b/src/main/java/org/skriptlang/skript/log/runtime/RuntimeLogHandler.java
@@ -50,7 +50,7 @@ public class RuntimeLogHandler implements OpenCloseable {
 	 * @param error The {@link RuntimeError} to be logged
 	 */
 	public void logError(RuntimeError error) {
-		CACHED_ERRORS.addFirst(error);
+		CACHED_ERRORS.add(0, error);
 	}
 
 	/**

--- a/src/main/java/org/skriptlang/skript/log/runtime/RuntimeLogHandler.java
+++ b/src/main/java/org/skriptlang/skript/log/runtime/RuntimeLogHandler.java
@@ -1,0 +1,110 @@
+package org.skriptlang.skript.log.runtime;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.log.SkriptLogger;
+import ch.njol.util.OpenCloseable;
+import org.jetbrains.annotations.Contract;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RuntimeLogHandler implements OpenCloseable {
+
+	private static final RuntimeErrorManager ERROR_MANAGER = RuntimeErrorManager.getInstance();
+
+	public RuntimeLogHandler() {}
+
+	private final List<RuntimeError> CACHED_ERRORS = new ArrayList<>();
+	private boolean printedErrors = false;
+
+	/**
+	 * Starts the current {@link RuntimeLogHandler} to catch runtime errors.
+	 */
+	public RuntimeLogHandler start() {
+		ERROR_MANAGER.startLogHandler(this);
+		return this;
+	}
+
+	/**
+	 * Stops the current {@link RuntimeLogHandler}
+	 */
+	public RuntimeLogHandler stop() {
+		if (!printedErrors && Skript.testing())
+			SkriptLogger.LOGGER.warning("Runtime log handler was not instructed to print anything.");
+		ERROR_MANAGER.stopLogHandler(this);
+		return this;
+	}
+
+	@Override
+	public void open() {
+		start();
+	}
+
+	@Override
+	public void close() {
+		stop();
+	}
+
+	/**
+	 * Logs a {@link RuntimeError}
+	 * @param error The {@link RuntimeError} to be logged
+	 */
+	public void logError(RuntimeError error) {
+		CACHED_ERRORS.addFirst(error);
+	}
+
+	/**
+	 * Prints all logged {@link RuntimeError}s
+	 * This handler is stopped if not already done.
+	 */
+	public void printErrors() {
+		assert !printedErrors;
+		printedErrors = true;
+		stop();
+		CACHED_ERRORS.forEach(ERROR_MANAGER::error);
+		CACHED_ERRORS.clear();
+	}
+
+	/**
+	 * Check if this {@link RuntimeLogHandler} is stopped and not logging {@link RuntimeError}s
+	 * @return {@code true} if stopped
+	 */
+	public boolean isStopped() {
+		return ERROR_MANAGER.isStopped(this);
+	}
+
+	/**
+	 * Gets the {@link List} of the logged {@link RuntimeError}s
+	 */
+	public List<RuntimeError> getErrors() {
+		return CACHED_ERRORS;
+	}
+
+	/**
+	 * Clears all logged {@link RuntimeError}s
+	 */
+	public void clear() {
+		CACHED_ERRORS.clear();
+	}
+
+	/**
+	 * Create a backup of this {@link RuntimeLogHandler}
+	 */
+	@Contract("-> new")
+	public RuntimeLogHandler backup() {
+		RuntimeLogHandler copy = new RuntimeLogHandler();
+		copy.CACHED_ERRORS.addAll(this.CACHED_ERRORS);
+		copy.printedErrors = this.printedErrors;
+		return copy;
+	}
+
+	/**
+	 * Restore this {@link RuntimeLogHandler} to a backup
+	 */
+	public void restore(RuntimeLogHandler copy) {
+		this.printedErrors = copy.printedErrors;
+		this.CACHED_ERRORS.clear();
+		this.CACHED_ERRORS.addAll(copy.CACHED_ERRORS);
+	}
+
+}

--- a/src/test/skript/tests/syntaxes/effects/EffWorldBorderExpand.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffWorldBorderExpand.sk
@@ -35,9 +35,13 @@ test "worldborder expand":
 	assert worldborder radius of {_border} is 100 with "Growing border by None changed the radius"
 	shrink {_border} to {_None}
 	assert worldborder radius of {_border} is 100 with "Shrinking border to None changed the radius"
-	shrink {_border} by NaN value
+	runtime:
+		shrink {_border} by NaN value
+	assert last runtime errors contains "You can't shrink a world border by NaN." with "Shrinking by NaN did not throw error"
 	assert worldborder radius of {_border} is 100 with "Shrinking border by NaN changed the radius"
-	grow {_border} to NaN value
+	runtime:
+		grow {_border} to NaN value
+	assert last runtime errors contains "You can't grow a world border to NaN." with "Growing by NaN did not throw error"
 	assert worldborder radius of {_border} is 100 with "Growing border to NaN changed the radius"
 
 	# infinite values

--- a/src/test/skript/tests/syntaxes/expressions/ExprWorldBorderCenter.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprWorldBorderCenter.sk
@@ -19,9 +19,13 @@ test "worldborder center":
 	assert worldborder center of {_border} is location(-4.5, 0, -34.2, "world") with "setting location of border to None moved border"
 	set worldborder center of {_border} to location({_None}, 0, {_None})
 	assert worldborder center of {_border} is location(-4.5, 0, -34.2, "world") with "using a location with None components changed the border center"
-	set worldborder center of {_border} to location(NaN value, 0, 1)
+	runtime:
+		set worldborder center of {_border} to location(NaN value, 0, 1)
+	assert last runtime errors contains "Your location can't have a NaN value as one of its components" with "x-coord NaN value did not throw error"
 	assert worldborder center of {_border} is location(-4.5, 0, -34.2, "world") with "using a location with x-coord NaN changed the border center"
-	set worldborder center of {_border} to location(2, 0, NaN value)
+	runtime:
+		set worldborder center of {_border} to location(2, 0, NaN value)
+	assert last runtime errors contains "Your location can't have a NaN value as one of its components" with "z-coord NaN value did not throw error"
 	assert worldborder center of {_border} is location(-4.5, 0, -34.2, "world") with "using a location with z-coord NaN changed the border center"
 	set worldborder center of {_border} to location(infinity value, 0, infinity value)
 	assert worldborder center of {_border} is location(29999984, 0, 29999984, "world") with "border center coords were not rounded correctly when using +infinity"

--- a/src/test/skript/tests/syntaxes/expressions/ExprWorldBorderDamageAmount.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprWorldBorderDamageAmount.sk
@@ -9,11 +9,17 @@ test "worldborder damage amount":
 	assert worldborder damage amount of {_border} is 1.5 with "Failed to set worldborder damage amount to a float"
 	set worldborder damage amount of {_border} to {_None}
 	assert worldborder damage amount of {_border} is 1.5 with "Setting worldborder damage amount to None changed the damage amount"
-	set worldborder damage amount of {_border} to NaN value
+	runtime:
+		set worldborder damage amount of {_border} to NaN value
+	assert last runtime errors contains "NaN is not a valid world border damage amount" with "NaN damage value did not throw error"
 	assert worldborder damage amount of {_border} is 1.5 with "Setting worldborder damage amount to NaN value changed the damage amount"
-	set worldborder damage amount of {_border} to infinity value
+	runtime:
+		set worldborder damage amount of {_border} to infinity value
+	assert last runtime errors contains "World border damage amount cannot be infinite" with "Infinity damage value did not throw error"
 	assert worldborder damage amount of {_border} is 1.5 with "Setting worldborder damage amount to infinity changed the damage amount"
-	set worldborder damage amount of {_border} to -infinity value
+	runtime:
+		set worldborder damage amount of {_border} to -infinity value
+	assert last runtime errors contains "World border damage amount cannot be infinite" with "Negative infinity damage value did not throw error"
 	assert worldborder damage amount of {_border} is 1.5 with "Setting worldborder damage amount to -infinity changed the damage amount"
 
 	# add tests
@@ -27,7 +33,9 @@ test "worldborder damage amount":
 	assert worldborder damage amount of {_border} is 1.5 with "Failed adding negative integer to damage amount"
 	add {_None} to worldborder damage amount of {_border}
 	assert worldborder damage amount of {_border} is 1.5 with "Adding None to worldborder damage amount changed the damage amount"
-	add NaN value to worldborder damage amount of {_border}
+	runtime:
+		add NaN value to worldborder damage amount of {_border}
+	assert last runtime errors contains "NaN is not a valid world border damage amount" with "Adding NaN damage value did not throw error"
 	assert worldborder damage amount of {_border} is 1.5 with "Adding NaN value to worldborder damage amount changed the damage amount"
 	add infinity value to worldborder damage amount of {_border}
 	assert worldborder damage amount of {_border} is 1.5 with "Adding infinity to worldborder damage amount changed the damage amount"


### PR DESCRIPTION
### Description
This PR aims to add a `RuntimeLogHandler` allowing `RuntimeErrors` printed from `RuntimeErrorManager` to be caught and logged.
With this addition, allows for a `SecRuntime` and `ExprRuntimeErrors` making the terminal for testing environments not be flooded with runtime errors and even grants the ability to make tests for expected runtime errors.

In the related issue (by me), I realized that `SecParse` never ran the code within the section, so I decided to make a new section and expression that way `SecParse` could maintain it's behavior.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7766 <!-- Links to related issues -->
