### PR TITLE
Add Timespan add/subtract/diff methods

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/DefaultOperations.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultOperations.java
@@ -4,7 +4,6 @@ import ch.njol.skript.util.Date;
 import ch.njol.skript.util.Timespan;
 import ch.njol.skript.util.Timespan.TimePeriod;
 import ch.njol.skript.util.Utils;
-import ch.njol.util.Math2;
 import org.bukkit.util.Vector;
 import org.skriptlang.skript.lang.arithmetic.Arithmetics;
 import org.skriptlang.skript.lang.arithmetic.Operator;
@@ -91,9 +90,9 @@ public class DefaultOperations {
 		});
 
 		// Timespan - Timespan
-		Arithmetics.registerOperation(Operator.ADDITION, Timespan.class, (left, right) -> new Timespan(Math2.addClamped(left.getAs(TimePeriod.MILLISECOND), right.getAs(TimePeriod.MILLISECOND))));
-		Arithmetics.registerOperation(Operator.SUBTRACTION, Timespan.class, (left, right) -> new Timespan(Math.max(0, left.getAs(TimePeriod.MILLISECOND) - right.getAs(TimePeriod.MILLISECOND))));
-		Arithmetics.registerDifference(Timespan.class, (left, right) -> new Timespan(Math.abs(left.getAs(TimePeriod.MILLISECOND) - right.getAs(TimePeriod.MILLISECOND))));
+		Arithmetics.registerOperation(Operator.ADDITION, Timespan.class, (left, right) -> left.add(right));
+		Arithmetics.registerOperation(Operator.SUBTRACTION, Timespan.class, (left, right) -> left.subtract(right));
+		Arithmetics.registerDifference(Timespan.class, (left, right) -> left.difference(right));
 		Arithmetics.registerDefaultValue(Timespan.class, Timespan::new);
 
 		// Timespan - Number

--- a/src/main/java/ch/njol/skript/util/Timespan.java
+++ b/src/main/java/ch/njol/skript/util/Timespan.java
@@ -174,7 +174,7 @@ public class Timespan implements YggdrasilSerializable, Comparable<Timespan>, Te
 		return pair.getFirst().withAmount(amount, flags);
 	}
 
-	private long millis;
+	private final long millis;
 
 	public Timespan() {
 		millis = 0;
@@ -258,21 +258,21 @@ public class Timespan implements YggdrasilSerializable, Comparable<Timespan>, Te
 	/**
 	 * Safely adds the specified timespan to this timespan, handling potential overflow.
 	 * @param timespan The timespan to add to this timespan
-	 * @return this object
+	 * @return a new Timespan object
 	 */
 	public Timespan add(Timespan timespan) {
-		millis = Math2.addClamped(millis, timespan.getAs(TimePeriod.MILLISECOND));
-		return this;
+		long millis = Math2.addClamped(this.millis, timespan.getAs(TimePeriod.MILLISECOND));
+		return new Timespan(millis);
 	}
 
 	/**
 	 * Safely subtracts the specified timespan from this timespan, handling potential underflow.
 	 * @param timespan The timespan to subtract from this timespan
-	 * @return this object
+	 * @return a new Timespan object
 	 */
 	public Timespan subtract(Timespan timespan) {
-		millis = Math.max(0, millis - timespan.getAs(TimePeriod.MILLISECOND));
-		return this;
+		long millis = Math.max(0, this.millis - timespan.getAs(TimePeriod.MILLISECOND));
+		return new Timespan(millis);
 	}
 
 	/**

--- a/src/main/java/ch/njol/skript/util/Timespan.java
+++ b/src/main/java/ch/njol/skript/util/Timespan.java
@@ -5,6 +5,7 @@ import ch.njol.skript.lang.ParseContext;
 import ch.njol.skript.localization.GeneralWords;
 import ch.njol.skript.localization.Language;
 import ch.njol.skript.localization.Noun;
+import ch.njol.util.Math2;
 import ch.njol.util.NonNullPair;
 import ch.njol.util.coll.CollectionUtils;
 import ch.njol.yggdrasil.YggdrasilSerializable;
@@ -173,7 +174,7 @@ public class Timespan implements YggdrasilSerializable, Comparable<Timespan>, Te
 		return pair.getFirst().withAmount(amount, flags);
 	}
 
-	private final long millis;
+	private long millis;
 
 	public Timespan() {
 		millis = 0;
@@ -252,6 +253,35 @@ public class Timespan implements YggdrasilSerializable, Comparable<Timespan>, Te
 	 */
 	public Duration getDuration() {
 		return Duration.ofMillis(millis);
+	}
+
+	/**
+	 * Safely adds the specified timespan to this timespan, handling potential overflow.
+	 * @param timespan The timespan to add to this timespan
+	 * @return this object
+	 */
+	public Timespan add(Timespan timespan) {
+		millis = Math2.addClamped(millis, timespan.getAs(TimePeriod.MILLISECOND));
+		return this;
+	}
+
+	/**
+	 * Safely subtracts the specified timespan from this timespan, handling potential underflow.
+	 * @param timespan The timespan to subtract from this timespan
+	 * @return this object
+	 */
+	public Timespan subtract(Timespan timespan) {
+		millis = Math.max(0, millis - timespan.getAs(TimePeriod.MILLISECOND));
+		return this;
+	}
+
+	/**
+	 * Calculates the difference between the specified timespan and this timespan.
+	 * @param timespan The timespan to get the difference of
+	 * @return a new Timespan object
+	 */
+	public Timespan difference(Timespan timespan) {
+		return new Timespan(Math.abs(millis - timespan.getAs(TimePeriod.MILLISECOND)));
 	}
 
 	@Override


### PR DESCRIPTION
### Problem
Having to write unnecessary code to get the timespan arithmetic operation, just for simple additions and subtractions. 


### Solution
Moves the arithmetic code inside the Timespan class so that the methods can be used quickly.


### Testing Completed
Manual testing was done to ensure that overflowing and underflowing are properly handled and that simple operations work fine. No code was changed, only moved around.


### Supporting Information
This was discussed in the dev channel


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
