### PR TITLE
Add expr ai test

### DIFF
--- a/src/test/skript/tests/syntaxes/expressions/ExprAI.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprAI.sk
@@ -1,6 +1,6 @@
 test "Entity AI Expression Functionality":
 	spawn a cow at location(0, 100, 0)
-	set {_cow} to last spawned entity
+	set {_cow} to last spawned cow
 
 	assert ai of {_cow} is true
 
@@ -25,7 +25,7 @@ test "Entity AI Expression Functionality":
 
 test "Entity AI with multiple entities":
 	spawn 2 cows at location(10, 100, 10)
-	set {_cows::*} to last spawned entities
+	set {_cows::*} to last spawned cow
 
 	set ai of {_cows::*} to false
 	loop {_cows::*}:
@@ -35,7 +35,7 @@ test "Entity AI with multiple entities":
 
 test "Setting AI to an unset value":
 	spawn a cow at location(20, 100, 20)
-	set {_cow} to last spawned entity
+	set {_cow} to last spawned cow
 
 	clear {_undefined}
 	set ai of {_cow} to {_undefined}
@@ -46,7 +46,7 @@ test "Setting AI to an unset value":
 
 test "Getting AI of a dead entity":
 	spawn a cow at location(30, 100, 30)
-	set {_cow} to last spawned entity
+	set {_cow} to last spawned cow
 
 	kill {_cow}
 	

--- a/src/test/skript/tests/syntaxes/expressions/ExprAI.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprAI.sk
@@ -1,0 +1,53 @@
+test "Entity AI Expression Functionality":
+    spawn a cow at location(0, 100, 0)
+    set {_cow} to last spawned entity
+
+    assert ai of {_cow} is true
+
+    set ai of {_cow} to false
+    assert ai of {_cow} is false
+
+    set ai of {_cow} to true
+    assert ai of {_cow} is true
+
+    set {_cow}'s ai to false
+    assert {_cow}'s ai is false
+
+    set artificial intelligence of {_cow} to true
+    assert artificial intelligence of {_cow} is true
+
+    set ai of {_cow} to no
+    assert ai of {_cow} is false
+    set ai of {_cow} to yes
+    assert ai of {_cow} is true
+
+    kill {_cow}
+
+test "Entity AI with multiple entities":
+    spawn 2 cows at location(10, 100, 10)
+    set {_cows::*} to last spawned entities
+
+    set ai of {_cows::*} to false
+    loop {_cows::*}:
+        assert ai of loop-value is false
+
+    kill {_cows::*}
+
+test "Setting AI to an unset value":
+    spawn a cow at location(20, 100, 20)
+    set {_cow} to last spawned entity
+    
+    clear {_undefined}
+    set ai of {_cow} to {_undefined}
+
+    assert ai of {_cow} is true
+
+    kill {_cow}
+
+test "Getting AI of a dead entity":
+    spawn a cow at location(30, 100, 30)
+    set {_cow} to last spawned entity
+
+    kill {_cow}
+
+    assert ai of {_cow} is true

--- a/src/test/skript/tests/syntaxes/expressions/ExprAI.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprAI.sk
@@ -1,53 +1,53 @@
 test "Entity AI Expression Functionality":
-    spawn a cow at location(0, 100, 0)
-    set {_cow} to last spawned entity
+	spawn a cow at location(0, 100, 0)
+	set {_cow} to last spawned entity
 
-    assert ai of {_cow} is true
+	assert ai of {_cow} is true
 
-    set ai of {_cow} to false
-    assert ai of {_cow} is false
+	set ai of {_cow} to false
+	assert ai of {_cow} is false
 
-    set ai of {_cow} to true
-    assert ai of {_cow} is true
+	set ai of {_cow} to true
+	assert ai of {_cow} is true
 
-    set {_cow}'s ai to false
-    assert {_cow}'s ai is false
+	set {_cow}'s ai to false
+	assert {_cow}'s ai is false
 
-    set artificial intelligence of {_cow} to true
-    assert artificial intelligence of {_cow} is true
+	set artificial intelligence of {_cow} to true
+	assert artificial intelligence of {_cow} is true
 
-    set ai of {_cow} to no
-    assert ai of {_cow} is false
-    set ai of {_cow} to yes
-    assert ai of {_cow} is true
+	set ai of {_cow} to no
+	assert ai of {_cow} is false
+	set ai of {_cow} to yes
+	assert ai of {_cow} is true
 
-    kill {_cow}
+	kill {_cow}
 
 test "Entity AI with multiple entities":
-    spawn 2 cows at location(10, 100, 10)
-    set {_cows::*} to last spawned entities
+	spawn 2 cows at location(10, 100, 10)
+	set {_cows::*} to last spawned entities
 
-    set ai of {_cows::*} to false
-    loop {_cows::*}:
-        assert ai of loop-value is false
+	set ai of {_cows::*} to false
+	loop {_cows::*}:
+		assert ai of loop-value is false
 
-    kill {_cows::*}
+	kill {_cows::*}
 
 test "Setting AI to an unset value":
-    spawn a cow at location(20, 100, 20)
-    set {_cow} to last spawned entity
-    
-    clear {_undefined}
-    set ai of {_cow} to {_undefined}
+	spawn a cow at location(20, 100, 20)
+	set {_cow} to last spawned entity
 
-    assert ai of {_cow} is true
+	clear {_undefined}
+	set ai of {_cow} to {_undefined}
 
-    kill {_cow}
+	assert ai of {_cow} is true
+
+	kill {_cow}
 
 test "Getting AI of a dead entity":
-    spawn a cow at location(30, 100, 30)
-    set {_cow} to last spawned entity
+	spawn a cow at location(30, 100, 30)
+	set {_cow} to last spawned entity
 
-    kill {_cow}
-
-    assert ai of {_cow} is true
+	kill {_cow}
+	
+	assert ai of {_cow} is true


### PR DESCRIPTION
### Problem
The Skript project has low test coverage for its existing syntax, which increases the risk of regressions. The core ExprAI syntax for getting and setting an entity's AI status had no automated tests.

### Solution
This PR introduces a test suite for ExprAI. The new test script verifies the following aspects of the expression:

Getting and setting the AI for single entities.

Handling lists of multiple entities.

Syntax aliases and patterns.

Boolean aliases.

Edge cases like setting to an unset value and querying a dead entity.

### Testing Completed
Added the ExprAI.sk syntax test. The full project test suite was run via .\gradlew clean build and passed successfully.

### Supporting Information
An interesting edge case was found during testing: querying the AI of an entity after it is killed returns true, not <none>. The added test currently asserts for this observed behavior. This is open for discussion on whether this is the desired final functionality.

---
**Completes:** none
**Related:** #6158 
