### PR TITLE
Enforce main thread when changing variables during structure loading

### DIFF
--- a/src/main/java/ch/njol/skript/structures/StructVariables.java
+++ b/src/main/java/ch/njol/skript/structures/StructVariables.java
@@ -1,26 +1,5 @@
 package ch.njol.skript.structures;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-
-import com.google.common.collect.Queues;
-import org.bukkit.event.Event;
-import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.Unmodifiable;
-import org.skriptlang.skript.lang.converter.Converters;
-import org.skriptlang.skript.lang.entry.EntryContainer;
-import org.skriptlang.skript.lang.script.Script;
-import org.skriptlang.skript.lang.script.ScriptData;
-import org.skriptlang.skript.lang.structure.Structure;
-
-import com.google.common.collect.ImmutableList;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.config.EntryNode;
@@ -37,10 +16,23 @@ import ch.njol.skript.lang.Variable;
 import ch.njol.skript.log.ParseLogHandler;
 import ch.njol.skript.log.SkriptLogger;
 import ch.njol.skript.registrations.Classes;
+import ch.njol.skript.util.Task;
 import ch.njol.skript.variables.Variables;
 import ch.njol.util.NonNullPair;
 import ch.njol.util.StringUtils;
 import ch.njol.util.coll.CollectionUtils;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Queues;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
+import org.skriptlang.skript.lang.converter.Converters;
+import org.skriptlang.skript.lang.entry.EntryContainer;
+import org.skriptlang.skript.lang.script.Script;
+import org.skriptlang.skript.lang.script.ScriptData;
+import org.skriptlang.skript.lang.structure.Structure;
+
+import java.util.*;
 
 @Name("Variables")
 @Description({
@@ -245,12 +237,15 @@ public class StructVariables extends Structure {
 		} else if (data.isLoaded()) {
 			return true;
 		}
-		for (NonNullPair<String, Object> pair : data.getVariables()) {
-			String name = pair.getKey();
-			if (Variables.getVariable(name, null, false) != null)
-				continue;
-			Variables.setVariable(name, pair.getValue(), null, false);
-		}
+		Task.callSync(() -> {
+				for (NonNullPair<String, Object> pair : data.getVariables()) {
+					String name = pair.getKey();
+					if (Variables.getVariable(name, null, false) != null)
+						continue;
+					Variables.setVariable(name, pair.getValue(), null, false);
+				}
+				return null;
+			});
 		data.loaded = true;
 		return true;
 	}

--- a/src/main/java/ch/njol/skript/structures/StructVariables.java
+++ b/src/main/java/ch/njol/skript/structures/StructVariables.java
@@ -238,14 +238,14 @@ public class StructVariables extends Structure {
 			return true;
 		}
 		Task.callSync(() -> {
-				for (NonNullPair<String, Object> pair : data.getVariables()) {
-					String name = pair.getKey();
-					if (Variables.getVariable(name, null, false) != null)
-						continue;
-					Variables.setVariable(name, pair.getValue(), null, false);
-				}
-				return null;
-			});
+			for (NonNullPair<String, Object> pair : data.getVariables()) {
+				String name = pair.getKey();
+				if (Variables.getVariable(name, null, false) != null)
+					continue;
+				Variables.setVariable(name, pair.getValue(), null, false);
+			}
+			return null;
+		});
 		data.loaded = true;
 		return true;
 	}

--- a/src/main/java/ch/njol/skript/test/runner/StructParse.java
+++ b/src/main/java/ch/njol/skript/test/runner/StructParse.java
@@ -12,11 +12,11 @@ import ch.njol.skript.doc.NoDoc;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.skript.lang.parser.ParserInstance;
 import ch.njol.skript.lang.util.ContextlessEvent;
 import ch.njol.skript.log.LogEntry;
 import ch.njol.skript.log.RetainingLogHandler;
 import ch.njol.skript.log.SkriptLogger;
+import ch.njol.skript.util.Task;
 import com.google.common.collect.Iterables;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
@@ -78,7 +78,10 @@ public class StructParse extends Structure {
 
 	@Override
 	public boolean postLoad() {
-		resultsExpression.change(ContextlessEvent.get(), logs, ChangeMode.SET);
+		Task.callSync(() -> {
+			resultsExpression.change(ContextlessEvent.get(), logs, ChangeMode.SET);
+			return null;
+		});
 		return true;
 	}
 


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
#7963 Variables were attempting to be set asynchronously when using the async script loader setting.

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
Changes StructParse and StructVariables to enforce using the main thread when changing variables.

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
Manual testing with the existing test scripts and the async loader enabled.

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->
This is very much a bandaid and not a comprehensive fix of async loading. There are no doubt many more issues with it.

---
**Completes:** #7963 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
