### PR TITLE
Fix function list params with single default values and improve safety of loading functions

### DIFF
--- a/src/main/java/ch/njol/skript/lang/function/Function.java
+++ b/src/main/java/ch/njol/skript/lang/function/Function.java
@@ -96,6 +96,8 @@ public abstract class Function<T> {
 				if (parameter.keyed && KeyProviderExpression.areKeysRecommended(parameter.def)) {
 					String[] keys = ((KeyProviderExpression<?>) parameter.def).getArrayKeys(event);
 					parameterValue = KeyedValue.zip(defaultValue, keys);
+				} else if (parameter.keyed && defaultValue.length == 1) { // see https://github.com/SkriptLang/Skript/pull/8135
+					parameterValue = KeyedValue.zip(defaultValue, null);
 				} else {
 					parameterValue = defaultValue;
 				}
@@ -127,8 +129,7 @@ public abstract class Function<T> {
 
 	private KeyedValue<Object> @Nullable [] convertToKeyed(Object[] values) {
 		if (values == null || values.length == 0)
-			//noinspection unchecked
-			return new KeyedValue[0];
+			return null;
 
 		if (values instanceof KeyedValue[])
 			//noinspection unchecked

--- a/src/main/java/ch/njol/skript/lang/function/Functions.java
+++ b/src/main/java/ch/njol/skript/lang/function/Functions.java
@@ -98,7 +98,17 @@ public abstract class Functions {
 			Skript.debug((signature.local ? "local " : "") + "function " + name + "(" + StringUtils.join(params, ", ") + ")"
 				+ (c != null ? " :: " + (signature.isSingle() ? c.getName().getSingular() : c.getName().getPlural()) : "") + ":");
 
-		Function<?> function = new ScriptFunction<>(signature, node);
+		Function<?> function;
+		try {
+			function = new ScriptFunction<>(signature, node);
+		} catch (SkriptAPIException ex) {
+			//noinspection ThrowableNotThrown
+			Skript.exception(ex, "Error while trying to load a function");
+
+			// avoid getting a "function is already registered" error when the function implementation is not known yet
+			Functions.unregisterFunction(signature);
+			return null;
+		}
 
 		if (namespace.getFunction(signature.name) == null) {
 			namespace.addFunction(function);

--- a/src/test/skript/tests/syntaxes/structures/StructFunction.sk
+++ b/src/test/skript/tests/syntaxes/structures/StructFunction.sk
@@ -46,3 +46,9 @@ test "function structure type hints":
 	parse:
 		type_hint_argument_test({_number})
 	assert the first element of the last parse logs is set # contains "The function 'type_hint_argument_test(boolean)' does not exist." (NEEDS FIXING)
+
+local function list_argument_single_default(x: texts="hey") :: texts:
+    return {_x::*}
+
+test "function list argument with a single default":
+	assert list_argument_single_default() = "hey"


### PR DESCRIPTION
### Problem
**Problem 1**

```applescript
local function test(arg1: texts="hey"):
    broadcast {_arg1::*}

on load:
    test()
```
The following code would not set `{_arg1::*}` to any value. Therefore, this code would return null.

**Problem 2**
Errors occurring during loading of functions would cause the function signature to be taken. This would disallow reloading the script to try and fix the problem, as the signature would still be in memory. This is mainly to improve reliability with addons who do not correctly handle invalid values.

### Solution
**Problem 1**
If a parameter is keyed and there is only one default value, the code will now convert this single value to a KeyedValue, allowing the variable to be set correctly. 

**Problem 2**
Adds a try/catch to loading ScriptFunctions. On a SkriptAPIException, the signature will be de-registered. This will allow users to attempt re-registration.

### Testing Completed

**Problem 1**
Added test to StructFunction.

**Problem 2**
Manual testing.

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
