### PR TITLE
ExprCopy + CondCanCopy

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondCanCopy.java
+++ b/src/main/java/ch/njol/skript/conditions/CondCanCopy.java
@@ -1,0 +1,36 @@
+package ch.njol.skript.conditions;
+
+import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.doc.*;
+import ch.njol.skript.registrations.Classes;
+
+@Name("Object Can Be Copied")
+@Description("Whether an object can be copied.")
+@Example("if a diamond can be copied: # True")
+@Example("if the last spawned entity can be copied: # False")
+@Since("INSERT VERSION")
+@Keywords({"copy"})
+public class CondCanCopy extends PropertyCondition<Object> {
+
+	static {
+		register(CondCanCopy.class, PropertyType.CAN, "be copied", "objects");
+	}
+
+	@Override
+	public boolean check(Object object) {
+		ClassInfo<?> classInfo = Classes.getSuperClassInfo(object.getClass());
+		return classInfo.getCloner() != null;
+	}
+
+	@Override
+	protected PropertyType getPropertyType() {
+		return PropertyType.CAN;
+	}
+
+	@Override
+	protected String getPropertyName() {
+		return "be copied";
+	}
+
+}

--- a/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
+++ b/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
@@ -5,13 +5,12 @@ import ch.njol.skript.SkriptAPIException;
 import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.util.LiteralUtils;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.function.Predicate;
-import org.jetbrains.annotations.ApiStatus;
 import org.skriptlang.skript.registration.SyntaxInfo;
 import org.skriptlang.skript.registration.SyntaxRegistry;
 import org.skriptlang.skript.util.Priority;
@@ -181,11 +180,10 @@ public abstract class PropertyCondition<T> extends Condition implements Predicat
 	private Expression<? extends T> expr;
 
 	@Override
-	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		//noinspection unchecked
-		expr = (Expression<? extends T>) expressions[0];
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		expr = LiteralUtils.defendExpression(exprs[0]);
 		setNegated(matchedPattern == 1);
-		return true;
+		return LiteralUtils.canInitSafely(expr);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprCopy.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCopy.java
@@ -1,0 +1,93 @@
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.doc.*;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.SyntaxStringBuilder;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.skript.registrations.Classes;
+import ch.njol.skript.util.LiteralUtils;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Name("Copy of Object")
+@Description({
+	"Get a copy of an object. Please note that not all objects are able to be copied.",
+	"If an object is not able to be copied, the object will be excluded from the result.",
+	"However, by including 'with fallback', you will get the original object, if it can not be copied."
+})
+@Example("set {_copy} to a copy of player's tool")
+@Example("""
+	set {_objects::*} to a diamond, chest[], and location(0, 0, 0)
+	set {_copies::*} to the copies of {_objects::*}
+	""")
+@Example("""
+	# This will return nothing because an entity can not be copied
+	set {_copy} to the copy of last spawned entity
+	
+	# This will return the original object
+	set {_copy} to the copy of last spawned entity with fallback
+	""")
+@Since("INSERT VERSION")
+@Keywords({"copy"})
+public class ExprCopy extends SimpleExpression<Object> {
+
+	static {
+		Skript.registerExpression(ExprCopy.class, Object.class, ExpressionType.SIMPLE,
+			"[the|a] copy of %objects% [with:with fallback]",
+			"[the] copies of %objects% [with:with fallback]",
+			"[the] copied %objects% [with:with fallback]");
+	}
+
+	private Expression<?> objects;
+	private boolean withFallback;
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		objects = LiteralUtils.defendExpression(exprs[0]);
+		withFallback = parseResult.hasTag("with");
+		return LiteralUtils.canInitSafely(objects);
+	}
+
+	@Override
+	protected Object @Nullable [] get(Event event) {
+		List<Object> copies = new ArrayList<>();
+		for (Object object : objects.getArray(event)) {
+			ClassInfo classInfo = Classes.getSuperClassInfo(object.getClass());
+			if (classInfo.getCloner() != null) {
+				//noinspection unchecked
+				copies.add(classInfo.clone(object));
+			} else if (withFallback) {
+				copies.add(object);
+			}
+		}
+		return copies.toArray();
+	}
+
+	@Override
+	public boolean isSingle() {
+		return objects.isSingle();
+	}
+
+	@Override
+	public Class<?> getReturnType() {
+		return Object.class;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		SyntaxStringBuilder builder = new SyntaxStringBuilder(event, debug);
+		builder.append("the copies of", objects);
+		if (withFallback)
+			builder.append("with fallback");
+		return builder.toString();
+	}
+
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprCopy.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCopy.java
@@ -21,7 +21,8 @@ import java.util.List;
 @Description({
 	"Get a copy of an object. Please note that not all objects are able to be copied.",
 	"If an object is not able to be copied, the object will be excluded from the result.",
-	"However, by including 'with fallback', you will get the original object, if it can not be copied."
+	"However, by including 'with fallback', you will get the original object, if it can not be copied.",
+	"Unlike the copy effect, this will only make copies of the objects and does not copy variable indices."
 })
 @Example("set {_copy} to a copy of player's tool")
 @Example("""
@@ -43,7 +44,7 @@ public class ExprCopy extends SimpleExpression<Object> {
 		Skript.registerExpression(ExprCopy.class, Object.class, ExpressionType.SIMPLE,
 			"[the|a] copy of %objects% [with:with fallback]",
 			"[the] copies of %objects% [with:with fallback]",
-			"[the] copied %objects% [with:with fallback]");
+			"[the] copied [objects of] %objects% [with:with fallback]");
 	}
 
 	private Expression<?> objects;

--- a/src/test/skript/tests/syntaxes/conditions/CondCanCopy.sk
+++ b/src/test/skript/tests/syntaxes/conditions/CondCanCopy.sk
@@ -1,0 +1,5 @@
+test "can be copied":
+	assert a diamond can be copied with "ItemType should be copyable"
+	assert location(0, 0, 0) can be copied with "Location should be copyable"
+	assert vector(0, 0, 0) can be copied with "Vector should be copyable"
+	assert chest[] can be copied with "BlockData should be copyable"

--- a/src/test/skript/tests/syntaxes/expressions/ExprCopy.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprCopy.sk
@@ -1,15 +1,38 @@
-test "copy objects":
-	set {_copy} to a copy of a diamond
-	assert {_copy} is a diamond with "ItemType should be copyable"
-
-	set {_original} to chest[]
+test "copy itemstack":
+	set {_original} to diamond (item stack)
 	set {_copy} to a copy of {_original}
-	assert {_copy} is chest[] with "BlockData should be copyable"
+	assert {_copy} is set with "Failed to copy ItemStack"
+	assert {_copy} is {_original} with "ItemStack copy should be equal to original"
+	set name of {_copy} to "Copy"
+	assert {_original} is not equal to {_copy} with "Change of ItemStack copy should not be equal to original"
 
-	set {_objects::*} to an emerald, location(0, 0, 0) and vector(5, 5, 5)
-	set {_copies::*} to the copies of {_objects::*}
-	assert {_copies::*} is an emerald, location(0, 0, 0) and vector(5, 5, 5) with "Should be able to copy objects of a list"
+test "copy blockdata":
+	set {_copy} to a copy of chest[]
+	assert {_copy} is set with "Failed to copy BlockData"
 
+test "copy location":
+	set {_original} to location(0, 0, 0)
+	set {_copy} to a copy of {_original}
+	assert {_copy} is set with "Failed to copy Location"
+	assert {_copy} is {_original} with "Location copy should be equal to original"
+	set the x-coord of {_copy} to 10
+	assert {_original} is not {_copy} with "Change of Location copy should not be equal to original"
+
+test "copy vector":
+	set {_original} to vector(0, 0, 0)
+	set {_copy} to a copy of {_original}
+	assert {_copy} is set with "Failed to copy Vector"
+	assert {_copy} is {_original} with "Vector copy should be equal to original"
+	set the yaw of {_copy} to 10
+	assert {_original} is not {_copy} with "Change of Vector copy should not be equal to original"
+
+test "copy multiple":
+	set {_original::*} to an emerald (item stack), location(0, 0, 0) and vector(0, 0, 0)
+	set {_copies::*} to the copies of {_original::*}
+	assert {_copies::*} is set with "Failed to copy multiple objects"
+	assert {_original::*} is {_copies::*} with "Copies of multiple objects should be equal to original objects"
+
+test "copy uncopyable entity":
 	spawn a pig at test-location:
 		set {_copy} to a copy of event-entity
 		assert {_copy} is not set with "Entity should not be copyable"

--- a/src/test/skript/tests/syntaxes/expressions/ExprCopy.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprCopy.sk
@@ -1,0 +1,19 @@
+test "copy objects":
+	set {_copy} to a copy of a diamond
+	assert {_copy} is a diamond with "ItemType should be copyable"
+
+	set {_original} to chest[]
+	set {_copy} to a copy of {_original}
+	assert {_copy} is chest[] with "BlockData should be copyable"
+
+	set {_objects::*} to an emerald, location(0, 0, 0) and vector(5, 5, 5)
+	set {_copies::*} to the copies of {_objects::*}
+	assert {_copies::*} is an emerald, location(0, 0, 0) and vector(5, 5, 5) with "Should be able to copy objects of a list"
+
+	spawn a pig at test-location:
+		set {_copy} to a copy of event-entity
+		assert {_copy} is not set with "Entity should not be copyable"
+		set {_copy} to a copy of event-entity with fallback
+		assert {_copy} is set with "Copy with fallback should not return null"
+		assert {_copy} is event-entity with "Copy with fallback should return original object"
+		clear event-entity


### PR DESCRIPTION
### Problem
There was no **expression** to grab copies of objects.
There was no way to check if an object was copyable or not.

### Solution
This PR adds `ExprCopy` allowing an **expression** usage of grabbing copies of objects.
If an object can not be copied/cloned then that object will be excluded.
Alternatively, users can opt in to return the original object if it can not be copied, by adding `with fallback`

This PR adds `CondCanCopy` allowing users to check if an object can be copied or not. Which would further help debugging and if they need to use `with fallback` when using `ExprCopy`

### Testing Completed
`ExprCopy.sk` and `CondCanCopy.sk`

### Supporting Information
N/A

---
**Completes:** #7874 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
