### PR TITLE
Fix Uncommon Arithmetic Type Errors

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/arithmetic/ArithmeticChain.java
+++ b/src/main/java/ch/njol/skript/expressions/arithmetic/ArithmeticChain.java
@@ -34,8 +34,7 @@ public class ArithmeticChain<L, R, T> implements ArithmeticGettable<T> {
 	private final ArithmeticGettable<R> right;
 	private final Operator operator;
 	private final Class<? extends T> returnType;
-	@Nullable
-	private OperationInfo<? extends L, ? extends R, ? extends T> operationInfo;
+	private final @Nullable OperationInfo<? extends L, ? extends R, ? extends T> operationInfo;
 
 	public ArithmeticChain(ArithmeticGettable<L> left, Operator operator, ArithmeticGettable<R> right, @Nullable OperationInfo<L, R, T> operationInfo) {
 		this.left = left;
@@ -63,6 +62,7 @@ public class ArithmeticChain<L, R, T> implements ArithmeticGettable<T> {
 		if (leftClass == Object.class && rightClass == Object.class)
 			return null;
 
+		OperationInfo<? extends L, ? extends R, ? extends T> operationInfo = this.operationInfo;
 		if (left == null && leftClass == Object.class) {
 			operationInfo = lookupOperationInfo(rightClass, OperationInfo::getRight);
 		} else if (right == null && rightClass == Object.class) {

--- a/src/test/skript/tests/syntaxes/expressions/ExprArithmetic.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprArithmetic.sk
@@ -265,6 +265,15 @@ test "arithmetic return types":
 	assert (y-coordinate of {_location} - 4) is 6 with "y-coordinate of {_location} - 4 is not 6 (got '%y-coordinate of {_location} - 4%')"
 
 test "arithmetic type switcheroo":
+	# operation info swap test
+	set {_a} to 1
+	set {_b} to 1
+	loop 2 times:
+		set {_x} to {_a} * {_b}
+		assert {_x} is set with "Failed to get a result"
+		set {_b} to a random vector
+
+	# operation info trick test
 	set {_a} to "Hello"
 	loop 2 times:
 		set {_x} to {_a} + {_b}

--- a/src/test/skript/tests/syntaxes/expressions/ExprArithmetic.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprArithmetic.sk
@@ -263,3 +263,9 @@ test "arithmetic return types":
 	# however, we can get more specific return types by returning the superclass of the return types of all Object-Number operations
 	set {_location} to location(0,10,0,"world")
 	assert (y-coordinate of {_location} - 4) is 6 with "y-coordinate of {_location} - 4 is not 6 (got '%y-coordinate of {_location} - 4%')"
+
+test "arithmetic type switcheroo":
+	set {_a} to "Hello"
+	loop 2 times:
+		set {_x} to {_a} + {_b}
+		set {_b} to 5


### PR DESCRIPTION
### Problem
It's possible to for valid operations to fail, and more rarely, type exceptions to occur when using variables with arithmetic operations. This occurs when OperationInfo resolution is delayed to runtime, which is the case for variables.


### Solution
This is caused by the resolved OperationInfo being **saved** for future executions (that is, the field on ArithmeticChain is updated). This unsafe (types can change, hence these issues), so I've updated the code to not modify the field. For future safety, I've made the field final.


### Testing Completed
Additional tests in `ExprArithmetic.sk` were added.

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
