### PR TITLE
add expr length tests

### DIFF
--- a/src/test/skript/tests/syntaxes/expressions/ExprLength.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprLength.sk
@@ -1,0 +1,34 @@
+test "basic string length":
+    assert length of "hello" is 5
+
+    set {_string} to "Skript"
+    assert length of {_string} is 6
+
+test "edge case string lengths":
+    set {_empty_string} to ""
+    assert length of {_empty_string} is 0
+
+    assert length of "   " is 3
+    assert length of "😂" is 2
+
+test "type conversion for length":
+    assert length of "12345" is 5
+
+    clear {_undefined}
+    assert length of {_undefined} is not set
+
+test "list looping behavior of length":
+    set {_list::*} to "a", "bb", and "cherry"
+    set {_lengths::*} to length of {_list::*}
+
+    assert {_lengths::1} is 1
+    assert {_lengths::2} is 2
+    assert {_lengths::3} is 6
+
+test "string interpolation":
+    set {_string} to "Skript"
+    set {_empty_string} to ""
+
+    assert "%length of "hello"%" is "5"
+    assert "%length of {_string}%" is "6"
+    assert "%length of {_empty_string}%" is "0"


### PR DESCRIPTION
### Problem
The Skript project currently has very low test coverage for its existing syntax, making it difficult to ensure changes don't introduce regressions. Specifically, the core length of expression was untested.


### Solution
This PR adds a new syntax test file, `ExprLength.sk`, to provide unit test coverage for the length of expressions.

The tests cover behavior for:

String literals and variables.

Edge cases like empty strings, whitespace, and Unicode characters.

Automatic type conversion from numbers.

The list-looping behavior when applied to a list of strings.

String interpolation.


### Testing Completed
Added the `ExprLength.sk` test. The full test suite was run via .\gradlew skriptTest and passed successfully.

### Supporting Information
None


---
**Completes:** none
**Related:** #6158 
