### PR TITLE
Improve default syntax ordering

### DIFF
--- a/src/main/java/org/skriptlang/skript/registration/SyntaxRegister.java
+++ b/src/main/java/org/skriptlang/skript/registration/SyntaxRegister.java
@@ -1,5 +1,6 @@
 package org.skriptlang.skript.registration;
 
+import ch.njol.util.StringUtils;
 import com.google.common.collect.ImmutableSet;
 import org.jetbrains.annotations.Nullable;
 
@@ -14,13 +15,44 @@ import java.util.concurrent.ConcurrentSkipListSet;
  */
 final class SyntaxRegister<I extends SyntaxInfo<?>> {
 
+	private static int calculateComplexityScore(SyntaxInfo<?> info) {
+		return info.patterns().stream()
+				.mapToInt(SyntaxRegister::calculateComplexityScore)
+				.max()
+				.orElseThrow(); // a syntax info should have at least one pattern
+	}
+
+	private static int calculateComplexityScore(String pattern) {
+		int score = 0;
+		char[] chars = pattern.toCharArray();
+		for (int i = 0; i < chars.length; i++) {
+			if (chars[i] == '%') {
+				if (i - 2 >= 0 && chars[i - 2] == '%') { // weigh "%thing% %thing%" heavier
+					score += 3;
+				} else {
+					score++;
+				}
+			}
+		}
+		return score;
+	}
+
 	private static final Comparator<SyntaxInfo<?>> SET_COMPARATOR = (a,b) -> {
 		if (a == b) { // only considered equal if registering the same infos
 			return 0;
 		}
-		int result = a.priority().compareTo(b.priority());
-		// when elements have the same priority, order by hashcode
-		return result != 0 ? result : Integer.compare(a.hashCode(), b.hashCode());
+		// priority is the primary factor in determining ordering
+		int priorityResult = a.priority().compareTo(b.priority());
+		if (priorityResult != 0) {
+			return priorityResult;
+		}
+		// otherwise, consider the complexity of the syntax
+		int scoreResult = Integer.compare(calculateComplexityScore(a), calculateComplexityScore(b));
+		if (scoreResult != 0) {
+			return scoreResult;
+		}
+		// otherwise, order by hashcode
+		return Integer.compare(a.hashCode(), b.hashCode());
 	};
 
 	final Set<I> syntaxes = new ConcurrentSkipListSet<>(SET_COMPARATOR);

--- a/src/main/java/org/skriptlang/skript/registration/SyntaxRegister.java
+++ b/src/main/java/org/skriptlang/skript/registration/SyntaxRegister.java
@@ -1,6 +1,5 @@
 package org.skriptlang.skript.registration;
 
-import ch.njol.util.StringUtils;
 import com.google.common.collect.ImmutableSet;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/main/java/org/skriptlang/skript/registration/SyntaxRegister.java
+++ b/src/main/java/org/skriptlang/skript/registration/SyntaxRegister.java
@@ -27,7 +27,8 @@ final class SyntaxRegister<I extends SyntaxInfo<?>> {
 		char[] chars = pattern.toCharArray();
 		for (int i = 0; i < chars.length; i++) {
 			if (chars[i] == '%') {
-				if (i - 2 >= 0 && chars[i - 2] == '%') { // weigh "%thing% %thing%" heavier
+				// weigh "%thing% %thing%" or "%thing% [%thing%]" heavier
+				if ((i - 2 >= 0 && chars[i - 2] == '%') || (i - 3 >= 0 && chars[i - 3] == '%')) {
 					score += 3;
 				} else {
 					score++;


### PR DESCRIPTION
### Problem
https://github.com/SkriptLang/Skript/pull/7879 changed syntax ordering so that it was no longer dependent on when the syntax was registered. However, most syntax is not using Priority yet, meaning more complex syntax (i.e. harder to parse) such as EffVisualEffect is being attempted early on in some cases (when it should instead be saved for last).


### Solution
While these more complex syntaxes should have a higher priority, I have created a simple metric for determining the "complexity" of a syntax. Currently, the metric simply considers how many percent signs a pattern contains (they have not yet been compiled and i didn't think it was worth doing that). The idea is that `percent signs = expressions` and `more expressions = more complex` (harder to parse) which is generally true


### Testing Completed
n/a


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
