### PR TITLE
Fix EffSort clobbering duplicate inputs

### DIFF
--- a/src/test/skript/tests/regressions/7926-eff sort doesn't allow duplicate values.sk
+++ b/src/test/skript/tests/regressions/7926-eff sort doesn't allow duplicate values.sk
@@ -1,0 +1,11 @@
+test "eff sort collapsing duplicates":
+	set {_levels::a} to 1
+	set {_levels::b} to 2
+
+	add (shuffled "a", "a", and "b") to {_items::*}
+
+	assert {_items::*} contains "a", "a", and "b" with "Items were not added correctly"
+
+	sort {_items::*} in descending order by {_levels::%input%}
+
+	assert {_items::*} is "b", "a", and "a" with "Items were not sorted correctly or duplicates were collapsed"


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
See #7926. Sorting a list with 2 of the same value would result in a sorted list with only 1 of that value instead of 2.

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
This was due to using a map to tie current and mapped values, which only allowed a single current value. The solution was to move to a List of paired values, which allows as many duplicated as desired.

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
Added a regression test.

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** #7926 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
