### PR TITLE
Fix ExprArithmetic Type Resolutions

### DIFF
--- a/src/main/java/org/skriptlang/skript/lang/arithmetic/Arithmetics.java
+++ b/src/main/java/org/skriptlang/skript/lang/arithmetic/Arithmetics.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Set;
 import java.util.HashSet;
 import java.util.function.Supplier;
@@ -80,6 +81,47 @@ public final class Arithmetics {
 	public static <T> List<OperationInfo<T, ?, ?>> getOperations(Operator operator, Class<T> type) {
 		return (List) getOperations(operator).stream()
 			.filter(info -> info.getLeft().isAssignableFrom(type))
+			.collect(Collectors.toList());
+	}
+
+	/**
+	 * Returns all valid operations from {@code operator} and {@code leftClass}.
+	 * Unlike {@link #getOperations(Operator, Class)}, this method considers Converters.
+	 * @param operator The operator for the desired operations
+	 * @param leftClass Class representing the desired left-hand argument type
+	 * @return A list containing all valid operations from {@code operator} and {@code leftClass}.
+	 * @param <L> The type of the left-hand argument
+	 */
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	public static <L> List<OperationInfo<L, ?, ?>> lookupLeftOperations(Operator operator, Class<L> leftClass) {
+		return (List) getOperations(operator).stream()
+			.map(info -> {
+				if (info.getLeft().isAssignableFrom(leftClass)) {
+					return info;
+				}
+				return info.getConverted(leftClass, info.getRight(), info.getReturnType());
+			})
+			.filter(Objects::nonNull)
+			.collect(Collectors.toList());
+	}
+
+	/**
+	 * Returns all valid operations from {@code operator} and {@code rightClass}.
+	 * @param operator The operator for the desired operations
+	 * @param rightClass Class representing the desired right-hand argument type
+	 * @return A list containing all valid operations from {@code operator} and {@code rightClass}.
+	 * @param <R> The type of the right-hand argument
+	 */
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	public static <R> List<OperationInfo<?, R, ?>> lookupRightOperations(Operator operator, Class<R> rightClass) {
+		return (List) getOperations(operator).stream()
+			.map(info -> {
+				if (info.getRight().isAssignableFrom(rightClass)) {
+					return info;
+				}
+				return info.getConverted(info.getLeft(), rightClass, info.getReturnType());
+			})
+			.filter(Objects::nonNull)
 			.collect(Collectors.toList());
 	}
 

--- a/src/test/skript/tests/syntaxes/expressions/ExprArithmetic.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprArithmetic.sk
@@ -278,3 +278,10 @@ test "arithmetic type switcheroo":
 	loop 2 times:
 		set {_x} to {_a} + {_b}
 		set {_b} to 5
+
+local function arithmetic_xp() returns experience:
+	return 5 xp
+
+test "arithmetic parse time conversion":
+	set {_x} to arithmetic_xp() + 5
+	assert {_x} is 10 with "failed to calculate experience + number"


### PR DESCRIPTION
### Problem
Currently, ExprArithmetic does not properly consider Converters (Converted Arithmetic Infos) when determining return types along with UnparsedLiteral resolutions. This led to some unexpected test failures when working on https://github.com/SkriptLang/Skript/pull/7892

### Solution
I added two new methods, `lookupLeftOperations` and `lookupRightOperations` for performing OperationInfo lookups (with converters) when only partial information is available. I used `lookup` as that method seems to be used when Converters are considered, whereas `get` is for exact looksup.

### Testing Completed
I have added a test case in `ExprArithmetic.sk` that tests the behavior against Experience. Here's what goes wrong currently:

When parsing for the line starts, the Operation information is `Experience + UnparsedLiteral (Object)`. When searching for `Experience + <anything>` operations, Skript finds nothing, as Converters are not attempted. However, it should find `Number + Number` as `Experience -> Number` is a registered Converter. Thus, by checking conversions, this line now parses successfully.


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
