### PR TITLE
Paper 1.21.6 Update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -246,7 +246,7 @@ void createTestTask(String name, String desc, String environments, int javaVersi
 def java21 = 21
 def java17 = 17
 
-def latestEnv = 'java21/paper-1.21.5.json'
+def latestEnv = 'java21/paper-1.21.6.json'
 def latestJava = java21
 def oldestJava = java17
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ groupid=ch.njol
 name=skript
 version=2.11.2
 jarName=Skript.jar
-testEnv=java21/paper-1.21.5
+testEnv=java21/paper-1.21.6
 testEnvJavaVersion=21

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -1412,6 +1412,7 @@ teleport causes:
 	unknown: unknown
 	dismount: dismount, dismounted
 	exit_bed: exit bed, exiting bed, bed exit
+	consumable_effect: consumable effect
 
 # -- Inventory Close Reasons --
 inventory close reasons:
@@ -2232,6 +2233,7 @@ sound categories:
 	records: record category, records category, jukebox category, jukeboxes category, noteblock category, noteblocks category, note block category, note blocks category
 	voice: voice category, speech category
 	weather: weather category
+	ui: ui, user interface
 
 # -- Panda Genes --
 genes:
@@ -2344,6 +2346,9 @@ attribute types:
 	submerged_mining_speed: player submerged mining speed, submerged mining speed
 	sweeping_damage_ratio: player sweeping damage ratio, sweeping damage ratio
 	spawn_reinforcements: zombie spawn reinforcements
+	camera_distance: camera distance
+	waypoint_transmit_range: waypoint transmit range
+	waypoint_receive_range: waypoint receive range
 
 # -- Environments --
 environments:

--- a/src/test/skript/environments/java21/paper-1.21.6.json
+++ b/src/test/skript/environments/java21/paper-1.21.6.json
@@ -1,0 +1,17 @@
+{
+	"name": "paper-1.21.6",
+	"resources": [
+		{"source": "server.properties.generic", "target": "server.properties"}
+	],
+	"paperDownloads": [
+		{
+			"version": "1.21.6",
+			"target": "paperclip.jar"
+		}
+	],
+	"skriptTarget": "plugins/Skript.jar",
+	"commandLine": [
+		"-Dcom.mojang.eula.agree=true",
+		"-jar", "paperclip.jar", "--nogui"
+	]
+}


### PR DESCRIPTION
### Problem
N/A

### Solution
Updates `build.gradle` and `gradle.properties` by changing `1.21.5` -> `1.21.6`
Adds `paper-1.21.6.json` for the testing environment
Updates `default.lang` for new entries in enums/registries

### Testing Completed
N/A

### Supporting Information
N/A

---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
