### PR TITLE
Allowed Sub Types in EntryDataExpression

### DIFF
--- a/src/main/java/org/skriptlang/skript/lang/entry/util/ExpressionEntryData.java
+++ b/src/main/java/org/skriptlang/skript/lang/entry/util/ExpressionEntryData.java
@@ -18,7 +18,7 @@ public class ExpressionEntryData<T> extends KeyValueEntryData<Expression<? exten
 
 	private static final Message M_IS = new Message("is");
 
-	private final Class<T>[] returnTypes;
+	private final Class<? extends T>[] returnTypes;
 
 	private final int flags;
 
@@ -26,7 +26,7 @@ public class ExpressionEntryData<T> extends KeyValueEntryData<Expression<? exten
 	 * @param returnType The expected return type of the matched expression.
 	 */
 	public ExpressionEntryData(
-		String key, @Nullable Expression<T> defaultValue, boolean optional, Class<T> returnType
+		String key, @Nullable Expression<? extends T> defaultValue, boolean optional, Class<? extends T> returnType
 	) {
 		this(key, defaultValue, optional, SkriptParser.ALL_FLAGS, returnType);
 	}
@@ -37,7 +37,7 @@ public class ExpressionEntryData<T> extends KeyValueEntryData<Expression<? exten
 	 *              javadoc for more details.
 	 */
 	public ExpressionEntryData(
-		String key, @Nullable Expression<T> defaultValue, boolean optional, Class<T> returnType, int flags
+		String key, @Nullable Expression<? extends T> defaultValue, boolean optional, Class<? extends T> returnType, int flags
 	) {
 		this(key, defaultValue, optional, flags, returnType);
 	}
@@ -47,7 +47,7 @@ public class ExpressionEntryData<T> extends KeyValueEntryData<Expression<? exten
 	 */
 	@SafeVarargs
 	public ExpressionEntryData(
-		String key, @Nullable Expression<T> defaultValue, boolean optional, Class<T>... returnTypes
+		String key, @Nullable Expression<? extends T> defaultValue, boolean optional, Class<? extends T>... returnTypes
 	) {
 		this(key, defaultValue, optional, SkriptParser.ALL_FLAGS, returnTypes);
 	}
@@ -59,7 +59,7 @@ public class ExpressionEntryData<T> extends KeyValueEntryData<Expression<? exten
 	 */
 	@SafeVarargs
 	public ExpressionEntryData(
-		String key, @Nullable Expression<T> defaultValue, boolean optional, int flags, Class<T>... returnTypes
+		String key, @Nullable Expression<? extends T> defaultValue, boolean optional, int flags, Class<? extends T>... returnTypes
 	) {
 		super(key, defaultValue, optional);
 		this.returnTypes = returnTypes;
@@ -68,7 +68,6 @@ public class ExpressionEntryData<T> extends KeyValueEntryData<Expression<? exten
 
 	@Override
 	@Nullable
-	@SuppressWarnings("unchecked")
 	protected Expression<? extends T> getValue(String value) {
 		Expression<? extends T> expression;
 		try (ParseLogHandler log = new ParseLogHandler().start()) {


### PR DESCRIPTION
### Problem
Previously, EntryDataExpression used T as the generic parameter for both the default value and the return types, this causes generics issues and didn't allow sub types to be used


### Solution
Allow sub types.

---
**Completes:** none that i'm aware of
**Related:** none that i'm aware of
