### PR TITLE
Fix overzealous literal type spec. parsing

### DIFF
--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -680,7 +680,11 @@ public class SkriptParser {
 				if (classInfoMatcher.matches()) {
 					String literalString = classInfoMatcher.group("literal");
 					String unparsedClassInfo = Noun.stripDefiniteArticle(classInfoMatcher.group("classinfo"));
-					return parseSpecifiedLiteral(literalString, unparsedClassInfo, log, types);
+					Expression<?> result = parseSpecifiedLiteral(literalString, unparsedClassInfo, types);
+					if (result != null) {
+						log.printLog();
+						return result;
+					}
 				}
 			}
 			if (exprInfo.classes.length == 1 && exprInfo.classes[0].getC() == Object.class) {
@@ -752,38 +756,31 @@ public class SkriptParser {
 	 * </p>
 	 * @param literalString A {@link String} representing a literal
 	 * @param unparsedClassInfo A {@link String} representing a class info
-	 * @param log The current {@link ParseLogHandler} for containing errors
 	 * @param types An {@link Array} of the acceptable {@link Class}es
 	 * @return {@link SimpleLiteral} or {@code null} if any checks fail
 	 */
 	private @Nullable Expression<?> parseSpecifiedLiteral(
 		String literalString,
 		String unparsedClassInfo,
-		ParseLogHandler log,
 		Class<?> ... types
 	) {
 		ClassInfo<?> classInfo = Classes.parse(unparsedClassInfo, ClassInfo.class, context);
 		if (classInfo == null) {
-			log.printError();
+			Skript.error("A " + unparsedClassInfo  + " is not a valid type.");
 			return null;
 		}
 		Parser<?> classInfoParser = classInfo.getParser();
 		if (classInfoParser == null || !classInfoParser.canParse(context)) {
 			Skript.error("A " + unparsedClassInfo  + " cannot be parsed.");
-			log.printError();
 			return null;
 		}
 		if (!checkAcceptedType(classInfo.getC(), types)) {
 			Skript.error(expr + " " + Language.get("is") + " " + notOfType(types));
-			log.printError();
 			return null;
 		}
 		Object parsedObject = classInfoParser.parse(literalString, context);
-		if (parsedObject != null) {
-			log.printLog();
+		if (parsedObject != null)
 			return new SimpleLiteral<>(parsedObject, false, new UnparsedLiteral(literalString));
-		}
-		log.printError();
 		return null;
 	}
 

--- a/src/test/skript/tests/regressions/7861-overzealous literal type specification.sk
+++ b/src/test/skript/tests/regressions/7861-overzealous literal type specification.sk
@@ -1,0 +1,8 @@
+test "literal specification breaks command arguments":
+	execute console command "littypecmd a (b)"
+	assert {littypecmd} is 1 with "Literal type specification broke command arguments"
+
+command /littypecmd <text>:
+	trigger:
+		if arg 1 is "a (b)":
+			set {littypecmd} to 1


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
Literal type specification was exiting parsing early if it failed instead of allowing later stages to try. #7861 

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
Stops the code from exiting early if literal type specification fails to parse. Only returns if it succeeded. Added an extra error about bad classinfo for more helpful error messages.

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
Added regression test.


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** #7861 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
