### PR TITLE
Fix bad FunctionRegistry#remove logic

### DIFF
--- a/src/main/java/ch/njol/skript/lang/function/Functions.java
+++ b/src/main/java/ch/njol/skript/lang/function/Functions.java
@@ -104,7 +104,11 @@ public abstract class Functions {
 			namespace.addFunction(function);
 		}
 
-		FunctionRegistry.getRegistry().register(script.getConfig().getFileName(), function);
+		if (function.getSignature().isLocal()) {
+			FunctionRegistry.getRegistry().register(script.getConfig().getFileName(), function);
+		} else {
+			FunctionRegistry.getRegistry().register(null, function);
+		}
 
 		return function;
 	}

--- a/src/test/java/ch/njol/skript/lang/function/FunctionRegistryTest.java
+++ b/src/test/java/ch/njol/skript/lang/function/FunctionRegistryTest.java
@@ -388,4 +388,34 @@ public class FunctionRegistryTest {
 		assertEquals(FunctionIdentifier.of(function2.getSignature()), identifier);
 	}
 
+	@Test
+	public void testRemoveGlobal() {
+		// create empty TEST_SCRIPT namespace such that it is not null
+		registry.register(TEST_SCRIPT, LOCAL_TEST_FUNCTION);
+		registry.remove(LOCAL_TEST_FUNCTION.getSignature());
+
+		assertEquals(RetrievalResult.NOT_REGISTERED, registry.getSignature(TEST_SCRIPT, FUNCTION_NAME).result());
+
+		// construct a global function with a non-null script, which happens in script functions
+		Signature<Boolean> signature = new Signature<>(TEST_SCRIPT, FUNCTION_NAME, new Parameter<?>[0],
+			false, DefaultClasses.BOOLEAN, true, "");
+		SimpleJavaFunction<Boolean> fn = new SimpleJavaFunction<>(signature) {
+			@Override
+			public Boolean @Nullable [] executeSimple(Object[][] params) {
+				return new Boolean[] { true };
+			}
+		};
+
+		// ensure new behaviour
+		assertThrows(IllegalArgumentException.class, () -> registry.register(TEST_SCRIPT, fn));
+
+		registry.register(null, fn);
+
+		assertEquals(RetrievalResult.EXACT, registry.getSignature(null, FUNCTION_NAME).result());
+
+		registry.remove(signature);
+
+		assertEquals(RetrievalResult.NOT_REGISTERED, registry.getSignature(null, FUNCTION_NAME).result());
+	}
+
 }

--- a/src/test/java/ch/njol/skript/lang/function/FunctionRegistryTest.java
+++ b/src/test/java/ch/njol/skript/lang/function/FunctionRegistryTest.java
@@ -388,8 +388,9 @@ public class FunctionRegistryTest {
 		assertEquals(FunctionIdentifier.of(function2.getSignature()), identifier);
 	}
 
+	// see https://github.com/SkriptLang/Skript/pull/8015
 	@Test
-	public void testRemoveGlobal() {
+	public void testRemoveGlobalScriptFunctions8015() {
 		// create empty TEST_SCRIPT namespace such that it is not null
 		registry.register(TEST_SCRIPT, LOCAL_TEST_FUNCTION);
 		registry.remove(LOCAL_TEST_FUNCTION.getSignature());


### PR DESCRIPTION
### Problem
**Bug explanation**
When removing functions from the FunctionRegistry, the `remove` method would attempt to get the namespace of the function being removed. To do this, it uses the script of the signature of the function. Functions registered in Java have no script, but functions registered in Skript do. 

Therefore, if a function was previously registered and unregistered, it would leave an empty namespace in the `namespaces` map. The old `remove` logic would then incorrectly assume that this is the namespace of the function being removed, since the Skript-based function has a non-null script, and then not do anything.

Since all unit tests are made using Java, remove would work fine for Java functions, as the namespace is always null. 

**Scope enforcement**
Also changes the register methods to enforce specifying exactly which namespace to register in, which increases clarity in where functions actually end up. Therefore, you are no longer able to register a local function to the global namespace by setting null as the namespace, and you are no longer able to register a global function to a local namespace by specifying a namespace in the `Registry#register(String namespace, String name, Class<?> args...)` arguments.

### Solution
Update the code to check whether the signature is local to determine which namespace to use.


### Testing Completed
Added a unit test which recreates the exact scenario in which this error would occur.


### Supporting Information
No breaking changes as FunctionRegistry is package-protected.


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
