### PR TITLE
Happy Ghast Addition

### DIFF
--- a/src/main/java/ch/njol/skript/entity/SimpleEntityData.java
+++ b/src/main/java/ch/njol/skript/entity/SimpleEntityData.java
@@ -222,6 +222,9 @@ public class SimpleEntityData extends EntityData<Entity> {
 			addSuperEntity("any chest boat", ChestBoat.class);
 		}
 
+		if (Skript.isRunningMinecraft(1, 21, 6))
+			addSimpleEntity("happy ghast", HappyGhast.class);
+
 		// Register zombie after Husk and Drowned to make sure both work
 		addSimpleEntity("zombie", Zombie.class);
 		// Register squid after glow squid to make sure both work

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -1331,6 +1331,10 @@ entities:
 	creaking:
 		name: creaking¦s
 		pattern: creaking[plural:s]
+	# 1.21.6 Entities
+	happy ghast:
+		name: happy ghast¦s
+		pattern: <age> happy ghast[plural:s]|baby:[happy] ghastling[plural:s]
 
 # -- Heal Reasons --
 heal reasons:


### PR DESCRIPTION
### Problem
Skript does not have support to spawn happy ghasts.

### Solution
Adds `happy ghast` into `SimpleEntityData` and `default.lang` allowing support for happy ghasts.

### Testing Completed
Manual spawning with pattern usage

### Supporting Information
N/A

---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
