### PR TITLE
Syntax Simplification 

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprBlock.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBlock.java
@@ -1,13 +1,6 @@
 package ch.njol.skript.expressions;
 
-import org.bukkit.Location;
-import org.bukkit.block.Block;
-import org.bukkit.event.Event;
-import org.jetbrains.annotations.Nullable;
-
 import ch.njol.skript.Skript;
-import org.skriptlang.skript.lang.converter.Converter;
-import org.skriptlang.skript.lang.converter.ConverterInfo;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -20,6 +13,11 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.ConvertedExpression;
 import ch.njol.skript.util.Direction;
 import ch.njol.util.Kleenean;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.lang.converter.ConverterInfo;
 
 /**
  * @author Peter Güttinger
@@ -48,12 +46,7 @@ public class ExprBlock extends WrapperExpression<Block> {
 		if (exprs.length > 0) {
 			setExpr(new ConvertedExpression<>(Direction.combine((Expression<? extends Direction>) exprs[0],
 					(Expression<? extends Location>) exprs[1]), Block.class,
-					new ConverterInfo<>(Location.class, Block.class, new Converter<Location, Block>() {
-				@Override
-				public Block convert(final Location l) {
-					return l.getBlock();
-				}
-			}, 0)));
+					new ConverterInfo<>(Location.class, Block.class, Location::getBlock, 0)));
 			return true;
 		} else {
 			setExpr(new EventValueExpression<>(Block.class));

--- a/src/main/java/ch/njol/skript/expressions/arithmetic/ExprArithmetic.java
+++ b/src/main/java/ch/njol/skript/expressions/arithmetic/ExprArithmetic.java
@@ -353,8 +353,35 @@ public class ExprArithmetic<L, R, T> extends SimpleExpression<T> {
 	@Override
 	public Expression<T> simplify() {
 		// simplify this expression IFF it's the top-level arithmetic expression
-		if ( isTopLevel && first instanceof Literal && second instanceof Literal)
+		if (isTopLevel)
+			return simplifyInternal();
+		return this;
+	}
+
+	/**
+	 * Simplifies an arithmetic expression regardless of whether it is the top-level expression.
+	 * @return the simplified expression
+	 */
+	private Expression<T> simplifyInternal() {
+		if (first instanceof ExprArithmetic<?,?,?> firstArith) {
+			//noinspection unchecked
+			first = (Expression<L>) firstArith.simplifyInternal();
+		} else {
+			//noinspection unchecked
+			first = (Expression<L>) first.simplify();
+		}
+
+		if (second instanceof ExprArithmetic<?,?,?> secondArith) {
+			//noinspection unchecked
+			second = (Expression<R>) secondArith.simplifyInternal();
+		} else {
+			//noinspection unchecked
+			second = (Expression<R>) second.simplify();
+		}
+
+		if (first instanceof Literal && second instanceof Literal)
 			return getAsSimplifiedLiteral();
+
 		return this;
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/base/WrapperExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/WrapperExpression.java
@@ -120,7 +120,8 @@ public abstract class WrapperExpression<T> extends SimpleExpression<T> {
 	
 	@Override
 	public Expression<? extends T> simplify() {
-		return expr;
+		setExpr(expr.simplify());
+		return this;
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/lang/Expression.java
+++ b/src/main/java/ch/njol/skript/lang/Expression.java
@@ -5,6 +5,7 @@ import ch.njol.skript.classes.Changer;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.classes.Changer.ChangerUtils;
 import ch.njol.skript.conditions.CondIsSet;
+import ch.njol.skript.lang.util.ContextlessEvent;
 import ch.njol.skript.lang.util.ConvertedExpression;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.skript.log.ErrorQuality;
@@ -16,6 +17,8 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.converter.Converter;
+import org.skriptlang.skript.lang.simplification.Simplifiable;
+import org.skriptlang.skript.lang.simplification.SimplifiedLiteral;
 
 import java.util.*;
 import java.util.function.Function;
@@ -30,7 +33,7 @@ import java.util.stream.StreamSupport;
  * @see SimpleExpression
  * @see SyntaxElement
  */
-public interface Expression<T> extends SyntaxElement, Debuggable, Loopable<T> {
+public interface Expression<T> extends SyntaxElement, Debuggable, Loopable<T>, Simplifiable<Expression<? extends T>> {
 
 	/**
 	 * Get the single value of this expression.
@@ -247,16 +250,16 @@ public interface Expression<T> extends SyntaxElement, Debuggable, Loopable<T> {
 	Expression<?> getSource();
 
 	/**
-	 * Simplifies the expression, e.g. if it only contains literals the expression may be simplified to a literal, and wrapped expressions are unwrapped.
-	 * <p>
-	 * After this method was used the toString methods are likely not useful anymore.
-	 * <p>
-	 * This method is not yet used but will be used to improve efficiency in the future.
+	 * Attempts to create a {@link SimplifiedLiteral} by evaluating the expression with a {@link ContextlessEvent}.
+	 * This should only be attempted IFF the expression's children are all literals and
+	 * {@link #getAll(Event)} would always return the exact same value, no matter the context in which it is called.
+	 * The value of {@link #toString(Event, boolean)} will be evaluated and captured for the literal's toString methods.
 	 *
-	 * @return A reference to a simpler version of this expression. Can change this expression directly and return itself if applicable, i.e. no references to the expression before
-	 *         this method call should be kept!
+	 * @return A simplified literal with the data from this expression's evaluation.
 	 */
-	Expression<? extends T> simplify();
+	default Literal<T> getAsSimplifiedLiteral() {
+		return SimplifiedLiteral.fromExpression(this);
+	}
 
 	/**
 	 * Tests whether this expression supports the given mode, and if yes what type it expects the <code>delta</code> to be.

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -42,6 +42,7 @@ import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.experiment.ExperimentalSyntax;
 import org.skriptlang.skript.lang.script.Script;
 import org.skriptlang.skript.lang.script.ScriptWarning;
+import org.skriptlang.skript.lang.simplification.Simplifiable;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -252,6 +253,9 @@ public class SkriptParser {
 							boolean success = element.init(parseResult.exprs, patternIndex, getParser().getHasDelayBefore(), parseResult);
 							if (success) {
 								log.printLog();
+								if (element instanceof Simplifiable<?> simplifiable)
+									//noinspection unchecked
+									return (T) simplifiable.simplify();
 								return element;
 							}
 						}

--- a/src/main/java/ch/njol/skript/lang/util/ConvertedExpression.java
+++ b/src/main/java/ch/njol/skript/lang/util/ConvertedExpression.java
@@ -18,7 +18,6 @@ import org.skriptlang.skript.lang.converter.Converters;
 import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.function.Predicate;
 
 /**
  * Represents a expression converted to another type. This, and not Expression, is the required return type of {@link SimpleExpression#getConvertedExpr(Class...)} because this
@@ -265,11 +264,7 @@ public class ConvertedExpression<F, T> implements Expression<T> {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public Expression<? extends T> simplify() {
-		Expression<? extends T> convertedExpression = source.simplify().getConvertedExpression(to);
-		if (convertedExpression != null)
-			return convertedExpression;
 		return this;
 	}
 

--- a/src/main/java/org/skriptlang/skript/bukkit/tags/elements/ExprTag.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/tags/elements/ExprTag.java
@@ -2,19 +2,11 @@ package org.skriptlang.skript.bukkit.tags.elements;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.config.Node;
-import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
-import ch.njol.skript.doc.Keywords;
-import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.RequiredPlugins;
-import ch.njol.skript.doc.Since;
+import ch.njol.skript.doc.*;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.skript.lang.util.ContextlessEvent;
 import ch.njol.skript.lang.util.SimpleExpression;
-import ch.njol.skript.lang.util.SimpleLiteral;
 import ch.njol.util.Kleenean;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Tag;
@@ -151,13 +143,6 @@ public class ExprTag extends SimpleExpression<Tag> implements SyntaxRuntimeError
 	public String toString(@Nullable Event event, boolean debug) {
 		String registry = types.length > 1 ? "" : " " + types[0].toString();
 		return origin.toString(datapackOnly) + registry + " tag " + names.toString(event, debug);
-	}
-
-	@Override
-	public Expression<? extends Tag> simplify() {
-		if (names instanceof Literal<String>)
-			return new SimpleLiteral<>(getArray(ContextlessEvent.get()), Tag.class, true);
-		return super.simplify();
 	}
 
 }

--- a/src/main/java/org/skriptlang/skript/bukkit/tags/elements/ExprTagContents.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/tags/elements/ExprTagContents.java
@@ -3,19 +3,12 @@ package org.skriptlang.skript.bukkit.tags.elements;
 import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.bukkitutil.EntityUtils;
-import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
-import ch.njol.skript.doc.Keywords;
-import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.Since;
+import ch.njol.skript.doc.*;
 import ch.njol.skript.entity.EntityData;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.skript.lang.util.ContextlessEvent;
 import ch.njol.skript.lang.util.SimpleExpression;
-import ch.njol.skript.lang.util.SimpleLiteral;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.util.Kleenean;
 import org.bukkit.Material;
@@ -130,15 +123,6 @@ public class ExprTagContents extends SimpleExpression<Object> {
 	@Override
 	public String toString(@Nullable Event event, boolean debug) {
 		return "the tag contents of " + tag.toString(event, debug);
-	}
-
-	@Override
-	public Expression<?> simplify() {
-		if (tag instanceof Literal<Tag<?>>) {
-			Object[] values = getArray(ContextlessEvent.get());
-			return new SimpleLiteral(values, values.getClass().getComponentType(), true);
-		}
-		return super.simplify();
 	}
 
 }

--- a/src/main/java/org/skriptlang/skript/lang/simplification/Simplifiable.java
+++ b/src/main/java/org/skriptlang/skript/lang/simplification/Simplifiable.java
@@ -1,0 +1,23 @@
+package org.skriptlang.skript.lang.simplification;
+
+import ch.njol.skript.lang.Debuggable;
+import ch.njol.skript.lang.SyntaxElement;
+import org.bukkit.event.Event;
+
+public interface Simplifiable<S extends SyntaxElement> {
+
+	/**
+	 * Simplifies this object. This should be called immediately after init() returns true.
+	 * If simplification is not possible, the object is returned as is.
+	 * <br>
+	 * References to the original object should be replaced with the simplified object.
+	 * <br>
+	 * Any returned object should attempt to maintain the original value of {@link Debuggable#toString(Event, boolean)}.
+	 * An addition indicating that the value was simplified can be added in the debug string. See {@link SimplifiedLiteral}
+	 * for an example.
+	 *
+	 * @return the simplified object.
+	 * @see SimplifiedLiteral
+	 */
+	S simplify();
+}

--- a/src/main/java/org/skriptlang/skript/lang/simplification/SimplifiedLiteral.java
+++ b/src/main/java/org/skriptlang/skript/lang/simplification/SimplifiedLiteral.java
@@ -1,0 +1,52 @@
+package org.skriptlang.skript.lang.simplification;
+
+
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.util.ContextlessEvent;
+import ch.njol.skript.lang.util.SimpleLiteral;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Represents a literal, i.e. a static value like a number or a string, that was created by simplifying another expression.
+ * Maintains a reference to the original expression for proper toString values.
+ * @param <T> the type of the literal
+ */
+public class SimplifiedLiteral<T> extends SimpleLiteral<T> {
+
+	public static <T> SimplifiedLiteral<T> fromExpression(Expression<T> original) {
+		Event event = ContextlessEvent.get();
+
+		if (original instanceof SimplifiedLiteral<T> literal)
+			return literal;
+
+		//noinspection unchecked
+		return new SimplifiedLiteral<>(
+			original.getAll(event),
+			(Class<T>) original.getReturnType(),
+			original.getAnd(),
+			original);
+	}
+
+	Expression<T> sourceExpr;
+
+	/**
+	 * Creates a new simplified literal.
+	 * @param data the data of the literal
+	 * @param type the type of the literal
+	 * @param and whether the literal is an "and" literal
+	 * @param source the source expression this literal was created from. Used for toString values.
+	 */
+	public SimplifiedLiteral(T[] data, Class<T> type, boolean and, Expression<T> source) {
+		super(data, type, and);
+		sourceExpr = source;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		if (debug)
+			return "[" + sourceExpr.toString(event, true) + " (SIMPLIFIED)]";
+		return sourceExpr.toString(event, false);
+	}
+
+}


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

Skript has always had this little method on Expression called simplify(), which has never been implemented. It's intended to take expressions and, if possible, simplify them to Literals or similarly simplify the code tree.
This PR attempts to properly implement that idea via a Simplifiable interface.

Every element is simplified immediately after init() in SkriptParser. In addition, it may be called at any time by parent elements, though it should be ensured that no other objects maintain critical references to the element, as simplify may return new objects.

ExprArithmetic is a special case that can only be simplified once all elements in the chain have been parsed and ordered, so it requires checking the ParsingStack to see if it's the top-level element in the chain. If so, it can then call simplify recursively on all elements in the chain.

Todo:
[ ] Properly simplify ConvertedExpressions. The existing method was stripping the converting part off a lot of converted expressions.
[ ] Implement simplify on many more expressions that could support it.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
