### PR TITLE
SkriptAddon#asOrigin

### DIFF
--- a/src/main/java/org/skriptlang/skript/addon/SkriptAddon.java
+++ b/src/main/java/org/skriptlang/skript/addon/SkriptAddon.java
@@ -4,6 +4,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 import org.skriptlang.skript.Skript;
 import org.skriptlang.skript.localization.Localizer;
+import org.skriptlang.skript.registration.SyntaxOrigin;
 import org.skriptlang.skript.registration.SyntaxRegistry;
 import org.skriptlang.skript.util.Registry;
 import org.skriptlang.skript.util.ViewProvider;
@@ -114,6 +115,15 @@ public interface SkriptAddon extends ViewProvider<SkriptAddon> {
 	@Contract("-> new")
 	default SkriptAddon unmodifiableView() {
 		return new SkriptAddonImpl.UnmodifiableAddon(this);
+	}
+
+	/**
+	 * Constructs a {@link SyntaxOrigin} from this {@link SkriptAddon}.
+	 * @return An origin pointing to this {@link SkriptAddon}.
+	 */
+	@Contract("-> new")
+	default SyntaxOrigin asOrigin() {
+		return SyntaxOrigin.of(this);
 	}
 
 }


### PR DESCRIPTION
### Problem
Addon developers have to go a round about way of getting a `SyntaxOrigin` of their `SkriptAddon`. Rather than a method being implemented into their `SkriptAddon` instance.

### Solution
Adds `#asOrigin` in `SkriptAddon` which calls `SyntaxOrigin#of` to have a centralized spot of creating `SyntaxOrigin`s
This allows addon developers easier access to obtain a `SyntaxOrigin`.

### Testing Completed
N/A

### Supporting Information
Note from issue:
> allows addons to internally cache their origin and remove the creation of a new AddonOrigin each time someone wants to use it.
While they can cache it themselves it makes more sense for an addon instance to remember it themselves

---
**Completes:** #7572 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
