### PR TITLE
Happy Ghast Equipment

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffEquip.java
+++ b/src/main/java/ch/njol/skript/effects/EffEquip.java
@@ -43,7 +43,10 @@ import org.jetbrains.annotations.UnknownNullability;
 	"unequip diamond chestplate from player",
 	"unequip player's armor"
 })
-@Since("1.0, 2.7 (multiple entities, unequip), 2.10 (wolves)")
+@Since({
+	"1.0, 2.7 (multiple entities, unequip), 2.10 (wolves)",
+	"INSERT VERSION (happy ghasts)"
+})
 public class EffEquip extends Effect {
 
 	private static final ItemType CHESTPLATE;

--- a/src/main/java/ch/njol/skript/effects/EffEquip.java
+++ b/src/main/java/ch/njol/skript/effects/EffEquip.java
@@ -1,7 +1,6 @@
 package ch.njol.skript.effects;
 
 import ch.njol.skript.Skript;
-import ch.njol.skript.aliases.ItemData;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.bukkitutil.PlayerUtils;
 import ch.njol.skript.doc.Description;
@@ -19,6 +18,7 @@ import org.bukkit.entity.ChestedHorse;
 import org.bukkit.entity.Horse;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Llama;
+import org.bukkit.entity.Mob;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Steerable;
 import org.bukkit.entity.Wolf;
@@ -46,18 +46,25 @@ import org.jetbrains.annotations.UnknownNullability;
 @Since("1.0, 2.7 (multiple entities, unequip), 2.10 (wolves)")
 public class EffEquip extends Effect {
 
-	private static ItemType CHESTPLATE;
-	private static ItemType LEGGINGS;
-	private static ItemType BOOTS;
-	private static ItemType CARPET = new ItemType(Tag.WOOL_CARPETS);
-	private static ItemType WOLF_ARMOR;
+	private static final ItemType CHESTPLATE;
+	private static final ItemType LEGGINGS;
+	private static final ItemType BOOTS;
+	private static final ItemType CARPET = new ItemType(Tag.WOOL_CARPETS);
+	private static final ItemType WOLF_ARMOR;
 	private static final ItemType HORSE_ARMOR = new ItemType(Material.LEATHER_HORSE_ARMOR, Material.IRON_HORSE_ARMOR, Material.GOLDEN_HORSE_ARMOR, Material.DIAMOND_HORSE_ARMOR);
 	private static final ItemType SADDLE = new ItemType(Material.SADDLE);
 	private static final ItemType CHEST = new ItemType(Material.CHEST);
+	private static final ItemType HAPPY_GHAST_HARNESS;
+
+	private static final Class<?> HAPPY_GHAST_CLASS;
 
 	static {
-		boolean hasWolfArmor = Skript.fieldExists(Material.class, "WOLF_ARMOR");
-		WOLF_ARMOR = hasWolfArmor ? new ItemType(Material.WOLF_ARMOR) : new ItemType();
+		// added in 1.20.5
+		if (Skript.fieldExists(Material.class, "WOLF_ARMOR")) {
+			WOLF_ARMOR = new ItemType(Material.WOLF_ARMOR);
+		} else {
+			WOLF_ARMOR = new ItemType();
+		}
 
 		// added in 1.20.6
 		if (Skript.fieldExists(Tag.class, "ITEM_CHEST_ARMOR")) {
@@ -71,7 +78,7 @@ public class EffEquip extends Effect {
 				Material.GOLDEN_CHESTPLATE,
 				Material.IRON_CHESTPLATE,
 				Material.DIAMOND_CHESTPLATE,
-        Material.NETHERITE_CHESTPLATE,
+				Material.NETHERITE_CHESTPLATE,
 				Material.ELYTRA
 			);
 
@@ -81,7 +88,7 @@ public class EffEquip extends Effect {
 				Material.GOLDEN_LEGGINGS,
 				Material.IRON_LEGGINGS,
 				Material.DIAMOND_LEGGINGS,
-        Material.NETHERITE_LEGGINGS
+				Material.NETHERITE_LEGGINGS
 			);
 
 			BOOTS = new ItemType(
@@ -90,12 +97,25 @@ public class EffEquip extends Effect {
 				Material.GOLDEN_BOOTS,
 				Material.IRON_BOOTS,
 				Material.DIAMOND_BOOTS,
-        Material.NETHERITE_BOOTS
+				Material.NETHERITE_BOOTS
 			);
+		}
+
+		// added in 1.21.6
+		if (Skript.fieldExists(Tag.class, "ITEMS_HARNESSES")) {
+			HAPPY_GHAST_HARNESS = new ItemType(Tag.ITEMS_HARNESSES);
+			try {
+				HAPPY_GHAST_CLASS = Class.forName("org.bukkit.entity.HappyGhast");
+			} catch (ClassNotFoundException e) {
+				throw new RuntimeException(e);
+			}
+		} else {
+			HAPPY_GHAST_HARNESS = new ItemType();
+			HAPPY_GHAST_CLASS = null;
 		}
 	}
 
-	private static final ItemType[] ALL_EQUIPMENT = new ItemType[] {CHESTPLATE, LEGGINGS, BOOTS, HORSE_ARMOR, SADDLE, CHEST, CARPET, WOLF_ARMOR};
+	private static final ItemType[] ALL_EQUIPMENT = new ItemType[] {CHESTPLATE, LEGGINGS, BOOTS, HORSE_ARMOR, SADDLE, CHEST, CARPET, WOLF_ARMOR, HAPPY_GHAST_HARNESS};
 
 	static {
 		Skript.registerEffect(EffEquip.class,
@@ -175,6 +195,14 @@ public class EffEquip extends Effect {
 					for (ItemStack item : itemType.getAll()) {
 						if (WOLF_ARMOR.isOfType(item))
 							equipment.setItem(EquipmentSlot.BODY, equip ? item : null);
+					}
+				}
+			} else if (HAPPY_GHAST_CLASS != null && HAPPY_GHAST_CLASS.isInstance(entity)) {
+				EntityEquipment equipment = ((Mob) entity).getEquipment();
+				for (ItemType itemType : itemTypes) {
+					for (ItemStack itemStack : itemType.getAll()) {
+						if (HAPPY_GHAST_HARNESS.isOfType(itemStack))
+							equipment.setItem(EquipmentSlot.BODY, equip ? itemStack : null);
 					}
 				}
 			} else {

--- a/src/main/java/ch/njol/skript/expressions/ExprArmorSlot.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprArmorSlot.java
@@ -15,15 +15,7 @@ import ch.njol.skript.util.slot.EquipmentSlot;
 import ch.njol.skript.util.slot.Slot;
 import ch.njol.util.Kleenean;
 import org.bukkit.Material;
-import org.bukkit.entity.AbstractHorse;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Horse;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Llama;
-import org.bukkit.entity.Pig;
-import org.bukkit.entity.Strider;
-import org.bukkit.entity.TraderLlama;
-import org.bukkit.entity.Wolf;
+import org.bukkit.entity.*;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.EntityEquipment;
 import org.jetbrains.annotations.Nullable;
@@ -71,6 +63,8 @@ public class ExprArmorSlot extends PropertyExpression<LivingEntity, Slot> {
 	static {
 		if (Material.getMaterial("WOLF_ARMOR") != null)
 			BODY_ENTITIES.add(Wolf.class);
+		if (Skript.classExists("org.bukkit.entity.HappyGhast"))
+			BODY_ENTITIES.add(HappyGhast.class);
 
 		register(ExprArmorSlot.class, Slot.class, "(%-*equipmentslots%|[the] armo[u]r[s]) [item:item[s]]", "livingentities");
 	}

--- a/src/main/java/ch/njol/skript/expressions/ExprArmorSlot.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprArmorSlot.java
@@ -35,6 +35,7 @@ import java.util.stream.Stream;
 	"<li>Horses: Horse armour (doesn't work on zombie or skeleton horses)</li>",
 	"<li>Wolves: Wolf Armor</li>",
 	"<li>Llamas (regular or trader): Carpet</li>",
+	"<li>Happy Ghasts: Harness</li>",
 	"</ul>",
 	"Saddle is a special slot that can only be used for: pigs, striders and horse types (horse, camel, llama, mule, donkey)."
 })
@@ -43,7 +44,10 @@ import java.util.stream.Stream;
 	"helmet of player is neither tag values of tag \"paper:helmets\" nor air # player is wearing a block, e.g. from another plugin"
 })
 @Keywords("armor")
-@Since("1.0, 2.8.0 (armor), 2.10 (body armor), 2.12 (saddle)")
+@Since({
+	"1.0, 2.8.0 (armor), 2.10 (body armor), 2.12 (saddle)",
+	"INSERT VERSION (happy ghast)"
+})
 public class ExprArmorSlot extends PropertyExpression<LivingEntity, Slot> {
 
 	private static final Set<Class<? extends Entity>> BODY_ENTITIES =

--- a/src/test/skript/tests/regressions/8086-happy ghast equipment.sk
+++ b/src/test/skript/tests/regressions/8086-happy ghast equipment.sk
@@ -1,0 +1,15 @@
+test "happy ghast equipment" when running minecraft "1.21.6":
+	spawn a happy ghast at test-location:
+		set {_entity} to entity
+
+	equip {_entity} with a red harness
+	assert the body slot of {_entity} is a red harness with "Equip effect did not equip harness to happy ghast"
+	unequip a red harness from {_entity}
+	assert the body slot of {_entity} is air with "Equip effect did not unequip harness from happy ghast"
+
+	set the body slot of {_entity} to a blue harness
+	assert the body slot of {_entity} is a blue harness with "ExprArmorSlot did not set body slot of happy ghast"
+	clear the body slot of {_entity}
+	assert the body slot of {_entity} is air with "ExprArmorSlot did not clear body slot of happy ghast"
+
+	clear entity within {_entity}


### PR DESCRIPTION
### Problem
Could not use `EffEquip` nor `ExprArmorSlot` to set/clear/equip/unequip the body slot of a  HappyGhast -  Harness

### Solution
Updates `EffEquip` and `ExprArmorSlot` to allow `HappyGhast`s

### Testing Completed
`8086-happy ghast equipment.sk`

### Supporting Information
N/A

---
**Completes:** #8084 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
