### PR TITLE
Literal Multiple Infos Warning

### DIFF
--- a/src/main/java/ch/njol/skript/classes/ClassInfo.java
+++ b/src/main/java/ch/njol/skript/classes/ClassInfo.java
@@ -279,6 +279,11 @@ public class ClassInfo<T> implements Debuggable {
 		return this;
 	}
 
+	/**
+	 * Sets the literal patterns of this {@link ClassInfo}
+	 * @param patterns The literal patterns
+	 * @return This {@link ClassInfo} object
+	 */
 	public ClassInfo<T> patterns(String[] patterns) {
 		this.patterns = patterns;
 		return this;
@@ -405,6 +410,10 @@ public class ClassInfo<T> implements Debuggable {
 		return documentationId;
 	}
 
+	/**
+	 * Gets all the literal patterns used for this {@link ClassInfo}.
+	 * @return The literal patterns, or {@code null}.
+	 */
 	public @Nullable String[] getPatterns() {
 		return patterns;
 	}

--- a/src/main/java/ch/njol/skript/classes/ClassInfo.java
+++ b/src/main/java/ch/njol/skript/classes/ClassInfo.java
@@ -71,6 +71,8 @@ public class ClassInfo<T> implements Debuggable {
 	@Nullable
 	private String documentationId = null;
 
+	private @Nullable String[] patterns = null;
+
 	/**
 	 * @param c The class
 	 * @param codeName The name used in patterns
@@ -277,6 +279,11 @@ public class ClassInfo<T> implements Debuggable {
 		return this;
 	}
 
+	public ClassInfo<T> patterns(String[] patterns) {
+		this.patterns = patterns;
+		return this;
+	}
+
 	// === GETTERS ===
 
 	public Class<T> getC() {
@@ -396,6 +403,10 @@ public class ClassInfo<T> implements Debuggable {
 	@Nullable
 	public String getDocumentationID() {
 		return documentationId;
+	}
+
+	public @Nullable String[] getPatterns() {
+		return patterns;
 	}
 
 	public boolean hasDocs() {

--- a/src/main/java/ch/njol/skript/classes/EnumClassInfo.java
+++ b/src/main/java/ch/njol/skript/classes/EnumClassInfo.java
@@ -77,7 +77,8 @@ public class EnumClassInfo<T extends Enum<T>> extends ClassInfo<T> {
 				public @NotNull String toVariableNameString(T constant) {
 					return enumUtils.toString(constant, StringMode.VARIABLE_NAME);
 				}
-			});
+			})
+			.patterns(enumUtils.getNames());
 		if (registerComparator)
 			Comparators.registerComparator(enumClass, enumClass, (o1, o2) -> Relation.get(o1.ordinal() - o2.ordinal()));
 	}

--- a/src/main/java/ch/njol/skript/classes/registry/RegistryClassInfo.java
+++ b/src/main/java/ch/njol/skript/classes/registry/RegistryClassInfo.java
@@ -63,7 +63,8 @@ public class RegistryClassInfo<R extends Keyed> extends ClassInfo<R> {
 			.supplier(registry::iterator)
 			.serializer(new RegistrySerializer<R>(registry))
 			.defaultExpression(defaultExpression)
-			.parser(registryParser);
+			.parser(registryParser)
+			.patterns(registryParser.getNames());
 
 		if (registerComparator)
 			Comparators.registerComparator(registryClass, registryClass, (o1, o2) -> Relation.get(o1.getKey().equals(o2.getKey())));

--- a/src/main/java/ch/njol/skript/classes/registry/RegistryParser.java
+++ b/src/main/java/ch/njol/skript/classes/registry/RegistryParser.java
@@ -135,6 +135,9 @@ public class RegistryParser<R extends Keyed> extends Parser<R> {
 		return StringUtils.join(strings, ", ");
 	}
 
+	/**
+	 * Gets all literal patterns used for this {@link RegistryParser}
+	 */
 	public String[] getNames() {
 		return names.values().toArray(String[]::new);
 	}

--- a/src/main/java/ch/njol/skript/classes/registry/RegistryParser.java
+++ b/src/main/java/ch/njol/skript/classes/registry/RegistryParser.java
@@ -135,4 +135,8 @@ public class RegistryParser<R extends Keyed> extends Parser<R> {
 		return StringUtils.join(strings, ", ");
 	}
 
+	public String[] getNames() {
+		return names.values().toArray(String[]::new);
+	}
+
 }

--- a/src/main/java/ch/njol/skript/conditions/CondCompare.java
+++ b/src/main/java/ch/njol/skript/conditions/CondCompare.java
@@ -1,35 +1,27 @@
 package ch.njol.skript.conditions;
 
-import ch.njol.skript.lang.VerboseAssert;
-
-import ch.njol.skript.log.ParseLogHandler;
-import org.bukkit.event.Event;
-import org.skriptlang.skript.lang.comparator.Comparator;
-import org.skriptlang.skript.lang.comparator.ComparatorInfo;
-import org.skriptlang.skript.lang.comparator.Comparators;
-import org.skriptlang.skript.lang.comparator.Relation;
-import org.jetbrains.annotations.Nullable;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
-import ch.njol.skript.lang.Condition;
-import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.ExpressionList;
-import ch.njol.skript.lang.Literal;
-import ch.njol.skript.lang.ParseContext;
+import ch.njol.skript.lang.*;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.skript.lang.UnparsedLiteral;
 import ch.njol.skript.lang.util.SimpleLiteral;
 import ch.njol.skript.log.ErrorQuality;
+import ch.njol.skript.log.ParseLogHandler;
 import ch.njol.skript.log.SkriptLogger;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.util.Patterns;
 import ch.njol.skript.util.Utils;
 import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.lang.comparator.Comparator;
+import org.skriptlang.skript.lang.comparator.ComparatorInfo;
+import org.skriptlang.skript.lang.comparator.Comparators;
+import org.skriptlang.skript.lang.comparator.Relation;
 import org.skriptlang.skript.lang.util.Cyclical;
 
 import java.util.function.Predicate;
@@ -238,12 +230,8 @@ public class CondCompare extends Condition implements VerboseAssert {
 			source = expression.getSource();
 
 		// Try to get access to unparsed content of it
-		if (source instanceof UnparsedLiteral) {
-			String unparsed = ((UnparsedLiteral) source).getData();
-			T data = Classes.parse(unparsed, type, ParseContext.DEFAULT);
-			if (data != null) { // Success, let's make a literal of it
-				return new SimpleLiteral<>(data, false, new UnparsedLiteral(unparsed));
-			}
+		if (source instanceof UnparsedLiteral unparsedLiteral) {
+			return unparsedLiteral.reparse(type);
 		}
 		return null; // Context-sensitive parsing failed; can't really help it
 	}

--- a/src/main/java/ch/njol/skript/conditions/CondContains.java
+++ b/src/main/java/ch/njol/skript/conditions/CondContains.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptConfig;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.lang.util.common.AnyContains;
+import ch.njol.skript.util.LiteralUtils;
 import org.skriptlang.skript.lang.comparator.Relation;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -59,8 +60,8 @@ public class CondContains extends Condition {
 
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		containers = exprs[0];
-		items = exprs[1];
+		containers = LiteralUtils.defendExpression(exprs[0]);
+		items = LiteralUtils.defendExpression(exprs[1]);
 
 		explicitSingle = matchedPattern == 2 && parseResult.mark != 1 || containers.isSingle();
 
@@ -71,7 +72,7 @@ public class CondContains extends Condition {
 		}
 
 		this.setNegated(matchedPattern % 2 == 1);
-		return true;
+		return LiteralUtils.canInitSafely(containers, items);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/registrations/Classes.java
+++ b/src/main/java/ch/njol/skript/registrations/Classes.java
@@ -227,6 +227,11 @@ public abstract class Classes {
 			throw new IllegalStateException("Cannot use classinfos until registration is over");
 	}
 
+	/**
+	 * Check if the {@code pattern} can be referenced to multiple {@link ClassInfo}s.
+	 * @param pattern The {@link String} pattern.
+	 * @return {@code True} if the {@code pattern} can be referenced to multiple {@link ClassInfo}s.
+	 */
 	public static boolean patternHasMultipleInfos(String pattern) {
 		pattern = pattern.toLowerCase(Locale.ENGLISH);
 		if (!registeredPatterns.containsKey(pattern))
@@ -234,9 +239,25 @@ public abstract class Classes {
 		return registeredPatterns.get(pattern).size() > 1;
 	}
 
+	/**
+	 * Get a {@link List} of the {@link ClassInfo}s the {@code pattern} can be referenced to.
+	 * @param pattern The {@link String} pattern.
+	 */
 	public static @Nullable List<ClassInfo<?>> getPatternInfos(String pattern) {
 		pattern = pattern.toLowerCase(Locale.ENGLISH);
 		return registeredPatterns.get(pattern);
+	}
+
+	/**
+	 * Get a {@link Map} containing the patterns that are referenced to multiple {@link ClassInfo}s.
+	 */
+	public static Map<String, List<ClassInfo<?>>> getAllMultiplePatternEntries() {
+		Map<String, List<ClassInfo<?>>> filtered = new HashMap<>();
+		registeredPatterns.forEach(((string, list) -> {
+			if (list.size() > 1)
+				filtered.put(string, list);
+		}));
+		return filtered;
 	}
 
 	@SuppressWarnings("null")

--- a/src/main/java/ch/njol/skript/registrations/Classes.java
+++ b/src/main/java/ch/njol/skript/registrations/Classes.java
@@ -251,7 +251,7 @@ public abstract class Classes {
 	/**
 	 * Get a {@link Map} containing the patterns that are referenced to multiple {@link ClassInfo}s.
 	 */
-	public static Map<String, List<ClassInfo<?>>> getAllMultiplePatternEntries() {
+	public static Map<String, List<ClassInfo<?>>> getAllMultiplePatterns() {
 		Map<String, List<ClassInfo<?>>> filtered = new HashMap<>();
 		registeredPatterns.forEach(((string, list) -> {
 			if (list.size() > 1)

--- a/src/main/java/ch/njol/skript/util/EnumUtils.java
+++ b/src/main/java/ch/njol/skript/util/EnumUtils.java
@@ -114,4 +114,8 @@ public final class EnumUtils<E extends Enum<E>> {
 		return StringUtils.join(parseMap.keySet(), ", ");
 	}
 
+	public String[] getNames() {
+		return names;
+	}
+
 }

--- a/src/main/java/ch/njol/skript/util/EnumUtils.java
+++ b/src/main/java/ch/njol/skript/util/EnumUtils.java
@@ -114,6 +114,9 @@ public final class EnumUtils<E extends Enum<E>> {
 		return StringUtils.join(parseMap.keySet(), ", ");
 	}
 
+	/**
+	 * Gets all literal patterns used for this {@link EnumUtils}.
+	 */
 	public String[] getNames() {
 		return names;
 	}

--- a/src/test/skript/tests/misc/literal multiple infos warning.sk
+++ b/src/test/skript/tests/misc/literal multiple infos warning.sk
@@ -1,0 +1,57 @@
+options:
+	error: "'unknown' has multiple types. Consider specifying which type to use: 'unknown (inventory action)'"
+
+using for each loops
+
+parse:
+	results: {LiteralMultipleWarn::FunctionObject}
+	code:
+		function a():: object:
+			return unknown
+
+test "literal multiple infos warning":
+	parse:
+		set {_test} to unknown
+	assert last parse logs contains {@error} with "Setting variable should throw warning"
+
+	parse:
+		if {_list::*} contains unknown:
+			broadcast "Filler"
+	assert last parse logs contains {@error} with "Contains should throw warning"
+
+	parse:
+		if the 1st element of {_list::*} is unknown:
+			broadcast "filler"
+	assert last parse logs contains {@error} with "Element of should throw warning"
+
+	parse:
+		filter {_list::*} to match:
+			input is unknown
+	assert last parse logs contains {@error} with "Filtering should throw warning"
+
+	parse:
+		for each {_value} in {_list::*}:
+			if {_value} is unknown:
+				broadcast "filler"
+	assert last parse logs contains {@error} with "For each should throw warning"
+
+	assert {LiteralMultipleWarn::FunctionObject} contains {@error} with "Function with Object return type should throw warning"
+	clear {LiteralMultipleWarn::*}
+
+parse:
+	results: {LiteralMultipleNoWarn::Damage}
+	code:
+		on damage:
+			if damage cause is unknown:
+				broadcast "filler"
+
+parse:
+	results: {LiteralMultipleNoWarn::FunctionDamageCause}
+	code:
+		function a():: damage cause:
+			return unknown
+
+test "literal multiple infos no warning":
+	assert {LiteralMultipleNoWarn::Damage} does not contain {@error} with "Condition check against shared type should not throw warning"
+	assert {LiteralMultipleNoWarn::FunctionDamageCause} does not contain {@error} with "Function with shared return type should not throw warning"
+	clear {LiteralMultipleNoWarn::*}


### PR DESCRIPTION
### Description
This PR aims to add a warning when a literal, that can be referenced to multiple ClassInfos/types, is used.
The warning informs the user that the literal can be referenced to multiple types and that they should consider specifying which type to use, using the new literal specification feature introduced in 2.11.

To achieve this, 
- `ClassInfo` has a `patterns` field with a corresponding `#patterns` setter and `#getPatterns` getter.
- `EnumUtils` and `RegistryParser` now have a `#getNames` which gets the patterns of the declared literals within `default.lang`
- `EnumClassInfo` and `RegistryClassInfo` use their corresponding `Utils/Parser#getNames` method with `ClassInfo#patterns`
- Registering a `ClassInfo` checks for the `patterns` of the `ClassInfo` and logs the literal patterns individually with a list of `ClassInfos` that literal pattern can be referenced to.

Additional methods have been added in `Classes`:
- `#patternHasMultipleInfos` : Check if a pattern can be referenced to multiple `ClassInfo`s
- `#getPatternInfos` : Gets all `ClassInfos` a pattern can be referenced to
- `#getAllMultiplePatterns` : Returns a filtered `Map` of  only the patterns that can be referenced to multiple types

`UnparsedLiteral` has been modified to check if that instance has been successfully converted via `#getConvertedExpression` or successfully reparsed via `#reparse`
`CondCompare#reparseLiteral` now uses the `UnparsedLiteral#reparse` to accommodate the data being logged.

This PR also fixes a bug that was present within `SkriptParser#parseSingleExpr` where when an element's pattern allowed multiple types, including `Object` for an expression (`%.../.../object%`) if all other types failed to be parsed and reached `Object`, it did not treat it correctly as seen with the prior condition check (`if (exprInfo.classes[0].getC() == Object.class) {`). Which lead to the literal being parsed as the first `ClassInfo` that gets registered with that pattern. Now the loop will log if it reaches `Object` and continue to attempt every other `ClassInfo`. If all fail, and `Object` was logged, will use the method `#getUnparsedLiteral` which is the code from the aforementioned condition, to prevent duplicated code.

With that change, a fix was required for `CondContains` as it did not properly handle `UnparsedLiteral`s.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
