### PR TITLE
Fix getting entities in a chunk

### DIFF
--- a/src/test/skript/tests/regressions/5829-entities in chunk.sk
+++ b/src/test/skript/tests/regressions/5829-entities in chunk.sk
@@ -1,0 +1,9 @@
+
+parse:
+	results: {5829::parse results}
+	code:
+		on chunk load:
+			broadcast all armor stands in event-chunk
+
+test "entities in chunk parsing":
+	assert {5829::parse results} is not set with "Failed to parse all armor stands in event-chunk"


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
The previous syntax would always prioritize %worlds% over %chunks%: https://github.com/SkriptLang/Skript/issues/5829#issuecomment-3031013067

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
Switched to `(world[s] %-worlds%|1:%-worlds/chunks%)` and treat the expression as a mix of worlds and chunks. Forcing the world keyword removes the conflict in the pattern.

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
5829-entities in chunk.sk


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->
It doesn't seem like chunk.getEntities() returns entities during chunk unload. I do not think that's fixable.

---
**Completes:** #5829 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
