### PR TITLE
Use proper deprecation warning for ExprNoDamageTicks

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprNoDamageTicks.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNoDamageTicks.java
@@ -1,6 +1,5 @@
 package ch.njol.skript.expressions;
 
-import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -15,6 +14,7 @@ import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.lang.script.ScriptWarning;
 
 @Name("No Damage Ticks")
 @Description("The number of ticks that an entity is invulnerable to damage for.")
@@ -32,7 +32,7 @@ public class ExprNoDamageTicks extends SimplePropertyExpression<LivingEntity, Lo
 
 	@Override
 	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		Skript.warning("This expression is deprecated. Please use 'invulnerability time' instead of 'invulnerability ticks'.");
+		ScriptWarning.printDeprecationWarning("This expression is deprecated. Please use 'invulnerability time' instead of 'invulnerability ticks'.");
 		return super.init(expressions, matchedPattern, isDelayed, parseResult);
 	}
 

--- a/src/test/skript/tests/syntaxes/expressions/ExprNoDamageTicks.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprNoDamageTicks.sk
@@ -1,3 +1,6 @@
+on script load:
+	suppress deprecated syntax warnings
+
 test "no damage ticks":
 	spawn zombie at test-location:
 		set {_entity} to entity


### PR DESCRIPTION
### Problem
ExprNoDamageTicks is deprecated, but it does not print a "proper" deprecation warning. Thus, it is not affected by suppressing those warnings. It also spams the tests a lot.


### Solution
I switched to the proper method from ScriptWarning. The warning itself remains the same.


### Testing Completed
I did suppress the warning for the existing test script and confirmed that it is no longer printed.


### Supporting Information
n/a


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
