### PR TITLE
Return type accuracy and usage improvements

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffToggle.java
+++ b/src/main/java/ch/njol/skript/effects/EffToggle.java
@@ -53,12 +53,12 @@ public class EffToggle extends Effect {
 		
 		/**
 		 * Determines the appropriate Type based on the return type of an expression.
-		 * @param returnType The class representing the return type
+		 * @param expression The expression to determine the type of.
 		 * @return The corresponding Type
 		 */
-		public static Type fromClass(Class<?> returnType) {
-			boolean isBlockType = Block.class.isAssignableFrom(returnType);
-			boolean isBooleanType = Boolean.class.isAssignableFrom(returnType);
+		public static Type fromClass(Expression<?> expression) {
+			boolean isBlockType = expression.canReturn(Block.class);
+			boolean isBooleanType = expression.canReturn(Boolean.class);
 			
 			if (isBlockType && !isBooleanType) {
 				return BLOCKS;
@@ -90,7 +90,7 @@ public class EffToggle extends Effect {
 		action = patterns.getInfo(matchedPattern);
 
 		// Determine expression type using the enum method
-		type = Type.fromClass(togglables.getReturnType());
+		type = Type.fromClass(togglables);
 		
 		// Validate based on type
 		if (type == Type.BOOLEANS && 

--- a/src/main/java/ch/njol/skript/effects/EffVisualEffect.java
+++ b/src/main/java/ch/njol/skript/effects/EffVisualEffect.java
@@ -79,7 +79,7 @@ public class EffVisualEffect extends Effect {
 				Skript.warning("Entity effects are visible to all players");
 			if (!hasLocationEffect && !direction.isDefault())
 				Skript.warning("Entity effects are always played on an entity");
-			if (hasEntityEffect && !Entity.class.isAssignableFrom(where.getReturnType())) {
+			if (hasEntityEffect && !where.canReturn(Entity.class)) {
 				Skript.error("Entity effects can only be played on entities");
 				return false;
 			}

--- a/src/main/java/ch/njol/skript/events/EvtClick.java
+++ b/src/main/java/ch/njol/skript/events/EvtClick.java
@@ -80,7 +80,7 @@ public class EvtClick extends SkriptEvent {
 	public boolean init(Literal<?>[] args, int matchedPattern, ParseResult parseResult) {
 		click = parseResult.mark == 0 ? ANY : parseResult.mark;
 		type = args[matchedPattern];
-		if (type != null && !ItemType.class.isAssignableFrom(type.getReturnType()) && !BlockData.class.isAssignableFrom(type.getReturnType())) {
+		if (type != null && !type.canReturn(ItemType.class) && !type.canReturn(BlockData.class)) {
 			Literal<EntityData<?>> entitydata = (Literal<EntityData<?>>) type;
 			if (click == LEFT) {
 				if (Vehicle.class.isAssignableFrom(entitydata.getSingle().getType())) {

--- a/src/main/java/ch/njol/skript/expressions/ExprAge.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAge.java
@@ -47,7 +47,7 @@ public class ExprAge extends SimplePropertyExpression<Object, Integer> {
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		isMax = parseResult.hasTag("max");
 		setExpr(exprs[0]);
-		if (isMax && Entity.class.isAssignableFrom(getExpr().getReturnType())) {
+		if (isMax && !getExpr().canReturn(Block.class)) {
 			Skript.error("Cannot use 'max age' expression with entities, use just the 'age' expression instead");
 			return false;
 		}

--- a/src/main/java/ch/njol/skript/expressions/ExprAttacker.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAttacker.java
@@ -61,7 +61,7 @@ public class ExprAttacker extends SimpleExpression<Entity> implements EventRestr
 	}
 	
 	@Nullable
-	private static Entity getAttacker(@Nullable Event e) {
+	static Entity getAttacker(@Nullable Event e) {
 		if (e == null)
 			return null;
 		if (e instanceof EntityDamageByEntityEvent) {

--- a/src/main/java/ch/njol/skript/expressions/ExprBannerPatterns.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBannerPatterns.java
@@ -218,20 +218,24 @@ public class ExprBannerPatterns extends PropertyExpression<Object, Pattern> {
 
 	@Override
 	public void change(Event event, Object @Nullable [] delta, ChangeMode mode) {
-		Pattern[] patterns = (Pattern[]) delta;
-		int placement = patternNumber == null ? 0 : patternNumber.getSingle(event);
-		List<Pattern> patternList = patterns != null ? Arrays.stream(patterns).toList() : new ArrayList<>();
+		int placement = 0;
+		if (patternNumber != null) {
+			Integer patternNum = patternNumber.getSingle(event);
+			if (patternNum != null) {
+				placement = patternNum;
+			}
+		}
+		List<Pattern> patterns = delta != null ? Arrays.stream(delta).map(Pattern.class::cast).toList() : new ArrayList<>();
 
-		Consumer<BannerMeta> metaChanger = null;
-		Consumer<Banner> blockChanger = null;
-
+		Consumer<BannerMeta> metaChanger;
+		Consumer<Banner> blockChanger;
 		if (placement >= 1) {
-			Pattern pattern = patternList.size() == 1 ? patternList.get(0) : null;
+			Pattern pattern = patterns.size() == 1 ? patterns.get(0) : null;
 			metaChanger = getPlacementMetaChanger(mode, placement, pattern);
 			blockChanger = getPlacementBlockChanger(mode, placement, pattern);
 		} else {
-			metaChanger = getAllMetaChanger(mode, patternList);
-			blockChanger = getAllBlockChanger(mode, patternList);
+			metaChanger = getAllMetaChanger(mode, patterns);
+			blockChanger = getAllBlockChanger(mode, patterns);
 		}
 
 		for (Object object : objects.getArray(event)) {

--- a/src/main/java/ch/njol/skript/expressions/ExprBeaconValues.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBeaconValues.java
@@ -189,8 +189,12 @@ public class ExprBeaconValues extends PropertyExpression<Block, Object> {
 	}
 
 	@Override
-	public Class<Object> getReturnType() {
-		return Object.class;
+	public Class<?> getReturnType() {
+		return switch (valueType) {
+			case PRIMARY, SECONDARY -> PotionEffectType.class;
+			case RANGE -> Double.class;
+			case TIER -> Integer.class;
+		};
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprColorOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprColorOf.java
@@ -92,27 +92,19 @@ public class ExprColorOf extends PropertyExpression<Object, Color> {
 
 	@Override
 	public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
-		Class<?> returnType = getExpr().getReturnType();
+		Expression<?> expression = getExpr();
 
-		if (returnType.isAssignableFrom(FireworkEffect.class))
+		if (expression.canReturn(FireworkEffect.class))
 			return CollectionUtils.array(Color[].class);
 
-		// double assignable checks are to allow both parent and child types, since variables return Object
-		// This does mean we have to be more stringent in checking the validity of the change mode in change() itself.
-		if ((returnType.isAssignableFrom(Display.class) || Display.class.isAssignableFrom(returnType)) && (mode == ChangeMode.RESET || mode == ChangeMode.SET))
+		if ((mode == ChangeMode.RESET || mode == ChangeMode.SET) && expression.canReturn(Display.class))
 			return CollectionUtils.array(Color.class);
 
-		// the following only support SET
-		if (mode != ChangeMode.SET)
-			return null;
-		if (returnType.isAssignableFrom(Entity.class)
-			|| Entity.class.isAssignableFrom(returnType)
-			|| returnType.isAssignableFrom(Block.class)
-			|| Block.class.isAssignableFrom(returnType)
-			|| returnType.isAssignableFrom(ItemType.class)
-		) {
+		if (mode == ChangeMode.SET &&
+			(expression.canReturn(Entity.class) || expression.canReturn(Block.class) || expression.canReturn(ItemType.class))) {
 			return CollectionUtils.array(Color.class);
 		}
+
 		return null;
 	}
 

--- a/src/main/java/ch/njol/skript/expressions/ExprDefaultValue.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDefaultValue.java
@@ -9,93 +9,77 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.util.SimpleExpression;
-import org.skriptlang.skript.lang.converter.Converters;
 import ch.njol.skript.util.LiteralUtils;
 import ch.njol.skript.util.Utils;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
-import org.jetbrains.annotations.Nullable;
 
-import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 @Name("Default Value")
 @Description("A shorthand expression for giving things a default value. If the first thing isn't set, the second thing will be returned.")
 @Examples({"broadcast {score::%player's uuid%} otherwise \"%player% has no score!\""})
 @Since("2.2-dev36")
-@SuppressWarnings("null")
-public class ExprDefaultValue<T> extends SimpleExpression<T> {
+public class ExprDefaultValue extends SimpleExpression<Object> {
 
 	static {
 		Skript.registerExpression(ExprDefaultValue.class, Object.class, ExpressionType.COMBINED,
 				"%objects% (otherwise|?) %objects%");
 	}
 
-	private final ExprDefaultValue<?> source;
-	private final Class<? extends T>[] types;
-	private final Class<T> superType;
-	@Nullable
-	private Expression<Object> first;
-	@Nullable
-	private Expression<Object> second;
+	private Class<?>[] types;
+	private Class<?> superType;
 
-	@SuppressWarnings("unchecked")
-	public ExprDefaultValue() {
-		this(null, (Class<? extends T>) Object.class);
-	}
-
-	@SuppressWarnings("unchecked")
-	private ExprDefaultValue(ExprDefaultValue<?> source, Class<? extends T>... types) {
-		this.source = source;
-		if (source != null) {
-			this.first = source.first;
-			this.second = source.second;
-		}
-		this.types = types;
-		this.superType = (Class<T>) Utils.getSuperType(types);
-	}
+	private Expression<Object> values;
+	private Expression<Object> defaultValues;
 
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
-		first = LiteralUtils.defendExpression(exprs[0]);
-		second = LiteralUtils.defendExpression(exprs[1]);
-		return LiteralUtils.canInitSafely(first, second);
-	}
-
-	@Override
-	@SuppressWarnings("unchecked")
-	protected T[] get(Event e) {
-		Object[] first = this.first.getArray(e);
-		Object values[] = first.length != 0 ? first : second.getArray(e);
-		try {
-			return Converters.convert(values, types, superType);
-		} catch (ClassCastException e1) {
-			return (T[]) Array.newInstance(superType, 0);
+		values = LiteralUtils.defendExpression(exprs[0]);
+		defaultValues = LiteralUtils.defendExpression(exprs[1]);
+		if (!LiteralUtils.canInitSafely(values, defaultValues)) {
+			return false;
 		}
+
+		Set<Class<?>> types = new HashSet<>();
+		Collections.addAll(types, values.possibleReturnTypes());
+		Collections.addAll(types, defaultValues.possibleReturnTypes());
+		this.types = types.toArray(new Class<?>[0]);
+		this.superType = Utils.getSuperType(this.types);
+
+		return true;
 	}
 
 	@Override
-	public <R> Expression<? extends R> getConvertedExpression(Class<R>... to) {
-		return new ExprDefaultValue<>(this, to);
-	}
-
-	@Override
-	public Expression<?> getSource() {
-		return source == null ? this : source;
-	}
-
-	@Override
-	public Class<? extends T> getReturnType() {
-		return superType;
+	protected Object[] get(Event event) {
+		Object[] values = this.values.getArray(event);
+		if (values.length != 0) {
+			return values;
+		}
+		return defaultValues.getArray(event);
 	}
 
 	@Override
 	public boolean isSingle() {
-		return first.isSingle() && second.isSingle();
+		return values.isSingle() && defaultValues.isSingle();
 	}
 
 	@Override
-	public String toString(Event e, boolean debug) {
-		return first.toString(e, debug) + " or else " + second.toString(e, debug);
+	public Class<?> getReturnType() {
+		return superType;
+	}
+
+	@Override
+	public Class<?>[] possibleReturnTypes() {
+		return Arrays.copyOf(types, types.length);
+	}
+
+	@Override
+	public String toString(Event event, boolean debug) {
+		return values.toString(event, debug) + " or else " + defaultValues.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprElement.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprElement.java
@@ -238,6 +238,22 @@ public class ExprElement<T> extends SimpleExpression<T> {
 	}
 
 	@Override
+	public Class<? extends T>[] possibleReturnTypes() {
+		if (!queue) {
+			return expr.possibleReturnTypes();
+		}
+		return super.possibleReturnTypes();
+	}
+
+	@Override
+	public boolean canReturn(Class<?> returnType) {
+		if (!queue) {
+			return expr.canReturn(returnType);
+		}
+		return super.canReturn(returnType);
+	}
+
+	@Override
 	public String toString(@Nullable Event event, boolean debug) {
 		String prefix;
 		switch (type) {

--- a/src/main/java/ch/njol/skript/expressions/ExprFacing.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFacing.java
@@ -72,7 +72,7 @@ public class ExprFacing extends SimplePropertyExpression<Object, Direction> {
 	@Override
 	@Nullable
 	public Class<?>[] acceptChange(final ChangeMode mode) {
-		if (!Block.class.isAssignableFrom(getExpr().getReturnType()))
+		if (!getExpr().canReturn(Block.class))
 			return null;
 		if (mode == ChangeMode.SET)
 			return CollectionUtils.array(Direction.class);

--- a/src/main/java/ch/njol/skript/expressions/ExprFilter.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprFilter.java
@@ -123,6 +123,16 @@ public class ExprFilter extends SimpleExpression<Object> implements InputSource 
 	}
 
 	@Override
+	public Class<?>[] possibleReturnTypes() {
+		return unfilteredObjects.possibleReturnTypes();
+	}
+
+	@Override
+	public boolean canReturn(Class<?> returnType) {
+		return unfilteredObjects.canReturn(returnType);
+	}
+
+	@Override
 	public String toString(@Nullable Event event, boolean debug) {
 		return unfilteredObjects.toString(event, debug) + " that match [" + unparsedCondition + "]";
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprInput.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprInput.java
@@ -22,6 +22,7 @@ import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.converter.Converters;
 
 import java.lang.reflect.Array;
+import java.util.Arrays;
 import java.util.Set;
 
 @Name("Input")
@@ -136,11 +137,15 @@ public class ExprInput<T> extends SimpleExpression<T> {
 		return superType;
 	}
 
+	@Override
+	public Class<? extends T>[] possibleReturnTypes() {
+		return Arrays.copyOf(types, types.length);
+	}
+
 	@Nullable
 	public ClassInfo<?> getSpecifiedType() {
 		return specifiedType;
 	}
-
 
 	@Override
 	public String toString(Event event, boolean debug) {

--- a/src/main/java/ch/njol/skript/expressions/ExprLastAttacker.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLastAttacker.java
@@ -8,46 +8,30 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
-import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
-import ch.njol.util.Kleenean;
 
 @Name("Last Attacker")
 @Description("The last block or entity that attacked an entity.")
 @Examples({"send \"%last attacker of event-entity%\""})
 @Since("2.5.1")
-public class ExprLastAttacker extends SimplePropertyExpression<Entity, Object> {
-	
+public class ExprLastAttacker extends SimplePropertyExpression<Entity, Entity> {
+
 	static {
-		register(ExprLastAttacker.class, Object.class, "last attacker", "entity");
+		register(ExprLastAttacker.class, Entity.class, "last attacker", "entity");
 	}
-	
-	@Nullable
-	private ExprAttacker attackerExpr;
-	
+
 	@Override
-	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
-		attackerExpr = new ExprAttacker();
-		setExpr((Expression<? extends Entity>) exprs[0]);
-		return true;
+	public @Nullable Entity convert(Entity entity) {
+		return ExprAttacker.getAttacker(entity.getLastDamageCause());
 	}
-	
-	
-	@Nullable
+
 	@Override
-	@SuppressWarnings("null")
-	public Object convert(Entity entity) {
-		return attackerExpr.get(entity.getLastDamageCause())[0];
+	public Class<? extends Entity> getReturnType() {
+		return Entity.class;
 	}
-	
-	@Override
-	public Class<?> getReturnType() {
-		return Object.class;
-	}
-	
+
 	@Override
 	protected String getPropertyName() {
 		return "last attacker";
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprLoopValue.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLoopValue.java
@@ -114,7 +114,7 @@ public class ExprLoopValue extends SimpleExpression<Object> {
 		SecLoop loop = null;
 
 		for (SecLoop l : getParser().getCurrentSections(SecLoop.class)) {
-			if ((c != null && c.isAssignableFrom(l.getLoopedExpression().getReturnType())) || "value".equalsIgnoreCase(s) || l.getLoopedExpression().isLoopOf(s)) {
+			if ((c != null && l.getLoopedExpression().canReturn(c)) || "value".equalsIgnoreCase(s) || l.getLoopedExpression().isLoopOf(s)) {
 				if (j < i) {
 					j++;
 					continue;
@@ -170,12 +170,26 @@ public class ExprLoopValue extends SimpleExpression<Object> {
 	}
 	
 	@Override
-	public Class<? extends Object> getReturnType() {
+	public Class<?> getReturnType() {
 		if (isIndex)
 			return String.class;
 		return loop.getLoopedExpression().getReturnType();
 	}
-	
+
+	@Override
+	public Class<?>[] possibleReturnTypes() {
+		if (isIndex)
+			return new Class[]{String.class};
+		return loop.getLoopedExpression().possibleReturnTypes();
+	}
+
+	@Override
+	public boolean canReturn(Class<?> returnType) {
+		if (isIndex)
+			return super.canReturn(returnType);
+		return loop.getLoopedExpression().canReturn(returnType);
+	}
+
 	@Override
 	protected Object @Nullable [] get(Event event) {
 		if (isVariableLoop) {

--- a/src/main/java/ch/njol/skript/expressions/ExprMetadata.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprMetadata.java
@@ -27,6 +27,7 @@ import org.skriptlang.skript.lang.converter.Converters;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @Name("Metadata")
@@ -148,6 +149,11 @@ public class ExprMetadata<T> extends SimpleExpression<T> {
 	@Override
 	public Class<? extends T> getReturnType() {
 		return superType;
+	}
+
+	@Override
+	public Class<? extends T>[] possibleReturnTypes() {
+		return Arrays.copyOf(types, types.length);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprReversedList.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprReversedList.java
@@ -88,6 +88,16 @@ public class ExprReversedList extends SimpleExpression<Object> {
 	}
 
 	@Override
+	public Class<?>[] possibleReturnTypes() {
+		return list.possibleReturnTypes();
+	}
+
+	@Override
+	public boolean canReturn(Class<?> returnType) {
+		return list.canReturn(returnType);
+	}
+
+	@Override
 	public String toString(@Nullable Event e, boolean debug) {
 		return "reversed " + list.toString(e, debug);
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprShuffledList.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprShuffledList.java
@@ -78,6 +78,16 @@ public class ExprShuffledList extends SimpleExpression<Object> {
 	}
 
 	@Override
+	public Class<?>[] possibleReturnTypes() {
+		return list.possibleReturnTypes();
+	}
+
+	@Override
+	public boolean canReturn(Class<?> returnType) {
+		return list.canReturn(returnType);
+	}
+
+	@Override
 	public boolean isSingle() {
 		return false;
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprSortedList.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSortedList.java
@@ -96,6 +96,16 @@ public class ExprSortedList extends SimpleExpression<Object> {
 	}
 
 	@Override
+	public Class<?>[] possibleReturnTypes() {
+		return list.possibleReturnTypes();
+	}
+
+	@Override
+	public boolean canReturn(Class<?> returnType) {
+		return list.canReturn(returnType);
+	}
+
+	@Override
 	public String toString(@Nullable Event e, boolean debug) {
 		return "sorted " + list.toString(e, debug);
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprTernary.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTernary.java
@@ -31,8 +31,8 @@ public class ExprTernary extends SimpleExpression<Object> {
 				"%objects% if <.+>[,] (otherwise|else) %objects%");
 	}
 
-	private Class<?> superReturnType;
-	private Class<?>[] returnTypes;
+	private Class<?>[] types;
+	private Class<?> superType;
 
 	private Expression<Object> ifTrue;
 	private Condition condition;
@@ -46,19 +46,21 @@ public class ExprTernary extends SimpleExpression<Object> {
 			Skript.error("Ternary operators may not be nested!");
 			return false;
 		}
-		if (!LiteralUtils.canInitSafely(ifTrue, ifFalse))
+		if (!LiteralUtils.canInitSafely(ifTrue, ifFalse)) {
 			return false;
+		}
 
 		String cond = parseResult.regexes.get(0).group();
 		condition = Condition.parse(cond, "Can't understand this condition: " + cond);
-		if (condition == null)
+		if (condition == null) {
 			return false;
+		}
 
-		Set<Class<?>> returnTypes = new HashSet<>();
-		Collections.addAll(returnTypes, ifTrue.possibleReturnTypes());
-		Collections.addAll(returnTypes, ifFalse.possibleReturnTypes());
-		this.returnTypes = returnTypes.toArray(new Class<?>[0]);
-		this.superReturnType = Utils.getSuperType(this.returnTypes);
+		Set<Class<?>> types = new HashSet<>();
+		Collections.addAll(types, ifTrue.possibleReturnTypes());
+		Collections.addAll(types, ifFalse.possibleReturnTypes());
+		this.types = types.toArray(new Class<?>[0]);
+		this.superType = Utils.getSuperType(this.types);
 
 		return true;
 	}
@@ -69,18 +71,18 @@ public class ExprTernary extends SimpleExpression<Object> {
 	}
 
 	@Override
+	public boolean isSingle() {
+		return ifTrue.isSingle() && ifFalse.isSingle();
+	}
+
+	@Override
 	public Class<?> getReturnType() {
-		return superReturnType;
+		return superType;
 	}
 
 	@Override
 	public Class<?>[] possibleReturnTypes() {
-		return Arrays.copyOf(returnTypes, returnTypes.length);
-	}
-
-	@Override
-	public boolean isSingle() {
-		return ifTrue.isSingle() && ifFalse.isSingle();
+		return Arrays.copyOf(types, types.length);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprTernary.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTernary.java
@@ -10,92 +10,66 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.util.SimpleExpression;
-import org.skriptlang.skript.lang.converter.Converters;
 import ch.njol.skript.util.LiteralUtils;
 import ch.njol.skript.util.Utils;
 import ch.njol.util.Kleenean;
-import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.event.Event;
-import org.jetbrains.annotations.Nullable;
 
-import java.lang.reflect.Array;
+import java.util.Arrays;
 
 @Name("Ternary")
 @Description("A shorthand expression for returning something based on a condition.")
 @Examples({"set {points} to 500 if {admin::%player's uuid%} is set else 100"})
 @Since("2.2-dev36")
-@SuppressWarnings("null")
-public class ExprTernary<T> extends SimpleExpression<T> {
+public class ExprTernary extends SimpleExpression<Object> {
 
 	static {
 		Skript.registerExpression(ExprTernary.class, Object.class, ExpressionType.COMBINED,
 				"%objects% if <.+>[,] (otherwise|else) %objects%");
 	}
 
-	private final ExprTernary<?> source;
-	private final Class<T> superType;
-	private final Class<? extends T>[] types;
-	@Nullable
+	private Class<?> superReturnType;
+	private Class<?>[] returnTypes;
+
 	private Expression<Object> ifTrue;
-	@Nullable
 	private Condition condition;
-	@Nullable
 	private Expression<Object> ifFalse;
-
-	@SuppressWarnings("unchecked")
-	public ExprTernary() {
-		this(null, (Class<? extends T>) Object.class);
-	}
-
-	@SuppressWarnings("unchecked")
-	private ExprTernary(ExprTernary<?> source, Class<? extends T>... types) {
-		this.source = source;
-		if (source != null) {
-			this.ifTrue = source.ifTrue;
-			this.ifFalse = source.ifFalse;
-			this.condition = source.condition;
-		}
-		this.types = types;
-		this.superType = (Class<T>) Utils.getSuperType(types);
-	}
 
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
 		ifTrue = LiteralUtils.defendExpression(exprs[0]);
 		ifFalse = LiteralUtils.defendExpression(exprs[1]);
-		if (ifFalse instanceof ExprTernary<?> || ifTrue instanceof ExprTernary<?>) {
+		if (ifFalse instanceof ExprTernary || ifTrue instanceof ExprTernary) {
 			Skript.error("Ternary operators may not be nested!");
 			return false;
 		}
+		if (!LiteralUtils.canInitSafely(ifTrue, ifFalse))
+			return false;
+
 		String cond = parseResult.regexes.get(0).group();
 		condition = Condition.parse(cond, "Can't understand this condition: " + cond);
-		return condition != null && LiteralUtils.canInitSafely(ifTrue, ifFalse);
+		if (condition == null)
+			return false;
+
+		returnTypes = new Class[]{ifTrue.getReturnType(), ifFalse.getReturnType()};
+		this.superReturnType = Utils.getSuperType(returnTypes);
+
+		return true;
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	protected T[] get(Event e) {
-		Object[] values = condition.check(e) ? ifTrue.getArray(e) : ifFalse.getArray(e);
-		try {
-			return Converters.convert(values, types, superType);
-		} catch (ClassCastException e1) {
-			return (T[]) Array.newInstance(superType, 0);
-		}
+	protected Object[] get(Event event) {
+		return condition.check(event) ? ifTrue.getArray(event) : ifFalse.getArray(event);
 	}
 
 	@Override
-	public <R> Expression<? extends R> getConvertedExpression(Class<R>... to) {
-		return new ExprTernary<>(this, to);
+	public Class<?> getReturnType() {
+		return superReturnType;
 	}
 
 	@Override
-	public Expression<?> getSource() {
-		return source == null ? this : source;
-	}
-
-	@Override
-	public Class<? extends T> getReturnType() {
-		return superType;
+	public Class<?>[] possibleReturnTypes() {
+		return Arrays.copyOf(returnTypes, returnTypes.length);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprTernary.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTernary.java
@@ -16,6 +16,9 @@ import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 @Name("Ternary")
 @Description("A shorthand expression for returning something based on a condition.")
@@ -51,8 +54,11 @@ public class ExprTernary extends SimpleExpression<Object> {
 		if (condition == null)
 			return false;
 
-		returnTypes = new Class[]{ifTrue.getReturnType(), ifFalse.getReturnType()};
-		this.superReturnType = Utils.getSuperType(returnTypes);
+		Set<Class<?>> returnTypes = new HashSet<>();
+		Collections.addAll(returnTypes, ifTrue.possibleReturnTypes());
+		Collections.addAll(returnTypes, ifFalse.possibleReturnTypes());
+		this.returnTypes = returnTypes.toArray(new Class<?>[0]);
+		this.superReturnType = Utils.getSuperType(this.returnTypes);
 
 		return true;
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprTransform.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTransform.java
@@ -134,6 +134,16 @@ public class ExprTransform extends SimpleExpression<Object> implements InputSour
 	}
 
 	@Override
+	public Class<?>[] possibleReturnTypes() {
+		return mappingExpr.possibleReturnTypes();
+	}
+
+	@Override
+	public boolean canReturn(Class<?> returnType) {
+		return mappingExpr.canReturn(returnType);
+	}
+
+	@Override
 	public boolean isLoopOf(String candidateString) {
 		return mappingExpr.isLoopOf(candidateString) || matchesReturnType(candidateString);
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprTypeOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTypeOf.java
@@ -7,15 +7,24 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.entity.EntityData;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.ConvertedExpression;
 import ch.njol.skript.util.EnchantmentType;
+import ch.njol.skript.util.Utils;
+import ch.njol.util.Kleenean;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.event.inventory.InventoryType;
 import org.skriptlang.skript.lang.converter.Converters;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 @Name("Type of")
 @Description({
@@ -36,9 +45,29 @@ public class ExprTypeOf extends SimplePropertyExpression<Object, Object> {
 			"entitydatas/itemtypes/inventories/potioneffects/blockdatas/enchantmenttypes");
 	}
 
+	private Class<?>[] returnTypes;
+	private Class<?> superReturnType;
+
 	@Override
-	protected String getPropertyName() {
-		return "type";
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		Expression<?> expression = expressions[0];
+		List<Class<?>> returnTypes = new ArrayList<>();
+		if (expression.canReturn(EntityData.class))
+			returnTypes.add(EntityData.class);
+		if (expression.canReturn(ItemType.class) || expression.canReturn(BlockData.class))
+			returnTypes.add(ItemType.class);
+		if (expression.canReturn(Inventory.class))
+			returnTypes.add(InventoryType.class);
+		if (expression.canReturn(PotionEffect.class))
+			returnTypes.add(PotionEffectType.class);
+		if (expression.canReturn(EnchantmentType.class))
+			returnTypes.add(Enchantment.class);
+		this.returnTypes = returnTypes.toArray(new Class<?>[0]);
+		if (returnTypes.isEmpty())
+			System.out.println("NO MATCH: " + Arrays.toString(expression.possibleReturnTypes()) + " | " + expression.toString(null, false) + "| " + getParser().getCurrentScript().getConfig().getFileName());
+		this.superReturnType = Utils.getSuperType(this.returnTypes);
+
+		return super.init(expressions, matchedPattern, isDelayed, parseResult);
 	}
 
 	@Override
@@ -63,12 +92,12 @@ public class ExprTypeOf extends SimplePropertyExpression<Object, Object> {
 
 	@Override
 	public Class<?> getReturnType() {
-		Class<?> returnType = getExpr().getReturnType();
-		return EntityData.class.isAssignableFrom(returnType) ? EntityData.class
-			: ItemType.class.isAssignableFrom(returnType) ? ItemType.class
-			: PotionEffectType.class.isAssignableFrom(returnType) ? PotionEffectType.class
-			: EnchantmentType.class.isAssignableFrom(returnType) ? Enchantment.class
-			: BlockData.class.isAssignableFrom(returnType) ? ItemType.class : Object.class;
+		return superReturnType;
+	}
+
+	@Override
+	public Class<?>[] possibleReturnTypes() {
+		return returnTypes;
 	}
 
 	@Override
@@ -77,6 +106,11 @@ public class ExprTypeOf extends SimplePropertyExpression<Object, Object> {
 		if (!Converters.converterExists(EntityData.class, to) && !Converters.converterExists(ItemType.class, to))
 			return null;
 		return super.getConvertedExpr(to);
+	}
+
+	@Override
+	protected String getPropertyName() {
+		return "type";
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprTypeOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTypeOf.java
@@ -23,7 +23,6 @@ import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 @Name("Type of")
@@ -63,8 +62,6 @@ public class ExprTypeOf extends SimplePropertyExpression<Object, Object> {
 		if (expression.canReturn(EnchantmentType.class))
 			returnTypes.add(Enchantment.class);
 		this.returnTypes = returnTypes.toArray(new Class<?>[0]);
-		if (returnTypes.isEmpty())
-			System.out.println("NO MATCH: " + Arrays.toString(expression.possibleReturnTypes()) + " | " + expression.toString(null, false) + "| " + getParser().getCurrentScript().getConfig().getFileName());
 		this.superReturnType = Utils.getSuperType(this.returnTypes);
 
 		return super.init(expressions, matchedPattern, isDelayed, parseResult);

--- a/src/main/java/ch/njol/skript/expressions/ExprXOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprXOf.java
@@ -71,6 +71,16 @@ public class ExprXOf extends PropertyExpression<Object, Object> {
 	}
 
 	@Override
+	public Class<?>[] possibleReturnTypes() {
+		return getExpr().possibleReturnTypes();
+	}
+
+	@Override
+	public boolean canReturn(Class<?> returnType) {
+		return getExpr().canReturn(returnType);
+	}
+
+	@Override
 	public String toString(@Nullable Event e, boolean debug) {
 		return amount.toString(e, debug) + " of " + getExpr().toString(e, debug);
 	}

--- a/src/main/java/ch/njol/skript/lang/Expression.java
+++ b/src/main/java/ch/njol/skript/lang/Expression.java
@@ -186,7 +186,8 @@ public interface Expression<T> extends SyntaxElement, Debuggable, Loopable<T> {
 	 */
 	default boolean canReturn(Class<?> returnType) {
 		for (Class<?> type : this.possibleReturnTypes()) {
-			if (returnType.isAssignableFrom(type))
+			// if a possible return type is Object, then this Expression could return anything
+			if (returnType.isAssignableFrom(type) || type == Object.class)
 				return true;
 		}
 		return false;

--- a/src/main/java/ch/njol/skript/lang/ExpressionList.java
+++ b/src/main/java/ch/njol/skript/lang/ExpressionList.java
@@ -7,6 +7,7 @@ import ch.njol.skript.lang.util.SimpleLiteral;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
+import com.google.common.collect.ImmutableSet;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 
@@ -44,7 +45,7 @@ public class ExpressionList<T> implements Expression<T> {
 		assert expressions != null;
 		this.expressions = expressions;
 		this.returnType = returnType;
-		this.possibleReturnTypes = possibleReturnTypes;
+		this.possibleReturnTypes = ImmutableSet.copyOf(possibleReturnTypes).toArray(new Class[0]);
 		this.and = and;
 		if (and) {
 			single = false;

--- a/src/main/java/ch/njol/skript/lang/Variable.java
+++ b/src/main/java/ch/njol/skript/lang/Variable.java
@@ -263,7 +263,7 @@ public class Variable<T> implements Expression<T>, KeyReceiverExpression<T>, Key
 
 	@Override
 	public Class<? extends T>[] possibleReturnTypes() {
-		return types;
+		return Arrays.copyOf(types, types.length);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/lang/Variable.java
+++ b/src/main/java/ch/njol/skript/lang/Variable.java
@@ -262,6 +262,11 @@ public class Variable<T> implements Expression<T>, KeyReceiverExpression<T>, Key
 	}
 
 	@Override
+	public Class<? extends T>[] possibleReturnTypes() {
+		return types;
+	}
+
+	@Override
 	public String toString(@Nullable Event event, boolean debug) {
 		StringBuilder stringBuilder = new StringBuilder()
 			.append("{");

--- a/src/main/java/ch/njol/skript/lang/function/ExprFunctionCall.java
+++ b/src/main/java/ch/njol/skript/lang/function/ExprFunctionCall.java
@@ -10,6 +10,8 @@ import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.converter.Converters;
 
+import java.util.Arrays;
+
 public class ExprFunctionCall<T> extends SimpleExpression<T> {
 
 	private final FunctionReference<?> function;
@@ -63,6 +65,11 @@ public class ExprFunctionCall<T> extends SimpleExpression<T> {
 	@Override
 	public Class<? extends T> getReturnType() {
 		return returnType;
+	}
+
+	@Override
+	public Class<? extends T>[] possibleReturnTypes() {
+		return Arrays.copyOf(returnTypes, returnTypes.length);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/lang/util/ConvertedExpression.java
+++ b/src/main/java/ch/njol/skript/lang/util/ConvertedExpression.java
@@ -40,12 +40,15 @@ public class ConvertedExpression<F, T> implements Expression<T> {
 	 * Converter information.
 	 */
 	private final Collection<ConverterInfo<? super F, ? extends T>> converterInfos;
+	private final Class<? extends T>[] returnTypes;
 
 	public ConvertedExpression(Expression<? extends F> source, Class<T> to, ConverterInfo<? super F, ? extends T> info) {
 		this.source = source;
 		this.to = to;
 		this.converter = info.getConverter();
 		this.converterInfos = Collections.singleton(info);
+		//noinspection unchecked
+		this.returnTypes = new Class[]{info.getTo()};
 	}
 
 	/**
@@ -59,6 +62,8 @@ public class ConvertedExpression<F, T> implements Expression<T> {
 		this.source = source;
 		this.to = to;
 		this.converterInfos = infos;
+		//noinspection unchecked
+		this.returnTypes = converterInfos.stream().map(ConverterInfo::getTo).distinct().toArray(Class[]::new);
 		this.converter = fromObject -> {
 			for (ConverterInfo<? super F, ? extends T> info : converterInfos) {
 				if (!performFromCheck || info.getFrom().isInstance(fromObject)) { // the converter is safe to attempt
@@ -127,8 +132,7 @@ public class ConvertedExpression<F, T> implements Expression<T> {
 
 	@Override
 	public Class<? extends T>[] possibleReturnTypes() {
-		//noinspection unchecked
-		return converterInfos.stream().map(ConverterInfo::getTo).distinct().toArray(Class[]::new);
+		return Arrays.copyOf(returnTypes, returnTypes.length);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/lang/util/ConvertedExpression.java
+++ b/src/main/java/ch/njol/skript/lang/util/ConvertedExpression.java
@@ -126,6 +126,12 @@ public class ConvertedExpression<F, T> implements Expression<T> {
 	}
 
 	@Override
+	public Class<? extends T>[] possibleReturnTypes() {
+		//noinspection unchecked
+		return converterInfos.stream().map(ConverterInfo::getTo).distinct().toArray(Class[]::new);
+	}
+
+	@Override
 	public boolean isSingle() {
 		return source.isSingle();
 	}

--- a/src/main/java/ch/njol/skript/sections/SecFor.java
+++ b/src/main/java/ch/njol/skript/sections/SecFor.java
@@ -109,7 +109,7 @@ public class SecFor extends SecLoop implements ExperimentalSyntax {
 		}
 		if (this.getParser().hasExperiment(Feature.QUEUES) // Todo: change this if other iterable things are added
 			&& expression.isSingle()
-			&& (expression instanceof Variable<?> || Iterable.class.isAssignableFrom(expression.getReturnType()))) {
+			&& (expression instanceof Variable<?> || expression.canReturn(Iterable.class))) {
 			// Some expressions return one thing but are potentially iterable anyway, e.g. queues
 			super.iterableSingle = true;
 		} else if (expression.isSingle()) {

--- a/src/main/java/ch/njol/skript/sections/SecLoop.java
+++ b/src/main/java/ch/njol/skript/sections/SecLoop.java
@@ -108,7 +108,7 @@ public class SecLoop extends LoopSection {
 
 		if (this.getParser().hasExperiment(Feature.QUEUES) // Todo: change this if other iterable things are added
 			&& expression.isSingle()
-			&& (expression instanceof Variable<?> || Iterable.class.isAssignableFrom(expression.getReturnType()))) {
+			&& (expression instanceof Variable<?> || expression.canReturn(Iterable.class))) {
 			// Some expressions return one thing but are potentially iterable anyway, e.g. queues
 			this.iterableSingle = true;
 		} else if (expression.isSingle()) {

--- a/src/main/java/ch/njol/skript/test/runner/ExprKeyValueSet.java
+++ b/src/main/java/ch/njol/skript/test/runner/ExprKeyValueSet.java
@@ -55,7 +55,21 @@ public class ExprKeyValueSet extends SimpleExpression<Object> implements KeyProv
 
 	@Override
 	public Class<?> getReturnType() {
-		return Object.class;
+		return variable == null ? String.class : variable.getReturnType();
+	}
+
+	@Override
+	public Class<?>[] possibleReturnTypes() {
+		if (variable == null)
+			return super.possibleReturnTypes();
+		return variable.possibleReturnTypes();
+	}
+
+	@Override
+	public boolean canReturn(Class<?> returnType) {
+		if (variable == null)
+			return super.canReturn(returnType);
+		return variable.canReturn(returnType);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/test/runner/ExprTestLoopPeeking.java
+++ b/src/main/java/ch/njol/skript/test/runner/ExprTestLoopPeeking.java
@@ -9,10 +9,10 @@ import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 
-public class ExprTestLoopPeeking extends SimpleExpression<Object> {
+public class ExprTestLoopPeeking extends SimpleExpression<Integer> {
 
 	static {
-		Skript.registerExpression(ExprTestLoopPeeking.class, Object.class, ExpressionType.SIMPLE,
+		Skript.registerExpression(ExprTestLoopPeeking.class, Integer.class, ExpressionType.SIMPLE,
 			"test loop peeking disabled",
 			"test loop peeking enabled");
 	}
@@ -26,8 +26,8 @@ public class ExprTestLoopPeeking extends SimpleExpression<Object> {
 	}
 
 	@Override
-	protected Object @Nullable [] get(Event event) {
-		return new Object[]{1, 2, 3, 4, 5};
+	protected Integer[] get(Event event) {
+		return new Integer[]{1, 2, 3, 4, 5};
 	}
 
 	@Override
@@ -36,8 +36,8 @@ public class ExprTestLoopPeeking extends SimpleExpression<Object> {
 	}
 
 	@Override
-	public Class<Object> getReturnType() {
-		return Object.class;
+	public Class<Integer> getReturnType() {
+		return Integer.class;
 	}
 
 	@Override

--- a/src/test/skript/tests/syntaxes/expressions/ExprDefaultValue.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprDefaultValue.sk
@@ -1,0 +1,14 @@
+test "ExprDefaultValue":
+
+	set {_x} to 5 otherwise 10
+	assert {_x} is 5 with "regular value was not returned"
+
+	set {_x} to length of ({_none} otherwise "Hello")
+	assert {_x} is set with "default value was not returned"
+
+	set {_x} to length of (5 otherwise "Hello")
+	assert {_x} is not set with "invalid regular value was not returned"
+
+	parse:
+		set {_x} to length of (5 otherwise 10)
+	assert last parse logs is set with "default value returning invalid type should not parse"

--- a/src/test/skript/tests/syntaxes/expressions/ExprTernary.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprTernary.sk
@@ -1,0 +1,11 @@
+test "ExprTernary":
+
+	set {_x} to true if true is true otherwise false
+	assert {_x} is true with "simple logic ternary failed"
+
+	set {_x} to the length of (5 if true is true otherwise "Goodbye")
+	assert {_x} is not set with "ternary returned wrong value"
+
+	parse:
+		set {_x} to length of (5 if true is true otherwise 10)
+	assert last parse logs is set with "ternary returning invalid type parsed"


### PR DESCRIPTION
### Problem
Some Expressions/Classes are not taking full advantage of the multiple return types system. Others have return types that are incorrectly setup. Ensuring detailed return types is also important for features like local variable type hints.


### Solution
I aim to integrate usage of `Expression#possibleReturnTypes` and `Expression#canReturn` where possible. I've also cleaned up some classes that were in need of it (to improve their return type logic).

A major change that I made is `Expression#canReturn` will **always** return true if one of the possible return types is Object. This appears to work without issue, but further testing is needed.

ExprTernary and ExprDefaultValue have been rewritten and their generics removed. I do not believe these are necessary anymore. The generic ConvertedExpression implementation is capable of ensuring type safety.

### Testing Completed
There is existing coverage of most of the modified syntax. I have added tests for ExprTernary and ExprDefaultValue since they were rewritten and previously did not have any tests.

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->
n/a

---
**Completes:** Fixes https://github.com/SkriptLang/Skript/issues/5060
**Related:** none <!-- Links to issues or discussions with related information -->
