### PR TITLE
Add case sensitivity support to ExprIndicesOf

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprIndicesOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprIndicesOf.java
@@ -1,16 +1,18 @@
 package ch.njol.skript.expressions;
 
+import ch.njol.skript.SkriptConfig;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Example;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.*;
 import ch.njol.skript.lang.simplification.SimplifiedLiteral;
 import ch.njol.skript.util.LiteralUtils;
+import ch.njol.util.StringUtils;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 
 import ch.njol.skript.Skript;
-import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
-import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
@@ -30,40 +32,46 @@ import java.util.*;
 		+ "and will return the string indices of the given value. "
 		+ "Positions can be used with any list and will return "
 		+ "the numerical position of the value in the list, counting up from 1. "
-		+ "As well, nothing is returned if the value is not found in the list."
+		+ "As well, nothing is returned if the value is not found in the list.",
+	"",
+	"Whether strings are compared case-sensitively or not can be configured in the Skript configuration.",
 })
-@Examples({
-	"set {_first} to the first position of \"@\" in the text argument",
-	"if {_s} contains \"abc\":",
-		"\tset {_s} to the first (position of \"abc\" in {_s} + 3) characters of {_s}",
-		"\t# removes everything after the first \"abc\" from {_s}",
-	"",
-	"set {_list::*} to 1, 2, 3, 1, 2, 3",
-	"set {_indices::*} to indices of the value 1 in {_list::*}",
-	"# {_indices::*} is now \"1\" and \"4\"",
-	"",
-	"set {_indices::*} to all indices of the value 2 in {_list::*}",
-	"# {_indices::*} is now \"2\" and \"5\"",
-	"",
-	"set {_positions::*} to all positions of the value 3 in {_list::*}",
-	"# {_positions::*} is now 3 and 6",
-	"",
-	"set {_otherlist::bar} to 100",
-	"set {_otherlist::hello} to \"hi\"",
-	"set {_otherlist::burb} to 100",
-	"set {_otherlist::tud} to \"hi\"",
-	"set {_otherlist::foo} to 100",
-	"",
-	"set {_indices::*} to the first index of the value 100 in {_otherlist::*}",
-	"# {_indices::*} is now \"bar\"",
-	"set {_indices::*} to the last index of the value 100 in {_otherlist::*}",
-	"# {_indices::*} is now \"foo\"",
-	"",
-	"set {_positions::*} to all positions of the value 100 in {_otherlist::*}",
-	"# {_positions::*} is now 1, 3 and 5",
-	"set {_positions::*} to all positions of the value \"hi\" in {_otherlist::*}",
-	"# {_positions::*} is now 2 and 4"
-})
+@Example("""
+	set {_first} to the first position of "@" in the text argument
+	if {_s} contains "abc":
+		set {_s} to the first (position of "abc" in {_s} + 3) characters of {_s}
+		# removes everything after the first "abc" from {_s}
+	""")
+@Example("""
+	set {_list::*} to 1, 2, 3, 1, 2, 3
+	set {_indices::*} to indices of the value 1 in {_list::*}
+	# {_indices::*} is now "1" and "4"
+
+	set {_indices::*} to all indices of the value 2 in {_list::*}
+	# {_indices::*} is now "2" and "5"
+
+	set {_positions::*} to all positions of the value 3 in {_list::*}
+	# {_positions::*} is now 3 and 6
+	""")
+@Example("""
+	set {_otherlist::bar} to 100
+	set {_otherlist::hello} to "hi"
+	set {_otherlist::burb} to 100
+	set {_otherlist::tud} to "hi"
+	set {_otherlist::foo} to 100
+
+	set {_indices::*} to the first index of the value 100 in {_otherlist::*}
+	# {_indices::*} is now "bar"
+
+	set {_indices::*} to the last index of the value 100 in {_otherlist::*}
+	# {_indices::*} is now "foo"
+
+	set {_positions::*} to all positions of the value 100 in {_otherlist::*}
+	# {_positions::*} is now 1, 3 and 5
+
+	set {_positions::*} to all positions of the value "hi" in {_otherlist::*}
+	# {_positions::*} is now 2 and 4
+	""")
 @Since("2.1, 2.12 (indices, positions of list)")
 public class ExprIndicesOf extends SimpleExpression<Object> {
 
@@ -129,8 +137,10 @@ public class ExprIndicesOf extends SimpleExpression<Object> {
 	}
 
 	private Long[] getStringPositions(String haystack, String needle) {
+		boolean caseSensitive = SkriptConfig.caseSensitive.value();
+
 		List<Long> positions = new ArrayList<>();
-		long position = haystack.indexOf(needle);
+		long position = StringUtils.indexOf(haystack, needle, caseSensitive);
 
 		if (position == -1)
 			return new Long[0];
@@ -138,13 +148,13 @@ public class ExprIndicesOf extends SimpleExpression<Object> {
 		if (indexType == IndexType.ALL) {
 			while (position != -1) {
 				positions.add(position + 1);
-				position = haystack.indexOf(needle, (int) position + 1);
+				position = StringUtils.indexOf(haystack, needle, (int) position + 1, caseSensitive);
 			}
-			return positions.toArray(new Long[0]);
+			return positions.toArray(Long[]::new);
 		}
 
 		if (indexType == IndexType.LAST)
-			position = haystack.lastIndexOf(needle);
+			position = StringUtils.lastIndexOf(haystack, needle, caseSensitive);
 
 		return new Long[]{position + 1};
 	}
@@ -160,7 +170,7 @@ public class ExprIndicesOf extends SimpleExpression<Object> {
 		while (iterator.hasNext()) {
 			position++;
 
-			if (!iterator.next().equals(value))
+			if (!equals(iterator.next(), value))
 				continue;
 
 			if (indexType == IndexType.FIRST)
@@ -185,7 +195,7 @@ public class ExprIndicesOf extends SimpleExpression<Object> {
 		while (iterator.hasNext()) {
 			var keyedValue = iterator.next();
 
-			if (!keyedValue.value().equals(value))
+			if (!equals(keyedValue.getValue(), value))
 				continue;
 			if (indexType == IndexType.FIRST)
 				return new String[]{keyedValue.key()};
@@ -200,6 +210,12 @@ public class ExprIndicesOf extends SimpleExpression<Object> {
 			return new String[]{indices.get(indices.size() - 1)};
 
 		return indices.toArray(String[]::new);
+	}
+
+	private boolean equals(Object key, Object value) {
+		if (key instanceof String keyString && value instanceof String valueString)
+			return StringUtils.equals(keyString, valueString, SkriptConfig.caseSensitive.value());
+		return key.equals(value);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprIndicesOf.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprIndicesOf.java
@@ -195,7 +195,7 @@ public class ExprIndicesOf extends SimpleExpression<Object> {
 		while (iterator.hasNext()) {
 			var keyedValue = iterator.next();
 
-			if (!equals(keyedValue.getValue(), value))
+			if (!equals(keyedValue.value(), value))
 				continue;
 			if (indexType == IndexType.FIRST)
 				return new String[]{keyedValue.key()};

--- a/src/main/java/ch/njol/util/StringUtils.java
+++ b/src/main/java/ch/njol/util/StringUtils.java
@@ -175,6 +175,61 @@ public abstract class StringUtils {
 	}
 
 	/**
+	 * Returns the index of the first occurrence of the needle in the haystack.
+	 * @param haystack the string to search in
+	 * @param needle the string to search for
+	 * @param caseSensitive whether the search should be case-sensitive
+	 * @return the index of the first occurrence of the needle in the haystack, or -1 if not found
+	 */
+	public static int indexOf(String haystack, String needle, boolean caseSensitive) {
+		int index;
+
+		if (caseSensitive)
+			index = haystack.indexOf(needle);
+		else
+			index = haystack.toLowerCase(Locale.ENGLISH).indexOf(needle.toLowerCase(Locale.ENGLISH));
+
+		return index;
+	}
+
+	/**
+	 * Returns the index of the first occurrence of the needle in the haystack, starting from the specified index.
+	 * @param haystack the string to search in
+	 * @param needle the string to search for
+	 * @param fromIndex the index to start searching from
+	 * @param caseSensitive whether the search should be case-sensitive
+	 * @return the index of the first occurrence of the needle in the haystack, or -1 if not found
+	 */
+	public static int indexOf(String haystack, String needle, int fromIndex, boolean caseSensitive) {
+		int index;
+
+		if (caseSensitive)
+			index = haystack.indexOf(needle, fromIndex);
+		else
+			index = haystack.toLowerCase(Locale.ENGLISH).indexOf(needle.toLowerCase(Locale.ENGLISH), fromIndex);
+
+		return index;
+	}
+
+	/**
+	 * Returns the index of the last occurrence of the needle in the haystack.
+	 * @param haystack the string to search in
+	 * @param needle the string to search for
+	 * @param caseSensitive whether the search should be case-sensitive
+	 * @return the index of the last occurrence of the needle in the haystack, or -1 if not found
+	 */
+	public static int lastIndexOf(String haystack, String needle, boolean caseSensitive) {
+		int index;
+
+		if (caseSensitive)
+			index = haystack.lastIndexOf(needle);
+		else
+			index = haystack.toLowerCase(Locale.ENGLISH).lastIndexOf(needle.toLowerCase(Locale.ENGLISH));
+
+		return index;
+	}
+
+	/**
 	 * Shorthand for <tt>{@link #numberAt(CharSequence, int, boolean) numberAt}(s, index, true)</tt>
 	 *
 	 * @param s

--- a/src/main/resources/config.sk
+++ b/src/main/resources/config.sk
@@ -150,7 +150,7 @@ maximum target block distance: 100
 
 case sensitive: false
 # Whether Skript's functions should be case sensitive or not.
-# This e.g. applies to the effect 'replace' and the conditions 'contains' and 'is/is not'.
+# This e.g. applies to the effect 'replace', expression 'indices of' and the conditions 'contains' and 'is/is not'.
 # Variable names are case-insensitive irrespective of this setting.
 
 case-insensitive variables: true


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
The current implementation of the `indices of` expression always performs case-sensitive string comparisons, without the ability to do otherwise.

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
This PR updates the behaviour so that string comparisons now follow the `case sensitive` option defined in Skript's configuration. As well, it updates usage of the old `@Examples` annotation to `@Example` and adds utility methods to `StringUtils`.


### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
I don't believe there is a good way to test this.


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->
Prior to the updates to this expression, `index of string in string` always used case-sensitive comparisons, so existing scripts that relied on that behaviour may now break if the `case sensitive` node is `false` in the configuration.

---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
