### PR TITLE
Prevent FFS from saving ephemeral vars on shutdown

### DIFF
--- a/src/main/java/ch/njol/skript/variables/FlatFileStorage.java
+++ b/src/main/java/ch/njol/skript/variables/FlatFileStorage.java
@@ -456,6 +456,10 @@ public class FlatFileStorage extends VariablesStorage {
 	 */
 	@SuppressWarnings("unchecked")
 	private void save(PrintWriter pw, String parent, TreeMap<String, Object> map) {
+		if (parent.startsWith(Variables.EPHEMERAL_VARIABLE_PREFIX))
+			// Skip ephemeral variables
+			return;
+
 		// Iterate over all children
 		for (Entry<String, Object> childEntry : map.entrySet()) {
 			Object childNode = childEntry.getValue();
@@ -470,6 +474,10 @@ public class FlatFileStorage extends VariablesStorage {
 			} else {
 				// Remove variable separator if needed
 				String name = childKey == null ? parent.substring(0, parent.length() - Variable.SEPARATOR.length()) : parent + childKey;
+
+				if (name.startsWith(Variables.EPHEMERAL_VARIABLE_PREFIX))
+					// Skip ephemeral variables
+					continue;
 
 				try {
 					// Loop over storages to make sure this variable is ours to store

--- a/src/main/java/ch/njol/skript/variables/Variables.java
+++ b/src/main/java/ch/njol/skript/variables/Variables.java
@@ -82,7 +82,7 @@ public class Variables {
 	 */
 	private static final String CONFIGURATION_SERIALIZABLE_PREFIX = "ConfigurationSerializable_";
 
-	private static final String EPHEMERAL_VARIABLE_PREFIX = "-";
+	public static final String EPHEMERAL_VARIABLE_PREFIX = "-";
 
 	private final static Multimap<Class<? extends VariablesStorage>, String> TYPES = HashMultimap.create();
 


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
FFS has a special save method that just pulls all variables and saves them on shutdown, bypassing the normal methods of variable saving. This is poor design but fixing it is out of scope for this pr.

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
Adds checks for ephemeral vars in the FFS save treemap method.

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
Manual testing

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** #8004 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
