### PR TITLE
Implement default simplify() on Expression

### DIFF
--- a/src/main/java/ch/njol/skript/lang/Expression.java
+++ b/src/main/java/ch/njol/skript/lang/Expression.java
@@ -255,6 +255,11 @@ public interface Expression<T> extends SyntaxElement, Debuggable, Loopable<T>, S
 	 */
 	Expression<?> getSource();
 
+	@Override
+	default Expression<? extends T> simplify() {
+		return this;
+	}
+
 	/**
 	 * Tests whether this expression supports the given mode, and if yes what type it expects the <code>delta</code> to be.
 	 * <p>


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
Addons that directly implement Expression had to be recompiled since `simplify()` moved from Expression to the Simplifiable interface.  

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
Providing a default implementation of simplify() removes the need to recompile.

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->
Developers should keep in mind that implementing simplify is still highly recommended if possible, since leaving it to the default impl means no simplification can be done.

---
**Completes:**  https://github.com/SkriptLang/skript-reflect/issues/141 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
