### PR TITLE
Clean up ScriptCommand

### DIFF
--- a/src/main/java/ch/njol/skript/command/Commands.java
+++ b/src/main/java/ch/njol/skript/command/Commands.java
@@ -231,8 +231,8 @@ public abstract class Commands {
 
 	public static void registerCommand(ScriptCommand command) {
 		// Validate that there are no duplicates
-		ScriptCommand existingCommand = commands.get(command.getLabel());
-		if (existingCommand != null && existingCommand.getLabel().equals(command.getLabel())) {
+		ScriptCommand existingCommand = commands.get(command.getName());
+		if (existingCommand != null && existingCommand.getName().equals(command.getName())) {
 			Script script = existingCommand.getScript();
 			Skript.error("A command with the name /" + existingCommand.getName() + " is already defined"
 				+ (script != null ? (" in " + script.getConfig().getFileName()) : "")
@@ -244,11 +244,10 @@ public abstract class Commands {
 			assert cmKnownCommands != null;// && cmAliases != null;
 			command.register(commandMap, cmKnownCommands, cmAliases);
 		}
-		commands.put(command.getLabel(), command);
-		for (String alias : command.getActiveAliases()) {
+		commands.put(command.getName(), command);
+		for (String alias : command.getAliases()) {
 			commands.put(alias.toLowerCase(Locale.ENGLISH), command);
 		}
-		command.registerHelp();
 	}
 
 	@Deprecated(since = "2.7.0", forRemoval = true)
@@ -264,7 +263,6 @@ public abstract class Commands {
 	}
 
 	public static void unregisterCommand(ScriptCommand scriptCommand) {
-		scriptCommand.unregisterHelp();
 		if (commandMap != null) {
 			assert cmKnownCommands != null;// && cmAliases != null;
 			scriptCommand.unregister(commandMap, cmKnownCommands, cmAliases);

--- a/src/main/java/ch/njol/skript/command/ScriptCommandEvent.java
+++ b/src/main/java/ch/njol/skript/command/ScriptCommandEvent.java
@@ -21,7 +21,7 @@ public class ScriptCommandEvent extends CommandEvent {
 	 * @param rest The rest of the command string (the arguments)
 	 */
 	public ScriptCommandEvent(ScriptCommand scriptCommand, CommandSender sender, String commandLabel, String rest) {
-		super(sender, scriptCommand.getLabel(), rest.split(" "));
+		super(sender, scriptCommand.getName(), rest.split(" "));
 		this.scriptCommand = scriptCommand;
 		this.commandLabel = commandLabel;
 		this.rest = rest;

--- a/src/main/java/ch/njol/skript/structures/StructCommand.java
+++ b/src/main/java/ch/njol/skript/structures/StructCommand.java
@@ -178,7 +178,7 @@ public class StructCommand extends Structure {
 
 		String command = matcher.group(1).toLowerCase();
 		ScriptCommand existingCommand = Commands.getScriptCommand(command);
-		if (existingCommand != null && existingCommand.getLabel().equals(command)) {
+		if (existingCommand != null && existingCommand.getName().equals(command)) {
 			Script script = existingCommand.getScript();
 			Skript.error("A command with the name /" + existingCommand.getName() + " is already defined"
 				+ (script != null ? (" in " + script.getConfig().getFileName()) : "")
@@ -283,9 +283,20 @@ public class StructCommand extends Structure {
 
 		Commands.currentArguments = currentArguments;
 		try {
-			scriptCommand = new ScriptCommand(getParser().getCurrentScript(), command, pattern.toString(), currentArguments, description, prefix,
-				usage, aliases, permission, permissionMessage, cooldown, cooldownMessage, cooldownBypass, cooldownStorage,
-				executableBy, entryContainer.get("trigger", SectionNode.class, false));
+			SectionNode trigger = entryContainer.get("trigger", SectionNode.class, false);
+			scriptCommand = new ScriptCommand.Builder(getParser().getCurrentScript(), trigger, command, pattern.toString())
+					.permissionMessage(permissionMessage)
+					.cooldownMessage(cooldownMessage)
+					.cooldownStorage(cooldownStorage)
+					.cooldownBypass(cooldownBypass)
+					.executableBy(executableBy)
+					.description(description)
+					.permission(permission)
+					.cooldown(cooldown)
+					.aliases(aliases)
+					.prefix(prefix)
+					.usage(usage)
+					.build();
 		} finally {
 			Commands.currentArguments = null;
 		}


### PR DESCRIPTION
### Problem
With an upcoming command system rewrite to use brigadier with switching to Paper in the future. The ScriptCommand needs to be cleaned up. So I added a builder because Skript is gonna add suggestions and parsing to the command, so with a builder, this makes it way easier to read and manage. The script command class has become a mess with additions over the years.