### PR TITLE
PropertyCondition#getExpr

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
+++ b/src/main/java/ch/njol/skript/conditions/base/PropertyCondition.java
@@ -7,11 +7,9 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.function.Predicate;
-import org.jetbrains.annotations.ApiStatus;
 import org.skriptlang.skript.registration.SyntaxInfo;
 import org.skriptlang.skript.registration.SyntaxRegistry;
 import org.skriptlang.skript.util.Priority;
@@ -204,6 +202,13 @@ public abstract class PropertyCondition<T> extends Condition implements Predicat
 
 	protected PropertyType getPropertyType() {
 		return PropertyType.BE;
+	}
+
+	/**
+	 * Gets the expression this condition checks a property of.
+	 */
+	public final Expression<? extends T> getExpr() {
+		return expr;
 	}
 
 	/**


### PR DESCRIPTION
### Problem
Elements that extend `PropertyCondition` and override `toString` needed  to override `init` to be able to get the expression for the  `toString`


### Solution
Adds `#getExpr` removing the need for overriding `init` to gain access to the expression.


### Testing Completed
N/A


### Supporting Information
N/A


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
