### PR TITLE
Added eating listeners and checks for players

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondIsEating.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsEating.java
@@ -3,24 +3,62 @@ package ch.njol.skript.conditions;
 import ch.njol.skript.Skript;
 import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.*;
+import io.papermc.paper.event.player.PlayerStopUsingItemEvent;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Panda;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
 
 @Name("Is Eating")
-@Description("Whether a panda or horse type (horse, camel, donkey, llama, mule) is eating.")
+@Description("Whether a player, panda or horse type (horse, camel, donkey, llama, mule) is eating.")
 @Example("""
 	if last spawned panda is eating:
 		force last spawned panda to stop eating
 	""")
 @Since("2.11")
-@RequiredPlugins("Paper (horse type)")
+@RequiredPlugins("Paper (horse type, players)")
 public class CondIsEating extends PropertyCondition<LivingEntity> {
 
-	private static final boolean SUPPORTS_HORSES = Skript.methodExists(AbstractHorse.class, "isEating");
+	public static class EatingListener implements Listener {
+
+		@EventHandler
+		public void onInteract(PlayerInteractEvent e) {
+			if (e.hasItem() && e.getMaterial().isEdible()) {
+				playersEating.add(e.getPlayer().getUniqueId());
+			}
+		}
+
+		@EventHandler
+		public void onStopUsingItem(PlayerStopUsingItemEvent e) {
+			playersEating.remove(e.getPlayer().getUniqueId());
+		}
+
+		@EventHandler
+		public void onQuit(PlayerQuitEvent e) {
+			playersEating.remove(e.getPlayer().getUniqueId());
+		}
+	}
+
+	private static final boolean
+		SUPPORTS_HORSES = Skript.methodExists(AbstractHorse.class, "isEating"),
+		SUPPORTS_PLAYERS = Skript.classExists("io.papermc.paper.event.player.PlayerStopUsingItemEvent");
+
+	private static final Set<UUID> playersEating = new HashSet<>();
 
 	static {
 		register(CondIsEating.class, "eating", "livingentities");
+		if (SUPPORTS_PLAYERS) {
+			Bukkit.getPluginManager().registerEvents(new EatingListener(), Skript.getInstance());
+		}
 	}
 
 	@Override
@@ -29,6 +67,8 @@ public class CondIsEating extends PropertyCondition<LivingEntity> {
 			return panda.isEating();
 		} else if (SUPPORTS_HORSES && entity instanceof AbstractHorse horse) {
 			return horse.isEating();
+		} else if (SUPPORTS_PLAYERS && entity instanceof Player player) {
+			return playersEating.contains(player.getUniqueId());
 		}
 		return false;
 	}


### PR DESCRIPTION
### Description
Added listeners and checks to assert whether players are eating, this uses the interact event to get whether the player is consuming an item, the stop using item event to get whether that is done and the quit event to make sure the player leaving (and interrupting the consumption) doesn't leave any trace, across these events the UUID of the player is added to and removed from a set whose contents are the players that are currently eating.

---
**Target Minecraft Versions:** any
**Requirements:** Paper
**Related Issues:** none
