### PR TITLE
Fixes and update Minecarts

### DIFF
--- a/src/main/java/ch/njol/skript/entity/EntityData.java
+++ b/src/main/java/ch/njol/skript/entity/EntityData.java
@@ -399,7 +399,6 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		return toString(0);
 	}
 
-	@SuppressWarnings("null")
 	protected Noun getName() {
 		return info.names[matchedPattern];
 	}
@@ -408,7 +407,6 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		return baby.isTrue() ? m_baby : baby.isFalse() ? m_adult : null;
 	}
 
-	@SuppressWarnings("null")
 	public String toString(int flags) {
 		Noun name = info.names[matchedPattern];
 		return baby.isTrue() ? m_baby.toString(name, flags) : baby.isFalse() ? m_adult.toString(name, flags) : name.toString(flags);
@@ -511,7 +509,6 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 	 * @param string String with optional indefinite article at the beginning
 	 * @return The parsed entity data
 	 */
-	@SuppressWarnings("null")
 	public static @Nullable EntityData<?> parse(String string) {
 		Iterator<EntityDataInfo<EntityData<?>>> it = new ArrayList<>(infos).iterator();
 		return SkriptParser.parseStatic(Noun.stripIndefiniteArticle(string), it, null);
@@ -806,15 +803,14 @@ public abstract class EntityData<E extends Entity> implements SyntaxElement, Ygg
 		World world = location.getWorld();
 		if (world == null)
 			return null;
-		try {
-			if (WORLD_1_17_CONSUMER) {
-				return (@Nullable E) WORLD_1_17_CONSUMER_METHOD.invoke(world, location, type,
-					(org.bukkit.util.Consumer<E>) consumer::accept);
+		if (WORLD_1_17_CONSUMER) {
+			try {
+				return (@Nullable E) WORLD_1_17_CONSUMER_METHOD.invoke(world, location, type, (org.bukkit.util.Consumer<E>) consumer::accept);
+			} catch (InvocationTargetException | IllegalAccessException e) {
+				if (Skript.testing())
+					Skript.exception(e, "Can't spawn " + type.getName());
+				return null;
 			}
-		} catch (InvocationTargetException | IllegalAccessException e) {
-			if (Skript.testing())
-				Skript.exception(e, "Can't spawn " + type.getName());
-			return null;
 		}
 		return world.spawn(location, type, consumer);
 	}

--- a/src/main/java/ch/njol/skript/entity/MinecartData.java
+++ b/src/main/java/ch/njol/skript/entity/MinecartData.java
@@ -110,7 +110,7 @@ public class MinecartData extends EntityData<Minecart> {
 
 	@Override
 	protected boolean equals_i(EntityData<?> obj) {
-		return obj instanceof MinecartData minecartData && (isSupertype || type == minecartData.type);
+		return obj instanceof MinecartData minecartData && type == minecartData.type;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/entity/MinecartData.java
+++ b/src/main/java/ch/njol/skript/entity/MinecartData.java
@@ -110,7 +110,9 @@ public class MinecartData extends EntityData<Minecart> {
 
 	@Override
 	protected boolean equals_i(EntityData<?> obj) {
-		return obj instanceof MinecartData minecartData && type == minecartData.type;
+		return obj instanceof MinecartData minecartData &&
+			isSupertype == minecartData.isSupertype &&
+			type == minecartData.type;
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/entity/MinecartData.java
+++ b/src/main/java/ch/njol/skript/entity/MinecartData.java
@@ -1,7 +1,6 @@
 package ch.njol.skript.entity;
 
 import java.util.ArrayList;
-
 import org.bukkit.entity.Minecart;
 import org.bukkit.entity.minecart.CommandMinecart;
 import org.bukkit.entity.minecart.ExplosiveMinecart;
@@ -12,20 +11,13 @@ import org.bukkit.entity.minecart.SpawnerMinecart;
 import org.bukkit.entity.minecart.StorageMinecart;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.skript.util.Utils;
 import ch.njol.skript.variables.Variables;
 
-/**
- * @author Peter Güttinger
- */
 public class MinecartData extends EntityData<Minecart> {
-	
-	@SuppressWarnings("null")
+
 	private static enum MinecartType {
-		ANY(Minecart.class, "minecart"),
 		NORMAL(RideableMinecart.class, "regular minecart"),
 		STORAGE(StorageMinecart.class, "storage minecart"),
 		POWERED(PoweredMinecart.class, "powered minecart"),
@@ -33,121 +25,101 @@ public class MinecartData extends EntityData<Minecart> {
 		EXPLOSIVE(ExplosiveMinecart.class, "explosive minecart"),
 		SPAWNER(SpawnerMinecart.class, "spawner minecart"),
 		COMMAND(CommandMinecart.class, "command minecart");
-		
-		@Nullable
-		final Class<? extends Minecart> c;
+
+		private final Class<? extends Minecart> entityClass;
 		private final String codeName;
-		
-		MinecartType(final @Nullable Class<? extends Minecart> c, final String codeName) {
-			this.c = c;
+
+		MinecartType(Class<? extends Minecart> entityClass, String codeName) {
+			this.entityClass = entityClass;
 			this.codeName = codeName;
 		}
-		
+
 		@Override
 		public String toString() {
 			return codeName;
 		}
-		
+
 		public static String[] codeNames;
 		static {
-			final ArrayList<String> cn = new ArrayList<>();
-			for (final MinecartType t : values()) {
-				if (t.c != null)
-					cn.add(t.codeName);
+			var names = new ArrayList<>();
+			names.add("minecart");
+			for (MinecartType type : values()) {
+				names.add(type.codeName);
 			}
-			codeNames = cn.toArray(new String[0]);
+			codeNames = names.toArray(new String[0]);
 		}
 	}
-	
+
 	static {
 		EntityData.register(MinecartData.class, "minecart", Minecart.class, 0, MinecartType.codeNames);
-		
 		Variables.yggdrasil.registerSingleClass(MinecartType.class, "MinecartType");
 	}
-	
-	private MinecartType type = MinecartType.ANY;
-	
+
+	private MinecartType type = MinecartType.NORMAL;
+	private boolean isSupertype = true;
+
 	public MinecartData() {}
-	
-	public MinecartData(final MinecartType type) {
+
+	public MinecartData(MinecartType type) {
+		this.matchedPattern = type.ordinal() + 1;
+		this.isSupertype = false;
 		this.type = type;
-		this.matchedPattern = type.ordinal();
 	}
-	
-	@SuppressWarnings("null")
+
 	@Override
-	protected boolean init(final Literal<?>[] exprs, final int matchedPattern, final ParseResult parseResult) {
-		type = MinecartType.values()[matchedPattern];
+	protected boolean init(Literal<?>[] exprs, int matchedPattern, ParseResult parseResult) {
+		if (matchedPattern == 0)
+			return true;
+
+		type = MinecartType.values()[--matchedPattern];
+		isSupertype = false;
 		return true;
 	}
-	
-	@SuppressWarnings("null")
+
 	@Override
-	protected boolean init(final @Nullable Class<? extends Minecart> c, final @Nullable Minecart e) {
-		final MinecartType[] ts = MinecartType.values();
-		for (int i = ts.length - 1; i >= 0; i--) {
-			final Class<?> mc = ts[i].c;
-			if (mc == null)
-				continue;
-			if (e == null ? mc.isAssignableFrom(c) : mc.isInstance(e)) {
-				type = ts[i];
-				return true;
+	protected boolean init(@Nullable Class<? extends Minecart> entityClass, @Nullable Minecart entity) {
+		for (MinecartType t : MinecartType.values()) {
+			Class<?> mc = t.entityClass;
+			if (entity == null ? mc.isAssignableFrom(entityClass) : mc.isInstance(entity)) {
+				isSupertype = false;
+				type = t;
+				break;
 			}
 		}
-		assert false;
-		return false;
+		return true;
 	}
-	
+
 	@Override
-	public void set(final Minecart entity) {}
-	
+	public void set(Minecart entity) {}
+
 	@Override
-	public boolean match(final Minecart entity) {
-		if (type == MinecartType.NORMAL && type.c == Minecart.class) // pre-1.5
-			return !(entity.getClass().equals(Utils.classForName("org.bukkit.entity.StorageMinecart"))
-					|| entity.getClass().equals(Utils.classForName("org.bukkit.entity.PoweredMinecart")));
-		return type.c != null && type.c.isInstance(entity);
+	public boolean match(Minecart entity) {
+		return isSupertype || type.entityClass.isInstance(entity);
 	}
-	
+
 	@Override
 	public Class<? extends Minecart> getType() {
-		return type.c != null ? type.c : Minecart.class;
+		return isSupertype ? Minecart.class : type.entityClass;
 	}
-	
+
 	@Override
 	protected int hashCode_i() {
 		return type.hashCode();
 	}
-	
+
 	@Override
-	protected boolean equals_i(final EntityData<?> obj) {
-		if (!(obj instanceof MinecartData))
-			return false;
-		final MinecartData other = (MinecartData) obj;
-		return type == other.type;
+	protected boolean equals_i(EntityData<?> obj) {
+		return obj instanceof MinecartData minecartData && (isSupertype || type == minecartData.type);
 	}
-	
-//		return type.name();
+
 	@Override
-	protected boolean deserialize(final String s) {
-		try {
-			type = MinecartType.valueOf(s);
-			return true;
-		} catch (final IllegalArgumentException e) {
-			return false;
-		}
+	public boolean isSupertypeOf(EntityData<?> other) {
+		return other instanceof MinecartData && isSupertype;
 	}
-	
+
 	@Override
-	public boolean isSupertypeOf(final EntityData<?> e) {
-		if (e instanceof MinecartData)
-			return type == MinecartType.ANY || ((MinecartData) e).type == type;
-		return false;
+	public @NotNull EntityData<?> getSuperType() {
+		return new MinecartData();
 	}
-	
-	@Override
-	public @NotNull EntityData getSuperType() {
-		return new MinecartData(type);
-	}
-	
+
 }

--- a/src/main/java/ch/njol/skript/entity/MinecartData.java
+++ b/src/main/java/ch/njol/skript/entity/MinecartData.java
@@ -115,7 +115,7 @@ public class MinecartData extends EntityData<Minecart> {
 
 	@Override
 	public boolean isSupertypeOf(EntityData<?> other) {
-		return other instanceof MinecartData && isSupertype;
+		return other instanceof MinecartData minecartData && (isSupertype || type == minecartData.type);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/entity/MinecartData.java
+++ b/src/main/java/ch/njol/skript/entity/MinecartData.java
@@ -71,6 +71,7 @@ public class MinecartData extends EntityData<Minecart> {
 		if (matchedPattern == 0)
 			return true;
 
+		// Avoid the first codeName, as the first codeName is used for super type any comparison
 		type = MinecartType.values()[--matchedPattern];
 		isSupertype = false;
 		return true;


### PR DESCRIPTION
### Problem
`minecart` maps to the Minecart.class which is an interface... You can't spawn an interface.

### Solution
Update the MinecartData class with proper handling of the different Minecart classes.

I also moved the `WORLD_1_17_CONSUMER` outside the try catch, because it doesn't need to be doing a try catch every time an entity is spawned.

All of these would fail prior to this pull request aside from the spawning of a storage minecart:
```vb
spawn a minecart at player # spawns RidableMinecart
if last spawned minecart is a storage minecart: #false
if last spawned minecart is a minecart: #true
if last spawned minecart is a regular minecart: #true
spawn a storage minecart at player # spawns StorageMinecart
if last spawned minecart is a storage minecart: #true
if last spawned minecart is a minecart: #true
if last spawned minecart is a regular minecart: #false
```

---
**Completes:** https://github.com/SkriptLang/Skript/issues/7663
