### PR TITLE
Support for the SyntaxInfo suppliers

### DIFF
--- a/src/main/java/ch/njol/skript/lang/ExpressionInfo.java
+++ b/src/main/java/ch/njol/skript/lang/ExpressionInfo.java
@@ -2,6 +2,8 @@ package ch.njol.skript.lang;
 
 import org.jetbrains.annotations.Nullable;
 
+import java.util.function.Supplier;
+
 /**
  * Represents an expression's information, for use when creating new instances of expressions.
  */
@@ -10,12 +12,24 @@ public class ExpressionInfo<E extends Expression<T>, T> extends SyntaxElementInf
 	public @Nullable ExpressionType expressionType;
 	public Class<T> returnType;
 
-	public ExpressionInfo(String[] patterns, Class<T> returnType, Class<E> expressionClass, String originClassPath) throws IllegalArgumentException {
-		this(patterns, returnType, expressionClass, originClassPath, null);
+	public ExpressionInfo(String[] patterns, Class<T> returnType, Class<E> expressionClass, String originClassPath)
+			throws IllegalArgumentException {
+		this(patterns, returnType, expressionClass, originClassPath, (Supplier<E>) null);
 	}
 
-	public ExpressionInfo(String[] patterns, Class<T> returnType, Class<E> expressionClass, String originClassPath, @Nullable ExpressionType expressionType) throws IllegalArgumentException {
-		super(patterns, expressionClass, originClassPath);
+	public ExpressionInfo(String[] patterns, Class<T> returnType, Class<E> expressionClass, String originClassPath,
+			@Nullable Supplier<E> supplier) throws IllegalArgumentException {
+		this(patterns, returnType, expressionClass, originClassPath, null, supplier);
+	}
+
+	public ExpressionInfo(String[] patterns, Class<T> returnType, Class<E> expressionClass, String originClassPath,
+			@Nullable ExpressionType expressionType) {
+		this(patterns, returnType, expressionClass, originClassPath, expressionType, null);
+	}
+
+	public ExpressionInfo(String[] patterns, Class<T> returnType, Class<E> expressionClass, String originClassPath,
+			@Nullable ExpressionType expressionType, @Nullable Supplier<E> supplier) throws IllegalArgumentException {
+		super(patterns, expressionClass, originClassPath, supplier);
 		this.returnType = returnType;
 		this.expressionType = expressionType;
 	}

--- a/src/main/java/ch/njol/skript/lang/SkriptEventInfo.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptEventInfo.java
@@ -20,6 +20,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Supplier;
 
 public sealed class SkriptEventInfo<E extends SkriptEvent> extends StructureInfo<E> permits ModernSkriptEventInfo {
 
@@ -32,15 +33,22 @@ public sealed class SkriptEventInfo<E extends SkriptEvent> extends StructureInfo
 
 	private final String id;
 
+	public SkriptEventInfo(String name, String[] patterns, Class<E> eventClass, String originClassPath,
+			Class<? extends Event>[] events) {
+		this(name, patterns, eventClass, originClassPath, events, null);
+	}
+
 	/**
 	 * @param name Capitalised name of the event without leading "On" which is added automatically (Start the name with an asterisk to prevent this).
 	 * @param patterns The Skript patterns to use for this event
 	 * @param eventClass The SkriptEvent's class
 	 * @param originClassPath The class path for the origin of this event.
 	 * @param events The Bukkit-Events this SkriptEvent listens to
+	 * @param supplier supplier ofr the syntax info instance
 	 */
-	public SkriptEventInfo(String name, String[] patterns, Class<E> eventClass, String originClassPath, Class<? extends Event>[] events) {
-		super(patterns, eventClass, originClassPath);
+	public SkriptEventInfo(String name, String[] patterns, Class<E> eventClass, String originClassPath,
+			Class<? extends Event>[] events, @Nullable Supplier<E> supplier) {
+		super(patterns, eventClass, originClassPath, supplier);
 		for (int i = 0; i < events.length; i++) {
 			for (int j = i + 1; j < events.length; j++) {
 				if (events[i].isAssignableFrom(events[j]) || events[j].isAssignableFrom(events[i])) {

--- a/src/main/java/org/skriptlang/skript/lang/structure/StructureInfo.java
+++ b/src/main/java/org/skriptlang/skript/lang/structure/StructureInfo.java
@@ -6,6 +6,8 @@ import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.entry.EntryValidator;
 import org.skriptlang.skript.registration.SyntaxInfo;
 
+import java.util.function.Supplier;
+
 /**
  * Special {@link SyntaxElementInfo} for {@link Structure}s that may contain information such as the {@link EntryValidator}.
  */
@@ -23,21 +25,42 @@ public class StructureInfo<E extends Structure> extends SyntaxElementInfo<E> {
 	public final SyntaxInfo.Structure.NodeType nodeType;
 
 	public StructureInfo(String[] patterns, Class<E> c, String originClassPath) throws IllegalArgumentException {
-		this(patterns, c, originClassPath, false);
+		this(patterns, c, originClassPath, (Supplier<E>) null);
 	}
 
-	public StructureInfo(String[] patterns, Class<E> elementClass, String originClassPath, boolean simple) throws IllegalArgumentException {
-		this(patterns, elementClass, originClassPath, null, simple ? SyntaxInfo.Structure.NodeType.SIMPLE : SyntaxInfo.Structure.NodeType.SECTION);
+	public StructureInfo(String[] patterns, Class<E> c, String originClassPath,
+			@Nullable Supplier<E> supplier) throws IllegalArgumentException {
+		this(patterns, c, originClassPath, false, supplier);
 	}
 
-	public StructureInfo(String[] patterns, Class<E> elementClass, String originClassPath, @Nullable EntryValidator entryValidator) throws IllegalArgumentException {
+	public StructureInfo(String[] patterns, Class<E> elementClass, String originClassPath, boolean simple)
+			throws IllegalArgumentException {
+		this(patterns, elementClass, originClassPath, simple, null);
+	}
+
+	public StructureInfo(String[] patterns, Class<E> elementClass, String originClassPath, boolean simple,
+			@Nullable Supplier<E> supplier) throws IllegalArgumentException {
+		this(patterns, elementClass, originClassPath, null,
+			simple ? SyntaxInfo.Structure.NodeType.SIMPLE : SyntaxInfo.Structure.NodeType.SECTION, supplier);
+	}
+
+	public StructureInfo(String[] patterns, Class<E> elementClass, String originClassPath,
+			@Nullable EntryValidator entryValidator) throws IllegalArgumentException {
 		this(patterns, elementClass, originClassPath, entryValidator, SyntaxInfo.Structure.NodeType.SECTION);
 	}
 
 	@ApiStatus.Experimental
 	public StructureInfo(String[] patterns, Class<E> elementClass, String originClassPath,
-						 @Nullable EntryValidator entryValidator, SyntaxInfo.Structure.NodeType nodeType) throws IllegalArgumentException {
-		super(patterns, elementClass, originClassPath);
+			@Nullable EntryValidator entryValidator, SyntaxInfo.Structure.NodeType nodeType)
+			throws IllegalArgumentException {
+		this(patterns, elementClass, originClassPath, entryValidator, nodeType, null);
+	}
+
+	@ApiStatus.Experimental
+	public StructureInfo(String[] patterns, Class<E> elementClass, String originClassPath,
+			@Nullable EntryValidator entryValidator, SyntaxInfo.Structure.NodeType nodeType,
+			@Nullable Supplier<E> supplier) {
+		super(patterns, elementClass, originClassPath, supplier);
 		this.entryValidator = entryValidator;
 		this.nodeType = nodeType;
 		this.simple = nodeType.canBeSimple();

--- a/src/main/java/org/skriptlang/skript/util/ClassUtils.java
+++ b/src/main/java/org/skriptlang/skript/util/ClassUtils.java
@@ -1,6 +1,13 @@
 package org.skriptlang.skript.util;
 
+import com.google.common.base.Preconditions;
+
+import java.lang.invoke.*;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
 /**
  * Utilities for interacting with classes.
@@ -14,6 +21,38 @@ public final class ClassUtils {
 	public static boolean isNormalClass(Class<?> clazz) {
 		return !clazz.isAnnotation() && !clazz.isArray() && !clazz.isPrimitive()
 				&& !clazz.isInterface() && !Modifier.isAbstract(clazz.getModifiers());
+	}
+
+	private static final Map<Class<?>, Supplier<?>> instanceSuppliers = new ConcurrentHashMap<>();
+
+	/**
+	 * Creates supplier for given class if its nullary constructor exists.
+	 *
+	 * @param type class to create the supplier for
+	 * @return supplier for the instances of given class, using its nullary constructor
+	 * @param <T> type
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> Supplier<T> instanceSupplier(Class<T> type) throws Throwable {
+		Supplier<?> cached = instanceSuppliers.get(type);
+		if (cached != null)
+			return (Supplier<T>) cached;
+		Preconditions.checkArgument(
+			!Modifier.isAbstract(type.getModifiers()) && !Modifier.isInterface(type.getModifiers()),
+			"You can not create instance supplier for abstract classes");
+		Constructor<T> nullaryConstructor = type.getDeclaredConstructor();
+		MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(type, MethodHandles.lookup());
+		MethodHandle methodHandle = lookup.unreflectConstructor(nullaryConstructor);
+		CallSite callSite = LambdaMetafactory.metafactory(lookup,
+			"get",
+			MethodType.methodType(Supplier.class),
+			MethodType.methodType(Object.class),
+			methodHandle,
+			methodHandle.type()
+		);
+		Supplier<T> created = (Supplier<T>) callSite.getTarget().invokeExact();
+		instanceSuppliers.put(type, created);
+		return created;
 	}
 
 }


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
The syntax info suppliers developers can provide in the new API are unused (lost during the conversion to SyntaxElementInfo). Skript parser then tries to create the instance using nullary constructor.

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
SyntaxElementInfo now stores its instance supplier. If none is provided, it uses the nullary constructor instead.
I also replaced repeated reflection calls with Supplier created using LambdaMetafactory that delegates to the nullary constructor.

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
quick test

---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
