### PR TITLE
Function overloading fixes and improvements

### DIFF
--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -1124,20 +1124,8 @@ public class SkriptParser {
 			ParserInstance parser = getParser();
 			Script currentScript = parser.isActive() ? parser.getCurrentScript() : null;
 			FunctionReference<T> functionReference = new FunctionReference<>(functionName, SkriptLogger.getNode(),
-					currentScript != null ? currentScript.getConfig().getFileName() : null, types, params);//.toArray(new Expression[params.size()]));
-			attempt_list_parse:
-			if (unaryArgument.get() && !functionReference.validateParameterArity(true)) {
-				try (ParseLogHandler ignored = SkriptLogger.startParseLogHandler()) {
-					SkriptParser alternative = new SkriptParser(args, flags | PARSE_LITERALS, context);
-					params = this.getFunctionArguments(() -> alternative.suppressMissingAndOrWarnings()
-								.parseExpressionList(ignored, Object.class), args, unaryArgument);
-					ignored.clear();
-					if (params == null)
-						break attempt_list_parse;
-				}
-				functionReference = new FunctionReference<>(functionName, SkriptLogger.getNode(),
-						currentScript != null ? currentScript.getConfig().getFileName() : null, types, params);
-			}
+					currentScript != null ? currentScript.getConfig().getFileName() : null, types, params);
+
 			if (!functionReference.validateFunction(true)) {
 				log.printError();
 				return null;

--- a/src/main/java/ch/njol/skript/lang/function/DynamicFunctionReference.java
+++ b/src/main/java/ch/njol/skript/lang/function/DynamicFunctionReference.java
@@ -1,7 +1,6 @@
 package ch.njol.skript.lang.function;
 
 import ch.njol.skript.ScriptLoader;
-import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionList;
 import ch.njol.skript.lang.util.common.AnyNamed;

--- a/src/main/java/ch/njol/skript/lang/function/DynamicFunctionReference.java
+++ b/src/main/java/ch/njol/skript/lang/function/DynamicFunctionReference.java
@@ -59,10 +59,10 @@ public class DynamicFunctionReference<Result>
 			// will return the first function found that matches name.
 			// TODO: add a way to specify param types
 			//noinspection unchecked
-			function = (Function<? extends Result>) FunctionRegistry.getRegistry().getFunction(source.getConfig().getFileName(), name).retrieved();
+			function = (Function<? extends Result>) Functions.getFunction(name, source.getConfig().getFileName());
 		} else {
 			//noinspection unchecked
-			function = (Function<? extends Result>) FunctionRegistry.getRegistry().getFunction(null, name).retrieved();
+			function = (Function<? extends Result>) Functions.getFunction(name, null);
 		}
 
 		this.resolved = function != null;

--- a/src/main/java/ch/njol/skript/lang/function/FunctionReference.java
+++ b/src/main/java/ch/njol/skript/lang/function/FunctionReference.java
@@ -142,12 +142,7 @@ public class FunctionReference<T> implements Contract, Executable<Event, T[]> {
 			} else {
 				searchType = parameterType;
 			}
-			ClassInfo<?> exact = Classes.getExactClassInfo(searchType);
-			if (exact != null) {
-				args.add(exact.getCodeName());
-			} else {
-				args.add("unknown type");
-			}
+			args.add(Classes.getSuperClassInfo(searchType).getCodeName());
 		}
 		String stringified = "%s(%s)".formatted(functionName, args);
 

--- a/src/main/java/ch/njol/skript/lang/function/FunctionReference.java
+++ b/src/main/java/ch/njol/skript/lang/function/FunctionReference.java
@@ -20,6 +20,7 @@ import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.converter.Converters;
 import org.skriptlang.skript.util.Executable;
+
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -294,13 +295,6 @@ public class FunctionReference<T> implements Contract, Executable<Event, T[]> {
 			return attempt.retrieved();
 		}
 
-		// if we can't find a signature based on param types, try to match any function
-		attempt = FunctionRegistry.getRegistry().getSignature(script, functionName);
-
-		if (attempt.result() == RetrievalResult.EXACT) {
-			return attempt.retrieved();
-		}
-
 		if (attempt.result() == RetrievalResult.AMBIGUOUS) {
 			ambiguousError(attempt.conflictingArgs());
 		}
@@ -320,13 +314,6 @@ public class FunctionReference<T> implements Contract, Executable<Event, T[]> {
 		}
 
 		Retrieval<Function<?>> attempt = FunctionRegistry.getRegistry().getFunction(script, functionName, parameterTypes);
-
-		if (attempt.result() == RetrievalResult.EXACT) {
-			return attempt.retrieved();
-		}
-
-		// if we can't find a signature based on param types, try to match any function
-		attempt = FunctionRegistry.getRegistry().getFunction(script, functionName);
 
 		if (attempt.result() == RetrievalResult.EXACT) {
 			return attempt.retrieved();

--- a/src/main/java/ch/njol/skript/lang/function/FunctionReference.java
+++ b/src/main/java/ch/njol/skript/lang/function/FunctionReference.java
@@ -134,12 +134,29 @@ public class FunctionReference<T> implements Contract, Executable<Event, T[]> {
 		Skript.debug("Validating function " + functionName);
 		Signature<?> sign = getRegisteredSignature();
 
+		StringJoiner args = new StringJoiner(", ");
+		for (Class<?> parameterType : parameterTypes) {
+			Class<?> searchType;
+			if (parameterType.isArray()) {
+				searchType = parameterType.componentType();
+			} else {
+				searchType = parameterType;
+			}
+			ClassInfo<?> exact = Classes.getExactClassInfo(searchType);
+			if (exact != null) {
+				args.add(exact.getCodeName());
+			} else {
+				args.add("unknown type");
+			}
+		}
+		String stringified = "%s(%s)".formatted(functionName, args);
+
 		// Check if the requested function exists
 		if (sign == null) {
 			if (first) {
-				Skript.error("The function '" + functionName + "' does not exist.");
+				Skript.error("The function '" + stringified + "' does not exist.");
 			} else {
-				Skript.error("The function '" + functionName + "' was deleted or renamed, but is still used in other script(s)."
+				Skript.error("The function '" + stringified + "' was deleted or renamed, but is still used in other script(s)."
 					+ " These will continue to use the old version of the function until Skript restarts.");
 				function = previousFunction;
 			}
@@ -152,9 +169,9 @@ public class FunctionReference<T> implements Contract, Executable<Event, T[]> {
 			ClassInfo<?> rt = sign.returnType;
 			if (rt == null) {
 				if (first) {
-					Skript.error("The function '" + functionName + "' doesn't return any value.");
+					Skript.error("The function '" + stringified + "' doesn't return any value.");
 				} else {
-					Skript.error("The function '" + functionName + "' was redefined with no return value, but is still used in other script(s)."
+					Skript.error("The function '" + stringified + "' was redefined with no return value, but is still used in other script(s)."
 						+ " These will continue to use the old version of the function until Skript restarts.");
 					function = previousFunction;
 				}
@@ -162,9 +179,9 @@ public class FunctionReference<T> implements Contract, Executable<Event, T[]> {
 			}
 			if (!Converters.converterExists(rt.getC(), returnTypes)) {
 				if (first) {
-					Skript.error("The returned value of the function '" + functionName + "', " + sign.returnType + ", is " + SkriptParser.notOfType(returnTypes) + ".");
+					Skript.error("The returned value of the function '" + stringified + "', " + sign.returnType + ", is " + SkriptParser.notOfType(returnTypes) + ".");
 				} else {
-					Skript.error("The function '" + functionName + "' was redefined with a different, incompatible return type, but is still used in other script(s)."
+					Skript.error("The function '" + stringified + "' was redefined with a different, incompatible return type, but is still used in other script(s)."
 						+ " These will continue to use the old version of the function until Skript restarts.");
 					function = previousFunction;
 				}
@@ -187,15 +204,15 @@ public class FunctionReference<T> implements Contract, Executable<Event, T[]> {
 			if (parameters.length > sign.getMaxParameters()) {
 				if (first) {
 					if (sign.getMaxParameters() == 0) {
-						Skript.error("The function '" + functionName + "' has no arguments, but " + parameters.length + " are given."
+						Skript.error("The function '" + stringified + "' has no arguments, but " + parameters.length + " are given."
 							+ " To call a function without parameters, just write the function name followed by '()', e.g. 'func()'.");
 					} else {
-						Skript.error("The function '" + functionName + "' has only " + sign.getMaxParameters() + " argument" + (sign.getMaxParameters() == 1 ? "" : "s") + ","
+						Skript.error("The function '" + stringified + "' has only " + sign.getMaxParameters() + " argument" + (sign.getMaxParameters() == 1 ? "" : "s") + ","
 							+ " but " + parameters.length + " are given."
 							+ " If you want to use lists in function calls, you have to use additional parentheses, e.g. 'give(player, (iron ore and gold ore))'");
 					}
 				} else {
-					Skript.error("The function '" + functionName + "' was redefined with a different, incompatible amount of arguments, but is still used in other script(s)."
+					Skript.error("The function '" + stringified + "' was redefined with a different, incompatible amount of arguments, but is still used in other script(s)."
 						+ " These will continue to use the old version of the function until Skript restarts.");
 					function = previousFunction;
 				}
@@ -206,10 +223,10 @@ public class FunctionReference<T> implements Contract, Executable<Event, T[]> {
 		// Not enough parameters
 		if (parameters.length < sign.getMinParameters()) {
 			if (first) {
-				Skript.error("The function '" + functionName + "' requires at least " + sign.getMinParameters() + " argument" + (sign.getMinParameters() == 1 ? "" : "s") + ","
+				Skript.error("The function '" + stringified + "' requires at least " + sign.getMinParameters() + " argument" + (sign.getMinParameters() == 1 ? "" : "s") + ","
 					+ " but only " + parameters.length + " " + (parameters.length == 1 ? "is" : "are") + " given.");
 			} else {
-				Skript.error("The function '" + functionName + "' was redefined with a different, incompatible amount of arguments, but is still used in other script(s)."
+				Skript.error("The function '" + stringified + "' was redefined with a different, incompatible amount of arguments, but is still used in other script(s)."
 					+ " These will continue to use the old version of the function until Skript restarts.");
 				function = previousFunction;
 			}
@@ -228,12 +245,12 @@ public class FunctionReference<T> implements Contract, Executable<Event, T[]> {
 						if (LiteralUtils.hasUnparsedLiteral(parameters[i])) {
 							Skript.error("Can't understand this expression: " + parameters[i].toString());
 						} else {
-							Skript.error("The " + StringUtils.fancyOrderNumber(i + 1) + " argument given to the function '" + functionName + "' is not of the required type " + p.type + "."
+							Skript.error("The " + StringUtils.fancyOrderNumber(i + 1) + " argument given to the function '" + stringified + "' is not of the required type " + p.type + "."
 								+ " Check the correct order of the arguments and put lists into parentheses if appropriate (e.g. 'give(player, (iron ore and gold ore))')."
 								+ " Please note that storing the value in a variable and then using that variable as parameter may suppress this error, but it still won't work.");
 						}
 					} else {
-						Skript.error("The function '" + functionName + "' was redefined with different, incompatible arguments, but is still used in other script(s)."
+						Skript.error("The function '" + stringified + "' was redefined with different, incompatible arguments, but is still used in other script(s)."
 							+ " These will continue to use the old version of the function until Skript restarts.");
 						function = previousFunction;
 					}
@@ -243,7 +260,7 @@ public class FunctionReference<T> implements Contract, Executable<Event, T[]> {
 						Skript.error("The " + StringUtils.fancyOrderNumber(i + 1) + " argument given to the function '" + functionName + "' is plural, "
 							+ "but a single argument was expected");
 					} else {
-						Skript.error("The function '" + functionName + "' was redefined with different, incompatible arguments, but is still used in other script(s)."
+						Skript.error("The function '" + stringified + "' was redefined with different, incompatible arguments, but is still used in other script(s)."
 							+ " These will continue to use the old version of the function until Skript restarts.");
 						function = previousFunction;
 					}

--- a/src/main/java/ch/njol/skript/lang/function/FunctionRegistry.java
+++ b/src/main/java/ch/njol/skript/lang/function/FunctionRegistry.java
@@ -278,7 +278,7 @@ final class FunctionRegistry implements Registry<Function<?>> {
 	public @NotNull Retrieval<Function<?>> getFunction(
 		@Nullable String namespace,
 		@NotNull String name,
-		@NotNull Class<?> @NotNull ... args
+		@NotNull Class<?>... args
 	) {
 		if (namespace == null) {
 			return getFunction(GLOBAL_NAMESPACE, FunctionIdentifier.of(name, false, args));
@@ -351,7 +351,7 @@ final class FunctionRegistry implements Registry<Function<?>> {
 	public Retrieval<Signature<?>> getSignature(
 		@Nullable String namespace,
 		@NotNull String name,
-		@NotNull Class<?> @NotNull ... args
+		@NotNull Class<?>... args
 	) {
 		if (namespace == null) {
 			return getSignature(GLOBAL_NAMESPACE, FunctionIdentifier.of(name, false, args));
@@ -600,7 +600,7 @@ final class FunctionRegistry implements Registry<Function<?>> {
 	 * @param args The arguments of the function.
 	 */
 	record FunctionIdentifier(@NotNull String name, boolean local, int minArgCount,
-							  @NotNull Class<?> @NotNull ... args) {
+							  @NotNull Class<?>... args) {
 
 		/**
 		 * Returns the identifier for the given arguments.
@@ -609,7 +609,7 @@ final class FunctionRegistry implements Registry<Function<?>> {
 		 * @param args The types of the arguments.
 		 * @return The identifier for the signature.
 		 */
-		static FunctionIdentifier of(@NotNull String name, boolean local, @NotNull Class<?> @NotNull ... args) {
+		static FunctionIdentifier of(@NotNull String name, boolean local, @NotNull Class<?>... args) {
 			Preconditions.checkNotNull(name, "name cannot be null");
 			Preconditions.checkNotNull(args, "args cannot be null");
 

--- a/src/main/java/ch/njol/skript/lang/function/Functions.java
+++ b/src/main/java/ch/njol/skript/lang/function/Functions.java
@@ -104,7 +104,11 @@ public abstract class Functions {
 			namespace.addFunction(function);
 		}
 
-		FunctionRegistry.getRegistry().register(script.getConfig().getFileName(), function);
+		if (function.getSignature().isLocal()) {
+			FunctionRegistry.getRegistry().register(script.getConfig().getFileName(), function);
+		} else {
+			FunctionRegistry.getRegistry().register(null, function);
+		}
 
 		return function;
 	}

--- a/src/main/java/ch/njol/skript/lang/function/Functions.java
+++ b/src/main/java/ch/njol/skript/lang/function/Functions.java
@@ -182,7 +182,7 @@ public abstract class Functions {
 				error.append("Function ");
 			}
 			error.append("'%s' with the same argument types already exists".formatted(signature.getName()));
-			if (existing.retrieved().isLocal()) {
+			if (existing.retrieved().script != null) {
 				error.append(" in script '%s'.".formatted(existing.retrieved().script));
 			} else {
 				error.append(".");

--- a/src/main/java/ch/njol/skript/lang/function/Functions.java
+++ b/src/main/java/ch/njol/skript/lang/function/Functions.java
@@ -67,7 +67,7 @@ public abstract class Functions {
 		javaNamespace.addFunction(function);
 		globalFunctions.put(function.getName(), javaNamespace);
 
-		FunctionRegistry.getRegistry().register(function);
+		FunctionRegistry.getRegistry().register(null, function);
 
 		return function;
 	}
@@ -174,7 +174,22 @@ public abstract class Functions {
 		// if this function has already been registered, only allow it if one function is local and one is global.
 		// if both are global or both are local, disallow.
 		if (existing.result() == RetrievalResult.EXACT && existing.retrieved().isLocal() == signature.isLocal()) {
-			Skript.error("Function '%s' with the same argument types already exists.".formatted(signature.getName()));
+			StringBuilder error = new StringBuilder();
+
+			if (existing.retrieved().isLocal()) {
+				error.append("Local function ");
+			} else {
+				error.append("Function ");
+			}
+			error.append("'%s' with the same argument types already exists".formatted(signature.getName()));
+			if (existing.retrieved().isLocal()) {
+				error.append(" in script '%s'.".formatted(existing.retrieved().script));
+			} else {
+				error.append(".");
+			}
+
+			Skript.error(error.toString());
+
 			return null;
 		}
 

--- a/src/test/java/ch/njol/skript/lang/function/FunctionRegistryTest.java
+++ b/src/test/java/ch/njol/skript/lang/function/FunctionRegistryTest.java
@@ -1,8 +1,8 @@
 package ch.njol.skript.lang.function;
 
 import ch.njol.skript.SkriptAPIException;
-import ch.njol.skript.lang.function.FunctionRegistry.FunctionIdentifier;
 import ch.njol.skript.lang.function.FunctionRegistry.RetrievalResult;
+import ch.njol.skript.lang.function.FunctionRegistry.FunctionIdentifier;
 import ch.njol.skript.lang.util.SimpleLiteral;
 import ch.njol.skript.registrations.DefaultClasses;
 import org.jetbrains.annotations.Nullable;
@@ -36,7 +36,7 @@ public class FunctionRegistryTest {
 		assertNull(registry.getFunction(null, FUNCTION_NAME).retrieved());
 		assertNull(registry.getFunction(null, FUNCTION_NAME).conflictingArgs());
 
-		registry.register(TEST_FUNCTION);
+		registry.register(null, TEST_FUNCTION);
 
 		assertNotSame(RetrievalResult.NOT_REGISTERED, registry.getSignature(null, FUNCTION_NAME).result());
 
@@ -57,13 +57,13 @@ public class FunctionRegistryTest {
 		assertNull(registry.getSignature(null, FUNCTION_NAME).retrieved());
 		assertNull(registry.getFunction(null, FUNCTION_NAME).retrieved());
 
-		registry.register(TEST_FUNCTION);
+		registry.register(null, TEST_FUNCTION);
 
 		assertNotSame(RetrievalResult.NOT_REGISTERED, registry.getSignature(null, FUNCTION_NAME).result());
 		assertEquals(TEST_FUNCTION.getSignature(), registry.getSignature(null, FUNCTION_NAME).retrieved());
 		assertEquals(TEST_FUNCTION, registry.getFunction(null, FUNCTION_NAME).retrieved());
 
-		assertThrows(SkriptAPIException.class, () -> registry.register(TEST_FUNCTION));
+		assertThrows(SkriptAPIException.class, () -> registry.register(null, TEST_FUNCTION));
 
 		assertNotSame(RetrievalResult.NOT_REGISTERED, registry.getSignature(null, FUNCTION_NAME).result());
 		assertEquals(TEST_FUNCTION.getSignature(), registry.getSignature(null, FUNCTION_NAME).retrieved());
@@ -78,7 +78,7 @@ public class FunctionRegistryTest {
 		assertNull(registry.getSignature(null, FUNCTION_NAME).retrieved());
 		assertNull(registry.getFunction(null, FUNCTION_NAME).retrieved());
 
-		registry.register(TEST_FUNCTION);
+		registry.register(null, TEST_FUNCTION);
 
 		assertNotSame(RetrievalResult.NOT_REGISTERED, registry.getSignature(null, FUNCTION_NAME).result());
 		assertEquals(TEST_FUNCTION.getSignature(), registry.getSignature(null, FUNCTION_NAME).retrieved());
@@ -90,7 +90,7 @@ public class FunctionRegistryTest {
 		assertNull(registry.getSignature(null, FUNCTION_NAME).retrieved());
 		assertNull(registry.getFunction(null, FUNCTION_NAME).retrieved());
 
-		registry.register(TEST_FUNCTION);
+		registry.register(null, TEST_FUNCTION);
 
 		assertNotSame(RetrievalResult.NOT_REGISTERED, registry.getSignature(null, FUNCTION_NAME).result());
 		assertEquals(TEST_FUNCTION.getSignature(), registry.getSignature(null, FUNCTION_NAME).retrieved());
@@ -131,7 +131,7 @@ public class FunctionRegistryTest {
 		assertNull(registry.getFunction(null, FUNCTION_NAME).retrieved());
 
 		registry.register(TEST_SCRIPT, LOCAL_TEST_FUNCTION);
-		registry.register(TEST_FUNCTION);
+		registry.register(null, TEST_FUNCTION);
 
 		assertNotSame(RetrievalResult.NOT_REGISTERED, registry.getSignature(TEST_SCRIPT, FUNCTION_NAME).result());
 		assertEquals(LOCAL_TEST_FUNCTION.getSignature(), registry.getSignature(TEST_SCRIPT, FUNCTION_NAME).retrieved());
@@ -173,7 +173,7 @@ public class FunctionRegistryTest {
 		assertNull(registry.getSignature(null, FUNCTION_NAME, Number.class).retrieved());
 		assertNull(registry.getFunction(null, FUNCTION_NAME, Number.class).retrieved());
 
-		registry.register(TEST_FUNCTION_B);
+		registry.register(null, TEST_FUNCTION_B);
 
 		assertNotSame(RetrievalResult.NOT_REGISTERED, registry.getSignature(null, FUNCTION_NAME, Boolean.class).result());
 		assertEquals(TEST_FUNCTION_B.getSignature(), registry.getSignature(null, FUNCTION_NAME, Boolean.class).retrieved());
@@ -182,7 +182,7 @@ public class FunctionRegistryTest {
 		assertNull(registry.getSignature(null, FUNCTION_NAME, Number.class).retrieved());
 		assertNull(registry.getFunction(null, FUNCTION_NAME, Number.class).retrieved());
 
-		registry.register(TEST_FUNCTION_N);
+		registry.register(null, TEST_FUNCTION_N);
 
 		assertNotSame(RetrievalResult.NOT_REGISTERED, registry.getSignature(null, FUNCTION_NAME, Boolean.class).result());
 		assertEquals(TEST_FUNCTION_B.getSignature(), registry.getSignature(null, FUNCTION_NAME, Boolean.class).retrieved());
@@ -191,8 +191,8 @@ public class FunctionRegistryTest {
 		assertEquals(TEST_FUNCTION_N.getSignature(), registry.getSignature(null, FUNCTION_NAME, Number.class).retrieved());
 		assertEquals(TEST_FUNCTION_N, registry.getFunction(null, FUNCTION_NAME, Number.class).retrieved());
 
-		assertThrows(SkriptAPIException.class, () -> registry.register(TEST_FUNCTION_B));
-		assertThrows(SkriptAPIException.class, () -> registry.register(TEST_FUNCTION_N));
+		assertThrows(SkriptAPIException.class, () -> registry.register(null, TEST_FUNCTION_B));
+		assertThrows(SkriptAPIException.class, () -> registry.register(null, TEST_FUNCTION_N));
 
 		assertNotSame(RetrievalResult.NOT_REGISTERED, registry.getSignature(null, FUNCTION_NAME, Boolean.class).result());
 		assertEquals(TEST_FUNCTION_B.getSignature(), registry.getSignature(null, FUNCTION_NAME, Boolean.class).retrieved());
@@ -214,7 +214,7 @@ public class FunctionRegistryTest {
 		assertNull(registry.getSignature(null, FUNCTION_NAME, Number.class).retrieved());
 		assertNull(registry.getFunction(null, FUNCTION_NAME, Number.class).retrieved());
 
-		registry.register(TEST_FUNCTION_B);
+		registry.register(null, TEST_FUNCTION_B);
 
 		assertNotSame(RetrievalResult.NOT_REGISTERED, registry.getSignature(null, FUNCTION_NAME, Boolean.class).result());
 		assertEquals(TEST_FUNCTION_B.getSignature(), registry.getSignature(null, FUNCTION_NAME, Boolean.class).retrieved());
@@ -232,7 +232,7 @@ public class FunctionRegistryTest {
 		assertNull(registry.getSignature(null, FUNCTION_NAME, Number.class).retrieved());
 		assertNull(registry.getFunction(null, FUNCTION_NAME, Number.class).retrieved());
 
-		registry.register(TEST_FUNCTION_N);
+		registry.register(null, TEST_FUNCTION_N);
 
 		assertSame(RetrievalResult.NOT_REGISTERED, registry.getSignature(null, FUNCTION_NAME, Boolean.class).result());
 		assertNull(registry.getSignature(null, FUNCTION_NAME, Boolean.class).retrieved());

--- a/src/test/skript/tests/misc/function overloading.sk
+++ b/src/test/skript/tests/misc/function overloading.sk
@@ -4,6 +4,9 @@ local function overloaded1(x: int) :: int:
 local function overloaded1(x: text) :: int:
 	return 2
 
+local function overloaded1() :: int:
+	return 3
+
 test "function overloading with 1 parameter":
 	set {_x} to true
 
@@ -16,6 +19,7 @@ test "function overloading with 1 parameter":
 
 	assert overloaded1(number within {_x}) = 1
 	assert overloaded1(text within {_x}) = 2
+	assert overloaded1() = 3
 
 function overloaded2(x: int, y: int) :: int:
 	return 1

--- a/src/test/skript/tests/misc/function overloading.sk
+++ b/src/test/skript/tests/misc/function overloading.sk
@@ -62,4 +62,4 @@ parse:
 
 test "function overloading with different return types":
 	assert size of {FunctionOverloading3::parse::*} = 1
-	assert {FunctionOverloading3::parse::1} = "Function 'overloaded3' with the same argument types already exists."
+	assert {FunctionOverloading3::parse::1} contains "Function 'overloaded3' with the same argument types already exists in script"

--- a/src/test/skript/tests/syntaxes/structures/StructFunction.sk
+++ b/src/test/skript/tests/syntaxes/structures/StructFunction.sk
@@ -45,4 +45,4 @@ test "function structure type hints":
 	set {_number} to true
 	parse:
 		type_hint_argument_test({_number})
-	assert the first element of the last parse logs contains "The 1st argument given to the function 'type_hint_argument_test' is not of the required type number."
+	assert the first element of the last parse logs contains "The function 'type_hint_argument_test(boolean)' does not exist."


### PR DESCRIPTION
### Problem
1. Fixes overloading for functions with no parameters. Previously, passing no parameters to `getFunction` or `getSignature` would match any function with the specified name. Now, passing no parameters will only match functions that also have no parameters.
2. Fixes overloading for functions with array parameters. Previously, if a function had an array as parameters, any function with the same name of the function would be matched. This would not allow for two version of, for example, `clamp` to exist. Now, instead of matching any function with the same name, the arguments are actually checked 
3. Removes outdated documentation for FunctionIdentifier (fixes #8031)
4. Adds more detailed error messages to the "function already exists" error (fixes #8030)


### Solution
1. Updates `candidates` to avoid returning any function when zero args are provided in the `provided` FunctionIdentifier.
2. First, Adds a single list value check to `candidates`, so functions like `mean` actually get matched on argument types. Second, for functions like `clamp(1, 2, 3)`, adds a check to allow `1` to pass as a list. Third, removes outdated code from SkriptParser for parsing single list value params.
3. Updated documentation.
4. Improved error message.


### Testing Completed
1. Adds a test.
2. Existing tests for functions like clamp and mean are sufficient.
3. NA
4. NA

### Supporting Information
Updates the test for StructFunction with local type hints as this part is now handled by FunctionReference.

---
**Completes:** #8030, #8031 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
