### PR TITLE
Add tolerance to divisible by condition

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondIsDivisibleBy.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsDivisibleBy.java
@@ -1,6 +1,7 @@
 package ch.njol.skript.conditions;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -11,33 +12,43 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.log.runtime.SyntaxRuntimeErrorProducer;
 
 @Name("Is Evenly Divisible By")
-@Description("Check if a number is evenly divisible by another number.")
+@Description("""
+	Checks if a number is evenly divisible by another number.
+	An optional tolerance can be provided to counteract floating point error. The default tolerance is 1e-10.
+	Any input smaller than the tolerance is considered to be 0.
+	This means too-small divisors will always return false, and too-small dividends will always return true.
+	""")
 @Examples({
 	"if 5 is evenly divisible by 5:",
 	"if 11 cannot be evenly divided by 10:",
 })
 @Since("2.10")
-public class CondIsDivisibleBy extends Condition {
+public class CondIsDivisibleBy extends Condition implements SyntaxRuntimeErrorProducer {
 
 	static {
 		Skript.registerCondition(CondIsDivisibleBy.class,
-			"%numbers% (is|are) evenly divisible by %number%",
-			"%numbers% (isn't|is not|aren't|are not) evenly divisible by %number%",
-			"%numbers% can be evenly divided by %number%",
-			"%numbers% (can't|can[ ]not) be evenly divided by %number%");
+			"%numbers% (is|are) evenly divisible by %number% [with [a] tolerance [of] %-number%]",
+			"%numbers% (isn't|is not|aren't|are not) evenly divisible by %number% [with [a] tolerance [of] %-number%]",
+			"%numbers% can be evenly divided by %number% [with [a] tolerance [of] %-number%]",
+			"%numbers% (can't|can[ ]not) be evenly divided by %number% [with [a] tolerance [of] %-number%]");
 	}
-	@SuppressWarnings("null")
+
 	private Expression<Number> dividend;
-	@SuppressWarnings("null")
 	private Expression<Number> divisor;
+	private @Nullable Expression<Number> epsilon;
+	private Node node;
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		dividend = (Expression<Number>) exprs[0];
 		divisor = (Expression<Number>) exprs[1];
+		epsilon = (Expression<Number>) exprs[2];
 		setNegated(matchedPattern == 1 || matchedPattern == 3);
+		node = getParser().getNode();
 		return true;
 	}
 
@@ -47,7 +58,36 @@ public class CondIsDivisibleBy extends Condition {
 		if (divisorNumber == null)
 			return isNegated();
 		double divisor = divisorNumber.doubleValue();
-		return dividend.check(event, dividendNumber -> (dividendNumber.doubleValue() % divisor == 0), isNegated());
+		if (divisor == 0) {
+			// Division by zero never passes
+			return isNegated();
+		}
+
+		Number epsilonNumber = epsilon != null ? epsilon.getSingle(event) : Skript.EPSILON;
+		if (epsilonNumber == null) {
+			epsilonNumber = Skript.EPSILON;
+		}
+		double epsilon = epsilonNumber.doubleValue();
+
+		if (epsilon <= 0 || Double.isNaN(epsilon)) {
+			error("Tolerance must be a positive, non-zero number, but was " + epsilonNumber + ".");
+			return isNegated();
+		}
+
+		if (divisor < epsilon) {
+			// If the divisor is smaller than the tolerance, we consider it to be 0
+			return isNegated();
+		}
+
+		return dividend.check(event, dividendNumber -> {
+			double remainder = Math.abs(dividendNumber.doubleValue() % divisor);
+			return remainder <= epsilon || remainder >= divisor - epsilon;
+		}, isNegated());
+	}
+
+	@Override
+	public Node getNode() {
+		return node;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/conditions/CondIsDivisibleBy.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsDivisibleBy.java
@@ -19,7 +19,7 @@ import org.skriptlang.skript.log.runtime.SyntaxRuntimeErrorProducer;
 	Checks if a number is evenly divisible by another number.
 	An optional tolerance can be provided to counteract floating point error. The default tolerance is 1e-10.
 	Any input smaller than the tolerance is considered to be 0.
-	This means too-small divisors will always return false, and too-small dividends will always return true.
+	This means divisors that are too small will always return false, and dividends that are too small will always return true.
 	""")
 @Examples({
 	"if 5 is evenly divisible by 5:",

--- a/src/main/java/ch/njol/skript/conditions/CondIsDivisibleBy.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsDivisibleBy.java
@@ -24,8 +24,9 @@ import org.skriptlang.skript.log.runtime.SyntaxRuntimeErrorProducer;
 @Examples({
 	"if 5 is evenly divisible by 5:",
 	"if 11 cannot be evenly divided by 10:",
+	"if 0.3 can be evenly divided by 0.1 with a tolerance of 0.0000001:"
 })
-@Since("2.10")
+@Since("2.10, INSERT VERSION (tolerance)")
 public class CondIsDivisibleBy extends Condition implements SyntaxRuntimeErrorProducer {
 
 	static {

--- a/src/test/skript/tests/syntaxes/conditions/CondIsDivisibleBy.sk
+++ b/src/test/skript/tests/syntaxes/conditions/CondIsDivisibleBy.sk
@@ -14,3 +14,15 @@ test "is divisible":
 	assert {_num} can be divided by 5 to fail with "You cannot divide by a string!"
 	set {_numlist::*} to "5", "10", and "15"
 	assert {_numlist::*} can be divided by 5 to fail with "You cannot divide by a string!"
+
+test "tolerances":
+	assert 0.3 can be evenly divided by 0.1 with "floating point error with 0.3 / 0.1"
+	assert 0.3 can be evenly divided by 0.1 with tolerance 0.01 with "floating point error with 0.3 / 0.1 at high tolerance"
+	assert 0.3 can be evenly divided by 0.1 with tolerance {_} with "floating point error with 0.3 / 0.1 at none tolerance"
+	assert 300000 is evenly divisible by 1/3 with "floating point error with 300000 / 1/3"
+	assert 3000000 is not evenly divisible by 1/3 with "unexpected floating point success with 3000000 / 1/3"
+	assert 3000000 is evenly divisible by 1/3 with tolerance 0.0001 with "unexpected floating point failure with 3000000 / 1/3 at high tolerance"
+	assert 5 is evenly divisible by 2.5 with tolerance 3 to fail with "too small divisor passed"
+	assert 0 is evenly divisible by 2 with tolerance 1 with "too small dividend failed"
+
+

--- a/src/test/skript/tests/syntaxes/conditions/CondIsDivisibleBy.sk
+++ b/src/test/skript/tests/syntaxes/conditions/CondIsDivisibleBy.sk
@@ -25,4 +25,3 @@ test "tolerances":
 	assert 5 is evenly divisible by 2.5 with tolerance 3 to fail with "too small divisor passed"
 	assert 0 is evenly divisible by 2 with tolerance 1 with "too small dividend failed"
 
-


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
The divisible by expression is particularly susceptible to floating point error compounding during the modulo operation. This means many common divisions like `0.3/0.1` return false when they should be true, due to slightly fp inaccuracies.

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
I may have gone a bit overboard. Nearly all reasonable cases can be fixed with a check against Skript.EPSILON, which ensures the result is within 1e-10 of evenly divisible. However, this fails when working with large or small numbers, or a combination of the two. For example, 3,000,000 / (1/3) fails as the error is slightly larger than 1e-10. 

Using ULP is sadly not helpful here, since the ulp for 3 million is 0.25 (way too large) and for 1/3 it is roughly 1e-17 (way too small). A fixed epsilon also fails if the user wants to work with small numbers, as a dividend of 1e-10 or smaller will always return true, no matter the divisor.

This PR implements a solution by defaulting to 1e-10 as the tolerance, but allowing the user to manually provide a tolerance if needed. This should covers nearly all cases by default and provide options for users it does not cover.

A few extra shortcut paths were added to speed things up.

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
Additional tests were added to CondIsDivisibleBy.sk to cover the new functionality.

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** #7930 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
