### PR TITLE
ExperimentalSyntax Error Messages

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffRun.java
+++ b/src/main/java/ch/njol/skript/effects/EffRun.java
@@ -12,6 +12,8 @@ import ch.njol.skript.util.LiteralUtils;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.lang.experiment.ExperimentData;
+import org.skriptlang.skript.lang.experiment.ExperimentalSyntax;
 import org.skriptlang.skript.util.Executable;
 
 @Name("Run (Experimental)")
@@ -24,7 +26,9 @@ import org.skriptlang.skript.util.Executable;
 @Since("2.10")
 @Keywords({"run", "execute", "reflection", "function"})
 @SuppressWarnings({"rawtypes", "unchecked"})
-public class EffRun extends Effect {
+public class EffRun extends Effect implements ExperimentalSyntax {
+
+	private static final ExperimentData EXPERIMENT_DATA = new ExperimentData().required(Feature.SCRIPT_REFLECTION);
 
 	static {
 		Skript.registerEffect(EffRun.class,
@@ -41,8 +45,6 @@ public class EffRun extends Effect {
 
 	@Override
 	public boolean init(Expression<?>[] expressions, int pattern, Kleenean isDelayed, ParseResult result) {
-		if (!this.getParser().hasExperiment(Feature.SCRIPT_REFLECTION))
-			return false;
 		this.executable = ((Expression<Executable>) expressions[0]);
 		this.hasArguments = result.hasTag("arguments");
 		if (hasArguments) {
@@ -59,6 +61,11 @@ public class EffRun extends Effect {
 			this.input = new DynamicFunctionReference.Input();
 		}
 		return true;
+	}
+
+	@Override
+	public ExperimentData getExperimentData() {
+		return EXPERIMENT_DATA;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprConfig.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprConfig.java
@@ -15,6 +15,8 @@ import ch.njol.skript.registrations.Feature;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.lang.experiment.ExperimentData;
+import org.skriptlang.skript.lang.experiment.ExperimentalSyntax;
 
 @Name("Config (Experimental)")
 @Description({
@@ -27,7 +29,9 @@ import org.jetbrains.annotations.Nullable;
 		broadcast "Bonjour!"
 	"""})
 @Since("2.10")
-public class ExprConfig extends SimpleExpression<Config> {
+public class ExprConfig extends SimpleExpression<Config> implements ExperimentalSyntax {
+
+	private static final ExperimentData EXPERIMENT_DATA = new ExperimentData().required(Feature.SCRIPT_REFLECTION);
 
 	static {
 		Skript.registerExpression(ExprConfig.class, Config.class, ExpressionType.SIMPLE,
@@ -39,14 +43,17 @@ public class ExprConfig extends SimpleExpression<Config> {
 
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		if (!this.getParser().hasExperiment(Feature.SCRIPT_REFLECTION))
-			return false;
 		this.config = SkriptConfig.getConfig();
 		if (config == null) {
 			Skript.warning("The main config is unavailable here!");
 			return false;
 		}
 		return true;
+	}
+
+	@Override
+	public ExperimentData getExperimentData() {
+		return EXPERIMENT_DATA;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprDequeuedQueue.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDequeuedQueue.java
@@ -5,7 +5,6 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
-import org.skriptlang.skript.lang.experiment.ExperimentalSyntax;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -14,7 +13,8 @@ import ch.njol.skript.registrations.Feature;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
-import org.skriptlang.skript.lang.experiment.ExperimentSet;
+import org.skriptlang.skript.lang.experiment.ExperimentData;
+import org.skriptlang.skript.lang.experiment.ExperimentalSyntax;
 import org.skriptlang.skript.lang.util.SkriptQueue;
 
 @Name("De-queue Queue (Experimental)")
@@ -34,6 +34,8 @@ import org.skriptlang.skript.lang.util.SkriptQueue;
 @Since("2.10 (experimental)")
 public class ExprDequeuedQueue extends SimpleExpression<Object> implements ExperimentalSyntax {
 
+	private static final ExperimentData EXPERIMENT_DATA = new ExperimentData().required(Feature.QUEUES);
+
 	static {
 		Skript.registerExpression(ExprDequeuedQueue.class, Object.class, ExpressionType.COMBINED,
 			"(de|un)queued %queue%", "unrolled %queue%");
@@ -49,8 +51,8 @@ public class ExprDequeuedQueue extends SimpleExpression<Object> implements Exper
 	}
 
 	@Override
-	public boolean isSatisfiedBy(ExperimentSet experimentSet) {
-		return experimentSet.hasExperiment(Feature.QUEUES);
+	public ExperimentData getExperimentData() {
+		return EXPERIMENT_DATA;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprFunction.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFunction.java
@@ -17,6 +17,8 @@ import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.lang.experiment.ExperimentData;
+import org.skriptlang.skript.lang.experiment.ExperimentalSyntax;
 import org.skriptlang.skript.lang.script.Script;
 
 import java.util.Objects;
@@ -29,7 +31,9 @@ import java.util.Objects;
 })
 @Since("2.10")
 @SuppressWarnings("rawtypes")
-public class ExprFunction extends SimpleExpression<DynamicFunctionReference> {
+public class ExprFunction extends SimpleExpression<DynamicFunctionReference> implements ExperimentalSyntax {
+
+	private static final ExperimentData EXPERIMENT_DATA = new ExperimentData().required(Feature.SCRIPT_REFLECTION);
 
 	static {
 		Skript.registerExpression(ExprFunction.class, DynamicFunctionReference.class, ExpressionType.COMBINED,
@@ -47,10 +51,7 @@ public class ExprFunction extends SimpleExpression<DynamicFunctionReference> {
 
 	@Override
 	@SuppressWarnings("null")
-	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed,
-                        ParseResult result) {
-		if (!this.getParser().hasExperiment(Feature.SCRIPT_REFLECTION))
-			return false;
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult result) {
 		this.mode = matchedPattern;
 		this.local = mode == 2 || expressions[1] != null;
 		switch (mode) {
@@ -67,6 +68,11 @@ public class ExprFunction extends SimpleExpression<DynamicFunctionReference> {
 		}
 		this.here = this.getParser().getCurrentScript();
 		return true;
+	}
+
+	@Override
+	public ExperimentData getExperimentData() {
+		return EXPERIMENT_DATA;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprNode.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNode.java
@@ -17,6 +17,8 @@ import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.lang.experiment.ExperimentData;
+import org.skriptlang.skript.lang.experiment.ExperimentalSyntax;
 
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -40,7 +42,9 @@ import java.util.Set;
 			broadcast name of loop-value"""
 })
 @Since("2.10")
-public class ExprNode extends PropertyExpression<Node, Node> {
+public class ExprNode extends PropertyExpression<Node, Node> implements ExperimentalSyntax {
+
+	private static final ExperimentData EXPERIMENT_DATA = new ExperimentData().required(Feature.SCRIPT_REFLECTION);
 
 	static {
 		Skript.registerExpression(ExprNode.class, Node.class, ExpressionType.PROPERTY,
@@ -57,8 +61,6 @@ public class ExprNode extends PropertyExpression<Node, Node> {
 	@Override
 	@SuppressWarnings("unchecked")
 	public boolean init(Expression<?>[] expressions, int pattern, Kleenean isDelayed, ParseResult parseResult) {
-		if (!this.getParser().hasExperiment(Feature.SCRIPT_REFLECTION))
-			return false;
 		this.isPath = pattern < 2;
 		switch (pattern) {
 			case 0:
@@ -73,6 +75,11 @@ public class ExprNode extends PropertyExpression<Node, Node> {
 				this.setExpr((Expression<? extends Node>) expressions[0]);
 		}
 		return true;
+	}
+
+	@Override
+	public ExperimentData getExperimentData() {
+		return EXPERIMENT_DATA;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprQueue.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprQueue.java
@@ -5,7 +5,6 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
-import org.skriptlang.skript.lang.experiment.ExperimentalSyntax;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -15,7 +14,8 @@ import ch.njol.skript.util.LiteralUtils;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
-import org.skriptlang.skript.lang.experiment.ExperimentSet;
+import org.skriptlang.skript.lang.experiment.ExperimentData;
+import org.skriptlang.skript.lang.experiment.ExperimentalSyntax;
 import org.skriptlang.skript.lang.util.SkriptQueue;
 
 import java.util.Iterator;
@@ -47,6 +47,8 @@ import java.util.Iterator;
 @Since("2.10 (experimental)")
 public class ExprQueue extends SimpleExpression<SkriptQueue> implements ExperimentalSyntax {
 
+	private static final ExperimentData EXPERIMENT_DATA = new ExperimentData().required(Feature.QUEUES);
+
 	static {
 		Skript.registerExpression(ExprQueue.class, SkriptQueue.class, ExpressionType.COMBINED,
 			"[a] [new] queue [(of|with) %-objects%]");
@@ -62,8 +64,8 @@ public class ExprQueue extends SimpleExpression<SkriptQueue> implements Experime
 	}
 
 	@Override
-	public boolean isSatisfiedBy(ExperimentSet experimentSet) {
-		return experimentSet.hasExperiment(Feature.QUEUES);
+	public ExperimentData getExperimentData() {
+		return EXPERIMENT_DATA;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprQueueStartEnd.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprQueueStartEnd.java
@@ -6,14 +6,14 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
-import org.skriptlang.skript.lang.experiment.ExperimentalSyntax;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.registrations.Feature;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
-import org.skriptlang.skript.lang.experiment.ExperimentSet;
+import org.skriptlang.skript.lang.experiment.ExperimentData;
+import org.skriptlang.skript.lang.experiment.ExperimentalSyntax;
 import org.skriptlang.skript.lang.util.SkriptQueue;
 
 import java.util.Arrays;
@@ -36,6 +36,8 @@ import java.util.Arrays;
 @Since("2.10 (experimental)")
 public class ExprQueueStartEnd extends SimplePropertyExpression<SkriptQueue, Object> implements ExperimentalSyntax {
 
+	private static final ExperimentData EXPERIMENT_DATA = new ExperimentData().required(Feature.QUEUES);
+
 	static {
 		register(ExprQueueStartEnd.class, Object.class, "(:start|end)", "queue");
 	}
@@ -49,8 +51,8 @@ public class ExprQueueStartEnd extends SimplePropertyExpression<SkriptQueue, Obj
 	}
 
 	@Override
-	public boolean isSatisfiedBy(ExperimentSet experimentSet) {
-		return experimentSet.hasExperiment(Feature.QUEUES);
+	public ExperimentData getExperimentData() {
+		return EXPERIMENT_DATA;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprResult.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprResult.java
@@ -14,6 +14,8 @@ import ch.njol.skript.util.LiteralUtils;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.lang.experiment.ExperimentData;
+import org.skriptlang.skript.lang.experiment.ExperimentalSyntax;
 import org.skriptlang.skript.util.Executable;
 
 @Name("Result (Experimental)")
@@ -29,7 +31,9 @@ import org.skriptlang.skript.util.Executable;
 })
 @Since("2.10")
 @Keywords({"run", "result", "execute", "function", "reflection"})
-public class ExprResult extends PropertyExpression<Executable<Event, Object>, Object> {
+public class ExprResult extends PropertyExpression<Executable<Event, Object>, Object> implements ExperimentalSyntax {
+
+	private static final ExperimentData EXPERIMENT_DATA = new ExperimentData().required(Feature.SCRIPT_REFLECTION);
 
 	static {
 		Skript.registerExpression(ExprResult.class, Object.class, ExpressionType.COMBINED,
@@ -41,10 +45,7 @@ public class ExprResult extends PropertyExpression<Executable<Event, Object>, Ob
 	private DynamicFunctionReference.Input input;
 
 	@Override
-	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed,
-						ParseResult result) {
-		if (!this.getParser().hasExperiment(Feature.SCRIPT_REFLECTION))
-			return false;
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult result) {
 		//noinspection unchecked
 		this.setExpr((Expression<? extends Executable<Event, Object>>) expressions[0]);
 		this.hasArguments = result.hasTag("arguments");
@@ -63,6 +64,11 @@ public class ExprResult extends PropertyExpression<Executable<Event, Object>, Ob
 			this.input = new DynamicFunctionReference.Input();
 		}
 		return true;
+	}
+
+	@Override
+	public ExperimentData getExperimentData() {
+		return EXPERIMENT_DATA;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprScripts.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprScripts.java
@@ -14,9 +14,10 @@ import ch.njol.skript.registrations.Feature;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.lang.experiment.ExperimentData;
+import org.skriptlang.skript.lang.experiment.ExperimentalSyntax;
 import org.skriptlang.skript.lang.script.Script;
 
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -31,7 +32,9 @@ import java.util.Objects;
 	"\t\tsend \"Unloaded Scripts: %disabled scripts%\" to player"
 })
 @Since("2.10")
-public class ExprScripts extends SimpleExpression<Script> {
+public class ExprScripts extends SimpleExpression<Script> implements ExperimentalSyntax {
+
+	private static final ExperimentData EXPERIMENT_DATA = new ExperimentData().required(Feature.SCRIPT_REFLECTION);
 
 	static {
 		Skript.registerExpression(ExprScripts.class, Script.class, ExpressionType.SIMPLE,
@@ -44,10 +47,13 @@ public class ExprScripts extends SimpleExpression<Script> {
 
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		if (!this.getParser().hasExperiment(Feature.SCRIPT_REFLECTION))
-			return false;
 		this.pattern = matchedPattern;
 		return true;
+	}
+
+	@Override
+	public ExperimentData getExperimentData() {
+		return EXPERIMENT_DATA;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprScriptsOld.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprScriptsOld.java
@@ -14,6 +14,8 @@ import ch.njol.skript.registrations.Feature;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.lang.experiment.ExperimentData;
+import org.skriptlang.skript.lang.experiment.ExperimentalSyntax;
 import org.skriptlang.skript.lang.script.Script;
 
 import java.io.File;
@@ -32,7 +34,9 @@ import java.util.stream.Collectors;
 	"\t\tsend \"Unloaded Scripts: %disabled scripts%\" to player"
 })
 @Since("2.5")
-public class ExprScriptsOld extends SimpleExpression<String> {
+public class ExprScriptsOld extends SimpleExpression<String> implements ExperimentalSyntax {
+
+	private static final ExperimentData EXPERIMENT_DATA = new ExperimentData().required(Feature.SCRIPT_REFLECTION);
 
 	static {
 		Skript.registerExpression(ExprScriptsOld.class, String.class, ExpressionType.SIMPLE,
@@ -49,12 +53,15 @@ public class ExprScriptsOld extends SimpleExpression<String> {
 
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		if (this.getParser().hasExperiment(Feature.SCRIPT_REFLECTION))
-			return false;
 		includeEnabled = matchedPattern <= 1;
 		includeDisabled = matchedPattern != 1;
 		noPaths = parseResult.mark == 1;
 		return true;
+	}
+
+	@Override
+	public ExperimentData getExperimentData() {
+		return EXPERIMENT_DATA;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -286,7 +286,7 @@ public class SkriptParser {
 		if (required != null) {
 			for (Experiment experiment : required) {
 				if (!experiments.hasExperiment(experiment)) {
-					Skript.error(experimentData.constructError());
+					Skript.error(experimentData.getErrorMessage());
 					return false;
 				}
 			}
@@ -295,7 +295,7 @@ public class SkriptParser {
 		if (disallowed != null) {
 			for (Experiment experiment : disallowed) {
 				if (experiments.hasExperiment(experiment)) {
-					Skript.error(experimentData.constructError());
+					Skript.error(experimentData.getErrorMessage());
 					return false;
 				}
 			}

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -281,7 +281,7 @@ public class SkriptParser {
 		ExperimentSet experiments = getParser().getExperimentSet();
 		ExperimentData experimentData = experimentalSyntax.getExperimentData();
 		if (!experimentData.isValid())
-			throw new IllegalArgumentException("An ExperimentalData must have required Experiments and/or disabled Experiements");
+			throw new IllegalArgumentException("An ExperimentalData must have required and/or disallowed Experiements");
 		Experiment[] required = experimentData.getRequired();
 		if (required != null) {
 			for (Experiment experiment : required) {

--- a/src/main/java/ch/njol/skript/sections/SecFor.java
+++ b/src/main/java/ch/njol/skript/sections/SecFor.java
@@ -8,7 +8,6 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
-import org.skriptlang.skript.lang.experiment.ExperimentalSyntax;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.TriggerItem;
@@ -21,7 +20,8 @@ import ch.njol.skript.util.LiteralUtils;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
-import org.skriptlang.skript.lang.experiment.ExperimentSet;
+import org.skriptlang.skript.lang.experiment.ExperimentData;
+import org.skriptlang.skript.lang.experiment.ExperimentalSyntax;
 
 import java.util.List;
 import java.util.Map;
@@ -52,6 +52,8 @@ import java.util.Map;
 })
 @Since("2.10")
 public class SecFor extends SecLoop implements ExperimentalSyntax {
+
+	private static final ExperimentData EXPERIMENT_DATA = new ExperimentData().required(Feature.FOR_EACH_LOOPS);
 
 	static {
 		Skript.registerSection(SecFor.class,
@@ -123,8 +125,8 @@ public class SecFor extends SecLoop implements ExperimentalSyntax {
 	}
 
 	@Override
-	public boolean isSatisfiedBy(ExperimentSet experimentSet) {
-		return experimentSet.hasExperiment(Feature.FOR_EACH_LOOPS);
+	public ExperimentData getExperimentData() {
+		return EXPERIMENT_DATA;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/structures/StructExample.java
+++ b/src/main/java/ch/njol/skript/structures/StructExample.java
@@ -4,7 +4,6 @@ import ch.njol.skript.ScriptLoader;
 import ch.njol.skript.Skript;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.doc.*;
-import org.skriptlang.skript.lang.experiment.ExperimentalSyntax;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.function.FunctionEvent;
@@ -13,7 +12,8 @@ import ch.njol.skript.registrations.Feature;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.entry.EntryContainer;
-import org.skriptlang.skript.lang.experiment.ExperimentSet;
+import org.skriptlang.skript.lang.experiment.ExperimentData;
+import org.skriptlang.skript.lang.experiment.ExperimentalSyntax;
 import org.skriptlang.skript.lang.structure.Structure;
 
 @NoDoc
@@ -30,6 +30,8 @@ import org.skriptlang.skript.lang.structure.Structure;
 })
 @Since("2.10")
 public class StructExample extends Structure implements ExperimentalSyntax {
+
+	private static final ExperimentData EXPERIMENT_DATA = new ExperimentData().required(Feature.EXAMPLES);
 
 	public static final Priority PRIORITY = new Priority(550);
 
@@ -50,8 +52,8 @@ public class StructExample extends Structure implements ExperimentalSyntax {
 	}
 
 	@Override
-	public boolean isSatisfiedBy(ExperimentSet experimentSet) {
-		return experimentSet.hasExperiment(Feature.EXAMPLES);
+	public ExperimentData getExperimentData() {
+		return EXPERIMENT_DATA;
 	}
 
 	@Override

--- a/src/main/java/org/skriptlang/skript/lang/experiment/ExperimentData.java
+++ b/src/main/java/org/skriptlang/skript/lang/experiment/ExperimentData.java
@@ -12,6 +12,7 @@ public class ExperimentData {
 
 	private Experiment @Nullable [] required = null;
 	private Experiment @Nullable [] disallowed = null;
+	private @Nullable String errorMessage = null;
 
 	public ExperimentData() {}
 
@@ -36,6 +37,16 @@ public class ExperimentData {
 	}
 
 	/**
+	 * Set the error message to be printed if the requirements of this {@link ExperimentData} are not met.
+	 * @param errorMessage The error message.
+	 * @return This {@link ExperimentData}.
+	 */
+	public ExperimentData errorMessage(String errorMessage) {
+		this.errorMessage = errorMessage;
+		return this;
+	}
+
+	/**
 	 * Get the {@link Experiment}s that must be enabled in order to use.
 	 */
 	public Experiment @Nullable [] getRequired() {
@@ -56,6 +67,14 @@ public class ExperimentData {
 	public boolean isValid() {
         return required != null || disallowed != null;
     }
+
+	/**
+	 * Get the error message to be printed when the requirements of this {@link ExperimentData} are not met.
+	 * If {@link #errorMessage} is {@code null}, will construct an error message via {@link #constructError()}.
+	 */
+	public String getErrorMessage() {
+		return errorMessage != null ? errorMessage : constructError();
+	}
 
 	/**
 	 * Construct a {@link String} combining what {@link Experiment}s need to be enabled and/or disabled in order to use.

--- a/src/main/java/org/skriptlang/skript/lang/experiment/ExperimentData.java
+++ b/src/main/java/org/skriptlang/skript/lang/experiment/ExperimentData.java
@@ -1,0 +1,94 @@
+package org.skriptlang.skript.lang.experiment;
+
+import ch.njol.util.StringUtils;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+
+/**
+ * Container for holding {@link Experiment}s that must be enabled or disabled to use.
+ */
+public class ExperimentData {
+
+	private Experiment @Nullable [] required = null;
+	private Experiment @Nullable [] disallowed = null;
+
+	public ExperimentData() {}
+
+	/**
+	 * Set the {@link Experiment}s that must be enabled in order to use.
+	 * @param required The {@link Experiment}s
+	 * @return This {@link ExperimentData}.
+	 */
+	public ExperimentData required(Experiment... required) {
+		this.required = required;
+		return this;
+	}
+
+	/**
+	 * Set the {@link Experiment}s that must be disabled in order to use.
+	 * @param disallowed The {@link Experiment}s
+	 * @return This {@link ExperimentData}.
+	 */
+	public ExperimentData disallowed(Experiment... disallowed) {
+		this.disallowed = disallowed;
+		return this;
+	}
+
+	/**
+	 * Get the {@link Experiment}s that must be enabled in order to use.
+	 */
+	public Experiment @Nullable [] getRequired() {
+		return required;
+	}
+
+	/**
+	 * Get the {@link Experiment}s that must be disabled in order to use.
+	 */
+	public Experiment @Nullable [] getDisallowed() {
+		return disallowed;
+	}
+
+	/**
+	 * Check if this {@link ExperimentData} is valid.
+	 * @return {@code True} if valid.
+	 */
+	public boolean isValid() {
+        return required != null || disallowed != null;
+    }
+
+	/**
+	 * Construct a {@link String} combining what {@link Experiment}s need to be enabled and/or disabled in order to use.
+	 */
+	public String constructError() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("This element is experimental. To use this, ");
+		if (required != null) {
+			builder.append("enable ");
+			builder.append(StringUtils.join(
+					Arrays.stream(required)
+						.map(experiment -> "'" + experiment.codeName() + "'")
+						.toArray(),
+				", "));
+			if (disallowed != null) {
+				builder.append(" and disable ");
+				builder.append(StringUtils.join(
+					Arrays.stream(disallowed)
+						.map(experiment -> "'" + experiment.codeName() + "'")
+						.toArray(),
+				", "));
+			}
+			builder.append(".");
+		} else {
+			assert disallowed != null;
+			builder.append("disable ");
+			builder.append(StringUtils.join(
+				Arrays.stream(disallowed)
+					.map(experiment -> "'" + experiment.codeName() + "'")
+					.toArray(),
+				", "));
+		}
+		return builder.toString();
+	}
+
+}

--- a/src/main/java/org/skriptlang/skript/lang/experiment/ExperimentalSyntax.java
+++ b/src/main/java/org/skriptlang/skript/lang/experiment/ExperimentalSyntax.java
@@ -1,8 +1,6 @@
 package org.skriptlang.skript.lang.experiment;
 
 import ch.njol.skript.lang.SyntaxElement;
-import org.skriptlang.skript.lang.experiment.Experiment;
-import org.skriptlang.skript.lang.experiment.ExperimentSet;
 
 /**
  * A syntax element that requires an experimental feature to be enabled.
@@ -11,11 +9,20 @@ public interface ExperimentalSyntax extends SyntaxElement {
 
 
 	/**
+	 * @deprecated Use {@link #getExperimentData()} instead.
 	 * Checks whether the required experiments are enabled for this syntax element.
 	 *
 	 * @param experimentSet An {@link Experiment} instance containing currently active experiments in the environment.
 	 * @return {@code true} if the element can be used.
 	 */
-	boolean isSatisfiedBy(ExperimentSet experimentSet);
+	@Deprecated(since = "INSERT VERSION", forRemoval = true)
+	default boolean isSatisfiedBy(ExperimentSet experimentSet) {
+		return false;
+	};
+
+	/**
+	 * Get the {@link ExperimentData} required for this {@link SyntaxElement}.
+	 */
+	ExperimentData getExperimentData();
 
 }


### PR DESCRIPTION
### Description
**The problem**
When `SyntaxElements` implementing `ExperimentalSyntax` were not satisfied, there was no error explaining why and defaulted to `Can't understand this ...` which can be misleading.

**Solution**
Now returns an `ExperimentData` that contains `Experiments` that are required and/or disallowed. If the requirements are not met, will print an error message either by the manual set message or constructing a messsage,

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
