### PR TITLE
Expose SectionContext

### DIFF
--- a/src/main/java/ch/njol/skript/lang/Section.java
+++ b/src/main/java/ch/njol/skript/lang/Section.java
@@ -196,8 +196,18 @@ public abstract class Section extends TriggerSection implements SyntaxElement, S
 		ParserInstance.registerData(SectionContext.class, SectionContext::new);
 	}
 
-	@SuppressWarnings("NotNullFieldNotInitialized")
-	protected static class SectionContext extends ParserInstance.Data {
+	/**
+	 * Data stored in the {@link ParserInstance} to keep track of the current section being parsed.
+	 * <br>
+	 * This is used to allow syntaxes to claim sections, and to provide the section node and trigger items
+	 * to syntaxes that need them. Failure to correctly manage this context via {@link #modify(SectionNode, List, Supplier)}
+	 * may result in sections being double claimed or infinite parsing loops.
+	 * <br>
+	 * Most users should never need to interact with this class, only those dealing with manual parsing of expressions
+	 * and similar behavior. Context is automatically handled in normal behavior via {@link Statement#parse(String, String)}
+	 * and other similar methods.
+	 */
+	public static class SectionContext extends ParserInstance.Data {
 
 		protected SectionNode sectionNode;
 		protected List<TriggerItem> triggerItems;
@@ -216,7 +226,7 @@ public abstract class Section extends TriggerSection implements SyntaxElement, S
 		 * <br>
 		 * See <a href="https://github.com/SkriptLang/Skript/pull/4353">Pull Request #4353</a> and <a href="https://github.com/SkriptLang/Skript/issues/4473">Issue #4473</a>.
 		 */
-		protected <T> T modify(SectionNode sectionNode, List<TriggerItem> triggerItems, Supplier<T> supplier) {
+		public <T> T modify(SectionNode sectionNode, List<TriggerItem> triggerItems, Supplier<T> supplier) {
 			SectionNode prevSectionNode = this.sectionNode;
 			List<TriggerItem> prevTriggerItems = this.triggerItems;
 			Debuggable owner = this.owner;


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
Testing in the addon development channel has revealed an issue when attempting to manually parse expressions, often as parts of sections or structures. The core issue is the inability for an addon to update SectionContext and tell the parser what section it's parsing. This manifests in different ways depending on the use case. In SkCheese, an infinite parsing loop can be created with the `new string` expression section where not updating the SectionNode in SectionContext leads to the same Node being parsed again and again, but always being given its parent node in init(). In Oopsk, it can manifest where a field in a struct instance section containing a section expression claims its parent section leading to a double-claim. In Jake's unreleased packet addon, it leads to a strange error where a nested section using an EntryValidator is given the wrong SectionNode and claims itself is an unexpected entry.

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
Makes SectionContext and SectionContext#modify() public for addon use.

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
None, no logic change was made.

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->
Relevant conversation: https://discord.com/channels/135877399391764480/836696328796897340/1409833163143905361

---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
