### PR TITLE
Expand Keyed Expression API

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffChange.java
+++ b/src/main/java/ch/njol/skript/effects/EffChange.java
@@ -270,6 +270,7 @@ public class EffChange extends Effect {
 		if (mode.supportsKeyedChange() && changer != null && delta != null
 			&& changer instanceof KeyProviderExpression<?> provider
 			&& changed instanceof KeyReceiverExpression<?> receiver
+			&& provider.canReturnKeys()
 			&& provider.areKeysRecommended()) {
 			receiver.change(event, delta, mode, provider.getArrayKeys(event));
 		} else {

--- a/src/main/java/ch/njol/skript/expressions/ExprKeyed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprKeyed.java
@@ -1,0 +1,85 @@
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.*;
+import ch.njol.skript.expressions.base.WrapperExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.KeyProviderExpression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Keyed")
+@Description({
+	"This expression is used to explicitly pass the keys alongside the values fo an expression.",
+	"For example, when setting a list variable or passing an expression to a function.",
+})
+@Example("""
+	set {_first::foo} to "value1"
+	set {_first::bar} to "value2"
+	set {_second::*} to keyed {_first::*}
+	# {_second::foo} is "value1" and {_second::bar} is "value2"
+	""")
+@Example("""
+	function indices(objects: objects) returns strings:
+		return indices of {_objects::*}
+
+	on load:
+		set {_list::foo} to "value1"
+		set {_list::bar} to "value2"
+		set {_list::baz} to "value3"
+
+		broadcast indices({_list::*}) # "1", "2", "3"
+		broadcast indices(keyed {_list::*}) # "foo", "bar", "baz"
+	""")
+@Example("""
+	function plusOne(numbers: numbers) returns numbers:
+		loop {_numbers::*}:
+			set {_numbers::%loop-index%} to loop-value + 1
+		return {_numbers::*}
+
+	on load:
+		set {_numbers::foo} to 1
+		set {_numbers::bar} to 2
+		set {_numbers::baz} to 3
+
+		set {_result::*} to keyed plusOne(keyed {_numbers::*})
+		# {_result::foo} is 2, {_result::bar} is 3, {_result::baz} is 4
+	""")
+@Since("INSERT VERSION")
+@Keywords("indexed")
+public class ExprKeyed extends WrapperExpression<Object> implements KeyProviderExpression<Object> {
+
+	static {
+		Skript.registerExpression(ExprKeyed.class, Object.class, ExpressionType.COMBINED, "(keyed|indexed) %~objects%");
+	}
+
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		if (!(expressions[0] instanceof KeyProviderExpression<?> keyProvider) || !keyProvider.canReturnKeys()) {
+			Skript.error(expressions[0] + " is not a keyed expression.");
+			return false;
+		}
+		setExpr(expressions[0]);
+		return true;
+	}
+
+	@Override
+	public @NotNull String @NotNull [] getArrayKeys(Event event) throws IllegalStateException {
+		return ((KeyProviderExpression<?>) getExpr()).getArrayKeys(event);
+	}
+
+	@Override
+	public @NotNull String @NotNull [] getAllKeys(Event event) {
+		return ((KeyProviderExpression<?>) getExpr()).getAllKeys(event);
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "keyed " + getExpr().toString(event, debug);
+	}
+
+}

--- a/src/main/java/ch/njol/skript/expressions/base/WrapperExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/WrapperExpression.java
@@ -22,16 +22,16 @@ import java.util.Iterator;
  * @author Peter Güttinger
  */
 public abstract class WrapperExpression<T> extends SimpleExpression<T> {
-	
+
 	private Expression<? extends T> expr;
-	
+
 	@SuppressWarnings("null")
 	protected WrapperExpression() {}
-	
+
 	public WrapperExpression(SimpleExpression<? extends T> expr) {
 		this.expr = expr;
 	}
-	
+
 	/**
 	 * Sets wrapped expression. Parser instance is automatically copied from
 	 * this expression.
@@ -40,89 +40,68 @@ public abstract class WrapperExpression<T> extends SimpleExpression<T> {
 	protected void setExpr(Expression<? extends T> expr) {
 		this.expr = expr;
 	}
-	
+
 	public Expression<?> getExpr() {
 		return expr;
 	}
-	
-	@Override
-	@Nullable
-	@SuppressWarnings("unchecked")
-	protected <R> ConvertedExpression<T, ? extends R> getConvertedExpr(Class<R>... to) {
-		for (Class<R> type : to) {
-			assert type != null;
-			ConverterInfo<? super T, ? extends R> conv = (ConverterInfo<? super T, ? extends R>) Converters.getConverterInfo(getReturnType(), type);
-			if (conv == null)
-				continue;
-			return new ConvertedExpression<T, R>(expr, type, conv) {
-				@Override
-				public String toString(@Nullable Event event, boolean debug) {
-					if (debug && event == null)
-						return "(" + WrapperExpression.this.toString(event, debug) + ")->" + to.getName();
-					return WrapperExpression.this.toString(event, debug);
-				}
-			};
-		}
-		return null;
-	}
-	
+
 	@Override
 	protected T[] get(Event event) {
 		return expr.getArray(event);
 	}
-	
+
 	@Override
 	@Nullable
 	public Iterator<? extends T> iterator(Event event) {
 		return expr.iterator(event);
 	}
-	
+
 	@Override
 	public boolean isSingle() {
 		return expr.isSingle();
 	}
-	
+
 	@Override
 	public boolean getAnd() {
 		return expr.getAnd();
 	}
-	
+
 	@Override
 	public Class<? extends T> getReturnType() {
 		return expr.getReturnType();
 	}
-	
+
 	@Override
 	@Nullable
 	public Class<?>[] acceptChange(ChangeMode mode) {
 		return expr.acceptChange(mode);
 	}
-	
+
 	@Override
 	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		expr.change(event, delta, mode);
 	}
-	
+
 	@Override
 	public boolean setTime(int time) {
 		return expr.setTime(time);
 	}
-	
+
 	@Override
 	public int getTime() {
 		return expr.getTime();
 	}
-	
+
 	@Override
 	public boolean isDefault() {
 		return expr.isDefault();
 	}
-	
+
 	@Override
 	public Expression<? extends T> simplify() {
 		return expr;
 	}
-	
+
 	@Override
 	@Nullable
 	public Object[] beforeChange(Expression<?> changed, @Nullable Object[] delta) {

--- a/src/main/java/ch/njol/skript/lang/Variable.java
+++ b/src/main/java/ch/njol/skript/lang/Variable.java
@@ -694,6 +694,11 @@ public class Variable<T> implements Expression<T>, KeyReceiverExpression<T>, Key
 	}
 
 	@Override
+	public boolean canReturnKeys() {
+		return list;
+	}
+
+	@Override
 	public boolean areKeysRecommended() {
 		return false; // We want `set {list::*} to {other::*}` reset numbering!
 	}

--- a/src/main/java/ch/njol/skript/lang/function/Function.java
+++ b/src/main/java/ch/njol/skript/lang/function/Function.java
@@ -2,17 +2,21 @@ package ch.njol.skript.lang.function;
 
 import ch.njol.skript.SkriptConfig;
 import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.KeyProviderExpression;
 import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.Bukkit;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
+import java.util.Map;
 
 /**
  * Functions can be called using arguments.
  */
 public abstract class Function<T> {
-	
+
 	/**
 	 * Execute functions even when some parameters are not present.
 	 * Field is updated by SkriptConfig in case of reloads.
@@ -20,11 +24,11 @@ public abstract class Function<T> {
 	public static boolean executeWithNulls = SkriptConfig.executeFunctionsWithMissingParams.value();
 
 	private final Signature<T> sign;
-	
+
 	public Function(Signature<T> sign) {
 		this.sign = sign;
 	}
-	
+
 	/**
 	 * Gets signature of this function that contains all metadata about it.
 	 * @return A function signature.
@@ -32,20 +36,20 @@ public abstract class Function<T> {
 	public Signature<T> getSignature() {
 		return sign;
 	}
-	
+
 	public String getName() {
 		return sign.getName();
 	}
-	
+
 	public Parameter<?>[] getParameters() {
 		return sign.getParameters();
 	}
-	
+
 	@SuppressWarnings("null")
 	public Parameter<?> getParameter(int index) {
 		return getParameters()[index];
 	}
-	
+
 	public boolean isSingle() {
 		return sign.isSingle();
 	}
@@ -53,9 +57,9 @@ public abstract class Function<T> {
 	public @Nullable ClassInfo<T> getReturnType() {
 		return sign.getReturnType();
 	}
-	
+
 	// FIXME what happens with a delay in a function?
-	
+
 	/**
 	 * Executes this function with given parameter.
 	 * @param params Function parameters. Must contain at least
@@ -64,61 +68,93 @@ public abstract class Function<T> {
 	 * @return The result(s) of this function
 	 */
 	public final T @Nullable [] execute(Object[][] params) {
-		FunctionEvent<? extends T> e = new FunctionEvent<>(this);
-		
+		FunctionEvent<? extends T> event = new FunctionEvent<>(this);
+
 		// Call function event only if requested by addon
 		// Functions may be called VERY often, so this might have performance impact
 		if (Functions.callFunctionEvents)
-			Bukkit.getPluginManager().callEvent(e);
-		
+			Bukkit.getPluginManager().callEvent(event);
+
 		// Parameters taken by the function.
 		Parameter<?>[] parameters = sign.getParameters();
-		
+
 		if (params.length > parameters.length) {
 			// Too many parameters, should have failed to parse
 			assert false : params.length;
 			return null;
 		}
-		
+
 		// If given less that max amount of parameters, pad remaining with nulls
-		Object[][] ps = params.length < parameters.length ? Arrays.copyOf(params, parameters.length) : params;
-		
+		Object[][] parameterValues = params.length < parameters.length ? Arrays.copyOf(params, parameters.length) : params;
+
 		// Execute parameters or default value expressions
 		for (int i = 0; i < parameters.length; i++) {
-			Parameter<?> p = parameters[i];
-			Object[] val = ps[i];
-			if (val == null) { // Go for default value
-				assert p.def != null; // Should've been parse error
-				val = p.def.getArray(e);
+			Parameter<?> parameter = parameters[i];
+			Object[] parameterValue = parameter.keyed ? convertToKeyed(parameterValues[i]) : parameterValues[i];
+			if (parameterValue == null) { // Go for default value
+				assert parameter.def != null; // Should've been parse error
+				Object[] defaultValue = parameter.def.getArray(event);
+				if (shouldUseKeys(parameter, parameter.def)) {
+					String[] keys = ((KeyProviderExpression<?>) parameter.def).getArrayKeys(event);
+					parameterValue = KeyProviderExpression.zip(defaultValue, keys);
+				} else {
+					parameterValue = defaultValue;
+				}
 			}
-			
+
 			/*
 			 * Cancel execution of function if one of parameters produces null.
 			 * This used to be the default behavior, but since scripts don't
 			 * really have a concept of nulls, it was changed. The config
 			 * option may be removed in future.
 			 */
-			if (!executeWithNulls && val.length == 0)
+			if (!executeWithNulls && parameterValue.length == 0)
 				return null;
-			ps[i] = val;
+			parameterValues[i] = parameterValue;
 		}
-		
+
 		// Execute function contents
-		T[] r = execute(e, ps);
+		T[] r = execute(event, parameterValues);
 		// Assert that return value type makes sense
 		assert sign.getReturnType() == null ? r == null : r == null
 			|| (r.length <= 1 || !sign.isSingle()) && !CollectionUtils.contains(r, null)
 			&& sign.getReturnType().getC().isAssignableFrom(r.getClass().getComponentType())
 			: this + "; " + Arrays.toString(r);
-				
+
 		// If return value is empty array, return null
 		// Otherwise, return the value (nullable)
 		return r == null || r.length > 0 ? r : null;
 	}
-	
+
+	private Map.Entry<String, Object> @Nullable [] convertToKeyed(Object[] values) {
+		if (values == null)
+			//noinspection unchecked
+			return new Map.Entry[0];
+
+		if (values.length == 0 || values instanceof Map.Entry[])
+			//noinspection unchecked
+			return (Map.Entry<String, Object>[]) values;
+
+		//noinspection unchecked
+		Map.Entry<String, Object>[] keyed = new Map.Entry[values.length];
+		for (int i = 0; i < values.length; i++) {
+			keyed[i] = values[i] instanceof Map.Entry<?,?> entry
+				? Map.entry(entry.getKey().toString(), entry.getValue())
+				: Map.entry(String.valueOf(i + 1), values[i]);
+		}
+		return keyed;
+	}
+
+	private boolean shouldUseKeys(Parameter<?> parameter, Expression<?> expression) {
+		return parameter.keyed
+			&& expression instanceof KeyProviderExpression<?> provider
+			&& provider.canReturnKeys()
+			&& provider.areKeysRecommended();
+	}
+
 	/**
 	 * Executes this function with given parameters. Usually, using
-	 * {@link #execute(Object[][])} is better; it handles optional arguments
+	 * {@link #execute(Object[][])} is better; it handles optional and keyed arguments
 	 * and function event creation automatically.
 	 * @param event Associated function event. This is usually created by Skript.
 	 * @param params Function parameters.
@@ -127,6 +163,13 @@ public abstract class Function<T> {
 	 * @return Function return value(s).
 	 */
 	public abstract T @Nullable [] execute(FunctionEvent<?> event, Object[][] params);
+
+	/**
+	 * @return The keys of the values returned by this function, or null if no keys are returned.
+	 */
+	public @NotNull String @Nullable [] returnedKeys() {
+		return null;
+	}
 
 	/**
 	 * Resets the return value of the {@code Function}.
@@ -140,5 +183,5 @@ public abstract class Function<T> {
 	public String toString() {
 		return (sign.local ? "local " : "") + "function " + sign.getName();
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/lang/function/FunctionReference.java
+++ b/src/main/java/ch/njol/skript/lang/function/FunctionReference.java
@@ -6,6 +6,7 @@ import ch.njol.skript.SkriptAPIException;
 import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.config.Node;
 import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.KeyProviderExpression;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.log.RetainingLogHandler;
 import ch.njol.skript.log.SkriptLogger;
@@ -18,12 +19,10 @@ import org.skriptlang.skript.util.Executable;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.converter.Converters;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
 /**
- * Reference to a Skript function.
+ * Reference to a {@link Function Skript function}.
  */
 public class FunctionReference<T> implements Contract, Executable<Event, T[]> {
 
@@ -37,7 +36,7 @@ public class FunctionReference<T> implements Contract, Executable<Event, T[]> {
 	 * succeeds, this is not null.
 	 */
 	private @Nullable Signature<? extends T> signature;
-  
+
 	/**
 	 * Actual function reference. Null before the function is called for first
 	 * time.
@@ -257,6 +256,12 @@ public class FunctionReference<T> implements Contract, Executable<Event, T[]> {
 		return function;
 	}
 
+	public String @Nullable [] returnedKeys() {
+		if (function != null)
+			return function.returnedKeys();
+		return null;
+	}
+
 	public boolean resetReturnValue() {
 		if (function != null)
 			return function.resetReturnValue();
@@ -277,28 +282,65 @@ public class FunctionReference<T> implements Contract, Executable<Event, T[]> {
 		// Prepare parameter values for calling
 		Object[][] params = new Object[singleListParam ? 1 : parameters.length][];
 		if (singleListParam && parameters.length > 1) { // All parameters to one list
-			List<Object> l = new ArrayList<>();
-			for (Expression<?> parameter : parameters)
-				l.addAll(Arrays.asList(parameter.getArray(event)));
-			params[0] = l.toArray();
-
-			// Don't allow mutating across function boundary; same hack is applied to variables
-			for (int i = 0; i < params[0].length; i++) {
-				params[0][i] = Classes.clone(params[0][i]);
-			}
+			params[0] = evaluateSingleListParameter(parameters, event, function.getParameter(0).keyed);
 		} else { // Use parameters in normal way
-			for (int i = 0; i < parameters.length; i++) {
-				Object[] array = parameters[i].getArray(event);
-				params[i] = Arrays.copyOf(array, array.length);
-				// Don't allow mutating across function boundary; same hack is applied to variables
-				for (int j = 0; j < params[i].length; j++) {
-					params[i][j] = Classes.clone(params[i][j]);
-				}
-			}
+			for (int i = 0; i < parameters.length; i++)
+				params[i] = evaluateParameter(parameters[i], event, function.getParameter(i).keyed);
 		}
 
 		// Execute the function
 		return function.execute(params);
+	}
+
+	private Object[] evaluateSingleListParameter(Expression<?>[] parameters, Event event, boolean keyed) {
+		if (!keyed) {
+			List<Object> list = new ArrayList<>();
+			for (Expression<?> parameter : parameters)
+				list.addAll(Arrays.asList(evaluateParameter(parameter, event, false)));
+			return list.toArray();
+		}
+
+		List<Object> values = new ArrayList<>();
+		Set<String> keys = new LinkedHashSet<>();
+		int keyIndex = 1;
+		for (Expression<?> parameter : parameters) {
+			Object[] valuesArray = parameter.getArray(event);
+			String[] keysArray = parameter instanceof KeyProviderExpression<?> keyProvider && keyProvider.canReturnKeys() && keyProvider.areKeysRecommended()
+				? keyProvider.getArrayKeys(event)
+				: null;
+
+			// Don't allow mutating across function boundary; same hack is applied to variables
+			for (Object value : valuesArray)
+				values.add(Classes.clone(value));
+
+			if (keysArray != null) {
+				keys.addAll(Arrays.asList(keysArray));
+				continue;
+			}
+
+			for (int i = 0; i < valuesArray.length; i++) {
+				while (keys.contains(String.valueOf(keyIndex)))
+					keyIndex++;
+				keys.add(String.valueOf(keyIndex));
+			}
+		}
+		return KeyProviderExpression.zip(values.toArray(), keys.toArray(new String[0]));
+	}
+
+	private Object[] evaluateParameter(Expression<?> parameter, Event event, boolean keyed) {
+		Object[] values = parameter.getArray(event);
+
+		// Don't allow mutating across function boundary; same hack is applied to variables
+		for (int i = 0; i < values.length; i++)
+			values[i] = Classes.clone(values[i]);
+
+		if (!keyed)
+			return values;
+
+		String[] keys = parameter instanceof KeyProviderExpression<?> keyProvider && keyProvider.canReturnKeys() && keyProvider.areKeysRecommended()
+			? keyProvider.getArrayKeys(event)
+			: null;
+		return KeyProviderExpression.zip(values, keys);
 	}
 
 	public boolean isSingle() {

--- a/src/main/java/ch/njol/skript/lang/function/JavaFunction.java
+++ b/src/main/java/ch/njol/skript/lang/function/JavaFunction.java
@@ -2,13 +2,13 @@ package ch.njol.skript.lang.function;
 
 import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.util.Contract;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-/**
- * @author Peter Güttinger
- */
 public abstract class JavaFunction<T> extends Function<T> {
-	
+
+	private @NotNull String @Nullable [] returnedKeys;
+
 	public JavaFunction(Signature<T> sign) {
 		super(sign);
 	}
@@ -20,15 +20,35 @@ public abstract class JavaFunction<T> extends Function<T> {
 	public JavaFunction(String name, Parameter<?>[] parameters, ClassInfo<T> returnType, boolean single, @Nullable Contract contract) {
 		this(new Signature<>("none", name, parameters, false, returnType, single, Thread.currentThread().getStackTrace()[3].getClassName(), contract));
 	}
-	
+
 	@Override
 	public abstract T @Nullable [] execute(FunctionEvent<?> event, Object[][] params);
+
+	@Override
+	public @NotNull String @Nullable [] returnedKeys() {
+		return returnedKeys;
+	}
+
+	/**
+	 * Sets the keys that will be returned by this function.
+	 * <br>
+	 * Note: The length of the keys array must match the number of return values.
+	 *
+	 * @param keys An array of keys to be returned by the function. Can be null.
+	 * @throws IllegalStateException If the function is returns a single value.
+	 */
+	public void setReturnedKeys(@NotNull String @Nullable [] keys) {
+		if (isSingle())
+			throw new IllegalStateException("Cannot return keys for a single return function");
+		assert this.returnedKeys == null;
+		this.returnedKeys = keys;
+	}
 
 	private String @Nullable [] description = null;
 	private String @Nullable [] examples = null;
 	private String @Nullable [] keywords;
 	private @Nullable String since = null;
-	
+
 	/**
 	 * Only used for Skript's documentation.
 	 *
@@ -39,7 +59,7 @@ public abstract class JavaFunction<T> extends Function<T> {
 		this.description = description;
 		return this;
 	}
-	
+
 	/**
 	 * Only used for Skript's documentation.
 	 *
@@ -62,7 +82,7 @@ public abstract class JavaFunction<T> extends Function<T> {
 		this.keywords = keywords;
 		return this;
 	}
-	
+
 	/**
 	 * Only used for Skript's documentation.
 	 *
@@ -92,6 +112,7 @@ public abstract class JavaFunction<T> extends Function<T> {
 
 	@Override
 	public boolean resetReturnValue() {
+		returnedKeys = null;
 		return true;
 	}
 

--- a/src/main/java/ch/njol/skript/lang/function/Parameter.java
+++ b/src/main/java/ch/njol/skript/lang/function/Parameter.java
@@ -33,31 +33,43 @@ public final class Parameter<T> {
 	 * then the valid variable names may not necessarily match this string in casing.
 	 */
 	final String name;
-	
+
 	/**
 	 * Type of the parameter.
 	 */
 	final ClassInfo<T> type;
-	
+
 	/**
 	 * Expression that will provide default value of this parameter
 	 * when the function is called.
 	 */
 	final @Nullable Expression<? extends T> def;
-	
+
 	/**
 	 * Whether this parameter takes one or many values.
 	 */
 	final boolean single;
-	
-	@SuppressWarnings("null")
+
+	/**
+	 * Whether this parameter takes in key-value pairs.
+	 * <br>
+	 * If this is true, a {@link java.util.Map.Entry} array containing key-value pairs will be passed to
+	 * {@link Function#execute(FunctionEvent, Object[][])} rather than a value-only object array.
+	 */
+	final boolean keyed;
+
 	public Parameter(String name, ClassInfo<T> type, boolean single, @Nullable Expression<? extends T> def) {
+		this(name, type, single, def, false);
+	}
+
+	public Parameter(String name, ClassInfo<T> type, boolean single, @Nullable Expression<? extends T> def, boolean keyed) {
 		this.name = name;
 		this.type = type;
 		this.def = def;
 		this.single = single;
+		this.keyed = keyed;
 	}
-	
+
 	/**
 	 * Get the Type of this parameter.
 	 * @return Type of the parameter
@@ -75,7 +87,7 @@ public final class Parameter<T> {
 		Expression<? extends T> d = null;
 		if (def != null) {
 			RetainingLogHandler log = SkriptLogger.startRetainingLog();
-			
+
 			// Parse the default value expression
 			try {
 				//noinspection unchecked
@@ -89,7 +101,7 @@ public final class Parameter<T> {
 				log.stop();
 			}
 		}
-		return new Parameter<>(name, type, single, d);
+		return new Parameter<>(name, type, single, d, !single);
 	}
 
 	/**
@@ -153,7 +165,7 @@ public final class Parameter<T> {
 		}
 		return params;
 	}
-	
+
 	/**
 	 * Get the name of this parameter.
 	 * <p>Will be used as name for the local variable that contains value of it inside function.</p>
@@ -162,7 +174,7 @@ public final class Parameter<T> {
 	public String getName() {
 		return name;
 	}
-	
+
 	/**
 	 * Get the Expression that will be used to provide the default value of this parameter when the function is called.
 	 * @return Expression that will provide default value of this parameter
@@ -170,7 +182,7 @@ public final class Parameter<T> {
 	public @Nullable Expression<? extends T> getDefaultExpression() {
 		return def;
 	}
-	
+
 	/**
 	 * Get whether this parameter takes one or many values.
 	 * @return True if this parameter takes one value, false otherwise
@@ -178,7 +190,7 @@ public final class Parameter<T> {
 	public boolean isSingleValue() {
 		return single;
 	}
-	
+
 	@Override
 	public String toString() {
 		return toString(Skript.debug());
@@ -187,5 +199,5 @@ public final class Parameter<T> {
 	public String toString(boolean debug) {
 		return name + ": " + Utils.toEnglishPlural(type.getCodeName(), !single) + (def != null ? " = " + def.toString(null, debug) : "");
 	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/lang/util/ConvertedKeyProviderExpression.java
+++ b/src/main/java/ch/njol/skript/lang/util/ConvertedKeyProviderExpression.java
@@ -1,0 +1,88 @@
+package ch.njol.skript.lang.util;
+
+import ch.njol.skript.lang.KeyProviderExpression;
+import org.apache.commons.lang3.ArrayUtils;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.lang.converter.ConverterInfo;
+import org.skriptlang.skript.lang.converter.Converters;
+
+import java.lang.reflect.Array;
+import java.util.Collection;
+import java.util.WeakHashMap;
+import java.util.function.Consumer;
+
+public class ConvertedKeyProviderExpression<F, T> extends ConvertedExpression<F, T> implements KeyProviderExpression<T> {
+
+	private final WeakHashMap<Event, KeyedValues> arrayKeysCache = new WeakHashMap<>();
+	private final WeakHashMap<Event, KeyedValues> allKeysCache = new WeakHashMap<>();
+
+	public ConvertedKeyProviderExpression(KeyProviderExpression<? extends F> source, Class<T> to, ConverterInfo<? super F, ? extends T> info) {
+		super(source, to, info);
+	}
+
+	public ConvertedKeyProviderExpression(KeyProviderExpression<? extends F> source, Class<T> to, Collection<ConverterInfo<? super F, ? extends T>> converterInfos, boolean performFromCheck) {
+		super(source, to, converterInfos, performFromCheck);
+	}
+
+	@Override
+	public T[] getArray(Event event) {
+		return get(getSource().getArray(event), getSource().getArrayKeys(event), keys -> arrayKeysCache.put(event, keys));
+	}
+
+	@Override
+	public T[] getAll(Event event) {
+		return get(getSource().getAll(event), getSource().getAllKeys(event), keys -> allKeysCache.put(event, keys));
+	}
+
+	private T[] get(F[] source, String[] keys, Consumer<KeyedValues> convertedKeysConsumer) {
+		//noinspection unchecked
+		T[] converted = (T[]) Array.newInstance(to, source.length);
+		Converters.convert(source, converted, converter);
+		convertedKeysConsumer.accept(new KeyedValues(converted, keys));
+		converted = ArrayUtils.removeAllOccurrences(converted, null);
+		return converted;
+	}
+
+	@Override
+	public KeyProviderExpression<? extends F> getSource() {
+		return (KeyProviderExpression<? extends F>) super.getSource();
+	}
+
+	@Override
+	public @NotNull String @NotNull [] getArrayKeys(Event event) throws IllegalStateException {
+		if (!arrayKeysCache.containsKey(event))
+			throw new IllegalStateException();
+		return arrayKeysCache.remove(event).keys();
+	}
+
+	@Override
+	public @NotNull String @NotNull [] getAllKeys(Event event) {
+		if (!allKeysCache.containsKey(event))
+			throw new IllegalStateException();
+		return allKeysCache.remove(event).keys();
+	}
+
+	@Override
+	public boolean canReturnKeys() {
+		return getSource().canReturnKeys();
+	}
+
+	@Override
+	public boolean areKeysRecommended() {
+		return getSource().areKeysRecommended();
+	}
+
+	private record KeyedValues(@Nullable Object[] values, String[] keys) {
+
+		@Override
+		public String[] keys() {
+			for (int i = 0; i < values.length; i++)
+				keys[i] = values[i] != null ? keys[i] : null;
+			return ArrayUtils.removeAllOccurrences(keys, null);
+		}
+
+	}
+
+}

--- a/src/main/java/org/skriptlang/skript/lang/converter/Converters.java
+++ b/src/main/java/org/skriptlang/skript/lang/converter/Converters.java
@@ -505,6 +505,25 @@ public final class Converters {
 	}
 
 	/**
+	 * A method for bulk-converting objects of a specific type using a specific Converter.
+	 * @param from The objects to convert.
+	 * @param destination An array that will be filled with the converted objects.
+	 *                    The size of this array will be used to determine how many objects to convert.
+	 *                    Objects that cannot be converted will be set to null.
+	 * @param converter The converter to use for conversion.
+	 */
+	public static <From, To> void convert(From[] from, To[] destination, Converter<? super From, ? extends To> converter) {
+		assertIsDoneLoading();
+
+		int length = Math.min(from.length, destination.length);
+		if (length == 0)
+			return;
+
+		for (int i = 0; i < length; i++)
+			destination[i] = from[i] != null ? converter.convert(from[i]) : null;
+	}
+
+	/**
 	 * A method that guarantees an object of <code>toType</code> is returned.
 	 * @param from The object to convert.
 	 * @param toType The type to convert into.

--- a/src/test/skript/tests/syntaxes/expressions/ExprKeyed.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprKeyed.sk
@@ -1,0 +1,80 @@
+local function objects(objects: objects) returns objects:
+	return {_objects::*}
+
+local function strings(strings: strings) returns strings:
+	return {_strings::*}
+
+test "set list to keyed list":
+	set {_a::1.foo} to "first"
+	set {_a::2.bar} to "second"
+	set {_a::3.baz} to "third"
+
+	set {_b::*} to keyed {_a::*}
+	assert size of {_b::*} is 3 with "{_b::*} should have 3 items"
+	assert {_b::1.foo} is "first" with "{_b::1.foo} should be 'first'"
+	assert {_b::2.bar} is "second" with "{_b::2.bar} should be 'second'"
+	assert {_b::3.baz} is "third" with "{_b::3.baz} should be 'third'"
+
+	set {_c::*} to {_a::*}
+	assert size of {_c::*} is 3 with "{_c::*} should have 3 items"
+	assert {_c::1} is "first" with "{_c::1} should be 'first'"
+	assert {_c::2} is "second" with "{_c::2} should be 'second'"
+	assert {_c::3} is "third" with "{_c::3} should be 'third'"
+
+test "set list to keyed function":
+	set {_a::1.foo} to "first"
+	set {_a::2.bar} to "second"
+	set {_a::3.baz} to "third"
+
+	set {_b::*} to keyed objects(keyed {_a::*})
+	assert size of {_b::*} is 3 with "{_b::*} should have 3 items"
+	assert {_b::1.foo} is "first" with "{_b::1.foo} should be 'first'"
+	assert {_b::2.bar} is "second" with "{_b::2.bar} should be 'second'"
+	assert {_b::3.baz} is "third" with "{_b::3.baz} should be 'third'"
+
+	set {_c::*} to keyed objects({_a::*})
+	assert size of {_c::*} is 3 with "{_c::*} should have 3 items"
+	assert {_c::1} is "first" with "{_c::1} should be 'first'"
+	assert {_c::2} is "second" with "{_c::2} should be 'second'"
+	assert {_c::3} is "third" with "{_c::3} should be 'third'"
+
+	set {_d::*} to objects({_a::*})
+	assert size of {_d::*} is 3 with "{_d::*} should have 3 items"
+	assert {_d::1} is "first" with "{_d::1} should be 'first'"
+	assert {_d::2} is "second" with "{_d::2} should be 'second'"
+	assert {_d::3} is "third" with "{_d::3} should be 'third'"
+
+	set {_e::*} to keyed objects("first", "second", "third")
+	assert size of {_e::*} is 3 with "{_e::*} should have 3 items"
+	assert {_e::1} is "first" with "{_e::1} should be 'first'"
+	assert {_e::2} is "second" with "{_e::2} should be 'second'"
+	assert {_e::3} is "third" with "{_e::3} should be 'third'"
+
+	set {_f::*} to keyed objects((keyed {_a::*}), "fourth", "fifth", "sixth")
+	assert size of {_f::*} is 6 with "{_f::*} should have 6 items"
+	assert {_f::1.foo} is "first" with "{_f::1.foo} should be 'first'"
+	assert {_f::2.bar} is "second" with "{_f::2.bar} should be 'second'"
+	assert {_f::3.baz} is "third" with "{_f::3.baz} should be 'third'"
+	assert {_f::1} is "fourth" with "{_f::1} should be 'fourth'"
+	assert {_f::2} is "fifth" with "{_f::2} should be 'fifth'"
+	assert {_f::3} is "sixth" with "{_f::3} should be 'sixth'"
+
+	set {_a::2} to "duplicate fifth"
+	set {_g::*} to keyed objects((keyed {_a::*}), "fourth", "fifth", "sixth")
+	assert size of {_g::*} is 7 with "{_g::*} should have 7 items"
+	assert {_g::1.foo} is "first" with "{_g::1.foo} should be 'first'"
+	assert {_g::2.bar} is "second" with "{_g::2.bar} should be 'second'"
+	assert {_g::3.baz} is "third" with "{_g::3.baz} should be 'third'"
+	assert {_g::1} is "fourth" with "{_g::1} should be 'fourth'"
+	assert {_g::2} is "duplicate fifth" with "{_g::2} should be 'duplicate fifth'"
+	assert {_g::3} is "fifth" with "{_g::3} should be 'fifth'"
+	assert {_g::4} is "sixth" with "{_g::4} should be 'sixth'"
+	delete {_a::2}
+
+	set {_a::number} to 100
+	set {_h::*} to keyed strings(keyed {_a::*})
+	assert size of {_h::*} is 3 with "{_h::*} should have 3 items"
+	assert {_h::1.foo} is "first" with "{_h::1.foo} should be 'first'"
+	assert {_h::2.bar} is "second" with "{_h::2.bar} should be 'second'"
+	assert {_h::3.baz} is "third" with "{_h::3.baz} should be 'third'"
+	assert {_h::number} is not set with "{_h::number} should not be set"


### PR DESCRIPTION
### Problem
Currently, the API is quite limited and not used anywhere by Skript. This leads to multiple issues:
1. Expressions implementing the `KeyProviderExpression` interface have no control over whether they can actually return keys. For example, variables implement this interface but only allow calling the key getter methods if the it's a list variable. This forces the caller to explicitly check if the `KeyProviderExpression` that was given to it is *not* a single variable.
2. If an expression returns `false` for `KeyProviderExpression#areKeysRecommended`, then there is no way to access those keys within a script by default.
3. Function parameters and return values do not make use of this API.
4. When converting a `KeyProviderExpression` using `Expression#getConvertedExpression` it will return a `ConvertedExpression`, which no longer exposes key-related methods - making it unusable in many scenarios.


### Solution
This PR expands the API and fixes some of the major issues by:
1. Adds a new `canReturnKeys` method which gives expressions the control over the ability to return keys.
2. Adds a new expression: `(keyed indexed) %~objects%`, to explicitly allow the use of the returned keys of an expression.
3. Allows script-defined and built-in functions to utilize the API:
   * When a `KeyProviderExpression` is passed as an argument and `KeyProviderExpression#areKeysRecommended` returns true, the values will be passed alongside its keys.
   * Functions can now return keyed expressions.
5. Creates a new `ConvertedKeyProviderExpression` class extending `ConvertedExpression` and implementing `KeyProviderExpression`, and returned when calling `ConvertedExpression.newInstance` on an expression implementing `KeyProviderExpression`.


### Testing Completed
`ExprKeyed.sk`


### Supporting Information
Script-defined functions have no control over whether its parameters accepts keys, meaning a function may break if a keyed expression is passed as an argument if the function relies on the argument's indices for its logic.

#### Todo:
- [ ] Implement the `KeyProviderExpression` interface for `ExprValueWithin`.
- [ ] Create a new method returning a key-value pair iterator for `KeyProviderExpression`s.
- [ ] Make `ExprIndices` support all expressions implementing the `KeyProviderExpression` interface, not just variables.


---
**Completes:** none
**Related:** none

