### PR TITLE
Type Properties/Attributes

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -107,6 +107,8 @@ import org.skriptlang.skript.lang.converter.Converter;
 import org.skriptlang.skript.lang.converter.Converters;
 import org.skriptlang.skript.lang.entry.EntryValidator;
 import org.skriptlang.skript.lang.experiment.ExperimentRegistry;
+import org.skriptlang.skript.lang.properties.Property;
+import org.skriptlang.skript.lang.properties.PropertyRegistry;
 import org.skriptlang.skript.lang.script.Script;
 import org.skriptlang.skript.lang.structure.Structure;
 import org.skriptlang.skript.lang.structure.StructureInfo;
@@ -370,6 +372,12 @@ public final class Skript extends JavaPlugin implements Listener {
 		return experimentRegistry;
 	}
 
+
+	private static PropertyRegistry propertyRegistry;
+	public static PropertyRegistry getPropertyRegistry() {
+		return propertyRegistry;
+	}
+
 	/**
 	 * @return The folder containing all Scripts.
 	 */
@@ -498,6 +506,9 @@ public final class Skript extends JavaPlugin implements Listener {
 		experimentRegistry = new ExperimentRegistry(this);
 		Feature.registerAll(getAddonInstance(), experimentRegistry);
 
+		propertyRegistry = new PropertyRegistry(this);
+		Property.registerDefaultProperties();
+
 		// Load classes which are always safe to use
 		new JavaClasses(); // These may be needed in configuration
 
@@ -523,7 +534,7 @@ public final class Skript extends JavaPlugin implements Listener {
 			if (pauseThreshold > -1) {
 				Skript.warning("Minecraft server pausing is enabled!");
 				Skript.warning("Scripts that interact with the world or entities may not work as intended when the server is paused and may crash your server.");
-				Skript.warning("Consider setting 'pause-when-empty-seconds' to -1 in server.properties to make sure you don't encounter any issues.");
+				Skript.warning("Consider setting 'pause-when-empty-seconds' to -1 in server.propertyRegistry to make sure you don't encounter any issues.");
 			}
 		}
 
@@ -577,6 +588,7 @@ public final class Skript extends JavaPlugin implements Listener {
 			getAddonInstance().loadClasses("ch.njol.skript",
 				"conditions", "effects", "events", "expressions", "entity", "sections", "structures");
 			getAddonInstance().loadClasses("org.skriptlang.skript.bukkit", "misc");
+			getAddonInstance().loadClasses("org.skriptlang.skript.lang", "properties");
 			// todo: become proper module once registry api is merged
 			FishingModule.load();
 			BreedingModule.load();

--- a/src/main/java/ch/njol/skript/classes/ClassInfo.java
+++ b/src/main/java/ch/njol/skript/classes/ClassInfo.java
@@ -6,16 +6,16 @@ import ch.njol.skript.lang.Debuggable;
 import ch.njol.skript.lang.DefaultExpression;
 import ch.njol.skript.lang.util.SimpleLiteral;
 import ch.njol.skript.localization.Noun;
+import ch.njol.skript.registrations.Classes;
 import ch.njol.util.coll.iterator.ArrayIterator;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.lang.properties.Property;
+import org.skriptlang.skript.lang.properties.PropertyInfo;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -475,5 +475,30 @@ public class ClassInfo<T> implements Debuggable {
 			return codeName + " (" + c.getCanonicalName() + ")";
 		return getName().getSingular();
 	}
+
+
+	private final Map<Property<?>, PropertyInfo<?>> propertyInfos = new HashMap<>();
+
+	public <Handler> ClassInfo<T> property(Property<Handler> property, @NotNull Handler handler) {
+		if (propertyInfos.containsKey(property)) {
+			throw new IllegalStateException("Property " + property.name() + " is already registered for the " + c.getName() + " type.");
+		}
+		propertyInfos.put(property, new PropertyInfo<>(property, handler));
+		Classes.CLASS_INFOS_BY_PROPERTY.computeIfAbsent(property, k -> new ArrayList<>()).add(this);
+		return this;
+	}
+
+	public boolean hasProperty(Property<?> property) {
+		return propertyInfos.containsKey(property);
+	}
+
+	public <Handler> @Nullable PropertyInfo<Handler> getPropertyInfo(Property<Handler> property) {
+		if (!propertyInfos.containsKey(property)) {
+			return null;
+		}
+		//noinspection unchecked
+		return (PropertyInfo<Handler>) propertyInfos.get(property);
+	}
+
 
 }

--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -60,7 +60,10 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.CachedServerIcon;
 import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.lang.properties.Property;
+import org.skriptlang.skript.lang.properties.Property.NameHandler;
 
 import java.io.StreamCorruptedException;
 import java.util.*;
@@ -580,7 +583,23 @@ public class BukkitClasses {
 					public String toVariableNameString(final Inventory i) {
 						return "inventory of " + Classes.toString(i.getHolder(), StringMode.VARIABLE_NAME);
 					}
-				}).changer(DefaultChangers.inventoryChanger));
+				}).changer(DefaultChangers.inventoryChanger)
+				.property(Property.CONTAINS, new Property.ContainsHandler<Inventory, Object>() {
+					@Override
+					public boolean contains(Inventory container, Object element) {
+						if (element instanceof ItemType type) {
+							return type.isContainedIn(container);
+						} else if (element instanceof ItemStack stack) {
+							return container.containsAtLeast(stack, stack.getAmount());
+						}
+						return false;
+					}
+
+					@Override
+					public Class<?>[] elementTypes() {
+						return new Class[]{ItemType.class, ItemStack.class};
+					}
+				}));
 
 		Classes.registerClass(new EnumClassInfo<>(InventoryAction.class, "inventoryaction", "inventory actions")
 				.user("inventory ?actions?")
@@ -679,7 +698,18 @@ public class BukkitClasses {
 					}
 				})
 				.changer(DefaultChangers.playerChanger)
-				.serializeAs(OfflinePlayer.class));
+				.serializeAs(OfflinePlayer.class)
+			.property(Property.NAME, new NameHandler<Player, String>() {
+				@Override
+				public String name(Player player) {
+					return player.getName();
+				}
+
+				@Override
+				public @NotNull Class<String> returnType() {
+					return String.class;
+				}
+			}));
 
 		Classes.registerClass(new ClassInfo<>(OfflinePlayer.class, "offlineplayer")
 				.user("offline ?players?")

--- a/src/main/java/ch/njol/skript/classes/data/JavaClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/JavaClasses.java
@@ -18,6 +18,8 @@ import ch.njol.yggdrasil.Fields;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Quaternionf;
+import org.skriptlang.skript.lang.properties.Property;
+import org.skriptlang.skript.lang.properties.Property.ContainsHandler;
 
 import java.io.StreamCorruptedException;
 import java.util.UUID;
@@ -300,6 +302,18 @@ public class JavaClasses {
 					@Override
 					public boolean mustSyncDeserialization() {
 						return false;
+					}
+				})
+				.property(Property.CONTAINS, new ContainsHandler<String, String>() {
+					@Override
+					public boolean contains(String container, String element) {
+						return StringUtils.contains(container, element, SkriptConfig.caseSensitive.value());
+					}
+
+					@Override
+					public Class<? extends String>[] elementTypes() {
+						//noinspection unchecked
+						return new Class[]{String.class};
 					}
 				}));
 

--- a/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
@@ -28,7 +28,9 @@ import ch.njol.yggdrasil.Fields;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.lang.properties.Property;
 import org.skriptlang.skript.lang.script.Script;
 import org.skriptlang.skript.lang.util.SkriptQueue;
 import org.skriptlang.skript.util.Executable;
@@ -217,7 +219,31 @@ public class SkriptClasses {
 					}
 				})
 				.cloner(ItemType::clone)
-				.serializer(new YggdrasilSerializer<>()));
+				.serializer(new YggdrasilSerializer<>())
+				.property(Property.NAME, new Property.NameHandler<ItemType, String>() {
+					@Override
+					public String name(ItemType itemType) {
+						return itemType.name();
+					}
+
+					@Override
+					public Class<?> @Nullable [] acceptChange(Changer.ChangeMode mode) {
+						if (mode == Changer.ChangeMode.SET || mode == Changer.ChangeMode.RESET)
+							return new Class[] {String.class};
+						return null;
+					}
+
+					@Override
+					public void change(ItemType itemType, Object @Nullable [] delta, Changer.ChangeMode mode) {
+						String name = delta != null ? (String) delta[0] : null;
+						itemType.setName(name);
+					}
+
+					@Override
+					public @NotNull Class<String> returnType() {
+						return String.class;
+					}
+				}));
 
 		Classes.registerClass(new ClassInfo<>(Time.class, "time")
 				.user("times?")

--- a/src/main/java/ch/njol/skript/lang/ExpressionList.java
+++ b/src/main/java/ch/njol/skript/lang/ExpressionList.java
@@ -149,13 +149,14 @@ public class ExpressionList<T> implements Expression<T> {
 	@SuppressWarnings("unchecked")
 	public <R> @Nullable Expression<? extends R> getConvertedExpression(Class<R>... to) {
 		Expression<? extends R>[] exprs = new Expression[expressions.length];
-		Class<?>[] returnTypes = new Class[expressions.length];
+		Set<Class<?>> possibleReturnTypeSet = new HashSet<>();
 		for (int i = 0; i < exprs.length; i++) {
 			if ((exprs[i] = expressions[i].getConvertedExpression(to)) == null)
 				return null;
-			returnTypes[i] = exprs[i].getReturnType();
+			possibleReturnTypeSet.addAll(Arrays.asList(exprs[i].possibleReturnTypes()));
 		}
-		return new ExpressionList<>(exprs, (Class<R>) Classes.getSuperClassInfo(returnTypes).getC(), returnTypes, and, this);
+		Class<?>[] possibleReturnTypes = possibleReturnTypeSet.toArray(new Class[0]);
+		return new ExpressionList<>(exprs, (Class<R>) Classes.getSuperClassInfo(possibleReturnTypes).getC(), possibleReturnTypes, and, this);
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/registrations/Classes.java
+++ b/src/main/java/ch/njol/skript/registrations/Classes.java
@@ -29,12 +29,11 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Chunk;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.Unmodifiable;
+import org.jetbrains.annotations.*;
 import org.skriptlang.skript.lang.converter.Converter;
 import org.skriptlang.skript.lang.converter.ConverterInfo;
 import org.skriptlang.skript.lang.converter.Converters;
+import org.skriptlang.skript.lang.properties.Property;
 
 import java.io.*;
 import java.lang.reflect.Array;
@@ -344,6 +343,15 @@ public abstract class Classes {
 		}
 		return list;
 	}
+
+
+	@ApiStatus.Internal
+	public static final Map<Property<?>, List<ClassInfo<?>>> CLASS_INFOS_BY_PROPERTY = new HashMap<>();
+
+	public static @NotNull List<ClassInfo<?>> getClassInfosByProperty(@NotNull Property<?> property) {
+		return CLASS_INFOS_BY_PROPERTY.getOrDefault(property, Collections.emptyList());
+	}
+
 
 	/**
 	 * Gets a class by its code name

--- a/src/main/java/org/skriptlang/skript/lang/properties/PropCondContains.java
+++ b/src/main/java/org/skriptlang/skript/lang/properties/PropCondContains.java
@@ -1,0 +1,105 @@
+package org.skriptlang.skript.lang.properties;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.Condition;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.lang.comparator.Comparators;
+import org.skriptlang.skript.lang.comparator.Relation;
+import org.skriptlang.skript.lang.properties.Property.ContainsHandler;
+import org.skriptlang.skript.lang.properties.PropertyUtils.PropertyMap;
+
+public class PropCondContains extends Condition {
+
+	static {
+		Skript.registerCondition(PropCondContains.class,
+			"property %inventories% (has|have) %itemtypes% [in [(the[ir]|his|her|its)] inventory]",
+			"property %inventories% (doesn't|does not|do not|don't) have %itemtypes% [in [(the[ir]|his|her|its)] inventory]",
+			"property %inventories/strings/objects% contain[(1¦s)] %itemtypes/strings/objects%",
+			"property %inventories/strings/objects% (doesn't|does not|do not|don't) contain %itemtypes/strings/objects%");
+	}
+
+	private Expression<?> haystack;
+	private Expression<?> needles;
+	private PropertyMap<ContainsHandler<?, ?>> properties;
+
+	boolean explicitSingle = false;
+
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+
+		this.haystack = PropertyUtils.asProperty(Property.CONTAINS, expressions[0]);
+		if (haystack == null) {
+			Skript.error("The expression " + expressions[0] + " returns types that do not contain anything.");
+			return false;
+		}
+		// determine if the expression truly has a name property
+
+		properties = PropertyUtils.getPossiblePropertyInfos(Property.CONTAINS, haystack);
+		if (properties.isEmpty()) {
+			Skript.error("The expression " + haystack + " returns types that do not contain anything.");
+			return false; // no name property found
+		}
+		// determine possible return types
+//		elementTypes = getElementTypes(properties);
+		this.needles = expressions[1];
+		explicitSingle = matchedPattern == 2 && parseResult.mark != 1 || haystack.isSingle();
+
+		needles = expressions[1];
+		return true;
+	}
+
+	private Class<?>[][] getElementTypes(PropertyMap<ContainsHandler<?, ?>> properties) {
+		return properties.values().stream()
+			.map((propertyInfo) -> propertyInfo.handler().elementTypes())
+			.toArray(Class<?>[][]::new);
+	}
+
+	@Override
+	public boolean check(Event event) {
+		Object[] haystacks = haystack.getAll(event);
+		boolean haystackAnd = haystack.getAnd();
+		Object[] needles = this.needles.getAll(event);
+		boolean needlesAnd = this.needles.getAnd();
+		if (haystacks.length == 0) {
+			return isNegated();
+		}
+
+		// We should compare the contents of the haystacks to the needles
+		if (explicitSingle) {
+			// use properties
+			return SimpleExpression.check(haystacks, (haystack) -> {
+				// for each haystack, determine property
+				//noinspection unchecked
+				var handler = (ContainsHandler<Object, Object>) properties.getHandler(haystack.getClass());
+				if (handler == null) {
+					return false;
+				}
+				// if found, use it to check against needles
+				return SimpleExpression.check(needles, (needle) ->
+						handler.canContain(needle.getClass())
+						&& handler.contains(haystack, needle),
+					false, needlesAnd);
+			}, isNegated(), haystackAnd);
+
+		// compare the haystacks themselves to the needles
+		} else {
+			return this.needles.check(event, o1 -> {
+				for (Object o2 : haystacks) {
+					if (Comparators.compare(o1, o2) == Relation.EQUAL)
+						return true;
+				}
+				return false;
+			}, isNegated());
+		}
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "x contains y";
+	}
+}

--- a/src/main/java/org/skriptlang/skript/lang/properties/PropExprName.java
+++ b/src/main/java/org/skriptlang/skript/lang/properties/PropExprName.java
@@ -1,0 +1,32 @@
+package org.skriptlang.skript.lang.properties;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.ExpressionType;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.lang.properties.Property.NameHandler;
+
+public class PropExprName extends PropertyBaseExpression<NameHandler<?,?>> {
+
+	static {
+		// Register the expression with Skript
+		Skript.registerExpression(PropExprName.class, Object.class, ExpressionType.PROPERTY, "[the] property name[s] of %objects%");
+	}
+
+	@Override
+	Property<NameHandler<?, ?>> getProperty() {
+		return Property.NAME;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	protected <T> @Nullable Object convert(Event event, NameHandler<?, ?> handler, T source) {
+		return ((NameHandler<T, ?>) handler).name(source);
+	}
+
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "name property of x";
+	}
+}

--- a/src/main/java/org/skriptlang/skript/lang/properties/Property.java
+++ b/src/main/java/org/skriptlang/skript/lang/properties/Property.java
@@ -1,0 +1,91 @@
+package org.skriptlang.skript.lang.properties;
+
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.classes.Changer.ChangeMode;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.addon.SkriptAddon;
+
+import java.util.Locale;
+
+public record Property<Handler>(
+		String name,
+		SkriptAddon provider,
+		@NotNull Class<? extends Handler> handler
+) {
+	public Property(@NotNull String name, SkriptAddon provider, @NotNull Class<? extends Handler> handler) {
+		this.name = name.toLowerCase(Locale.ENGLISH);
+		this.provider = provider;
+		this.handler = handler;
+	}
+
+	public static <Handler> Property<Handler> of(
+			@NotNull String name,
+			@NotNull SkriptAddon provider,
+			@NotNull Class<? extends Handler> handler) {
+		return new Property<>(name, provider, handler);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> Class<T> toHandlerType(Class<?> rawClass) {
+		return (Class<T>) rawClass;
+	}
+
+	public static final Property<NameHandler<?, ?>> NAME = Property.of(
+			"name",
+			Skript.instance(),
+			toHandlerType(NameHandler.class));
+
+	public static final Property<ContainsHandler<?, ?>> CONTAINS = Property.of(
+			"contains",
+			Skript.instance(),
+			toHandlerType(ContainsHandler.class));
+
+//	public static final Property AMOUNT = new Property("amount", Skript.getAddonInstance());
+//	@SuppressWarnings("unchecked")
+//	public static final Property<ContainsHandler<?, ?>> CONTAINS = new Property<>("contains", Skript.getAddonInstance(), (Class<? extends ContainsHandler<?, ?>>) ContainsHandler.class);
+//	public static final Property VALUED = new Property("valued", Skript.getAddonInstance());
+
+	public static void registerDefaultProperties() {
+		// Register default propertyRegistry here
+		// Example: PropertyRegistry.getInstance().register(new Property("example", SkriptAddon.getInstance(), ExampleExpression.class));
+		// This method can be called during addon initialization to ensure default propertyRegistry are registered.
+		PropertyRegistry propertyRegistry = Skript.getPropertyRegistry();
+		propertyRegistry.register(NAME);
+		propertyRegistry.register(CONTAINS);
+	}
+
+	public interface ExpressionPropertyHandler<Type, ReturnType> {
+		// Handler for the NAME property
+		ReturnType name(Type named);
+		default Class<?> @Nullable [] acceptChange(ChangeMode mode) {
+			return null;
+		}
+		default void change(Type named, Object @Nullable [] delta, ChangeMode mode) {
+			throw new UnsupportedOperationException("Changing the name is not supported for this property.");
+		}
+		@NotNull Class<ReturnType> returnType();
+	}
+
+	/**
+	 * no returning arrays
+	 * @param <Named>
+	 * @param <Name>
+	 */
+	public interface NameHandler<Named, Name> extends ExpressionPropertyHandler<Named, Name> {	}
+
+	public interface ContainsHandler<Container, Element> {
+		boolean contains(Container container, Element element);
+		Class<? extends Element>[] elementTypes();
+		default boolean canContain(Class<?> type) {
+			for (Class<? extends Element> elementType : elementTypes()) {
+				if (elementType.isAssignableFrom(type)) {
+					return true;
+				}
+			}
+			return false;
+		}
+	}
+
+}

--- a/src/main/java/org/skriptlang/skript/lang/properties/PropertyBaseExpression.java
+++ b/src/main/java/org/skriptlang/skript/lang/properties/PropertyBaseExpression.java
@@ -1,0 +1,186 @@
+package org.skriptlang.skript.lang.properties;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.expressions.base.PropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.skript.util.Utils;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.lang.properties.Property.ExpressionPropertyHandler;
+import org.skriptlang.skript.lang.properties.PropertyUtils.PropertyMap;
+
+import java.lang.reflect.Array;
+import java.util.*;
+import java.util.function.Function;
+
+public abstract class PropertyBaseExpression<Handler extends ExpressionPropertyHandler<?,?>> extends SimpleExpression<Object> {
+
+	abstract Property<Handler> getProperty();
+
+	protected static void register(Class<? extends PropertyBaseExpression<?>> expressionClass, String property) {
+		Skript.registerExpression(expressionClass, Object.class, ExpressionType.PROPERTY, PropertyExpression.getPatterns(property, "objects"));
+	}
+
+	private Expression<?> expr;
+	private PropertyMap<Handler> properties;
+	private Class<?>[] returnTypes;
+	private Class<?> returnType;
+	private final Property<Handler> property = getProperty();
+
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		this.expr = PropertyUtils.asProperty(property, expressions[0]);
+		if (expr == null) {
+			Skript.error("The expression " + expressions[0] + " returns types that do not have a name.");
+			return false;
+		}
+
+		// get all possible property infos for the expression's return types
+		properties = PropertyUtils.getPossiblePropertyInfos(property, expr);
+		if (properties.isEmpty()) {
+			Skript.error("The expression " + expr + " returns types that do not have a name.");
+			return false; // no name property found
+		}
+
+		// determine possible return types
+		returnTypes = getPropertyReturnTypes(properties, Handler::returnType);
+		returnType = Utils.getSuperType(returnTypes);
+		return true;
+	}
+
+	private Class<?> @NotNull [] getPropertyReturnTypes(@NotNull PropertyMap<Handler> properties, Function<Handler, Class<?>> getReturnType) {
+		return properties.values().stream()
+			.map((propertyInfo) -> getReturnType.apply(propertyInfo.handler()))
+			.filter(type -> type != Object.class)
+			.toArray(Class<?>[]::new);
+	}
+
+	@Override
+	protected Object @Nullable [] get(Event event) {
+		return expr.stream(event)
+			.map(source -> {
+				var handler = properties.getHandler(source.getClass());
+				if (handler == null) {
+					return null; // no property info found, skip
+				}
+				return convert(event, handler, source);
+			})
+			.filter(Objects::nonNull)
+			.toArray(size -> (Object[]) Array.newInstance(getReturnType(), size));
+	}
+
+	protected void preConvert(Event event) {}
+
+	protected abstract <T> @Nullable Object convert(Event event, Handler handler, T source);
+
+	@Override
+	public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
+		Set<Class<?>> allowedChangeTypes = new HashSet<>();
+		for (PropertyInfo<Handler> propertyInfo : properties.values()) {
+			Class<?>[] types = propertyInfo.handler().acceptChange(mode);
+			changeDetails.storeTypes(mode, propertyInfo, types);
+			if (types != null) {
+				if (mode == ChangeMode.DELETE || mode == ChangeMode.RESET) {
+					// if we are deleting or resetting, we can accept any type
+					return new Class[0];
+				} else {
+					allowedChangeTypes.addAll(Arrays.asList(types));
+				}
+			}
+		}
+		if (allowedChangeTypes.isEmpty()) {
+			return null; // no types accepted
+		}
+		return allowedChangeTypes.toArray(new Class[0]);
+	}
+
+	private final ChangeDetails changeDetails = new ChangeDetails();
+
+	class ChangeDetails extends EnumMap<ChangeMode, Map<PropertyInfo<Handler>, Class<?>[]>> {
+
+		public ChangeDetails() {
+			super(ChangeMode.class);
+		}
+
+		public void storeTypes(ChangeMode mode, PropertyInfo<Handler> propertyInfo, Class<?>[] types) {
+			Map<PropertyInfo<Handler>, Class<?>[]> map = computeIfAbsent(mode, k -> new HashMap<>());
+			map.put(propertyInfo, types);
+		}
+
+		public Class<?>[] getTypes(ChangeMode mode, PropertyInfo<Handler> propertyInfo) {
+			Map<PropertyInfo<Handler>, Class<?>[]> map = get(mode);
+			if (map != null) {
+				return map.get(propertyInfo);
+			}
+			return null; // no types found for this mode and property info
+		}
+
+	}
+
+
+	// TOOD:
+	// Track which property handlers accept which change modes and which classes
+	// so the change method is safe
+
+	@Override
+	public void change(Event event, Object @Nullable [] delta, ChangeMode mode) {
+		for (Object nameHaver : expr.getArray(event)) {
+			PropertyInfo<Handler> propertyInfo;
+			// check if we don't already know the right info for this class
+			if (properties.containsKey(nameHaver.getClass())) {
+				propertyInfo = properties.get(nameHaver.getClass());
+			} else {
+				// search for assignable property info
+				propertyInfo = properties.lookupPropertyInfo(nameHaver.getClass());
+			}
+			if (propertyInfo == null) {
+				continue; // no property info found, skip
+			}
+
+			// check against allowed change types
+			Class<?>[] allowedTypes = changeDetails.getTypes(mode, propertyInfo);
+			if (allowedTypes == null)
+				continue; // no types accepted for this mode and property info
+
+			if (allowedTypes.length == 0 && !(mode == ChangeMode.DELETE || mode == ChangeMode.RESET)) {
+				continue; // not deleting or resetting, and no types accepted
+			}
+
+			for (Class<?> allowedType : allowedTypes) {
+				// array type, compare to delta
+				// single type, compare to delta[0]
+				if ((allowedType.isArray() && allowedType.isInstance(delta))
+					|| (delta != null && allowedType.isInstance(delta[0]))) {
+					// if the nameHaver is allowed, change
+					@SuppressWarnings("unchecked")
+					var handler = (Property.NameHandler<Object, ?>) propertyInfo.handler();
+					handler.change(nameHaver, delta, mode);
+				}
+				// if allowed type is singular, take delta[0]
+			}
+
+			// no matching types, go next
+		}
+	}
+
+	@Override
+	public boolean isSingle() {
+		return expr.isSingle();
+	}
+
+	@Override
+	public Class<?> getReturnType() {
+		return returnType;
+	}
+
+	@Override
+	public Class<?>[] possibleReturnTypes() {
+		return returnTypes;
+	}
+}

--- a/src/main/java/org/skriptlang/skript/lang/properties/PropertyInfo.java
+++ b/src/main/java/org/skriptlang/skript/lang/properties/PropertyInfo.java
@@ -1,0 +1,4 @@
+package org.skriptlang.skript.lang.properties;
+
+public record PropertyInfo<Handler>(Property<Handler> property, Handler handler) {
+}

--- a/src/main/java/org/skriptlang/skript/lang/properties/PropertyRegistry.java
+++ b/src/main/java/org/skriptlang/skript/lang/properties/PropertyRegistry.java
@@ -1,0 +1,68 @@
+package org.skriptlang.skript.lang.properties;
+
+import ch.njol.skript.Skript;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Unmodifiable;
+import org.skriptlang.skript.util.Registry;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+
+public class PropertyRegistry implements Registry<Property> {
+
+	private final Map<String, Property> properties;
+	private final Skript skript;
+
+	public PropertyRegistry(Skript skript) {
+		this.skript = skript;
+		this.properties = new java.util.HashMap<>();
+	}
+
+	public boolean register(@NotNull Property property) {
+		String name = property.name();
+		if (properties.containsKey(name)) {
+			Skript.error("Property '" + name + "' is already registered by " + properties.get(name).provider().name() + ".");
+			return false; // Property already registered
+		}
+		properties.put(name, property);
+		Skript.debug("Registered property '" + name + "' provided by " + property.provider().name() + ".");
+		return true;
+	}
+
+	public boolean unregister(@NotNull Property property) {
+		String name = property.name();
+		return unregister(name);
+	}
+
+	public boolean unregister(String name) {
+		name = name.toLowerCase(Locale.ENGLISH);
+		if (!properties.containsKey(name)) {
+			Skript.error("Property '" + name + "' is not registered and cannot be unregistered.");
+			return false; // Property not registered
+		}
+		properties.remove(name);
+		Skript.debug("Unregistered property '" + name + "'.");
+		return true;
+	}
+
+	@Override
+	public @Unmodifiable Collection<Property> elements() {
+		return Collections.unmodifiableCollection(properties.values());
+	}
+
+	public Property get(String name) {
+		return properties.get(name);
+	}
+
+	public boolean isRegistered(@NotNull Property property) {
+		return isRegistered(property.name());
+	}
+
+	public boolean isRegistered(@NotNull String name) {
+		return properties.containsKey(name.toLowerCase(Locale.ENGLISH));
+	}
+
+
+}

--- a/src/main/java/org/skriptlang/skript/lang/properties/PropertyUtils.java
+++ b/src/main/java/org/skriptlang/skript/lang/properties/PropertyUtils.java
@@ -1,0 +1,87 @@
+package org.skriptlang.skript.lang.properties;
+
+import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.registrations.Classes;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.List;
+
+public class PropertyUtils {
+
+
+
+
+	public static class PropertyMap<Handler> extends HashMap<Class<?>, PropertyInfo<Handler>> {
+		public @Nullable Handler getHandler(Class<?> inputClass) {
+			PropertyInfo<Handler> propertyInfo;
+			// check if we don't already know the right info for this class
+			if (containsKey(inputClass)) {
+				propertyInfo = get(inputClass);
+			} else {
+				// search for assignable property info
+				propertyInfo = lookupPropertyInfo(inputClass);
+			}
+			if (propertyInfo == null) {
+				// no property info found, return null
+				return null;
+			}
+			// get the name using the property handler
+			return propertyInfo.handler();
+		}
+
+		public PropertyInfo<Handler> lookupPropertyInfo(Class<?> actualClass) {
+			Class<?> closestClass = null;
+			for (Class<?> candidateClass : keySet()) {
+				// need to make sure we get the closest match
+				if (candidateClass.isAssignableFrom(actualClass)) {
+					if (closestClass == null || closestClass.isAssignableFrom(candidateClass)) {
+						closestClass = candidateClass;
+					}
+				}
+			}
+
+			var propertyInfo = get(closestClass);
+			// add to properties so we don't have to search again
+			put(actualClass, propertyInfo);
+			return propertyInfo;
+		}
+
+	}
+
+	public static Expression<?> asProperty(Property<?> property, Expression<?> expr) {
+		if (expr == null) {
+			return null; // no expression to convert
+		}
+
+		// get all types with a name property
+		List<ClassInfo<?>> namedClassInfos = Classes.getClassInfosByProperty(property);
+		Class<?>[] namedClasses = namedClassInfos.stream().map(ClassInfo::getC).toArray(Class[]::new);
+
+		//noinspection unchecked,rawtypes
+		return expr.getConvertedExpression((Class[]) namedClasses);
+	}
+
+
+	public static <Handler> PropertyMap<Handler> getPossiblePropertyInfos(
+		Property<Handler> property,
+		Expression<?> expr
+	) {
+		PropertyMap<Handler> propertyInfos = new PropertyMap<>();
+		// for each return type, check if it has a name property
+		for (Class<?> returnType : expr.possibleReturnTypes()) {
+			ClassInfo<?> classInfo = Classes.getSuperClassInfo(returnType);
+			// get property
+			var propertyInfo = classInfo.getPropertyInfo(property);
+			if (propertyInfo == null) {
+				continue; // no name property
+			}
+			propertyInfos.put(classInfo.getC(), propertyInfo);
+		}
+		return propertyInfos;
+	}
+
+
+
+}


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
One of the most irritating problems that has plagued the Skript ecosystem for ages is the inability for two implementations of the same syntax pattern to exist at the same time. In Skript itself, it forces long, complicated Expr classes that handle 7 different types, and in addons it causes syntax conflicts or awkward naming schemes to avoid any possible conflict with other addons or Skript.

AnyX was somewhat recently introduced to assist in this case, by allowing any type to be converted to a uniform interface class that has a common method to use. This works well, but has little to no parse-time information capabilities. There's no way to check if a type that implements `AnyContains` can contain strings, items, or entities until runtime, when it's basically too late.

It's also difficult to handle changers and any non-`get()` behavior with AnyX, due to the same reasons of limited parse time information. This can make determining `allowChange` and possible return types near impossible to do accurately.

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
This PR introduces the concept of Type Properties (name wip, property is already rather prevalent in code). These are very free-form properties that can be registered with Skript using a name and a handler interface. Any ClassInfo can use the `.property()` method to declare that they implement this property and how they implement it.

This means that Skript, SkBee, and Disky may all have their own implementations of `size of x` for their own types without conflicting. You could do `lengths of ("xyz" and {skript-particle-rectangle})` with no issue. `toggle x` could work for any type from any addon that wants to use that property.

#### Implementing a Property
This system revolves around the `Property` class, which is, by itself, just a string and an addon reference. Any addon can register a property, though no two addons can register the same property name. Properties require a "handler" class to be supplied at creation to declare the interface all implementations must follow. This can be as simple as:
```java
interface LengthHandler<T> {
    double length(T object);
}

Property.LENGTH = Property.of("length", Skript.getInstance(), toHandlerType(LengthHandler.class);
Skript.getPropertyRegistry().register(LENGTH);
```
or something much more complex, with changers or complicated behaviors. There are no restrictions. The `toHandlerType` method is used to properly cast the class reference to the correct generic type, since class references are raw. It's an ugly double cast so the method is provided for convenience.

When a `ClassInfo` wants to implement a property, they use the `ClassInfo#property(Property, Handler)` method. This adds the provided handler implementation to the class' properties for later use. Each property may only be implemented once on a `ClassInfo`.
```java
new ClassInfo<Rectangle>(...)
    .property(Property.LENGTH, new LengthHandler<Rectangle>() {
        double length(Rectangle rect) { return rect.length(); }
    });
```

#### Creating a syntax that uses a property's handler

Up till now, this has been very simple for the user. The more complex part is creating a syntax that takes advantage of these properties to actually do something. For simple property expressions (properties that lead to patterns similar to the actual SPE syntaxes, like `name of x`), I provide a relative simple base class to extend:
```java
public class PropExprName extends PropertyBaseExpression<NameHandler<?,?>> {
	// registration is using %object%
	static {
		Skript.registerExpression(PropExprName.class, Object.class, ExpressionType.PROPERTY, "[the] property name[s] of %objects%");
	}

	// what property should be used
	@Override
	Property<NameHandler<?, ?>> getProperty() {
		return Property.NAME;
	}

	// This is called for each input object that has the NAME property.
	// The casting is unfortunately a requirement. I spent hours trying to figure out the generics here to no avail.
	@Override
	@SuppressWarnings("unchecked")
	protected <T> @Nullable Object convert(Event event, NameHandler<?, ?> handler, T source) {
		return ((NameHandler<T, ?>) handler).name(source);
	}

	// nothing special here.
	@Override
	public String toString(@Nullable Event event, boolean debug) {
		return "name property of x";
	}
}
```
This does require the user to have their handler implement the `ExpressionPropertyHandler`:
```java
	public interface ExpressionPropertyHandler<Type, ReturnType> {
		default Class<?> @Nullable [] acceptChange(ChangeMode mode) {
			return null;
		}
		default void change(Type named, Object @Nullable [] delta, ChangeMode mode) {
			throw new UnsupportedOperationException("Changing the name is not supported for this property.");
		}
		@NotNull Class<ReturnType> returnType();
	}


	public interface NameHandler<Named, Name> extends ExpressionPropertyHandler<Named, Name> {
		Name name(Named named);
	}
```

In return, changers and property checks are handled for you. This is what I believe most properties will use.

However, this API is very powerful and allows way more outside of that. The power, though, comes at the cost of complexity. Users who want unique properties will have to handle property management, type checks, and evaluation themselves. It's not that bad but it is certainly complex.

The main things to handle are:
#### Determining the relevant properties:

<details>

Nearly every property will contain something like this in their init():
```java
this.haystack = PropertyUtils.asProperty(Property.CONTAINS, expressions[0]);
if (haystack == null) {
	Skript.error("The expression " + expressions[0] + " returns types that do not contain anything.");
	return false;
}
// determine if the expression truly has a name property

properties = PropertyUtils.getPossiblePropertyInfos(Property.CONTAINS, haystack);
if (properties.isEmpty()) {
	Skript.error("The expression " + haystack + " returns types that do not contain anything.");
	return false; // no name property found
}
```
These `PropertyUtils` methods (location not final) are meant to assist in, respectively, converting an input expression into one that returns things with the given property and getting all the possible handlers that one could need given the expression's return types. `getPossiblePropertyInfos` in specific is important, since it returns the most useful part of the api, the `PropertyMap`.

A `PropertyMap` is a `HashMap<Class, PropertyInfo>` with 2 special methods: `getHandler(Class)` and `lookupPropertyInfo(Class)`. `getHandler` is the main method you should be using, which returns an appropriate Handler implementation for the given class. `lookupPropertyInfo` is mainly a helper method for `getHandler`, but may be useful. It determines the closest class to the given class that has a property in the map already. This lookup is cached, so after the call, a new entry should exist in the map, either to null if no property exists, or to a `PropertyInfo`. This allows, for example, `OfflinePlayer` to have a property implemented and for `Player` to also use that property.

</details>

#### Using the properties
<details>
This will vary depending on the property you're implementing, but nearly all will be relying on `PropertyMap#getHandler` extensively. The general flow should be:

* evaluate expression
* loop contents
* get class of content
* get handler for that class
* use handler as required

For example, here's my implementation of `CondContains` using properties:
```java
Object[] haystacks = haystack.getAll(event);
boolean haystackAnd = haystack.getAnd();
Object[] needles = this.needles.getAll(event);
boolean needlesAnd = this.needles.getAnd();
if (haystacks.length == 0) {
	return isNegated();
}

// We should compare the contents of the haystacks to the needles
if (explicitSingle) {
	// use properties
	return SimpleExpression.check(haystacks, (haystack) -> {
		// for each haystack, determine property
		//noinspection unchecked
		var handler = (ContainsHandler<Object, Object>) properties.getHandler(haystack.getClass());
		if (handler == null) {
			return false;
		}
		// if found, use it to check against needles
		return SimpleExpression.check(needles, (needle) ->
				handler.canContain(needle.getClass())
				&& handler.contains(haystack, needle),
			false, needlesAnd);
	}, isNegated(), haystackAnd);
}
```
</details>
Implementation details can vary wildly between properties, but `PropertyBaseExpression` is a good example of some of the more complex details a property may encounter. `PropCondContains` is a good example of a simpler custom property implementation.

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->

Only manual testing has been done so far.


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


#### FOR REVIEWERS

Class locations, names, and details are not final and shouldn't be focused on. Likewise for the lack of documentation. For now, reviews and comments should be limited to critiques of or suggestions for the design of the API, or the code within the implemented methods. I intend to add:
* parity with all existing AnyX classes
* methods for documentation info so docs can link to/from properties, types that implement the property, and syntaxes that use the property.
* possibly a base Handler class all handlers should extend.

---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** #7644 #7919 #7675 #7416 #8136  <!-- Links to issues or discussions with related information -->
