### PR TITLE
Add missing suffocation method for Block implementations.

### DIFF
--- a/src/main/java/ch/njol/skript/util/BlockStateBlock.java
+++ b/src/main/java/ch/njol/skript/util/BlockStateBlock.java
@@ -495,6 +495,11 @@ public class BlockStateBlock implements Block {
 	}
 
 	@Override
+	public boolean isSuffocating() {
+		return state.getBlock().isSuffocating();
+	}
+
+	@Override
 	public @NotNull VoxelShape getCollisionShape() {
 		return state.getBlock().getCollisionShape();
 	}

--- a/src/main/java/ch/njol/skript/util/DelayedChangeBlock.java
+++ b/src/main/java/ch/njol/skript/util/DelayedChangeBlock.java
@@ -476,6 +476,11 @@ public class DelayedChangeBlock implements Block {
 	}
 
 	@Override
+	public boolean isSuffocating() {
+		return block.isSuffocating();
+	}
+
+	@Override
 	@NotNull
 	public VoxelShape getCollisionShape() {
 		return block.getCollisionShape();


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

There's a new isSuffocating method in 1.21.5 that BSB and DCB do not currently implement, causing builds to fail.
This implements it on both classes.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
