### PR TITLE
Adds an ARGB method to the Color API

### DIFF
--- a/src/main/java/ch/njol/skript/util/Color.java
+++ b/src/main/java/ch/njol/skript/util/Color.java
@@ -44,4 +44,12 @@ public interface Color extends YggdrasilExtendedSerializable {
 	 */
 	String getName();
 
+	/**
+	 * Gets the color as an ARGB integer.
+	 * @return ARGB integer.
+	 */
+	default int asARGB() {
+		return asBukkitColor().asARGB();
+	}
+
 }


### PR DESCRIPTION
### Problem
Minecraft internally in NMS uses ARGB frequently. Skript base Color class doesn't have a quick method for getting the ARGB of a color without being a SkriptColor

### Solution
Adds a method to allow overriding ARGB in your custom implementation Color class.

---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
