### PR TITLE
Update ExprGameRule

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprGameRule.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprGameRule.java
@@ -1,5 +1,7 @@
 package ch.njol.skript.expressions;
 
+import ch.njol.skript.registrations.Classes;
+import ch.njol.skript.util.Utils;
 import org.bukkit.GameRule;
 import org.bukkit.World;
 import org.bukkit.event.Event;
@@ -61,6 +63,14 @@ public class ExprGameRule extends SimpleExpression<GameruleValue> {
 			Object value = delta[0];
 			if (value instanceof Number number && gamerule.getType().equals(Integer.class)) {
 				value = number.intValue();
+			} else if (!value.getClass().equals(gamerule.getType())) {
+				String currentClassName = Classes.toString(Classes.getSuperClassInfo(value.getClass()));
+				currentClassName = Utils.a(currentClassName) + " " + currentClassName;
+
+				String targetClassName = Classes.toString(Classes.getSuperClassInfo(gamerule.getType()));
+				targetClassName = Utils.a(targetClassName) + " " + targetClassName;
+
+				error("The " + gamerule.getName() + " gamerule can only be set to " + targetClassName + ", not " + currentClassName);
 			}
 
 			for (World gameruleWorld : worlds.getArray(event)) {

--- a/src/main/java/ch/njol/skript/expressions/ExprGameRule.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprGameRule.java
@@ -43,7 +43,7 @@ public class ExprGameRule extends SimpleExpression<GameruleValue> {
 	
 	@Override
 	@Nullable
-	public Class<?>[] acceptChange(final ChangeMode mode) {
+	public Class<?>[] acceptChange(ChangeMode mode) {
 		if (mode == ChangeMode.SET) {
 			return new Class[]{Boolean.class, Number.class};
 		}
@@ -51,9 +51,9 @@ public class ExprGameRule extends SimpleExpression<GameruleValue> {
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
 		if (mode == ChangeMode.SET) {
-			GameRule gamerule = this.gamerule.getSingle(e);
+			GameRule gamerule = this.gamerule.getSingle(event);
 			if (gamerule == null) {
 				return;
 			}
@@ -63,7 +63,7 @@ public class ExprGameRule extends SimpleExpression<GameruleValue> {
 				value = number.intValue();
 			}
 
-			for (World gameruleWorld : worlds.getArray(e)) {
+			for (World gameruleWorld : worlds.getArray(event)) {
                 gameruleWorld.setGameRule(gamerule, value);
 			}
 		}
@@ -71,13 +71,13 @@ public class ExprGameRule extends SimpleExpression<GameruleValue> {
 		
 	@Nullable
 	@Override
-	protected GameruleValue[] get(Event e) {
-		GameRule<?> gamerule = this.gamerule.getSingle(e);
+	protected GameruleValue[] get(Event event) {
+		GameRule<?> gamerule = this.gamerule.getSingle(event);
 		if (gamerule == null) {
 			return null;
 		}
 
-		World[] worlds = this.worlds.getArray(e);
+		World[] worlds = this.worlds.getArray(event);
 		GameruleValue[] gameruleValues = new GameruleValue[worlds.length];
 		int index = 0;
 
@@ -101,8 +101,8 @@ public class ExprGameRule extends SimpleExpression<GameruleValue> {
 	}
 	
 	@Override
-	public String toString(@Nullable Event e, boolean debug) {
-		return "the gamerule " + gamerule.toString(e, debug) + " of worlds " + worlds.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "the gamerule " + gamerule.toString(event, debug) + " of worlds " + worlds.toString(event, debug);
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprGameRule.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprGameRule.java
@@ -71,6 +71,7 @@ public class ExprGameRule extends SimpleExpression<GameruleValue> {
 				targetClassName = Utils.a(targetClassName);
 
 				error("The " + gamerule.getName() + " gamerule can only be set to " + targetClassName + ", not " + currentClassName + ".");
+				return;
 			}
 
 			for (World gameruleWorld : worlds.getArray(event)) {

--- a/src/main/java/ch/njol/skript/expressions/ExprGameRule.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprGameRule.java
@@ -10,7 +10,6 @@ import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.RequiredPlugins;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
@@ -18,74 +17,82 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.skript.util.GameruleValue;
 import ch.njol.util.Kleenean;
-import ch.njol.util.coll.CollectionUtils;
 
 @Name("Gamerule Value")
 @Description("The gamerule value of a world.")
 @Examples({"set the gamerule commandBlockOutput of world \"world\" to false"})
 @Since("2.5")
-@RequiredPlugins("Minecraft 1.13+")
 public class ExprGameRule extends SimpleExpression<GameruleValue> {
 	
 	static {
-		if (Skript.classExists("org.bukkit.GameRule")) {
-			Skript.registerExpression(ExprGameRule.class, GameruleValue.class, ExpressionType.COMBINED,
-				"[the] gamerule %gamerule% of %worlds%");
-		}
+		Skript.registerExpression(ExprGameRule.class, GameruleValue.class, ExpressionType.COMBINED, "[the] gamerule %gamerule% of %worlds%");
 	}
-	
-	@SuppressWarnings("null")
+
+	private boolean isSingleWorld;
+
 	private Expression<GameRule> gamerule;
-	@SuppressWarnings("null")
-	private Expression<World> world;
+	private Expression<World> worlds;
 	
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		gamerule = (Expression<GameRule>) exprs[0];
-		world = (Expression<World>) exprs[1];
+		worlds = (Expression<World>) exprs[1];
+		isSingleWorld = worlds.isSingle();
 		return true;
 	}
 	
 	@Override
 	@Nullable
 	public Class<?>[] acceptChange(final ChangeMode mode) {
-		if (mode == ChangeMode.SET) 
-            return CollectionUtils.array(Boolean.class, Number.class);
+		if (mode == ChangeMode.SET) {
+			return new Class[]{Boolean.class, Number.class};
+		}
 		return null;
 	}
 	
 	@Override
 	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
-		assert delta != null;
 		if (mode == ChangeMode.SET) {
-			GameRule bukkitGamerule = gamerule.getSingle(e);
-			if (bukkitGamerule == null) 
-                return;
-			for (World gameruleWorld : world.getArray(e))
-                gameruleWorld.setGameRule(bukkitGamerule, delta[0]);
+			GameRule gamerule = this.gamerule.getSingle(e);
+			if (gamerule == null) {
+				return;
+			}
+
+			Object value = delta[0];
+			if (value instanceof Number number && gamerule.getType().equals(Integer.class)) {
+				value = number.intValue();
+			}
+
+			for (World gameruleWorld : worlds.getArray(e)) {
+                gameruleWorld.setGameRule(gamerule, value);
+			}
 		}
 	}
 		
 	@Nullable
 	@Override
 	protected GameruleValue[] get(Event e) {
-		GameRule<?> bukkitGamerule = gamerule.getSingle(e);
-		if (bukkitGamerule == null) 
-            return null;
-		World[] gameruleWorlds = world.getArray(e);
-		GameruleValue[] gameruleValues = new GameruleValue[gameruleWorlds.length];
+		GameRule<?> gamerule = this.gamerule.getSingle(e);
+		if (gamerule == null) {
+			return null;
+		}
+
+		World[] worlds = this.worlds.getArray(e);
+		GameruleValue[] gameruleValues = new GameruleValue[worlds.length];
 		int index = 0;
-		for (World gameruleWorld : gameruleWorlds) {
-			Object gameruleValue = gameruleWorld.getGameRuleValue(bukkitGamerule);
+
+		for (World world : worlds) {
+			Object gameruleValue = world.getGameRuleValue(gamerule);
 			assert gameruleValue != null;
 			gameruleValues[index++] = new GameruleValue<>(gameruleValue);
 		}
+
 		return gameruleValues;
 	}
 	
 	@Override
 	public boolean isSingle() {
-		return false;
+		return isSingleWorld;
 	}
 	
 	@Override
@@ -95,6 +102,7 @@ public class ExprGameRule extends SimpleExpression<GameruleValue> {
 	
 	@Override
 	public String toString(@Nullable Event e, boolean debug) {
-		return "the gamerule value of " + gamerule.toString(e, debug) + " for world " + world.toString(e, debug);
+		return "the gamerule " + gamerule.toString(e, debug) + " of worlds " + worlds.toString(e, debug);
 	}
+
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprGameRule.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprGameRule.java
@@ -65,12 +65,12 @@ public class ExprGameRule extends SimpleExpression<GameruleValue> {
 				value = number.intValue();
 			} else if (!value.getClass().equals(gamerule.getType())) {
 				String currentClassName = Classes.toString(Classes.getSuperClassInfo(value.getClass()));
-				currentClassName = Utils.a(currentClassName) + " " + currentClassName;
+				currentClassName = Utils.a(currentClassName);
 
 				String targetClassName = Classes.toString(Classes.getSuperClassInfo(gamerule.getType()));
-				targetClassName = Utils.a(targetClassName) + " " + targetClassName;
+				targetClassName = Utils.a(targetClassName);
 
-				error("The " + gamerule.getName() + " gamerule can only be set to " + targetClassName + ", not " + currentClassName);
+				error("The " + gamerule.getName() + " gamerule can only be set to " + targetClassName + ", not " + currentClassName + ".");
 			}
 
 			for (World gameruleWorld : worlds.getArray(event)) {


### PR DESCRIPTION
### Problem
- isSingle always returns false even if a single value is returned
- Before setting a gamerule, it doesn't check if the gamerule can be assigned to the given value, which prints errors during runtime.

### Solution
Fixed the problems and updated the outdated code. Also adds runtime errors for when you use a wrong value for a gamemode (ex. boolean for spawnRadius)

### Testing Completed
```
on load:
  set {_w} to world("world")
  set gamerule spawnRadius of {_w} to 5.3
  broadcast whether gamerule spawnRadius of {_w} is 5

  set gamerule spawnRadius of {_w} to 6
  broadcast whether gamerule spawnRadius of {_w} is 6

  set gamerule doFireTick of {_w} to true
  broadcast whether gamerule doFireTick of {_w} is true

  # errors
  set gamerule doFireTick of {_w} to 5
  set gamerule spawnRadius of {_w} to true
```

---
**Completes:** #7939
**Related:** none <!-- Links to issues or discussions with related information -->
