### PR TITLE
docs: add definition for generic Type parameter in AnyContains Javadoc

### DIFF
--- a/src/main/java/ch/njol/skript/lang/util/common/AnyContains.java
+++ b/src/main/java/ch/njol/skript/lang/util/common/AnyContains.java
@@ -8,6 +8,14 @@ import org.jetbrains.annotations.UnknownNullability;
  * Anything implementing this (or convertible to this) can be used by the {@link ch.njol.skript.conditions.CondContains}
  * conditions.
  *
+ * @param <Type> the type of objects that this container can check for containment.
+ *               This represents the expected type of elements that the container
+ *               is designed to hold or work with.
+ *               When calling {@link #contains(Object)}, the parameter should be of this type,
+ *               or safely castable to it.
+ *               Implementations may use {@link #isSafeToCheck(Object)} to verify
+ *               that an object is a suitable candidate before performing a containment check.
+ *
  * @see AnyProvider
  */
 @FunctionalInterface


### PR DESCRIPTION
### Problem
The generic parameter `Type` in the `AnyContains` interface was not documented, which caused confusion for users and contributors about its purpose and usage.

### Solution
Added a clear and detailed Javadoc description for the `Type` generic parameter in the `AnyContains` interface. This documentation explains what `Type` represents, how it relates to the `contains` method, and how implementations should handle type safety via `isSafeToCheck`.

### Testing Completed
Reviewed the updated Javadoc locally to ensure clarity and correctness. No functional code changes were made, so no unit tests were necessary.

### Supporting Information
This change improves code readability and developer experience by clarifying the usage of generics in the `AnyContains` interface.

**Completes:** #7902 
**Related:** none 