### PR TITLE
Fix nullable direction combine

### DIFF
--- a/src/main/java/ch/njol/skript/util/Direction.java
+++ b/src/main/java/ch/njol/skript/util/Direction.java
@@ -357,8 +357,15 @@ public class Direction implements YggdrasilRobustSerializable {
 			}
 		}
 	}
-	
-	public static Expression<Location> combine(final Expression<? extends Direction> dirs, final Expression<? extends Location> locs) {
+
+	/*
+	 * Combines direction and location expressions.
+	 * Useful for syntaxes to allow Skripters to have more control over their locations.
+	 */
+	public static @Nullable Expression<Location> combine(final Expression<? extends Direction> dirs, final Expression<? extends Location> locs) {
+		if (dirs == null || locs == null)
+			return null;
+
 		return new SimpleExpression<Location>() {
 			@SuppressWarnings("null")
 			@Override

--- a/src/main/java/ch/njol/skript/util/Direction.java
+++ b/src/main/java/ch/njol/skript/util/Direction.java
@@ -361,8 +361,11 @@ public class Direction implements YggdrasilRobustSerializable {
 	/*
 	 * Combines direction and location expressions.
 	 * Useful for syntaxes to allow Skripters to have more control over their locations.
+	 * @param dirs The direction expressions to combine.
+	 * @param locs The location expressions to combine.
+	 * @return A combined expression or null if any of the inputs are null.
 	 */
-	public static @Nullable Expression<Location> combine(final Expression<? extends Direction> dirs, final Expression<? extends Location> locs) {
+	public static @Nullable Expression<Location> combine(@Nullable Expression<? extends Direction> dirs, @Nullable Expression<? extends Location> locs) {
 		if (dirs == null || locs == null)
 			return null;
 


### PR DESCRIPTION
### Problem
If your syntax has nullable expressions `[%-direction% %-location%]` and used directly `expression = Direction.combine((Expression<Direction>) exprs[0], (Expression<Location>) exprs[1]);` it'll throw a null pointer on use.

### Solution
Rather than having to check if both expressions are null before calling the combine method, you can now properly do the single line call, and the returned expression will be the expected null if the syntax was wanting the expression to be null if not present.

---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
