### PR TITLE
ExprDecimalPlaces

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprDecimalPlaces.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDecimalPlaces.java
@@ -1,0 +1,44 @@
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Example;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.util.Math2;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Number of Decimal Places")
+@Description("Gets the number of decimal places in a number.")
+@Example("""
+	set {_decimalPlaces} to the number of decimal places from 1.23456789
+	# {_decimalPlaces} = 8
+	""")
+@Since("INSERT VERSION")
+public class ExprDecimalPlaces extends SimplePropertyExpression<Number, Long> {
+
+	static {
+		register(ExprDecimalPlaces.class, Long.class, "number of decimal places", "numbers");
+	}
+
+	@Override
+	public @Nullable Long convert(Number number) {
+		if (!(number instanceof Double doubleValue))
+			return null;
+		String[] split = doubleValue.toString().split("\\.");
+		if (split.length != 2)
+			return null;
+		return Math2.fit(0, split[1].length(), Long.MAX_VALUE);
+	}
+
+	@Override
+	public Class<Long> getReturnType() {
+		return Long.class;
+	}
+
+	@Override
+	protected String getPropertyName() {
+		return "number of decimal places";
+	}
+
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprDecimalPlaces.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDecimalPlaces.java
@@ -1,34 +1,123 @@
 package ch.njol.skript.expressions;
 
+import ch.njol.skript.Skript;
+import ch.njol.skript.SkriptConfig;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
-import ch.njol.skript.expressions.base.SimplePropertyExpression;
-import ch.njol.util.Math2;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.SyntaxStringBuilder;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Name("Number of Decimal Places")
-@Description("Gets the number of decimal places in a number.")
+@Description("""
+	Gets the number of decimal places in a number.
+	This expression will limit the number of decimal places to the 'number accuracy' option in the config, which is 2 by default.
+	Providing a custom limit will override the default behavior with the provided integer limit.
+	Specifying 'with no limit' will get as many decimal places as possible from the provided number(s).
+	""")
 @Example("""
-	set {_decimalPlaces} to the number of decimal places of 1.23456789
+	# the 'number accuracy' option in the config is 2 by default
+	set {_decimalPlaces1} to the number of decimal places of 1.2345
+	# {_decimalPlaces} = 2
+	set {_decimalPlaces} to the number of decimal places 1.2
+	# {_decimalPlaces} = 1
+	set {_decimalPlaces2} to the number of decimal places of 1.00000001
+	# {_decimalPlaces} = 2
+	""")
+@Example("""
+	set {_decimalPlaces} to the number of decimal places of 1.234567 with a limit of 4
+	# {_decimalPlaces} = 4
+	set {_decimalPlaces} to the number of decimal places of 1.23456 with a limit of 7
+	# {_decimalPlaces} = 5
+	set {_decimalPlaces} to the number of decimal places of 1.000000001 with a limit of 6
+	# {_decimalPlaces} = 6
+	""")
+@Example("""
+	set {_decimalPlaces} to the number of decimal places of 1.23456789 with no limit
 	# {_decimalPlaces} = 8
+	set {_decimalPlaces} to the number of decimal places of 1.0000000000001 with no limit
+	# {_decimalPlaces} = 13
+	""")
+@Example("""
+	set {_decimalPlaces} to the number of decimal places of 1
+	set {_decimalPlaces} to the number of decimal places of 1.00000000000
+	set {_decimalPlaces} to the number of decimal places of 1.00000 with a limit of 4
+	set {_decimalPlaces} to the number of decimal places of 1.0000000 with no limit
+	# {_decimalPlaces} = <none>
 	""")
 @Since("INSERT VERSION")
-public class ExprDecimalPlaces extends SimplePropertyExpression<Number, Long> {
+public class ExprDecimalPlaces extends SimpleExpression<Long> {
+
+	private static final double EPSILON = 1e-9;
 
 	static {
-		register(ExprDecimalPlaces.class, Long.class, "number of decimal places", "numbers");
+		Skript.registerExpression(ExprDecimalPlaces.class, Long.class, ExpressionType.COMBINED,
+			"[the] number of decimal places of %numbers% [limited:with a (limit|cap) of %-integer%]",
+			"[the] number of decimal places of %numbers% with no (limit|cap)");
+	}
+
+	private Expression<Number> numbers;
+	private @Nullable Expression<Integer> limit;
+	private boolean isLimited;
+	private boolean isUnlimited;
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		//noinspection unchecked
+		numbers = (Expression<Number>) exprs[0];
+		isLimited = parseResult.hasTag("limited");
+		isUnlimited = matchedPattern == 1;
+		if (isLimited) {
+			//noinspection unchecked
+			limit = (Expression<Integer>) exprs[1];
+		}
+		return true;
 	}
 
 	@Override
-	public @Nullable Long convert(Number number) {
-		if (!(number instanceof Double doubleValue))
-			return null;
-		String[] split = doubleValue.toString().split("\\.");
-		if (split.length != 2)
-			return null;
-		return Math2.fit(0, split[1].length(), Long.MAX_VALUE);
+	protected Long @Nullable [] get(Event event) {
+		List<Long> decimalPlaces = new ArrayList<>();
+		Integer limit = Integer.MAX_VALUE;
+		if (isLimited) {
+			assert this.limit != null;
+			limit = this.limit.getSingle(event);
+			if (limit == null)
+				return null;
+		} else if (!isUnlimited) {
+			limit = SkriptConfig.numberAccuracy.value();
+		}
+		for (Number number : numbers.getArray(event)) {
+			if (!(number instanceof Double doubleValue)) {
+				continue;
+			}
+			double x = Double.valueOf(doubleValue);
+			long decimalPlace = 0L;
+			for (int i = 0; i < limit; i++) {
+				if (Math.abs(x % 1) > EPSILON && Math.abs((x % 1) - 1) > EPSILON) {
+					x *= 10;
+					decimalPlace++;
+				} else {
+					break;
+				}
+			}
+			decimalPlaces.add(decimalPlace);
+		}
+		return decimalPlaces.toArray(Long[]::new);
+	}
+
+	@Override
+	public boolean isSingle() {
+		return numbers.isSingle();
 	}
 
 	@Override
@@ -37,8 +126,16 @@ public class ExprDecimalPlaces extends SimplePropertyExpression<Number, Long> {
 	}
 
 	@Override
-	protected String getPropertyName() {
-		return "number of decimal places";
+	public String toString(@Nullable Event event, boolean debug) {
+		SyntaxStringBuilder builder = new SyntaxStringBuilder(event, debug);
+		builder.append("the number of decimal places of", numbers);
+		if (isLimited) {
+			assert limit != null;
+			builder.append("with a limit of", limit);
+		} else if (isUnlimited) {
+			builder.append("with no limit");
+		}
+		return builder.toString();
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprDecimalPlaces.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDecimalPlaces.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.Nullable;
 @Name("Number of Decimal Places")
 @Description("Gets the number of decimal places in a number.")
 @Example("""
-	set {_decimalPlaces} to the number of decimal places from 1.23456789
+	set {_decimalPlaces} to the number of decimal places of 1.23456789
 	# {_decimalPlaces} = 8
 	""")
 @Since("INSERT VERSION")

--- a/src/test/skript/tests/syntaxes/expressions/ExprDecimalPlaces
+++ b/src/test/skript/tests/syntaxes/expressions/ExprDecimalPlaces
@@ -1,6 +1,19 @@
 test "decimal places":
-	assert (the number of decimal places of 1.234) is 3 with "Should return 3 decimal places"
-	assert (the number of decimal places of 1.23456789) is 8 with "Should return 8 decimal places"
-	assert (the number of decimal places of 1.000000000000001) is 15 with "Should return 15 decimal places
-	assert (the number of decimal places of 1.0000000000) is not set with "Should return null for trailing zeros"
-	assert (the number of decimal places of 1) is not set with "Should return null for no decimal number"
+	assert (the number of decimal places of 1.2) is 1 with "Decimal places should be 1 (number accuracy)"
+	assert (the number of decimal places of 1.234) is 2 with "Decimal places should be limited to 2 (number accuracy)"
+
+	assert (the number of decimal places of 1.2345 with a limit of 3) is 3 with "Decimal places should be limited to 3 (limit)"
+	assert (the number of decimal places of 1.2345 with a limit of 4) is 4 with "Decimal places should be 4 (limit)"
+
+	assert (the number of decimal places of 1.23456789 with no limit) is 8 with "Decimal places should be 8 (no limit)"
+	assert (the number of decimal places of 1.23456789123456789 with no limit) is 17 with "Decimal places should be 17 (no limit)"
+
+	assert (the number of decimal places of 1.00000000) is not set with "Decimal places should return null for trailing zeros"
+	assert (the number of decimal places of 1.00000000 with a limit of 4) is not set with "Decimal places should return null for trailing zeros (limit)"
+	assert (the number of decimal places of 1.00000000 with no limit) is not set with "Decimal places should return null for trailing zeros (no limit)"
+
+	assert (the number of decimal places of 1.0000001) is 2 with "Decimal places of trailing zeros and a one, should be 2 (number accuracy)"
+	assert (the number of decimal places of 1.0000001 with a limit of 5) is 5 with "Decimal places of trailing zeros and a one, should be 5 (limit)"
+	assert (the number of decimal places of 1.0000001 with no limit) is 7 with "Decimal places of trailing zeros and a one, should be 7 (no limit)"
+
+	assert (the number of decimal places of 1) is not set with "Decimal places of '1' should be null"

--- a/src/test/skript/tests/syntaxes/expressions/ExprDecimalPlaces
+++ b/src/test/skript/tests/syntaxes/expressions/ExprDecimalPlaces
@@ -1,0 +1,6 @@
+test "decimal places":
+	assert (the number of decimal places of 1.234) is 3 with "Should return 3 decimal places"
+	assert (the number of decimal places of 1.23456789) is 8 with "Should return 8 decimal places"
+	assert (the number of decimal places of 1.000000000000001) is 15 with "Should return 15 decimal places
+	assert (the number of decimal places of 1.0000000000) is not set with "Should return null for trailing zeros"
+	assert (the number of decimal places of 1) is not set with "Should return null for no decimal number"


### PR DESCRIPTION
### Problem
There is no expression allowing users to get how many decimal places a number goes into. Also was requested in the linked issue.

### Solution
Adds `ExprDecimalPlaces` allowing users to quickly and easily get how many decimal places a number goes into.

### Testing Completed
`ExprDecimalPlaces.sk`

### Supporting Information
N/A

---
**Completes:** #7948 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
