### PR TITLE
Fix up some tests, remove the_end, gradle cleaning, testing env fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,6 @@ dependencies {
 }
 
 checkstyle {
-	group = 'help'
 	configFile = new File("checkstyle.xml")
 	sourceSets = [] // disables checkstyle after build task
 }

--- a/build.gradle
+++ b/build.gradle
@@ -268,6 +268,7 @@ compileTestJava.options.encoding = 'UTF-8'
 String environments = 'src/test/skript/environments/';
 String env = project.property('testEnv') == null ? latestEnv : project.property('testEnv') + '.json'
 int envJava = project.property('testEnvJavaVersion') == null ? latestJava : Integer.parseInt(project.property('testEnvJavaVersion') as String)
+
 createTestTask('quickTest', 'Runs tests on one environment being the latest supported Java and Minecraft.', environments + latestEnv, latestJava, 0)
 createTestTask('skriptTestJava21', 'Runs tests on all Java 21 environments.', environments + 'java21', java21, 0)
 createTestTask('skriptTestJava17', 'Runs tests on all Java 17 environments.', environments + 'java17', java17, 0)
@@ -286,6 +287,12 @@ createTestTask('JUnitJava17', 'Runs JUnit tests on all Java 17 environments.', e
 tasks.register('JUnit') {
 	description = 'Runs JUnit tests on all environments.'
 	dependsOn JUnitJava17, JUnitJava21
+}
+
+tasks.register('quickTests') {
+	description = 'Runs quick test and junit quick.'
+	dependsOn quickTest
+	mustRunAfter JUnitQuick
 }
 
 // Build flavor configurations

--- a/build.gradle
+++ b/build.gradle
@@ -51,11 +51,13 @@ dependencies {
 }
 
 checkstyle {
+	group = 'help'
 	configFile = new File("checkstyle.xml")
 	sourceSets = [] // disables checkstyle after build task
 }
 
 task checkAliases {
+	group = 'skript'
 	description 'Checks for the existence of the aliases.'
 	doLast {
 		def aliasFolder = project.file('skript-aliases')

--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,7 @@ void createTestTask(String name, String desc, String environments, int javaVersi
 		if (modifiers.contains(Modifiers.DEV_MODE)) {
 			standardInput = System.in
 		}
-		group = 'execution'
+		group = 'skript'
 		classpath = files([
 			artifact,
 			project.configurations.runtimeClasspath.find { it.name.startsWith('gson') },
@@ -279,6 +279,7 @@ createTestTask('genReleaseDocs', 'Generates the Skript documentation website htm
 tasks.register('skriptTest') {
 	description = 'Runs tests on all environments.'
 	dependsOn skriptTestJava17, skriptTestJava21
+	group = 'skript'
 }
 
 createTestTask('JUnitQuick', 'Runs JUnit tests on one environment being the latest supported Java and Minecraft.', environments + latestJUnitEnv, latestJUnitJava, 0, Modifiers.JUNIT)
@@ -287,12 +288,14 @@ createTestTask('JUnitJava17', 'Runs JUnit tests on all Java 17 environments.', e
 tasks.register('JUnit') {
 	description = 'Runs JUnit tests on all environments.'
 	dependsOn JUnitJava17, JUnitJava21
+	group = 'skript'
 }
 
 tasks.register('quickTests') {
 	description = 'Runs quick test and junit quick.'
 	dependsOn quickTest
 	mustRunAfter JUnitQuick
+	group = 'skript'
 }
 
 // Build flavor configurations

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 # Done to increase the memory available to gradle.
 # Ensure encoding is consistent across systems.
-org.gradle.jvmargs=-Xmx1G -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx3G -Dfile.encoding=UTF-8
+org.gradle.configureondemand=true
 org.gradle.parallel=true
 
 groupid=ch.njol

--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -729,7 +729,7 @@ public final class Skript extends JavaPlugin implements Listener {
 						try {
 							if (logHandler.getCount() == 0)
 								Skript.info(m_no_errors.toString());
-							if (scriptInfo.files == 0)
+							if (scriptInfo.files == 0 && !Skript.testing())
 								Skript.warning(m_no_scripts.toString());
 							if (Skript.logNormal() && scriptInfo.files > 0)
 								Skript.info(m_scripts_loaded.toString(

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -2207,6 +2207,7 @@ spawn reasons:
 	# 1.21
 	trial_spawner: trial spawner, trial mob spawner, trial creature spawner
 	enchantment: enchantment
+	rehydration: rehydration, rehydrate
 
 # -- Difficulties --
 difficulties:
@@ -2826,6 +2827,12 @@ types:
 	numbered: numbered thing¦s @a
 	valued: valued thing¦s @a
 	containing: container¦s @a
+
+	# Testing
+	testgui: testgui
+	exemplus: exemplus
+	aardwolf: aardwolf
+	hoof: hoof
 
 	# Hooks
 	money: money

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -2207,6 +2207,7 @@ spawn reasons:
 	# 1.21
 	trial_spawner: trial spawner, trial mob spawner, trial creature spawner
 	enchantment: enchantment
+	# 1.21.8
 	rehydration: rehydration, rehydrate
 
 # -- Difficulties --

--- a/src/test/resources/runner_data/bukkit.yml.generic
+++ b/src/test/resources/runner_data/bukkit.yml.generic
@@ -1,0 +1,34 @@
+# Copy of 1.21.8
+
+settings:
+  allow-end: false # Skript
+  warn-on-overload: false # Skript
+  permissions-file: permissions.yml
+  update-folder: update
+  plugin-profiling: false
+  connection-throttle: 4000
+  query-plugins: true
+  deprecated-verbose: default
+  shutdown-message: Server closed
+  minimum-api: none
+  use-map-color-cache: true
+spawn-limits:
+  monsters: 70
+  animals: 10
+  water-animals: 5
+  water-ambient: 20
+  water-underground-creature: 5
+  axolotls: 5
+  ambient: 15
+chunk-gc:
+  period-in-ticks: 600
+ticks-per:
+  animal-spawns: 400
+  monster-spawns: 1
+  water-spawns: 1
+  water-ambient-spawns: 1
+  water-underground-creature-spawns: 1
+  axolotl-spawns: 1
+  ambient-spawns: 1
+  autosave: 6000
+aliases: now-in-commands.yml

--- a/src/test/skript/environments/java17/paper-1.19.4.json
+++ b/src/test/skript/environments/java17/paper-1.19.4.json
@@ -1,7 +1,8 @@
 {
 	"name": "paper-1.19.4",
 	"resources": [
-		{"source": "server.properties.generic", "target": "server.properties"}
+		{"source": "server.properties.generic", "target": "server.properties"},
+		{"source": "bukkit.yml.generic", "target": "bukkit.yml"}
 	],
 	"paperDownloads": [
 		{

--- a/src/test/skript/environments/java17/paper-1.20.4.json
+++ b/src/test/skript/environments/java17/paper-1.20.4.json
@@ -1,7 +1,8 @@
 {
 	"name": "paper-1.20.4",
 	"resources": [
-		{"source": "server.properties.generic", "target": "server.properties"}
+		{"source": "server.properties.generic", "target": "server.properties"},
+		{"source": "bukkit.yml.generic", "target": "bukkit.yml"}
 	],
 	"paperDownloads": [
 		{

--- a/src/test/skript/environments/java21/paper-1.20.6.json
+++ b/src/test/skript/environments/java21/paper-1.20.6.json
@@ -1,7 +1,8 @@
 {
 	"name": "paper-1.20.6",
 	"resources": [
-		{"source": "server.properties.generic", "target": "server.properties"}
+		{"source": "server.properties.generic", "target": "server.properties"},
+		{"source": "bukkit.yml.generic", "target": "bukkit.yml"}
 	],
 	"paperDownloads": [
 		{

--- a/src/test/skript/environments/java21/paper-1.21.3.json
+++ b/src/test/skript/environments/java21/paper-1.21.3.json
@@ -1,7 +1,8 @@
 {
 	"name": "paper-1.21.3",
 	"resources": [
-		{"source": "server.properties.generic", "target": "server.properties"}
+		{"source": "server.properties.generic", "target": "server.properties"},
+		{"source": "bukkit.yml.generic", "target": "bukkit.yml"}
 	],
 	"paperDownloads": [
 		{

--- a/src/test/skript/environments/java21/paper-1.21.4.json
+++ b/src/test/skript/environments/java21/paper-1.21.4.json
@@ -1,7 +1,8 @@
 {
 	"name": "paper-1.21.4",
 	"resources": [
-		{"source": "server.properties.generic", "target": "server.properties"}
+		{"source": "server.properties.generic", "target": "server.properties"},
+		{"source": "bukkit.yml.generic", "target": "bukkit.yml"}
 	],
 	"paperDownloads": [
 		{

--- a/src/test/skript/environments/java21/paper-1.21.5.json
+++ b/src/test/skript/environments/java21/paper-1.21.5.json
@@ -1,7 +1,8 @@
 {
 	"name": "paper-1.21.5",
 	"resources": [
-		{"source": "server.properties.generic", "target": "server.properties"}
+		{"source": "server.properties.generic", "target": "server.properties"},
+		{"source": "bukkit.yml.generic", "target": "bukkit.yml"}
 	],
 	"paperDownloads": [
 		{

--- a/src/test/skript/environments/java21/paper-1.21.8.json
+++ b/src/test/skript/environments/java21/paper-1.21.8.json
@@ -1,7 +1,8 @@
 {
 	"name": "paper-1.21.8",
 	"resources": [
-		{"source": "server.properties.generic", "target": "server.properties"}
+		{"source": "server.properties.generic", "target": "server.properties"},
+		{"source": "bukkit.yml.generic", "target": "bukkit.yml"}
 	],
 	"paperDownloads": [
 		{

--- a/src/test/skript/junit/EvtHarvestBlockTest.sk
+++ b/src/test/skript/junit/EvtHarvestBlockTest.sk
@@ -2,9 +2,9 @@ options:
 	test: "org.skriptlang.skript.test.tests.syntaxes.events.EvtHarvestBlockTest"
 
 test "EvtHarvestBlock" when running junit:
-	set {_tests::*} to "event plain - called", "event plain - player", "event plain - block", "event plain - equipment"
+	set {_tests::*} to "event plain - called", "event plain - player", "event plain - block" and "event plain - equipment"
 	add "event plain - drops" to {_tests::*}
-	add "event typed - called", "event typed - player", "event typed - block", "event typed - equipment" to {_tests::*}
+	add "event typed - called", "event typed - player", "event typed - block" and "event typed - equipment" to {_tests::*}
 	add "event typed - drops" to {_tests::*}
 
 	ensure {@test} completes {_tests::*}

--- a/src/test/skript/tests/misc/effect commands.sk
+++ b/src/test/skript/tests/misc/effect commands.sk
@@ -1,4 +1,4 @@
 test "effect commands":
 
 	# assume if something goes wrong we'll get an exception
-	execute console command "!broadcast ""effect commands test"""
+	execute console command "!set {test} to ""effect commands test"""

--- a/src/test/skript/tests/misc/literal multiple infos warning.sk
+++ b/src/test/skript/tests/misc/literal multiple infos warning.sk
@@ -9,6 +9,9 @@ parse:
 		function a():: object:
 			return unknown
 
+function empty():
+	stop
+
 test "literal multiple infos warning":
 	parse:
 		set {_test} to unknown
@@ -16,12 +19,12 @@ test "literal multiple infos warning":
 
 	parse:
 		if {_list::*} contains unknown:
-			broadcast "Filler"
+			empty()
 	assert last parse logs matches {@error} with "Contains should throw warning"
 
 	parse:
 		if the 1st element of {_list::*} is unknown:
-			broadcast "filler"
+			empty()
 	assert last parse logs matches {@error} with "Element of should throw warning"
 
 	parse:
@@ -32,7 +35,7 @@ test "literal multiple infos warning":
 	parse:
 		for each {_value} in {_list::*}:
 			if {_value} is unknown:
-				broadcast "filler"
+				empty()
 	assert last parse logs matches {@error} with "For each should throw warning"
 
 	assert {LiteralMultipleWarn::FunctionObject} matches {@error} with "Function with Object return type should throw warning"
@@ -43,7 +46,7 @@ parse:
 	code:
 		on damage:
 			if damage cause is unknown:
-				broadcast "filler"
+				empty()
 
 parse:
 	results: {LiteralMultipleNoWarn::FunctionDamageCause}

--- a/src/test/skript/tests/misc/literal multiple infos warning.sk
+++ b/src/test/skript/tests/misc/literal multiple infos warning.sk
@@ -10,7 +10,7 @@ parse:
 			return unknown
 
 function empty():
-	stop
+	exit
 
 test "literal multiple infos warning":
 	parse:

--- a/src/test/skript/tests/regressions/6424-inventory-holder-location.sk
+++ b/src/test/skript/tests/regressions/6424-inventory-holder-location.sk
@@ -1,7 +1,6 @@
 test "inventory holder location":
 	set {_b} to the test-block
 	set {_prev} to type of block at {_b}
-	broadcast {_prev}
 
 	set block at {_b} to a chest
 	set {_inv} to inventory of {_b}

--- a/src/test/skript/tests/regressions/7718-broadcast evaluates vstrings twice.sk
+++ b/src/test/skript/tests/regressions/7718-broadcast evaluates vstrings twice.sk
@@ -1,5 +1,5 @@
 test "broadcast evaluates vstrings twice":
-	broadcast "%func()%"
+	broadcast func() in the world "world"
 	assert {7718::calls} is 1 with "Called func() more than once"
 	delete {7718::calls}
 

--- a/src/test/skript/tests/regressions/7940-cond is within not respecting or lists.sk
+++ b/src/test/skript/tests/regressions/7940-cond is within not respecting or lists.sk
@@ -1,4 +1,4 @@
 test "CondIsWithin or lists":
 	set {_loc} to spawn of world "world"
 	loop 10 times:
-		assert {_loc} is within world "world", world "world_nether", or world "world_the_end" with "within or list failed"
+		assert {_loc} is within world "world", world "doesn't exist", or world "another" with "within or list failed"

--- a/src/test/skript/tests/syntaxes/expressions/ExprCustomModelData.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprCustomModelData.sk
@@ -17,7 +17,6 @@ test "new custom model data expression" when running minecraft "1.21.4":
 
 	set model data strings of {_item} to "hello" and "world"
 	assert model data of {_item} is 456 with "wrong model data"
-	broadcast full model data of {_item}
 	assert full model data of {_item} is 456, 52, "hello", and "world" with "wrong full model data"
 	assert model data floats of {_item} is 456 and 52 with "wrong model data floats"
 	assert model data flags of {_item} is not set with "wrong model data flags"

--- a/src/test/skript/tests/syntaxes/expressions/ExprHash.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprHash.sk
@@ -1,4 +1,5 @@
 test "MD5 hash":
+	suppress deprecated syntax warning
 	assert "hello world" hashed with MD5 is "5eb63bbbe01eeed093cb22bb8f5acdc3" with "incorrect hash"
 
 test "SHA-256 hash":

--- a/src/test/skript/tests/syntaxes/expressions/ExprVectorBetweenLocations.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprVectorBetweenLocations.sk
@@ -5,11 +5,9 @@ test "vector between locations":
 	set {_vec} to vector between {_loc1} and {_loc2}
 	assert {_vec} is vector(10,10,10) with "vector between locations in same world failed (expected %vector(10,10,10)%, got %{_vec}%)"
 
-	set {_world2} to world("world_the_end")
-	assert {_world2} is set with "no end world found"
-	set {_loc3} to location(10,10,10,{_world2})
+	set {_loc3} to location(10,10,10)
 	set {_vec2} to vector between {_loc1} and {_loc3}
-	assert {_vec2} is vector(10,10,10) with "vector between locations in different worlds failed (expected %vector(10,10,10)%, got %{_vec2}%)"
+	assert {_vec2} is vector(10,10,10) with "vector between locations2 (expected %vector(10,10,10)%, got %{_vec2}%)"
 
 	set {_vec3} to vector between {_loc1} and {_loc1}
 	assert {_vec3} is vector(0,0,0) with "vector between same locations failed (expected %vector(0,0,0)%, got %{_vec3}%)"

--- a/src/test/skript/tests/syntaxes/expressions/ExprVectorBetweenLocations.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprVectorBetweenLocations.sk
@@ -7,7 +7,7 @@ test "vector between locations":
 
 	set {_loc3} to location(10,10,10)
 	set {_vec2} to vector between {_loc1} and {_loc3}
-	assert {_vec2} is vector(10,10,10) with "vector between locations2 (expected %vector(10,10,10)%, got %{_vec2}%)"
+	assert {_vec2} is vector(10,10,10) with "vector between locations 1 and 3 (expected %vector(10,10,10)%, got %{_vec2}%)"
 
 	set {_vec3} to vector between {_loc1} and {_loc1}
 	assert {_vec3} is vector(0,0,0) with "vector between same locations failed (expected %vector(0,0,0)%, got %{_vec3}%)"

--- a/src/test/skript/tests/syntaxes/expressions/ExprVectorBetweenLocations.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprVectorBetweenLocations.sk
@@ -5,9 +5,5 @@ test "vector between locations":
 	set {_vec} to vector between {_loc1} and {_loc2}
 	assert {_vec} is vector(10,10,10) with "vector between locations in same world failed (expected %vector(10,10,10)%, got %{_vec}%)"
 
-	set {_loc3} to location(10,10,10)
-	set {_vec2} to vector between {_loc1} and {_loc3}
-	assert {_vec2} is vector(10,10,10) with "vector between locations 1 and 3 (expected %vector(10,10,10)%, got %{_vec2}%)"
-
 	set {_vec3} to vector between {_loc1} and {_loc1}
 	assert {_vec3} is vector(0,0,0) with "vector between same locations failed (expected %vector(0,0,0)%, got %{_vec3}%)"

--- a/src/test/skript/tests/syntaxes/expressions/ExprWorldEnvironment.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprWorldEnvironment.sk
@@ -1,5 +1,4 @@
 test "world environment":
 	assert environment of world "world" is normal with "main overworld was not environment ""normal"""
-	assert environment of world "world_the_end" is the end with "world_the_end was not environment ""the end"""
 	set {_environment} to environment of world "world"
 	assert {_environment} is overworld with "environment of world didn't compare with a variable"


### PR DESCRIPTION
### Problem
There are some random debug broadcasts, and tests that broadcast, some tests printing warnings. The End world is generating when it doesn't need to be, been meaning to remove that since I added the resources similarly to the nether being disabled, and there are some missing default lang nodes.

### Solution
To fix the tests, add a bukkit.yml to avoid generating the end so that the boolean is set to false, and add the missing default lang nodes. The extra broadcasts and the end generating aren't needed because they just slow down the tests. Increases the gradle memory, ensures to not include skript-aliases project when building. Also fixes missing gradle tasks in the category:
```
Skript tasks
------------
checkAliases - Checks for the existence of the aliases.
genNightlyDocs - Generates the Skript documentation website html files.
genReleaseDocs - Generates the Skript documentation website html files for a release.
JUnit - Runs JUnit tests on all environments.
JUnitJava17 - Runs JUnit tests on all Java 17 environments.
JUnitJava21 - Runs JUnit tests on all Java 21 environments.
JUnitQuick - Runs JUnit tests on one environment being the latest supported Java and Minecraft.
quickTest - Runs tests on one environment being the latest supported Java and Minecraft.
quickTests - Runs quick test and junit quick.
skriptProfile - Starts the testing server with JProfiler support.
skriptTest - Runs tests on all environments.
skriptTestDev - Runs testing server and uses 'system.in' for command input, stop server to finish.
skriptTestJava17 - Runs tests on all Java 17 environments.
skriptTestJava21 - Runs tests on all Java 21 environments.
```

---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
