### PR TITLE
EffSecShoot Fix Sections/Consumers

### DIFF
--- a/src/main/java/ch/njol/skript/sections/EffSecShoot.java
+++ b/src/main/java/ch/njol/skript/sections/EffSecShoot.java
@@ -238,8 +238,7 @@ public class EffSecShoot extends EffectSection {
 						try {
 							//noinspection removal
 							launchWithBukkitConsumer.invoke(livingShooter, type, vector, (org.bukkit.util.Consumer<? extends Entity>) afterSpawn::accept);
-						} catch (Exception ignored) {
-						}
+						} catch (Exception ignored) {}
 					} else if (caseUsage == CaseUsage.PROJECTILE_WORLD_TRIGGER_BUKKIT) {
 						try {
 							//noinspection removal
@@ -310,10 +309,7 @@ public class EffSecShoot extends EffectSection {
 			}
 			ShootEvent shootEvent = new ShootEvent(entity, shooter);
 			lastSpawned = entity;
-			Variables.setLocalVariables(shootEvent, Variables.copyLocalVariables(event));
-			TriggerItem.walk(trigger, shootEvent);
-			Variables.setLocalVariables(event, Variables.copyLocalVariables(shootEvent));
-			Variables.removeLocals(shootEvent);
+			Variables.withLocalVariables(event, shootEvent, () -> TriggerItem.walk(trigger, shootEvent));
 		};
 	}
 

--- a/src/main/java/ch/njol/skript/sections/EffSecShoot.java
+++ b/src/main/java/ch/njol/skript/sections/EffSecShoot.java
@@ -102,7 +102,7 @@ public class EffSecShoot extends EffectSection {
 			@Override
 			public @Nullable Entity shootHandler(EntityData<?> entityData, LivingEntity shooter, Location location, Class<? extends Entity> type, Vector vector, Consumer<?> consumer) {
 				//noinspection unchecked,rawtypes
-                shooter.getWorld().spawn(location, type, (Consumer) consumer);
+				shooter.getWorld().spawn(location, type, (Consumer) consumer);
 				return null;
 			}
 		};
@@ -236,12 +236,14 @@ public class EffSecShoot extends EffectSection {
 					CaseUsage caseUsage = getCaseUsage(isProjectile, useWorldSpawn, trigger != null);
 					if (caseUsage == CaseUsage.PROJECTILE_NO_WORLD_TRIGGER_BUKKIT) {
 						try {
-							launchWithBukkitConsumer.invoke(livingShooter, type, vector, afterSpawnBukkit(event, entityData, livingShooter, vector));
+							//noinspection removal
+							launchWithBukkitConsumer.invoke(livingShooter, type, vector, (org.bukkit.util.Consumer<? extends Entity>) afterSpawn::accept);
 						} catch (Exception ignored) {
 						}
 					} else if (caseUsage == CaseUsage.PROJECTILE_WORLD_TRIGGER_BUKKIT) {
 						try {
-							worldSpawnWithBukkitConsumer.invoke(livingShooter.getWorld(), type, afterSpawnBukkit(event, entityData, livingShooter, vector));
+							//noinspection removal
+							worldSpawnWithBukkitConsumer.invoke(livingShooter.getWorld(), type, (org.bukkit.util.Consumer<? extends Entity>) afterSpawn::accept);
 						} catch (Exception ignored) {}
 					} else {
 						finalProjectile = caseUsage.shootHandler(entityData, livingShooter, shooterLoc, type, vector, afterSpawn);
@@ -298,28 +300,6 @@ public class EffSecShoot extends EffectSection {
 	}
 
 	private Consumer<? extends Entity> afterSpawn(Event event, EntityData<?> entityData, @Nullable LivingEntity shooter, Vector vector) {
-		return entity -> {
-			entity.setVelocity(vector);
-			if (entity instanceof Fireball fireball)
-				fireball.setShooter(shooter);
-			else if (entity instanceof Projectile projectile) {
-				projectile.setShooter(shooter);
-				set(projectile, entityData);
-			}
-			ShootEvent shootEvent = new ShootEvent(entity, shooter);
-			lastSpawned = entity;
-			Variables.setLocalVariables(shootEvent, Variables.copyLocalVariables(event));
-			TriggerItem.walk(trigger, shootEvent);
-			Variables.setLocalVariables(event, Variables.copyLocalVariables(shootEvent));
-			Variables.removeLocals(shootEvent);
-		};
-	}
-
-	/**
-	 * MC 1.19 uses Bukkit Consumer for LivingEntity#launchProjectile instead of Java Consumer
-	 */
-	@SuppressWarnings({"deprecation", "removal"})
-	private org.bukkit.util.Consumer<? extends Entity> afterSpawnBukkit(Event event, EntityData<?> entityData, @Nullable LivingEntity shooter, Vector vector) {
 		return entity -> {
 			entity.setVelocity(vector);
 			if (entity instanceof Fireball fireball)

--- a/src/test/skript/tests/syntaxes/sections/EffSecShoot.sk
+++ b/src/test/skript/tests/syntaxes/sections/EffSecShoot.sk
@@ -33,28 +33,55 @@ test "EffSecShoot":
 	clear entity within {_shooter}
 	clear entity within {_shooter2}
 
-test "EffSecShoot Velocity":
+test "EffSecShoot From Entity - Velocity":
 	spawn a pig at test-location:
 		set {_shooter} to entity
 
 	make {_shooter} shoot an egg at speed 1:
 		set {_sectionVelocity} to velocity of event-entity
 	make {_shooter} shoot an egg at speed 1
-	assert the velocity of last shot entity is {_sectionVelocity} with "EffSecShoot egg velocities don't match"
+	assert the velocity of last shot entity is {_sectionVelocity} with "EffSecShoot from entity - egg velocities don't match"
 
 	make {_shooter} shoot a pig at speed 2:
 		set {_sectionVelocity} to velocity of event-entity
 	make {_shooter} shoot a pig at speed 2
-	assert the velocity of last shot entity is {_sectionVelocity} with "EffSecShoot pig velocities don't match"
+	assert the velocity of last shot entity is {_sectionVelocity} with "EffSecShoot from entity - pig velocities don't match"
 
 	make {_shooter} shoot an arrow at speed 3:
 		set {_sectionVelocity} to velocity of event-entity
 	make {_shooter} shoot an arrow at speed 3
-	assert the velocity of last shot entity is {_sectionVelocity} with "EffSecShoot arrow velocities don't match"
+	assert the velocity of last shot entity is {_sectionVelocity} with "EffSecShoot from entity - arrow velocities don't match"
 
-	make {_shooter} shoot an fireball at speed 4:
+	if running minecraft "1.20.0":
+		# 1.19.4 velocity is off by 1 vector-z
+		make {_shooter} shoot an fireball at speed 4:
+			set {_sectionVelocity} to velocity of event-entity
+		make {_shooter} shoot a fireball at speed 4
+		assert the velocity of last shot entity is {_sectionVelocity} with "EffSecShoot from entity - fireball velocities don't match"
+
+	clear all entities
+
+test "EffSecShoot From Location - Velocity":
+	set {_location} to test-location ~ vector(0,10,0)
+
+	make {_location} shoot an egg at speed 1:
 		set {_sectionVelocity} to velocity of event-entity
-	make {_shooter} shoot a fireball at speed 4
-	assert the velocity of last shot entity is {_sectionVelocity} with "EffSecShoot fireball velocities don't match"
+	make {_location} shoot an egg at speed 1
+	assert the velocity of last shot entity is {_sectionVelocity} with "EffSecShoot from location - egg velocities don't match"
+
+	make {_location} shoot a pig at speed 2:
+		set {_sectionVelocity} to velocity of event-entity
+	make {_location} shoot a pig at speed 2
+	assert the velocity of last shot entity is {_sectionVelocity} with "EffSecShoot from location - pig velocities don't match"
+
+	make {_location} shoot an arrow at speed 3:
+		set {_sectionVelocity} to velocity of event-entity
+	make {_location} shoot an arrow at speed 3
+	assert the velocity of last shot entity is {_sectionVelocity} with "EffSecShoot from location - arrow velocities don't match"
+
+	make {_location} shoot an fireball at speed 4:
+		set {_sectionVelocity} to velocity of event-entity
+	make {_location} shoot a fireball at speed 4
+	assert the velocity of last shot entity is {_sectionVelocity} with "EffSecShoot from location - fireball velocities don't match"
 
 	clear all entities

--- a/src/test/skript/tests/syntaxes/sections/EffSecShoot.sk
+++ b/src/test/skript/tests/syntaxes/sections/EffSecShoot.sk
@@ -32,3 +32,29 @@ test "EffSecShoot":
 
 	clear entity within {_shooter}
 	clear entity within {_shooter2}
+
+test "EffSecShoot Velocity":
+	spawn a pig at test-location:
+		set {_shooter} to entity
+
+	make {_shooter} shoot an egg at speed 1:
+		set {_sectionVelocity} to velocity of event-entity
+	make {_shooter} shoot an egg at speed 1
+	assert the velocity of last shot entity is {_sectionVelocity} with "EffSecShoot egg velocities don't match"
+
+	make {_shooter} shoot a pig at speed 2:
+		set {_sectionVelocity} to velocity of event-entity
+	make {_shooter} shoot a pig at speed 2
+	assert the velocity of last shot entity is {_sectionVelocity} with "EffSecShoot pig velocities don't match"
+
+	make {_shooter} shoot an arrow at speed 3:
+		set {_sectionVelocity} to velocity of event-entity
+	make {_shooter} shoot an arrow at speed 3
+	assert the velocity of last shot entity is {_sectionVelocity} with "EffSecShoot arrow velocities don't match"
+
+	make {_shooter} shoot an fireball at speed 4:
+		set {_sectionVelocity} to velocity of event-entity
+	make {_shooter} shoot a fireball at speed 4
+	assert the velocity of last shot entity is {_sectionVelocity} with "EffSecShoot fireball velocities don't match"
+
+	clear all entities


### PR DESCRIPTION
### Description
This PR aims to fix `EffSecShoot`:
- When using a section, the shot/spawned entity data did not have the velocity set.  Due to the consumers not setting the velocity.
- 1.20.1- `World#spawn` with Consumer used Bukkit consumers

Adds tests for each `CaseUsage` via spawning a fireball, projectile, and an entity, from both a living entity shooter and a location shooter, matching the velocities.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7824 <!-- Links to related issues -->
