### PR TITLE
Match Any Default Expression

### DIFF
--- a/src/main/java/ch/njol/skript/lang/DefaultExpressionError.java
+++ b/src/main/java/ch/njol/skript/lang/DefaultExpressionError.java
@@ -1,0 +1,143 @@
+package ch.njol.skript.lang;
+
+import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.lang.SkriptParser.ExprInfo;
+import ch.njol.util.StringUtils;
+
+import java.util.List;
+
+/**
+ * Utility enum for identifying the type of error and getting the error message for {@link SkriptParser#getDefaultExpressions(ExprInfo, String)}
+ */
+public enum DefaultExpressionError {
+
+	NOT_FOUND {
+		@Override
+		public String getError(List<String> codeNames, String pattern) {
+			StringBuilder builder = new StringBuilder();
+			String combinedComma = StringUtils.join(codeNames, ", ");
+			String combinedSlash = StringUtils.join(codeNames, "/");
+			builder.append("The class");
+			if (codeNames.size() > 1)
+				builder.append("es");
+			builder.append(" '")
+				.append(combinedComma)
+				.append(" ' ");
+			if (codeNames.size() > 1)  {
+				builder.append("do ");
+			} else {
+				builder.append("does ");
+			}
+			builder.append("not provide a default expression. Either allow null (with %-")
+				.append(combinedSlash)
+				.append("%) or make it mandatory [pattern: ")
+				.append(pattern)
+				.append("]");
+			return builder.toString();
+		}
+	},
+	NOT_LITERAL {
+		@Override
+		public String getError(List<String> codeNames, String pattern) {
+			StringBuilder builder = new StringBuilder();
+			String combinedComma = StringUtils.join(codeNames, ", ");
+			String combinedSlash = StringUtils.join(codeNames, "/");
+			builder.append("The default expression");
+			if (codeNames.size() > 1)
+				builder.append("s");
+			builder.append(" of '")
+				.append(combinedComma)
+				.append("' ");
+			if (codeNames.size() > 1) {
+				builder.append("are ");
+			} else {
+				builder.append("is ");
+			}
+			builder.append("not a literal. Either allow null (with %-*")
+				.append(combinedSlash)
+				.append("%) or make it mandatory [pattern: ")
+				.append(pattern)
+				.append("]");
+			return builder.toString();
+		}
+	},
+	LITERAL {
+		@Override
+		public String getError(List<String> codeNames, String pattern) {
+			StringBuilder builder = new StringBuilder();
+			String combinedComma = StringUtils.join(codeNames, ", ");
+			String combinedSlash = StringUtils.join(codeNames, "/");
+			builder.append("The default expression");
+			if (codeNames.size() > 1)
+				builder.append("s");
+			builder.append(" of '")
+				.append(combinedComma)
+				.append("' ");
+			if (codeNames.size() > 1) {
+				builder.append("are ");
+			} else {
+				builder.append("is ");
+			}
+			builder.append("a literal. Either allow null (with %-~")
+				.append(combinedSlash)
+				.append("%) or make it mandatory [pattern: ")
+				.append(pattern)
+				.append("]");
+			return builder.toString();
+		}
+	},
+	NOT_SINGLE {
+		@Override
+		public String getError(List<String> codeNames, String pattern) {
+			StringBuilder builder = new StringBuilder();
+			String combinedComma = StringUtils.join(codeNames, ", ");
+			builder.append("The default expression");
+			if (codeNames.size() > 1)
+				builder.append("s");
+			builder.append(" of '")
+				.append(combinedComma)
+				.append("' ");
+			if (codeNames.size() > 1) {
+				builder.append("are ");
+			} else {
+				builder.append("is ");
+			}
+			builder.append("not a single-element expression. Change your pattern to allow multiple elements or make the expression mandatory [pattern: ")
+				.append(pattern)
+				.append("]");
+			return builder.toString();
+		}
+	},
+	TIME_STATE {
+		@Override
+		public String getError(List<String> codeNames, String pattern) {
+			StringBuilder builder = new StringBuilder();
+			String combinedComma = StringUtils.join(codeNames, ", ");
+			builder.append("The default expression");
+			if (codeNames.size() > 1)
+				builder.append("s");
+			builder.append(" of '")
+				.append(combinedComma)
+				.append("' ");
+			if (codeNames.size() > 1) {
+				builder.append("do ");
+			} else {
+				builder.append("does ");
+			}
+			builder.append("not have distinct time states. [pattern: ")
+				.append(pattern)
+				.append("]");
+			return builder.toString();
+		}
+	};
+
+	/**
+	 * Returns an error message for the given type.
+	 *
+	 * @param codeNames The codeNames of {@link ClassInfo}s to include in the error message.
+	 * @param pattern The pattern to include in the error message.
+	 * @return error message.
+	 */
+	public abstract String getError(List<String> codeNames, String pattern);
+
+}


### PR DESCRIPTION
### Problem
When creating a `SyntaxElement` and including an optional multi-typed expression in the pattern (`[%type1/type2%]`) then having a `defaultExpression` for the `ClassInfo` of `type2` but not for `type1`, `SkriptParser` fails to check if any of the types have a `defaultExpression`.
Resulting in a `SkriptAPIException` since `type1` does not have a `defaultExpression`

### Solution
Adds `#getDefaultExpressions` which will check every `ClassInfo` of `ExprInfo` to retrieve all available `DefaultExpressions`.
Changes `#getDefaultExpression` to return the first object from `#getDefaultExpression`
When no `DefaultExpression` are available, combines error messages and codenames for 1 `SkriptAPIException`

### Testing Completed
manual

### Supporting Information
N/A

---
**Completes:** #8079 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
