### PR TITLE
Use StopTrigger ExecutionIntent in EffExit when applicable

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffExit.java
+++ b/src/main/java/ch/njol/skript/effects/EffExit.java
@@ -101,7 +101,7 @@ public class EffExit extends Effect {
 		debug(event, false);
 		for (SectionExitHandler section : sectionsToExit)
 			section.exit(event);
-		if (outerSection == null)
+		if (outerSection == null) // "stop trigger"
 			return null;
 		return outerSection instanceof LoopSection loopSection ? loopSection.getActualNext() : outerSection.getNext();
 	}
@@ -113,11 +113,15 @@ public class EffExit extends Effect {
 
 	@Override
 	public @Nullable ExecutionIntent executionIntent() {
+		if (outerSection == null)
+			return ExecutionIntent.stopTrigger();
 		return ExecutionIntent.stopSections(breakLevels);
 	}
 
 	@Override
 	public String toString(@Nullable Event event, boolean debug) {
+		if (outerSection == null)
+			return "stop trigger";
 		return "stop " + breakLevels + " " + names[type];
 	}
 


### PR DESCRIPTION
### Problem
EffExit currently uses the StopSections intent even for `stop trigger`. While stopping *all* sections is technically correct, it is more accurate (and useful) to use the StopTrigger intent.


### Solution
Simply checks `outerSection == null` (true only for `stop trigger`) and returns the appropriate intent.


### Testing Completed
No additional tests are needed/applicable.


### Supporting Information
I planned to use ExecutionIntent in supporting local variable type hints. I ran into this issue.


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
