### PR TITLE
Update ExprSecCreateWorldBorder

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprSecCreateWorldBorder.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSecCreateWorldBorder.java
@@ -7,8 +7,11 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SectionExpression;
-import ch.njol.skript.lang.*;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.Trigger;
+import ch.njol.skript.lang.TriggerItem;
 import ch.njol.skript.registrations.EventValues;
 import ch.njol.skript.variables.Variables;
 import ch.njol.util.Kleenean;
@@ -41,12 +44,10 @@ public class ExprSecCreateWorldBorder extends SectionExpression<WorldBorder> {
 		EventValues.registerEventValue(CreateWorldborderEvent.class, WorldBorder.class, CreateWorldborderEvent::getWorldBorder);
 	}
 
-	private WorldBorder worldBorder;
 	private Trigger trigger = null;
 
 	@Override
-	public boolean init(Expression[] expressions, int pattern, Kleenean delayed, ParseResult result, @Nullable SectionNode node, @Nullable List list) {
-		worldBorder = Bukkit.createWorldBorder();
+	public boolean init(Expression<?>[] expressions, int pattern, Kleenean delayed, ParseResult result, @Nullable SectionNode node, @Nullable List<TriggerItem> triggerItems) {
 		if (node != null) {
 			AtomicBoolean isDelayed = new AtomicBoolean(false);
 			Runnable afterLoading = () -> isDelayed.set(!getParser().getHasDelayBefore().isFalse());
@@ -61,6 +62,7 @@ public class ExprSecCreateWorldBorder extends SectionExpression<WorldBorder> {
 
 	@Override
 	protected WorldBorder @Nullable [] get(Event event) {
+		WorldBorder worldBorder = Bukkit.createWorldBorder();
 		if (trigger == null) 
 			return new WorldBorder[] {worldBorder};
 		CreateWorldborderEvent worldborderEvent = new CreateWorldborderEvent(worldBorder);

--- a/src/main/java/ch/njol/skript/sections/ExprSecCreateWorldBorder.java
+++ b/src/main/java/ch/njol/skript/sections/ExprSecCreateWorldBorder.java
@@ -1,4 +1,4 @@
-package ch.njol.skript.expressions;
+package ch.njol.skript.sections;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.config.SectionNode;


### PR DESCRIPTION
### Description
This PR fixes `ExprSecCreateWorldBorder` by changing the creation of the `WorldBorder` from `init` to `get`.
Allowing new `WorldBorder`s for each time the same instance calls `get`. (i.e. inside functions and loops)

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7825 <!-- Links to related issues -->
