### PR TITLE
Allow Function Names to Start with Underscore

### DIFF
--- a/src/main/java/ch/njol/skript/lang/function/Functions.java
+++ b/src/main/java/ch/njol/skript/lang/function/Functions.java
@@ -73,7 +73,7 @@ public abstract class Functions {
 		return function;
 	}
 
-	public final static String functionNamePattern = "[\\p{IsAlphabetic}][\\p{IsAlphabetic}\\p{IsDigit}_]*";
+	public final static String functionNamePattern = "[\\p{IsAlphabetic}_][\\p{IsAlphabetic}\\p{IsDigit}_]*";
 
 	/**
 	 * Loads a script function from given node.

--- a/src/test/skript/tests/syntaxes/structures/StructFunction.sk
+++ b/src/test/skript/tests/syntaxes/structures/StructFunction.sk
@@ -13,7 +13,11 @@ local function local() :: number:
 local function bar() :: boolean:
 	return true
 
+local function _blob() :: string:
+	return "blub"
+
 test "functions":
 	assert foo() is true with "function return type failed"
 	assert local() is not 1 with "global function parsed before local function"
 	assert bar() is true with "local function didn't execute correctly"
+	assert _blob() is "blub" with "function that starts with underscore didn't execute correctly"


### PR DESCRIPTION
### Problem
In languages like Python and JavaScript, starting function names with underscores is a common pattern to indicate that the function is private or meant for internal use only. Skript currently doesn't allow this for seemingly no reason.


### Solution
Changes the function name pattern to allow underscores at the beginning


### Testing Completed
Added a simple test to `StructFunction.sk`

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
