### PR TITLE
Ensure ExpressionList#possibleReturnTypes is accurate after getConvertedExpression

### DIFF
--- a/src/main/java/ch/njol/skript/lang/ExpressionList.java
+++ b/src/main/java/ch/njol/skript/lang/ExpressionList.java
@@ -149,13 +149,14 @@ public class ExpressionList<T> implements Expression<T> {
 	@SuppressWarnings("unchecked")
 	public <R> @Nullable Expression<? extends R> getConvertedExpression(Class<R>... to) {
 		Expression<? extends R>[] exprs = new Expression[expressions.length];
-		Class<?>[] returnTypes = new Class[expressions.length];
+		Set<Class<?>> possibleReturnTypeSet = new HashSet<>();
 		for (int i = 0; i < exprs.length; i++) {
 			if ((exprs[i] = expressions[i].getConvertedExpression(to)) == null)
 				return null;
-			returnTypes[i] = exprs[i].getReturnType();
+			possibleReturnTypeSet.addAll(Arrays.asList(exprs[i].possibleReturnTypes()));
 		}
-		return new ExpressionList<>(exprs, (Class<R>) Classes.getSuperClassInfo(returnTypes).getC(), returnTypes, and, this);
+		Class<?>[] possibleReturnTypes = possibleReturnTypeSet.toArray(new Class[0]);
+		return new ExpressionList<>(exprs, (Class<R>) Classes.getSuperClassInfo(possibleReturnTypes).getC(), possibleReturnTypes, and, this);
 	}
 
 	@Override


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
During the implementation of type properties, I had some issues with determining the possible return types of a converted ExpressionList. If I converted `me and {tool}` to Player and ItemType, it would give me a EL with the possibleReturnTypes of Player and Object. In getConvertedExpression, it was taking `getReturnType` of the component expressions and using that for possible return types, rather than asking for `possibleReturnTypes` to get the most accurate information.

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
The solution was to add all the possibleReturnTypes from the elements into a set and use that as the list's possible return types. This avoids unnecessary supertypes and gives the most accurate information.

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
Manual confirmation. This will be tested further once type properties is implemented.

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
