### PR TITLE
Fix potential resolution failure with single list parameter function calls

### DIFF
--- a/src/main/java/ch/njol/skript/lang/function/FunctionRegistry.java
+++ b/src/main/java/ch/njol/skript/lang/function/FunctionRegistry.java
@@ -435,7 +435,7 @@ final class FunctionRegistry implements Registry<Function<?>> {
 				// make sure all types in the passed array are valid for the array parameter
 				Class<?> arrayType = candidate.args[0].componentType();
 				for (Class<?> arrayArg : provided.args) {
-					if (!Converters.converterExists(arrayType, arrayArg)) {
+					if (!Converters.converterExists(arrayArg, arrayType)) {
 						continue candidates;
 					}
 				}

--- a/src/test/skript/tests/regressions/8070-single list parameter functions can fail to resolve.sk
+++ b/src/test/skript/tests/regressions/8070-single list parameter functions can fail to resolve.sk
@@ -1,0 +1,7 @@
+local function test(p: potion effect types):
+	stop
+
+test "single list parameter functions":
+	parse:
+		test(night vision and glowing)
+	assert last parse logs is not set with "function call failed to parse"


### PR DESCRIPTION
### Problem
Function calls for single list parameter functions could fail to resolve. Consider the example:
```applescript
function test(p: potion effect types):
	stop
on load:
	test(night vision and glowing)
```
The function registry should be able to resolve this, but it fails to do so. However, this does not occur with all types. After some investigation, I found that the `converterExists` check for resolving these single list parameter functions had the parameters mistakenly swapped.

### Solution
I swapped the parameters which resolved the issue.


### Testing Completed
I have included a regression test.


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** #8070 
**Related:** none <!-- Links to issues or discussions with related information -->
