### PR TITLE
Limit literal specification regex pattern to improve matching behavior.

### DIFF
--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -1123,6 +1123,10 @@ public class SkriptParser {
 			}
 			final SkriptParser skriptParser = new SkriptParser(args, flags | PARSE_LITERALS, context);
 			params = this.getFunctionArguments(() -> skriptParser.suppressMissingAndOrWarnings().parseExpression(Object.class), args, unaryArgument);
+			if (params == null) {
+				log.printError();
+				return null;
+			}
 
 			ParserInstance parser = getParser();
 			Script currentScript = parser.isActive() ? parser.getCurrentScript() : null;

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -472,7 +472,7 @@ public class SkriptParser {
 	}
 
 	private static final String INVALID_LSPEC_CHARS = "[^,():/\"'\\[\\]}{]";
-	private static final Pattern LITERAL_SPECIFICATION_PATTERN = Pattern.compile("(?<literal>" + INVALID_LSPEC_CHARS + "+) \\((?<classinfo>[\\w ]+)\\)");
+	private static final Pattern LITERAL_SPECIFICATION_PATTERN = Pattern.compile("(?<literal>" + INVALID_LSPEC_CHARS + "+) \\((?<classinfo>[\\w\\p{L} ]+)\\)");
 
 	private @Nullable Expression<?> parseSingleExpr(boolean allowUnparsedLiteral, @Nullable LogEntry error, ExprInfo exprInfo) {
 		if (expr.isEmpty()) // Empty expressions return nothing, obviously

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -467,31 +467,12 @@ public class SkriptParser {
 				log.printError();
 				return null;
 			}
-			if (types[0] == Object.class) {
-				// Do check if a literal with this name actually exists before returning an UnparsedLiteral
-				if (!allowUnparsedLiteral || Classes.parseSimple(expr, Object.class, context) == null) {
-					log.printError();
-					return null;
-				}
-				log.clear();
-				LogEntry logError = log.getError();
-				return (Literal<? extends T>) new UnparsedLiteral(expr, logError != null && (error == null || logError.quality > error.quality) ? logError : error);
-			}
-			for (Class<? extends T> type : types) {
-				log.clear();
-				assert type != null;
-				T parsedObject = Classes.parse(expr, type, context);
-				if (parsedObject != null) {
-					log.printLog();
-					return new SimpleLiteral<>(parsedObject, false);
-				}
-			}
-			log.printError();
-			return null;
+			return parseAsLiteral(allowUnparsedLiteral, log, error, types);
 		}
 	}
 
-	private static final Pattern LITERAL_SPECIFICATION_PATTERN = Pattern.compile("(?<literal>[^(]+) \\((?<classinfo>[^)]+)\\)");
+	private static final String INVALID_LSPEC_CHARS = "[^,():/\"'\\[\\]}{]";
+	private static final Pattern LITERAL_SPECIFICATION_PATTERN = Pattern.compile("(?<literal>" + INVALID_LSPEC_CHARS + "+) \\((?<classinfo>" + INVALID_LSPEC_CHARS + "+)\\)");
 
 	private @Nullable Expression<?> parseSingleExpr(boolean allowUnparsedLiteral, @Nullable LogEntry error, ExprInfo exprInfo) {
 		if (expr.isEmpty()) // Empty expressions return nothing, obviously
@@ -675,56 +656,80 @@ public class SkriptParser {
 				log.printError();
 				return null;
 			}
-			if (expr.endsWith(")") && expr.indexOf("(") != -1) {
-				Matcher classInfoMatcher = LITERAL_SPECIFICATION_PATTERN.matcher(expr);
-				if (classInfoMatcher.matches()) {
-					String literalString = classInfoMatcher.group("literal");
-					String unparsedClassInfo = Noun.stripDefiniteArticle(classInfoMatcher.group("classinfo"));
-					Expression<?> result = parseSpecifiedLiteral(literalString, unparsedClassInfo, types);
-					if (result != null) {
-						log.printLog();
-						return result;
-					}
-				}
-			}
-			if (exprInfo.classes.length == 1 && exprInfo.classes[0].getC() == Object.class) {
-				if (!allowUnparsedLiteral) {
-					log.printError();
-					return null;
-				}
-				return getUnparsedLiteral(log, error);
-			}
-			boolean containsObjectClass = false;
-			for (ClassInfo<?> classInfo : exprInfo.classes) {
-				log.clear();
-				assert classInfo.getC() != null;
-				if (classInfo.getC().equals(Object.class)) {
-					// If 'Object.class' is an option, needs to be treated as previous behavior
-					// But we also want to be sure every other 'ClassInfo' is attempted to be parsed beforehand
-					containsObjectClass = true;
-					continue;
-				}
-				Object parsedObject = Classes.parse(expr, classInfo.getC(), context);
-				if (parsedObject != null) {
-					log.printLog();
-					return new SimpleLiteral<>(parsedObject, false, new UnparsedLiteral(expr));
-				}
-			}
-			if (allowUnparsedLiteral && containsObjectClass)
-				return getUnparsedLiteral(log, error);
-			if (expr.startsWith("\"") && expr.endsWith("\"") && expr.length() > 1) {
-				for (ClassInfo<?> aClass : exprInfo.classes) {
-					if (!aClass.getC().isAssignableFrom(String.class))
-						continue;
-					VariableString string = VariableString.newInstance(expr.substring(1, expr.length() - 1));
-					if (string instanceof LiteralString)
-						return string;
-					break;
-				}
-			}
-			log.printError();
-			return null;
+			return parseAsLiteral(allowUnparsedLiteral, log, error, nonNullTypes);
 		}
+	}
+
+	/**
+	 * Helper method for {@link #parseSingleExpr(boolean, LogEntry, Class[])} and {@link #parseSingleExpr(boolean, LogEntry, ExprInfo)}.
+	 * Attempts to parse {@link #expr} as a literal. Prints errors.
+	 *
+	 * @param allowUnparsedLiteral If {@code true}, will allow unparsed literals to be returned.
+	 * @param log The current {@link ParseLogHandler} to use for logging.
+	 * @param error A {@link LogEntry} containing a default error to be printed if failed to parse.
+	 * @param types The valid types to parse the literal as.
+	 * @return {@link Expression} of type {@code T} if successful, otherwise {@code null}.<br>
+	 * @param <T> The type of the literal to parse.<br>
+	 */
+	@SafeVarargs
+	private <T> @Nullable Expression<? extends T> parseAsLiteral(
+			boolean allowUnparsedLiteral,
+			ParseLogHandler log,
+			@Nullable LogEntry error,
+			Class<? extends T>... types
+	) {
+		if (expr.endsWith(")") && expr.contains("(")) {
+			Matcher classInfoMatcher = LITERAL_SPECIFICATION_PATTERN.matcher(expr);
+			if (classInfoMatcher.matches()) {
+				String literalString = classInfoMatcher.group("literal");
+				String unparsedClassInfo = Noun.stripDefiniteArticle(classInfoMatcher.group("classinfo"));
+				Expression<? extends T> result = parseSpecifiedLiteral(literalString, unparsedClassInfo, types);
+				if (result != null) {
+					log.printLog();
+					return result;
+				}
+			}
+		}
+		if (types.length == 1 && types[0] == Object.class) {
+			if (!allowUnparsedLiteral) {
+				log.printError();
+				return null;
+			}
+			//noinspection unchecked
+			return (Expression<? extends T>) getUnparsedLiteral(log, error);
+		}
+		boolean containsObjectClass = false;
+		for (Class<?> type : types) {
+			log.clear();
+			if (type == Object.class) {
+				// If 'Object.class' is an option, needs to be treated as previous behavior
+				// But we also want to be sure every other 'ClassInfo' is attempted to be parsed beforehand
+				containsObjectClass = true;
+				continue;
+			}
+			//noinspection unchecked
+			T parsedObject = (T) Classes.parse(expr, type, context);
+			if (parsedObject != null) {
+				log.printLog();
+				return new SimpleLiteral<>(parsedObject, false, new UnparsedLiteral(expr));
+			}
+		}
+		if (allowUnparsedLiteral && containsObjectClass)
+			//noinspection unchecked
+			return (Expression<? extends T>) getUnparsedLiteral(log, error);
+		if (expr.startsWith("\"") && expr.endsWith("\"") && expr.length() > 1) {
+			for (Class<?> type : types) {
+				if (!type.isAssignableFrom(String.class))
+					continue;
+				VariableString string = VariableString.newInstance(expr.substring(1, expr.length() - 1));
+				if (string instanceof LiteralString)
+					//noinspection unchecked
+					return (Expression<? extends T>) string;
+				break;
+			}
+		}
+		log.printError();
+		return null;
 	}
 
 	/**
@@ -759,10 +764,11 @@ public class SkriptParser {
 	 * @param types An {@link Array} of the acceptable {@link Class}es
 	 * @return {@link SimpleLiteral} or {@code null} if any checks fail
 	 */
-	private @Nullable Expression<?> parseSpecifiedLiteral(
+	@SafeVarargs
+	private <T> @Nullable Expression<? extends T> parseSpecifiedLiteral(
 		String literalString,
 		String unparsedClassInfo,
-		Class<?> ... types
+		Class<? extends T> ... types
 	) {
 		ClassInfo<?> classInfo = Classes.parse(unparsedClassInfo, ClassInfo.class, context);
 		if (classInfo == null) {
@@ -778,7 +784,8 @@ public class SkriptParser {
 			Skript.error(expr + " " + Language.get("is") + " " + notOfType(types));
 			return null;
 		}
-		Object parsedObject = classInfoParser.parse(literalString, context);
+		//noinspection unchecked
+		T parsedObject = (T) classInfoParser.parse(literalString, context);
 		if (parsedObject != null)
 			return new SimpleLiteral<>(parsedObject, false, new UnparsedLiteral(literalString));
 		return null;
@@ -1116,10 +1123,6 @@ public class SkriptParser {
 			}
 			final SkriptParser skriptParser = new SkriptParser(args, flags | PARSE_LITERALS, context);
 			params = this.getFunctionArguments(() -> skriptParser.suppressMissingAndOrWarnings().parseExpression(Object.class), args, unaryArgument);
-			if (params == null) {
-				log.printError();
-				return null;
-			}
 
 			ParserInstance parser = getParser();
 			Script currentScript = parser.isActive() ? parser.getCurrentScript() : null;

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -472,7 +472,7 @@ public class SkriptParser {
 	}
 
 	private static final String INVALID_LSPEC_CHARS = "[^,():/\"'\\[\\]}{]";
-	private static final Pattern LITERAL_SPECIFICATION_PATTERN = Pattern.compile("(?<literal>" + INVALID_LSPEC_CHARS + "+) \\((?<classinfo>" + INVALID_LSPEC_CHARS + "+)\\)");
+	private static final Pattern LITERAL_SPECIFICATION_PATTERN = Pattern.compile("(?<literal>" + INVALID_LSPEC_CHARS + "+) \\((?<classinfo>[\\w ]+)\\)");
 
 	private @Nullable Expression<?> parseSingleExpr(boolean allowUnparsedLiteral, @Nullable LogEntry error, ExprInfo exprInfo) {
 		if (expr.isEmpty()) // Empty expressions return nothing, obviously

--- a/src/test/skript/tests/misc/literal specification.sk
+++ b/src/test/skript/tests/misc/literal specification.sk
@@ -30,6 +30,13 @@ test "literal specification":
 	assert firework (the item type) is an item type with "Literal specification should work with definite articles"
 	assert firework (an entity type) is an entity type with "Literal specification should work with indefinite article"
 
+local function test(entity: entitytype, item: itemtype):
+	assert {_entity} is an entity type with "Literal specification should work with entitytype"
+	assert {_item} is an item type with "Literal specification should work with itemtype"
+
+test "literal specification in functions":
+	test(firework (entity type), firework (item type))
+
 test "literal specification error":
 	parse:
 		set {_block} to oak log (block)


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
Literal specification didn't work so well in function parameters: `func(red, black (color))` would fail to parse.

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
Enforces stricter regex match rules (no {}()\"' and so on in the literal, and only letters, numbers, and spaces in the codename).
Also ensures the two parseSingleExpr implementations are unified in behavior, as previously only one would attempt specified literals. Pulled duplicate code into a helper method.

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
added to literal specification.sk

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
