### PR TITLE
preInit Follow Up + SectionExpression#isSectionOnly

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffWakeupSleep.java
+++ b/src/main/java/ch/njol/skript/effects/EffWakeupSleep.java
@@ -16,7 +16,6 @@ import org.bukkit.Location;
 import org.bukkit.entity.*;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
-import org.skriptlang.skript.log.runtime.SyntaxRuntimeErrorProducer;
 
 @Name("Wake And Sleep")
 @Description({
@@ -36,7 +35,7 @@ import org.skriptlang.skript.log.runtime.SyntaxRuntimeErrorProducer;
 	"make player wake up without spawn location update"
 })
 @Since("2.11")
-public class EffWakeupSleep extends Effect implements SyntaxRuntimeErrorProducer {
+public class EffWakeupSleep extends Effect {
 
 	static {
 		Skript.registerEffect(EffWakeupSleep.class,
@@ -55,7 +54,6 @@ public class EffWakeupSleep extends Effect implements SyntaxRuntimeErrorProducer
 	private boolean sleep;
 	private boolean force;
 	private boolean setSpawn;
-	private Node node;
 
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
@@ -70,7 +68,6 @@ public class EffWakeupSleep extends Effect implements SyntaxRuntimeErrorProducer
 			//noinspection unchecked
 			this.location = Direction.combine((Expression<Direction>) exprs[1], (Expression<Location>) exprs[2]);
 		}
-		node = getParser().getNode();
 		return true;
 	}
 
@@ -109,11 +106,6 @@ public class EffWakeupSleep extends Effect implements SyntaxRuntimeErrorProducer
 		}
 		if (failed)
 			warning("The provided location is not set. This effect will have no effect for villagers and players.");
-	}
-
-	@Override
-	public Node getNode() {
-		return node;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/effects/EffWorldBorderExpand.java
+++ b/src/main/java/ch/njol/skript/effects/EffWorldBorderExpand.java
@@ -17,7 +17,6 @@ import ch.njol.util.Math2;
 import org.bukkit.WorldBorder;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
-import org.skriptlang.skript.log.runtime.SyntaxRuntimeErrorProducer;
 
 @Name("Expand/Shrink World Border")
 @Description({
@@ -30,7 +29,7 @@ import org.skriptlang.skript.log.runtime.SyntaxRuntimeErrorProducer;
 	"shrink world border of world \"world\" to 100 in 10 seconds"
 })
 @Since("2.11")
-public class EffWorldBorderExpand extends Effect implements SyntaxRuntimeErrorProducer {
+public class EffWorldBorderExpand extends Effect {
 
 	static {
 		Skript.registerEffect(EffWorldBorderExpand.class,
@@ -48,7 +47,6 @@ public class EffWorldBorderExpand extends Effect implements SyntaxRuntimeErrorPr
 	private Expression<Number> numberExpr;
 	private @Nullable Expression<Timespan> timespan;
 	private static final double MAX_WORLDBORDER_SIZE = 59999968;
-	private Node node;
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -59,7 +57,6 @@ public class EffWorldBorderExpand extends Effect implements SyntaxRuntimeErrorPr
 		shrink = matchedPattern > 1;
 		radius = parseResult.hasTag("radius");
 		to = parseResult.hasTag("to");
-		node = getParser().getNode();
 		return true;
 	}
 
@@ -95,11 +92,6 @@ public class EffWorldBorderExpand extends Effect implements SyntaxRuntimeErrorPr
 				worldBorder.setSize(size, speed);
 			}
 		}
-	}
-
-	@Override
-	public Node getNode() {
-		return node;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprWorldBorderCenter.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprWorldBorderCenter.java
@@ -11,13 +11,12 @@ import org.bukkit.Location;
 import org.bukkit.WorldBorder;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
-import org.skriptlang.skript.log.runtime.SyntaxRuntimeErrorProducer;
 
 @Name("Center of World Border")
 @Description("The center of a world border.")
 @Examples("set world border center of {_worldborder} to location(10, 0, 20)")
 @Since("2.11")
-public class ExprWorldBorderCenter extends SimplePropertyExpression<WorldBorder, Location> implements SyntaxRuntimeErrorProducer {
+public class ExprWorldBorderCenter extends SimplePropertyExpression<WorldBorder, Location> {
 
 	static {
 		registerDefault(ExprWorldBorderCenter.class, Location.class, "world[ ]border (center|middle)", "worldborders");

--- a/src/main/java/ch/njol/skript/expressions/ExprWorldBorderDamageAmount.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprWorldBorderDamageAmount.java
@@ -10,7 +10,6 @@ import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.WorldBorder;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
-import org.skriptlang.skript.log.runtime.SyntaxRuntimeErrorProducer;
 
 @Name("Damage Amount of World Border")
 @Description({
@@ -19,7 +18,7 @@ import org.skriptlang.skript.log.runtime.SyntaxRuntimeErrorProducer;
 })
 @Examples("set world border damage amount of {_worldborder} to 1")
 @Since("2.11")
-public class ExprWorldBorderDamageAmount extends SimplePropertyExpression<WorldBorder, Double> implements SyntaxRuntimeErrorProducer {
+public class ExprWorldBorderDamageAmount extends SimplePropertyExpression<WorldBorder, Double>  {
 
 	static {
 		registerDefault(ExprWorldBorderDamageAmount.class, Double.class, "world[ ]border damage amount", "worldborders");

--- a/src/main/java/ch/njol/skript/expressions/base/SectionExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/SectionExpression.java
@@ -91,6 +91,13 @@ public abstract class SectionExpression<Value> extends SimpleExpression<Value> {
 	}
 
 	/**
+	 * Get if this {@link SectionExpression} can only be used as a {@link Section}.
+	 */
+	public boolean isSectionOnly() {
+		return false;
+	}
+
+	/**
 	 * @return A dummy trigger item representing the section belonging to this
 	 */
 	public final Section getAsSection() {

--- a/src/main/java/ch/njol/skript/lang/Condition.java
+++ b/src/main/java/ch/njol/skript/lang/Condition.java
@@ -2,6 +2,7 @@ package ch.njol.skript.lang;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.config.Node;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
@@ -9,6 +10,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.condition.Conditional;
+import org.skriptlang.skript.log.runtime.SyntaxRuntimeErrorProducer;
 import org.skriptlang.skript.registration.SyntaxInfo;
 import org.skriptlang.skript.util.Priority;
 
@@ -20,7 +22,7 @@ import java.util.function.Predicate;
  *
  * @see Skript#registerCondition(Class, String...)
  */
-public abstract class Condition extends Statement implements Conditional<Event> {
+public abstract class Condition extends Statement implements Conditional<Event>, SyntaxRuntimeErrorProducer {
 
 	public enum ConditionType {
 		/**
@@ -62,6 +64,14 @@ public abstract class Condition extends Statement implements Conditional<Event> 
 
 	protected Condition() {}
 
+	private Node node;
+
+	@Override
+	public boolean preInit() {
+		node = getParser().getNode();
+		return true;
+	}
+
 	/**
 	 * Checks whether this condition is satisfied with the given event. This should not alter the event or the world in any way, as conditions are only checked until one returns
 	 * false. All subsequent conditions of the same trigger will then be omitted.<br/>
@@ -95,6 +105,11 @@ public abstract class Condition extends Statement implements Conditional<Event> 
 	 */
 	public final boolean isNegated() {
 		return negated;
+	}
+
+	@Override
+	public Node getNode() {
+		return node;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/lang/Effect.java
+++ b/src/main/java/ch/njol/skript/lang/Effect.java
@@ -1,12 +1,14 @@
 package ch.njol.skript.lang;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.config.Node;
 import ch.njol.skript.lang.function.EffFunctionCall;
 import ch.njol.skript.log.ParseLogHandler;
 import ch.njol.skript.log.SkriptLogger;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.log.runtime.SyntaxRuntimeErrorProducer;
 
 import java.util.Iterator;
 
@@ -16,9 +18,17 @@ import java.util.Iterator;
  *
  * @see Skript#registerEffect(Class, String...)
  */
-public abstract class Effect extends Statement {
+public abstract class Effect extends Statement implements SyntaxRuntimeErrorProducer {
 
 	protected Effect() {}
+
+	private Node node;
+
+	@Override
+	public boolean preInit() {
+		node = getParser().getNode();
+		return true;
+	}
 
 	/**
 	 * Executes this effect.
@@ -62,6 +72,11 @@ public abstract class Effect extends Statement {
 			log.printError();
 			return null;
 		}
+	}
+
+	@Override
+	public Node getNode() {
+		return node;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/lang/ExpressionSection.java
+++ b/src/main/java/ch/njol/skript/lang/ExpressionSection.java
@@ -1,7 +1,9 @@
 package ch.njol.skript.lang;
 
+import ch.njol.skript.Skript;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.expressions.base.SectionExpression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.ApiStatus;
@@ -30,8 +32,13 @@ public class ExpressionSection extends Section {
 	}
 
 	@Override
-	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		SectionContext context = getParser().getData(SectionContext.class);
+		assert context != null;
+		if (context.sectionNode == null && expression.isSectionOnly()) {
+			Skript.error("This expression can only be used as a section.");
+			return false;
+		}
 		return this.init(expressions, matchedPattern, isDelayed, parseResult, context.sectionNode, context.triggerItems)
 			&& context.claim(expression);
 	}

--- a/src/main/java/ch/njol/skript/lang/Section.java
+++ b/src/main/java/ch/njol/skript/lang/Section.java
@@ -2,6 +2,7 @@ package ch.njol.skript.lang;
 
 import ch.njol.skript.ScriptLoader;
 import ch.njol.skript.Skript;
+import ch.njol.skript.config.Node;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.parser.ParserInstance;
@@ -10,6 +11,7 @@ import org.bukkit.event.Event;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.log.runtime.SyntaxRuntimeErrorProducer;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -40,7 +42,15 @@ import java.util.function.Supplier;
  *
  * @see Skript#registerSection(Class, String...)
  */
-public abstract class Section extends TriggerSection implements SyntaxElement {
+public abstract class Section extends TriggerSection implements SyntaxElement, SyntaxRuntimeErrorProducer {
+
+	private Node node;
+
+	@Override
+	public boolean preInit() {
+		node = getParser().getNode();
+		return true;
+	}
 
 	/**
 	 * This method should not be overridden unless you know what you are doing!
@@ -244,6 +254,11 @@ public abstract class Section extends TriggerSection implements SyntaxElement {
 			return owner != null;
 		}
 
+	}
+
+	@Override
+	public Node getNode() {
+		return node;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/test/runner/ExprSecRunnable.java
+++ b/src/main/java/ch/njol/skript/test/runner/ExprSecRunnable.java
@@ -9,7 +9,6 @@ import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.Trigger;
 import ch.njol.skript.lang.TriggerItem;
-import ch.njol.skript.variables.Variables;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -46,10 +45,6 @@ public class ExprSecRunnable extends SectionExpression<Object> {
 						ParseResult result,
 						@Nullable SectionNode node,
 						@Nullable List<TriggerItem> triggerItems) {
-		if (node == null) {
-			Skript.error("Runnable expression needs a section!");
-			return false;
-		}
 		loadCode(node);
 		return true;
 	}
@@ -63,6 +58,11 @@ public class ExprSecRunnable extends SectionExpression<Object> {
 
 	@Override
 	public boolean isSingle() {
+		return true;
+	}
+
+	@Override
+	public boolean isSectionOnly() {
 		return true;
 	}
 


### PR DESCRIPTION
### Problem
1. The new `#preInit` method that was added, was only taken advantage of in `SimpleExpression` allowing default implementation of `SyntaxRuntimeErrorProducer` and was not done for `Effect`, `Condition` and `Section`.

2. There was no API to distinguish if a `SectionExpression` could only be used as a `Section`.

### Solution
1. Overrides `#preInit` in `Effect`, `Condition`, and `Section` setting the `Node` and implementing `SyntaxRuntimeErrorProducer` allowing all elements by default to have access to it. Including sub types that elements extend such as `EffectSection` and `SectionExpression`

2. Adds a `#isSectionOnly` in `SectionExpression` allowing to check if it can only be used as a `Section`.
    - With this, adds a default error in `ExpressionSection` where if the `SectionNode` is null and `SectionExpression#isSectionOnly` returns true, prints an error and returns false in `ExpressionSection#init`.


### Testing Completed
N/A


### Supporting Information
N/A


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
