### PR TITLE
Scientific notation

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -1,0 +1,47 @@
+name: Update the gradle wrapper to the latest version
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  update-gradle-wrapper:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'adopt'
+          cache: gradle
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Get latest Gradle version
+        id: get_latest_gradle
+        run: |
+          response=$(curl -s https://services.gradle.org/versions/current)
+          latest_version=$(echo $response | jq -r '.version')
+          echo "LATEST_GRADLE_VERSION=$latest_version" >> $GITHUB_ENV
+          latest_download_url=$(echo $response | jq -r '.downloadUrl')
+          echo "LATEST_GRADLE_DOWNLOAD_URL=$latest_download_url" >> $GITHUB_ENV
+      - name: Update gradle-wrapper.properties
+        run: |
+          sed -i "s|^distributionUrl=.*$|distributionUrl=${LATEST_GRADLE_DOWNLOAD_URL}|" gradle/wrapper/gradle-wrapper.properties
+          ./gradlew wrapper --gradle-version ${LATEST_GRADLE_VERSION}
+      - name: Validate gradle wrapper
+        uses: gradle/wrapper-validation-action@v2
+      - name: Build Skript and run test scripts
+        run: ./gradlew clean quickTest
+      - name: Commit and push changes
+        if: success()
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add gradle/wrapper/
+          git commit -m "Update Gradle wrapper to ${LATEST_GRADLE_VERSION}"
+          git push

--- a/src/main/java/ch/njol/skript/classes/data/JavaClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/JavaClasses.java
@@ -30,6 +30,14 @@ public class JavaClasses {
 	public static final int VARIABLENAME_NUMBERACCURACY = 8;
 
 	/**
+	 * The pattern for scientific notation.
+	 * <p>
+	 * The pattern is the letter {@code e} or {@code E} followed by a sign and one or more digits.
+	 * </p>
+	 */
+	public static final String SCIENTIFIC_PATTERN = "(?:[eE][+-]\\d+)?";
+
+	/**
 	 * The format of an integer.
 	 * <p>
 	 * Has an optional negative sign and may contain one underscores followed by any number of digits.
@@ -49,8 +57,8 @@ public class JavaClasses {
 	 * </p>
 	 */
 	public static final Pattern INTEGER_PATTERN =
-		Pattern.compile("(?<num>" + INTEGER_NUMBER_PATTERN + ")" +
-			"(?: (?:in )?(?:(?<rad>rad(?:ian)?s?)|deg(?:ree)?s?))?");
+		Pattern.compile("(?<num>%s%s)(?: (?:in )?(?:(?<rad>rad(?:ian)?s?)|deg(?:ree)?s?))?"
+			.formatted(INTEGER_NUMBER_PATTERN, SCIENTIFIC_PATTERN));
 
 	/**
 	 * The format of a decimal number.
@@ -74,8 +82,8 @@ public class JavaClasses {
 	 * </p>
 	 */
 	public static final Pattern DECIMAL_PATTERN =
-		Pattern.compile("(?<num>" + DECIMAL_NUMBER_PATTERN + ")" +
-			"(?: (?:in )?(?:(?<rad>rad(?:ian)?s?)|deg(?:ree)?s?))?");
+		Pattern.compile("(?<num>%s%s)(?: (?:in )?(?:(?<rad>rad(?:ian)?s?)|deg(?:ree)?s?))?"
+			.formatted(DECIMAL_NUMBER_PATTERN, SCIENTIFIC_PATTERN));
 
 	static {
 		Classes.registerClass(new ClassInfo<>(Object.class, "object")

--- a/src/main/java/ch/njol/skript/classes/data/JavaClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/JavaClasses.java
@@ -35,7 +35,7 @@ public class JavaClasses {
 	 * The pattern is the letter {@code e} or {@code E} followed by a sign and one or more digits.
 	 * </p>
 	 */
-	public static final String SCIENTIFIC_PATTERN = "(?:[eE][+-]\\d+)?";
+	public static final String SCIENTIFIC_PATTERN = "(?:[eE][+-]?\\d+)?";
 
 	/**
 	 * The format of an integer.
@@ -57,7 +57,7 @@ public class JavaClasses {
 	 * </p>
 	 */
 	public static final Pattern INTEGER_PATTERN =
-		Pattern.compile("(?<num>%s%s)(?: (?:in )?(?:(?<rad>rad(?:ian)?s?)|deg(?:ree)?s?))?"
+		Pattern.compile("(?<num>%s%s)(?: (?:in )?(?:(?<rad>rad(?:ian)?)|deg(?:ree)?)s?)?"
 			.formatted(INTEGER_NUMBER_PATTERN, SCIENTIFIC_PATTERN));
 
 	/**
@@ -82,7 +82,7 @@ public class JavaClasses {
 	 * </p>
 	 */
 	public static final Pattern DECIMAL_PATTERN =
-		Pattern.compile("(?<num>%s%s)(?: (?:in )?(?:(?<rad>rad(?:ian)?s?)|deg(?:ree)?s?))?"
+		Pattern.compile("(?<num>%s%s)(?: (?:in )?(?:(?<rad>rad(?:ian)?)|deg(?:ree)?)s?)?"
 			.formatted(DECIMAL_NUMBER_PATTERN, SCIENTIFIC_PATTERN));
 
 	static {

--- a/src/main/java/ch/njol/skript/classes/data/JavaClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/JavaClasses.java
@@ -102,7 +102,7 @@ public class JavaClasses {
 					"Please note that many expressions only need integers, i.e. " +
 						"will discard any fractional parts of any numbers without producing an error.",
 					"Radians will be converted to degrees.")
-				.usage("[-]###[.###] [[in ](rad[ian][s]|deg[ree][s])]</code> (any amount of digits; very large numbers will be truncated though)")
+				.usage("[-]###[.###] [e[+|-]###] [[in ](rad[ian][s]|deg[ree][s])]")
 				.examples(
 					"set the player's health to 5.5",
 					"set {_temp} to 2*{_temp} - 2.5",

--- a/src/test/skript/tests/misc/scientific notation.sk
+++ b/src/test/skript/tests/misc/scientific notation.sk
@@ -1,0 +1,12 @@
+test "scientific notation":
+	assert 1.23e+4 is 12300 with "1.23e4 is not 12300"
+	assert 1.23e-4 is 0.000123 with "1.23e-4 is not 0.000123"
+	assert 1.23E+4 is 12300 with "1.23E4 is not 12300"
+	assert 1.23E-4 is 0.000123 with "1.23E-4 is not 0.000123"
+
+	assert 123e+2 is 12300 with "123e2 is not 12300"
+	assert 123e-2 is 1.23 with "123e-2 is not 1.23"
+
+	assert 1.23e+4 degs is 12300 with "1.23e+4 degs is not 12300"
+
+	set {_x} to 1.23e+4

--- a/src/test/skript/tests/misc/scientific notation.sk
+++ b/src/test/skript/tests/misc/scientific notation.sk
@@ -8,5 +8,3 @@ test "scientific notation":
 	assert 123e-2 is 1.23 with "123e-2 is not 1.23"
 
 	assert 1.23e+4 degs is 12300 with "1.23e+4 degs is not 12300"
-
-	set {_x} to 1.23e+4

--- a/src/test/skript/tests/misc/scientific notation.sk
+++ b/src/test/skript/tests/misc/scientific notation.sk
@@ -8,3 +8,4 @@ test "scientific notation":
 	assert 123e-2 is 1.23 with "123e-2 is not 1.23"
 
 	assert 1.23e+4 degs is 12300 with "1.23e+4 degs is not 12300"
+	assert 1.23e4 degs is 12300 with "1.23e4 degs is not 12300"


### PR DESCRIPTION
### Problem
Scientific notation is a way of easily representing large numbers, such as `1.23e+9` representing `1 230 000 000`. Most major languages have support for representing numbers like this, but Skript doesn't :(


### Solution
Updates the existing regex for integer and rational numbers to include allowing the use of the format `X[eE][+-]Y`. No implementation changes were necessary, as the existing methods allow this change to pass the tests.


### Testing Completed
`scientific notation.sk` test added, manually confirmed to be working.


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** #4553 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
