### PR TITLE
Make ExprExcept tests more reliable, fixes simplification bug

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprExcept.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprExcept.java
@@ -6,11 +6,9 @@ import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.WrapperExpression;
-import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.ExpressionList;
-import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.*;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.skript.lang.SyntaxStringBuilder;
+import ch.njol.skript.lang.simplification.SimplifiedLiteral;
 import ch.njol.skript.util.LiteralUtils;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
@@ -68,6 +66,14 @@ public class ExprExcept extends WrapperExpression<Object> {
 				return true;
 			})
 			.toArray(o -> (Object[]) Array.newInstance(getReturnType(), o));
+	}
+
+	@Override
+	public Expression<?> simplify() {
+		setExpr(getExpr().simplify());
+		if (getExpr() instanceof Literal<?> && exclude instanceof Literal<?>)
+			return SimplifiedLiteral.fromExpression(this);
+		return this;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/base/WrapperExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/WrapperExpression.java
@@ -5,14 +5,11 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.SyntaxElement;
-import ch.njol.skript.lang.util.ConvertedExpression;
+import ch.njol.skript.lang.simplification.SimplifiedLiteral;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
-import org.skriptlang.skript.lang.converter.ConverterInfo;
-import org.skriptlang.skript.lang.converter.Converters;
-import ch.njol.skript.lang.simplification.SimplifiedLiteral;
 
 import java.util.Iterator;
 
@@ -99,6 +96,14 @@ public abstract class WrapperExpression<T> extends SimpleExpression<T> {
 		return expr.isDefault();
 	}
 
+	/**
+	 * This method must be overridden if the subclass uses more than one expression.
+	 * i.e. if only {@link #setExpr(Expression)} is used, this method does not need to be overridden.
+	 * But if a second expression is stored, this method must be overridden to account for that.
+	 * <br>
+	 * <br>
+	 * {@inheritDoc}
+	 */
 	@Override
 	public Expression<? extends T> simplify() {
 		setExpr(expr.simplify());

--- a/src/test/skript/tests/syntaxes/expressions/ExprExcept.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprExcept.sk
@@ -51,5 +51,4 @@ test "except 'or' objects":
 
 local function excludes() returns strings:
 	add 1 to {exprexcept::count}
-	broadcast "test"
 	return "a", "b", "c", "d", and "e"

--- a/src/test/skript/tests/syntaxes/expressions/ExprExcept.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprExcept.sk
@@ -13,31 +13,43 @@ test "except items":
 	assert {_except::*} is not set with "Failed to exclude all"
 
 test "except entities":
-	spawn 5 zombies at test-location
-	set {_zombie} to last spawned zombie
-	add {_zombie} to {_exclude::*}
+	set {_nums::*} to 1, 2, 3, 4, and 5
 
-	assert size of all zombies except {_zombie} is 4 with "Failed to exclude zombie"
-	assert size of all entities except {_exclude::*} is 4 with "Failed to exclude list (zombie)"
+	assert size of {_nums::*} except 5 is 4 with "Failed to exclude 5"
+	assert size of {_nums::*} except 1 and 5 is 3 with "Failed to exclude 1 and 5"
+	assert size of {_nums::*} excluding -1 is 5 with "Excluding -1 should not change the list"
 
-	spawn 5 skeletons at test-location
-	set {_skeleton} to last spawned skeleton
-	add {_skeleton} to {_exclude::*}
+	set {_exclude::*} to 3, 7, and 1.1
+	assert size of {_nums::*} excluding {_exclude::*} is 4 with "Failed to exclude multiple numbers"
 
-	assert size of all skeletons excluding {_skeleton} is 4 with "Failed to exclude skeleton"
-	assert size of all entities excluding {_exclude::*} is 8 with "Failed to exclude list (zombie, skeleton)"
 
+	set {_types::*} to a zombie, a skeleton, and a villager
+	assert size of {_types::*} excluding a zombie is 2 with "Failed to exclude zombie"
+	assert size of {_types::*} excluding a zombie and a skeleton is 1 with "Failed to exclude zombie and skeleton"
+
+	delete all villagers
 	spawn 5 villagers at test-location
 	set {_villager} to last spawned villager
 	add {_villager} to {_exclude::*}
 
 	assert size of all villagers not including {_villager} is 4 with "Failed to exclude villager"
-	assert size of all entities not including {_exclude::*} is 12 with "Failed to exclude list (zombie, skeleton, villager)"
 
 	clear all entities
+
+	set {exprexcept::count} to 0
+
+	assert ("a", "z", and 3) excluding excludes() is "z" and 3 with "Failed to exclude the result of a function call"
+
+	assert {exprexcept::count} is 1 with "Function call was not executed exactly once"
+
 
 test "except 'or' objects":
 	assert (1 or 2) except 2 is 1 with "Failed to exclude '2' from an 'or' list"
 
 	set {_item} to (a diamond or an iron ingot or an emerald) excluding a diamond
 	assert {_item} is (an iron ingot or an emerald) with "Failed to exclude 'diamond' from an 'or' item list"
+
+local function excludes() returns strings:
+	add 1 to {exprexcept::count}
+	broadcast "test"
+	return "a", "b", "c", "d", and "e"


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
#7995 reported intermittent failures of the expr except tests. Additionally, ExprExcept was being unintentionally simplified due to not properly overriding WrapperExpression's simplify method.

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
Changes the tests to be more resistant to other tests' shenanigans by focusing less on entities and clearing entities before testing.
Also adds a test case to help check against the simplification bug.

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
ExprExcept.sk updated.


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** #7995<!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
