### PR TITLE
ExprInput Fix

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprInput.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprInput.java
@@ -49,7 +49,7 @@ public class ExprInput<T> extends SimpleExpression<T> {
 
 	@Nullable
 	private final ExprInput<?> source;
-	private final Class<? extends T>[] types;
+	private Class<? extends T>[] types;
 	private Class<T> superType;
 
 	private InputSource inputSource;
@@ -101,9 +101,11 @@ public class ExprInput<T> extends SimpleExpression<T> {
 			default:
 				specifiedType = null;
 		}
-		if (specifiedType != null)
+		if (specifiedType != null) {
 			//noinspection unchecked
 			superType = (Class<T>) specifiedType.getC();
+			types = new Class[]{superType};
+		}
 		return true;
 	}
 

--- a/src/test/skript/tests/syntaxes/expressions/ExprFilter.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprFilter.sk
@@ -15,3 +15,8 @@ test "where filter":
 	assert ({_list::*} where [input is (("foo" and "bar") where [input is "bar"])]) is "bar" with "Failed filter with filter within condition"
 	assert (({_list::*} where [input is "foo"]) where [input is "foo"]) is "foo" with "Failed chained filters"
 	assert {_list::*} where [input index is "2" or "3"] is "bar" and "foobar" with "Failed input index filter"
+
+test "input conversion":
+	set {_strings::*} to "test1", "test2", "test3" and "4test"
+	assert size of ({_strings::*} where [the first 4 characters of string input is "test"]) is 3 with "input was not correctly casted"
+	assert size of ({_strings::*} where [the last string color of string input is not set]) is 0 with "input was not correctly casted"


### PR DESCRIPTION
### Problem
When specifying a type for `ExprInput` via `%*classinfo% input`, the returned array from `#get` was not of the specified type due to `types` only containing `Object.class`.
Thus causing a `ClassCastException` when being used as a typed array parameter.

### Solution
When a type is specified, the `types` field is updated to accommodate the type.

### Testing Completed
`ExprFilter.sk`

Manual:
```applescript
function get() :: offlineplayers:
	return offline players

command /fail:
	trigger:
		send title "<#00ff00>&lExample" with subtitle "%get() where [gamemode of player input is survival]%" to all players
```

https://github.com/user-attachments/assets/f94448a2-2af0-4b53-8de5-7a971310e94b

### Supporting Information
N/A

---
**Completes:** #8163 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
