### PR TITLE
Fix type-aware function parsing for functions with only optional arguments

### DIFF
--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -1234,7 +1234,7 @@ public final class SkriptParser {
 				boolean trySingle = false;
 				boolean trySinglePlural = false;
 				for (var signature : signatures) {
-					trySingle |= signature.getMinParameters() == 1 || signature.getMaxParameters() == 1;
+					trySingle |= signature.getMinParameters() <= 1 || signature.getMaxParameters() == 1;
 					trySinglePlural |= trySingle && !signature.getParameter(0).isSingleValue();
 					for (int i = 0; i < signature.getMaxParameters(); i++) {
 						if (signatureDatas.size() <= i) {

--- a/src/test/skript/tests/regressions/8187-functions behave wrong with all default args.sk
+++ b/src/test/skript/tests/regressions/8187-functions behave wrong with all default args.sk
@@ -1,0 +1,7 @@
+local function test(x: number = 3, y: number = 5) returns number:
+	return {_x} + {_y}
+
+test "functions behave wrong with all default args":
+	assert test() is 8 with "no args did not use both default values"
+	assert test(1) is 6 with "only one arg did not use the second default value"
+	assert test(1, 2) is 3 with "both args still used a default value"


### PR DESCRIPTION
### Problem
When attempting to parse function arguments, SkriptParser uses a "shortcut" to determine whether parsing the input as a single expression is necessary. Those cases were determined to be:
- The function has only 1 parameter
- The function has only 1 required parameter (e.g. all others have default values)

However, I failed to consider the case that a function might have 0 required parameters. For a function like that, with multiple parameters that are all optional, the case where that function is called with only one argument could not be parsed properly.

### Solution
This is a single-character fix so that single expression parsing is also attempted for functions with 0 minimum arguments.


### Testing Completed
I have implemented a regression test for this behavior. I confirmed that it failed before the fix (with the same error as the reported issue).


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** https://github.com/SkriptLang/Skript/issues/8187
**Related:** none <!-- Links to issues or discussions with related information -->
