### PR TITLE
Remove extra colon from fire resistant documentation example

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffFireResistant.java
+++ b/src/main/java/ch/njol/skript/effects/EffFireResistant.java
@@ -18,43 +18,43 @@ import org.jetbrains.annotations.Nullable;
 @Name("Make Fire Resistant")
 @Description("Makes items fire resistant.")
 @Examples({
-    "make player's tool fire resistant",
-    "make {_items::*} not resistant to fire"
+	"make player's tool fire resistant",
+	"make {_items::*} not resistant to fire"
 })
 @RequiredPlugins("Spigot 1.20.5+")
 @Since("2.9.0")
 public class EffFireResistant extends Effect {
 
-    static {
-        if (Skript.methodExists(ItemMeta.class, "setFireResistant", boolean.class)) {
-            Skript.registerEffect(EffFireResistant.class, "make %itemtypes% [:not] (fire resistant|resistant to fire)");
-        }
-    }
+	static {
+		if (Skript.methodExists(ItemMeta.class, "setFireResistant", boolean.class)) {
+			Skript.registerEffect(EffFireResistant.class, "make %itemtypes% [:not] (fire resistant|resistant to fire)");
+		}
+	}
 
-    @SuppressWarnings("NotNullFieldNotInitialized")
-    private Expression<ItemType> items;
-    private boolean not;
+	@SuppressWarnings("NotNullFieldNotInitialized")
+	private Expression<ItemType> items;
+	private boolean not;
 
-    @Override
-    @SuppressWarnings("unchecked")
-    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-        items = (Expression<ItemType>) exprs[0];
-        not = parseResult.hasTag("not");
-        return true;
-    }
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		items = (Expression<ItemType>) exprs[0];
+		not = parseResult.hasTag("not");
+		return true;
+	}
 
-    @Override
-    protected void execute(Event event) {
-        for (ItemType item : this.items.getArray(event)) {
-            ItemMeta meta = item.getItemMeta();
-            meta.setFireResistant(!not);
-            item.setItemMeta(meta);
-        }
-    }
+	@Override
+	protected void execute(Event event) {
+		for (ItemType item : this.items.getArray(event)) {
+			ItemMeta meta = item.getItemMeta();
+			meta.setFireResistant(!not);
+			item.setItemMeta(meta);
+		}
+	}
 
-    @Override
-    public String toString(@Nullable Event event, boolean debug) {
-        return "make " + items.toString(event, debug) + (not ? " not" : "") + " fire resistant";
-    }
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "make " + items.toString(event, debug) + (not ? " not" : "") + " fire resistant";
+	}
 
 }

--- a/src/main/java/ch/njol/skript/effects/EffFireResistant.java
+++ b/src/main/java/ch/njol/skript/effects/EffFireResistant.java
@@ -18,42 +18,43 @@ import org.jetbrains.annotations.Nullable;
 @Name("Make Fire Resistant")
 @Description("Makes items fire resistant.")
 @Examples({
-	"make player's tool fire resistant:",
-	"make {_items::*} not resistant to fire"
+    "make player's tool fire resistant",
+    "make {_items::*} not resistant to fire"
 })
 @RequiredPlugins("Spigot 1.20.5+")
 @Since("2.9.0")
 public class EffFireResistant extends Effect {
 
-	static {
-		if (Skript.methodExists(ItemMeta.class, "setFireResistant", boolean.class))
-			Skript.registerEffect(EffFireResistant.class, "make %itemtypes% [:not] (fire resistant|resistant to fire)");
-	}
+    static {
+        if (Skript.methodExists(ItemMeta.class, "setFireResistant", boolean.class)) {
+            Skript.registerEffect(EffFireResistant.class, "make %itemtypes% [:not] (fire resistant|resistant to fire)");
+        }
+    }
 
-	@SuppressWarnings("NotNullFieldNotInitialized")
-	private Expression<ItemType> items;
-	private boolean not;
+    @SuppressWarnings("NotNullFieldNotInitialized")
+    private Expression<ItemType> items;
+    private boolean not;
 
-	@Override
-	@SuppressWarnings("unchecked")
-	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		items = (Expression<ItemType>) exprs[0];
-		not = parseResult.hasTag("not");
-		return true;
-	}
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        items = (Expression<ItemType>) exprs[0];
+        not = parseResult.hasTag("not");
+        return true;
+    }
 
-	@Override
-	protected void execute(Event event) {
-		for (ItemType item : this.items.getArray(event)) {
-			ItemMeta meta = item.getItemMeta();
-			meta.setFireResistant(!not);
-			item.setItemMeta(meta);
-		}
-	}
+    @Override
+    protected void execute(Event event) {
+        for (ItemType item : this.items.getArray(event)) {
+            ItemMeta meta = item.getItemMeta();
+            meta.setFireResistant(!not);
+            item.setItemMeta(meta);
+        }
+    }
 
-	@Override
-	public String toString(@Nullable Event event, boolean debug) {
-		return "make " + items.toString(event, debug) + (not ? " not" : "") + " fire resistant";
-	}
+    @Override
+    public String toString(@Nullable Event event, boolean debug) {
+        return "make " + items.toString(event, debug) + (not ? " not" : "") + " fire resistant";
+    }
 
 }


### PR DESCRIPTION
This PR fixes a small documentation issue by removing an extra colon 
from the "Make Fire Resistant" example in EffFireResistant.java.

## Changes
- Removed extra colon from the example:
  ```diff
  - make player's tool fire resistant:
  + make player's tool fire resistant