### PR TITLE
ExprScriptFileErrors

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprScriptFileErrors.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprScriptFileErrors.java
@@ -1,0 +1,67 @@
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Example;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Last Reloaded Errors")
+@Description("The errors from the last singular or multiple scripts that were reloaded or enabled via an effect.")
+@Example("""
+	reload script named "test.sk"
+	if last reloaded errors is set:
+		disable script file "test.sk"
+	""")
+@Example("""
+	enable script named "-test.sk"
+	if last enabled errors is set:
+		disable script file "test.sk"
+	""")
+@Since("INSERT VERSION")
+public class ExprScriptFileErrors extends SimpleExpression<String> {
+
+	static {
+		Skript.registerExpression(ExprScriptFileErrors.class, String.class, ExpressionType.SIMPLE,
+			"[the] last (:reloaded|enabled) [script|skript] errors");
+	}
+
+	public static String[] lastReloadedErrors = null;
+	public static String[] lastEnabledErrors = null;
+
+	private boolean getReloaded;
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		getReloaded = parseResult.hasTag("reloaded");
+		return true;
+	}
+
+	@Override
+	protected String @Nullable [] get(Event event) {
+		return getReloaded ? lastReloadedErrors : lastEnabledErrors;
+	}
+
+	@Override
+	public boolean isSingle() {
+		return false;
+	}
+
+	@Override
+	public Class<? extends String> getReturnType() {
+		return String.class;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "the last reloaded script errors";
+	}
+
+}

--- a/src/test/skript/tests/misc/-reloadErrors.sk
+++ b/src/test/skript/tests/misc/-reloadErrors.sk
@@ -1,0 +1,2 @@
+on load:
+	set {_filler} to blah

--- a/src/test/skript/tests/syntaxes/expressions/ExprScriptErrors.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprScriptErrors.sk
@@ -1,0 +1,13 @@
+options:
+	path: "../../../../../../src/test/skript/tests/"
+
+test "enabled errors":
+	set {_path} to {@path} + "misc/-reloadErrors.sk"
+	enable script named {_path}
+	assert last enabled errors contains "Can't understand this expression: 'blah'" with "Did not retrieve last enabled errors"
+
+test "reloaded errors":
+	set {_path} to {@path} + "misc/reloadErrors.sk"
+	reload script named {_path}
+	assert last reloaded errors contains "Can't understand this expression: 'blah'" with "Did not retrieve last reloaded errors"
+	disable script named {_path}


### PR DESCRIPTION
### Description
This PR aims to add an expression that will allow the user to obtain the last reloaded/enabled errors when using the skript effect.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
