### PR TITLE
Properly Handle Blockdata in Click Event

### DIFF
--- a/src/main/java/ch/njol/skript/events/EvtClick.java
+++ b/src/main/java/ch/njol/skript/events/EvtClick.java
@@ -175,17 +175,17 @@ public class EvtClick extends SkriptEvent {
 		if (type != null) {
 			BlockData blockDataCheck = block != null ? block.getBlockData() : null;
 			return type.check(event, (Predicate<Object>) object -> {
-				if (entity != null) {
+				if (object instanceof BlockData blockData) {
+					return blockDataCheck != null && blockDataCheck.matches(blockData);
+				} else if (entity != null) {
 					if (object instanceof EntityData<?> entityData) {
 						return entityData.isInstance(entity);
-					} else {
-						Relation compare = DefaultComparators.entityItemComparator.compare(EntityData.fromEntity(entity), (ItemType) object);
+					} else if (object instanceof ItemType itemType) {
+						Relation compare = DefaultComparators.entityItemComparator.compare(EntityData.fromEntity(entity), itemType);
 						return Relation.EQUAL.isImpliedBy(compare);
 					}
 				} else if (object instanceof ItemType itemType) {
 					return itemType.isOfType(block);
-				} else if (blockDataCheck != null && object instanceof BlockData blockData)  {
-					return blockDataCheck.matches(blockData);
 				}
 				return false;
 			});

--- a/src/main/java/ch/njol/skript/events/EvtClick.java
+++ b/src/main/java/ch/njol/skript/events/EvtClick.java
@@ -175,9 +175,7 @@ public class EvtClick extends SkriptEvent {
 		if (type != null) {
 			BlockData blockDataCheck = block != null ? block.getBlockData() : null;
 			return type.check(event, (Predicate<Object>) object -> {
-				if (object instanceof BlockData blockData) {
-					return blockDataCheck != null && blockDataCheck.matches(blockData);
-				} else if (entity != null) {
+				 if (entity != null) {
 					if (object instanceof EntityData<?> entityData) {
 						return entityData.isInstance(entity);
 					} else if (object instanceof ItemType itemType) {
@@ -186,6 +184,8 @@ public class EvtClick extends SkriptEvent {
 					}
 				} else if (object instanceof ItemType itemType) {
 					return itemType.isOfType(block);
+				} else if (object instanceof BlockData blockData) {
+					return blockDataCheck != null && blockDataCheck.matches(blockData);
 				}
 				return false;
 			});

--- a/src/main/java/ch/njol/skript/events/EvtClick.java
+++ b/src/main/java/ch/njol/skript/events/EvtClick.java
@@ -175,7 +175,7 @@ public class EvtClick extends SkriptEvent {
 		if (type != null) {
 			BlockData blockDataCheck = block != null ? block.getBlockData() : null;
 			return type.check(event, (Predicate<Object>) object -> {
-				 if (entity != null) {
+				if (entity != null) {
 					if (object instanceof EntityData<?> entityData) {
 						return entityData.isInstance(entity);
 					} else if (object instanceof ItemType itemType) {

--- a/src/main/java/ch/njol/skript/events/EvtClick.java
+++ b/src/main/java/ch/njol/skript/events/EvtClick.java
@@ -179,6 +179,8 @@ public class EvtClick extends SkriptEvent {
 					if (object instanceof EntityData<?> entityData) {
 						return entityData.isInstance(entity);
 					} else if (object instanceof ItemType itemType) {
+						// for cases like `on right click on oak boat` try to compare the boat item to the boat entity
+						// therefore blockdata check isn't needed here
 						Relation compare = DefaultComparators.entityItemComparator.compare(EntityData.fromEntity(entity), itemType);
 						return Relation.EQUAL.isImpliedBy(compare);
 					}


### PR DESCRIPTION
### Problem
If you use the `on right click on %blockdata%` pattern and click on an entity, it always assumes the object is either an entity or an item type, but not block data, which can cause the server to crash.


### Solution
Moved the blockdata check a bit earlier to fix the issue and added an `instanceof ItemType` check to prevent possible crashes in the future.


### Testing Completed
Tested `on right click on pig`, `on right click on stone`, `on right click on stone_button[]` and `on right click on stone_button[powered=false]` to ensure nothing was broken with this fix.


---
**Completes:** #7885 
**Related:** none <!-- Links to issues or discussions with related information -->
