### PR TITLE
Fix loss of converter info with ExprLoopValue

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprLoopValue.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLoopValue.java
@@ -1,20 +1,17 @@
 package ch.njol.skript.expressions;
 
 import ch.njol.skript.Skript;
-import ch.njol.skript.lang.KeyProviderExpression;
-import ch.njol.skript.lang.KeyedValue;
-import org.skriptlang.skript.lang.converter.ConverterInfo;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.KeyProviderExpression;
+import ch.njol.skript.lang.KeyedValue;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.skript.lang.util.ConvertedExpression;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.skript.registrations.Classes;
-import org.skriptlang.skript.lang.converter.Converters;
 import ch.njol.skript.sections.SecLoop;
 import ch.njol.skript.util.Utils;
 import ch.njol.util.Kleenean;
@@ -148,19 +145,6 @@ public class ExprLoopValue extends SimpleExpression<Object> {
 	@Override
 	public boolean isSingle() {
 		return true;
-	}
-	
-	@Override
-	@Nullable
-	@SuppressWarnings("unchecked")
-	protected <R> ConvertedExpression<Object, ? extends R> getConvertedExpr(Class<R>... to) {
-		if (isKeyedLoop && !isIndex) {
-			Class<R> superType = (Class<R>) Utils.getSuperType(to);
-			return new ConvertedExpression<>(this, superType,
-					new ConverterInfo<>(Object.class, superType, o -> Converters.convert(o, to), 0));
-		} else {
-			return super.getConvertedExpr(to);
-		}
 	}
 	
 	@Override

--- a/src/test/skript/tests/regressions/8108-exprloopvalue losing converter info.sk
+++ b/src/test/skript/tests/regressions/8108-exprloopvalue losing converter info.sk
@@ -1,0 +1,23 @@
+###
+this test converts an itemtype to itemstack, which is not AnyNamed.
+If the loop value loses its converter info, it will not be
+able to use the name of loop-value expression.
+This is due to the returned value being ItemStack, and failing
+the instanceof AnyNamed check.
+
+If the loop value retains its converter info, it will be able to
+convert to AnyNamed and use the name of loop-value expression.
+###
+
+
+test "expr loop value loses converter info":
+	set {_item::*} to asItemStack(phantom membrane named "Test")
+	loop {_item::*}:
+		# these should always pass
+		assert loop-value is a phantom membrane with "loop-value is not a phantom membrane"
+		assert loop-value is a phantom membrane named "Test" with "loop-value is not a phantom membrane named 'Test'"
+		# the critical assert
+		assert name of loop-value is "Test" with "name of loop-value is not 'Test'. ExprLoopValue may have lost converter info"
+
+local function asItemStack(i: item) :: item:
+    return {_i}


### PR DESCRIPTION

### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
In specific cases, `loop-value` failed to convert to the expected type due to a loss of converter info that lead to simplification ultimately determining that it only needed an Object -> Object converter, which is effectively `return this`. This lead to issues like #8108 where the name of loop-value could not be determined due to an ItemStack being returned, which is not AnyNamed, rather than the ItemStack being converted to AnyNamed via ItemType.

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
The problem stemmed from ExprLoopValue#getConvertedExpression, which had a special implementation that at one point was probably useful? It effectively just made a dynamic converter using Converters.convert to attempt each possible to type in order. 

Sharp-eyed viewers may note this as being what ConvertedExpression#newInstance does during init, so really it's just a runtime call to CE#newInstance, if we're matching high level behavior. However, it results in a CE that thinks it's just a simple Object->Object converter and doesn't actually know what it's supposed to be doing, leading to the loss of info mentioned previously.

Replacing this special converter with CE#newInstance results in the expected ConvertedExpression being formed, with CInfos to each of the possible return types, and all the necessary information retained. This also makes the condition in ELV#gCE() useless, since the super impl is just CE#newInstance, so the whole method can be and was removed.

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
Added a new regression test based on the code provided in #8108.

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** #8108 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
