### PR TITLE
Fix reverse-order config lines

### DIFF
--- a/src/main/java/ch/njol/skript/config/SectionNode.java
+++ b/src/main/java/ch/njol/skript/config/SectionNode.java
@@ -80,7 +80,6 @@ public class SectionNode extends Node implements Iterable<Node> {
 	public void add(int index, @NotNull Node node) {
 		Preconditions.checkArgument(index >= 0 && index <= size(), "index out of bounds: %s", index);
 
-		node.remove();
 		nodes.add(index, node);
 		node.parent = this;
 		node.config = config;


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->

New additions to config were being added in reverse-line-order:
D
C
B
A

This was due to removing the node from the reference config when adding to the live config. This PR stops removing nodes when adding.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
