### PR TITLE
Better runtime error filtering

### DIFF
--- a/src/main/java/ch/njol/skript/sections/SecCatchErrors.java
+++ b/src/main/java/ch/njol/skript/sections/SecCatchErrors.java
@@ -68,7 +68,6 @@ public class SecCatchErrors extends Section implements ExperimentalSyntax {
 		TriggerItem.walk(first, event);
         ExprCaughtErrors.lastErrors = catcher.getCachedErrors().stream().map(RuntimeError::error).toArray(String[]::new);
 		catcher.clearCachedErrors()
-			.clearCachedFrames()
 			.stop();
 		return walk(event, false);
 	}

--- a/src/main/java/org/skriptlang/skript/log/runtime/RuntimeErrorCatcher.java
+++ b/src/main/java/org/skriptlang/skript/log/runtime/RuntimeErrorCatcher.java
@@ -1,13 +1,14 @@
 package org.skriptlang.skript.log.runtime;
 
+import ch.njol.skript.Skript;
 import ch.njol.skript.log.SkriptLogger;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnmodifiableView;
 import org.skriptlang.skript.log.runtime.Frame.FrameOutput;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map.Entry;
 import java.util.logging.Level;
 
 /**
@@ -20,7 +21,8 @@ public class RuntimeErrorCatcher implements RuntimeErrorConsumer {
 
 	private final List<RuntimeError> cachedErrors = new ArrayList<>();
 
-	private final List<Entry<FrameOutput, Level>> cachedFrames = new ArrayList<>();
+	// hard limit on stored errors to prevent a runaway loop from filling up memory, for example.
+	private static final int ERROR_LIMIT = 1000;
 
 	public RuntimeErrorCatcher() {}
 
@@ -28,7 +30,12 @@ public class RuntimeErrorCatcher implements RuntimeErrorConsumer {
 	 * Gets the {@link RuntimeErrorManager}.
 	 */
 	private RuntimeErrorManager getManager() {
-		return RuntimeErrorManager.getInstance();
+		return Skript.getRuntimeErrorManager();
+	}
+
+	@Override
+	public @Nullable RuntimeErrorFilter getFilter() {
+		return null; // no filter means everything gets printed.
 	}
 
 	/**
@@ -47,7 +54,7 @@ public class RuntimeErrorCatcher implements RuntimeErrorConsumer {
 	/**
 	 * Stops this {@link RuntimeErrorCatcher}, removing from {@link RuntimeErrorManager} and restoring the previous
 	 * {@link RuntimeErrorConsumer}s from {@link #storedConsumers}.
-	 * Prints all cached {@link RuntimeError}s, {@link #cachedErrors}, and cached {@link FrameOutput}s, {@link #cachedFrames}.
+	 * Prints all cached {@link RuntimeError}s, {@link #cachedErrors}.
 	 */
 	public void stop() {
 		if (!getManager().removeConsumer(this)) {
@@ -57,8 +64,6 @@ public class RuntimeErrorCatcher implements RuntimeErrorConsumer {
 		getManager().addConsumers(storedConsumers.toArray(RuntimeErrorConsumer[]::new));
 		for (RuntimeError runtimeError : cachedErrors)
 			storedConsumers.forEach(consumer -> consumer.printError(runtimeError));
-		for (Entry<FrameOutput, Level> entry : cachedFrames)
-			storedConsumers.forEach(consumer -> consumer.printFrameOutput(entry.getKey(), entry.getValue()));
 	}
 
 	/**
@@ -69,13 +74,6 @@ public class RuntimeErrorCatcher implements RuntimeErrorConsumer {
 	}
 
 	/**
-	 * Gets all cached {@link FrameOutput}s stored with its corresponding {@link Level} in an {@link Entry}
-	 */
-	public @UnmodifiableView List<Entry<FrameOutput, Level>> getCachedFrames() {
-		return Collections.unmodifiableList(cachedFrames);
-	}
-
-	/**
 	 * Clear all cached {@link RuntimeError}s.
 	 */
 	public RuntimeErrorCatcher clearCachedErrors() {
@@ -83,37 +81,15 @@ public class RuntimeErrorCatcher implements RuntimeErrorConsumer {
 		return this;
 	}
 
-	/**
-	 * Clears all cached {@link FrameOutput}s.
-	 */
-	public RuntimeErrorCatcher clearCachedFrames() {
-		cachedFrames.clear();
-		return this;
-	}
-
 	@Override
 	public void printError(RuntimeError error) {
-		cachedErrors.add(error);
+		if (cachedErrors.size() < ERROR_LIMIT)
+			cachedErrors.add(error);
 	}
 
 	@Override
 	public void printFrameOutput(FrameOutput output, Level level) {
-		cachedFrames.add(new Entry<FrameOutput, Level>() {
-			@Override
-			public FrameOutput getKey() {
-				return output;
-			}
-
-			@Override
-			public Level getValue() {
-				return level;
-			}
-
-			@Override
-			public Level setValue(Level value) {
-				return null;
-			}
-		});
+		// do nothing, this won't be called since we have no filter.
 	}
 
 }

--- a/src/main/java/org/skriptlang/skript/log/runtime/RuntimeErrorConsumer.java
+++ b/src/main/java/org/skriptlang/skript/log/runtime/RuntimeErrorConsumer.java
@@ -1,5 +1,7 @@
 package org.skriptlang.skript.log.runtime;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.util.logging.Level;
 
 /**
@@ -14,6 +16,15 @@ public interface RuntimeErrorConsumer {
 	 * @param error The error to print.
 	 */
 	void printError(RuntimeError error);
+
+	/**
+	 * @return The filter to use when checking if this consumer should print an error. Defaults to the standard
+	 * 			config-driven filter. May be null if no filter should be used (also disables frame outputs). This value
+	 * 			MUST be effectively final.
+	 */
+	default @Nullable RuntimeErrorFilter getFilter() {
+		return RuntimeErrorManager.standardFilter;
+	}
 
 	/**
 	 * Prints the output of a frame, including skipped errors, timeouts, and whatever other information required.

--- a/src/main/java/org/skriptlang/skript/log/runtime/RuntimeErrorFilter.java
+++ b/src/main/java/org/skriptlang/skript/log/runtime/RuntimeErrorFilter.java
@@ -1,0 +1,48 @@
+package org.skriptlang.skript.log.runtime;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.logging.Level;
+
+public class RuntimeErrorFilter {
+
+	private Frame errorFrame, warningFrame;
+
+	public RuntimeErrorFilter(Frame.FrameLimit errorFrameLimits, Frame.FrameLimit warningFrameLimits) {
+		this.errorFrame = new Frame(errorFrameLimits);
+		this.warningFrame = new Frame(warningFrameLimits);
+	}
+
+	/**
+	 * Tests whether a runtime error should be printed or not.
+	 * @param error True if it should be printed, false if not.
+	 */
+	public boolean test(@NotNull RuntimeError error) {
+		// print if < limit
+		return (error.level() == Level.SEVERE && errorFrame.add(error))
+			|| (error.level() == Level.WARNING && warningFrame.add(error));
+	}
+
+	public void setErrorFrameLimits(Frame.FrameLimit limits) {
+		this.errorFrame = new Frame(limits);
+	}
+
+	public void setWarningFrameLimits(Frame.FrameLimit limits) {
+		this.warningFrame = new Frame(limits);
+	}
+
+	/**
+	 * @return The frame containing emitted errors.
+	 */
+	public Frame getErrorFrame() {
+		return errorFrame;
+	}
+
+	/**
+	 * @return The frame containing emitted warnings.
+	 */
+	public Frame getWarningFrame() {
+		return warningFrame;
+	}
+
+}

--- a/src/main/java/org/skriptlang/skript/log/runtime/RuntimeErrorManager.java
+++ b/src/main/java/org/skriptlang/skript/log/runtime/RuntimeErrorManager.java
@@ -169,18 +169,14 @@ public class RuntimeErrorManager implements Closeable {
 	 */
 	public boolean removeConsumer(RuntimeErrorConsumer consumer) {
 		synchronized (filterMap) {
-			var iterator = filterMap.entrySet().iterator();
-			while (iterator.hasNext()) {
-				var entry = iterator.next();
-				boolean removed = entry.getValue().remove(consumer);
-				if (entry.getValue().isEmpty()) {
-					iterator.remove();
-				}
-				if (removed)
-					return true;
-			}
+			var set = filterMap.get(consumer.getFilter());
+			if (set == null)
+				 return false;
+			boolean removed = set.remove(consumer);
+			if (set.isEmpty())
+				filterMap.remove(consumer.getFilter());
+			return removed;
 		}
-		return false;
 	}
 
 	/**

--- a/src/main/java/org/skriptlang/skript/log/runtime/RuntimeErrorManager.java
+++ b/src/main/java/org/skriptlang/skript/log/runtime/RuntimeErrorManager.java
@@ -9,9 +9,7 @@ import org.jetbrains.annotations.NotNull;
 import org.skriptlang.skript.log.runtime.Frame.FrameLimit;
 
 import java.io.Closeable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 import java.util.logging.Level;
 
 /**
@@ -39,38 +37,45 @@ public class RuntimeErrorManager implements Closeable {
 		return instance;
 	}
 
+	static RuntimeErrorFilter standardFilter;
+
 	/**
 	 * Refreshes the runtime error manager for Skript, pulling from the config values.
 	 * Tracked consumers are maintained during refreshes.
 	 */
 	public static void refresh() {
 		long frameLength = SkriptConfig.runtimeErrorFrameDuration.value().getAs(Timespan.TimePeriod.TICK);
+		if (instance == null) {
+			instance = new RuntimeErrorManager(frameLength);
+		} else {
+			var oldMap = instance.filterMap;
+			instance = new RuntimeErrorManager(frameLength);
+			instance.filterMap.putAll(oldMap);
+		}
 
 		int errorLimit = SkriptConfig.runtimeErrorLimitTotal.value();
 		int errorLineLimit = SkriptConfig.runtimeErrorLimitLine.value();
 		int errorLineTimeout = SkriptConfig.runtimeErrorLimitLineTimeout.value();
 		int errorTimeoutLength = Math.max(SkriptConfig.runtimeErrorTimeoutDuration.value(), 1);
-		FrameLimit errorFrame = new FrameLimit(errorLimit, errorLineLimit, errorLineTimeout, errorTimeoutLength);
+		var errorLimits = new FrameLimit(errorLimit, errorLineLimit, errorLineTimeout, errorTimeoutLength);
 
 		int warningLimit = SkriptConfig.runtimeWarningLimitTotal.value();
 		int warningLineLimit = SkriptConfig.runtimeWarningLimitLine.value();
 		int warningLineTimeout = SkriptConfig.runtimeWarningLimitLineTimeout.value();
 		int warningTimeoutLength = Math.max(SkriptConfig.runtimeWarningTimeoutDuration.value(), 1);
-		FrameLimit warningFrame = new FrameLimit(warningLimit, warningLineLimit, warningLineTimeout, warningTimeoutLength);
+		var warningsLimits = new FrameLimit(warningLimit, warningLineLimit, warningLineTimeout, warningTimeoutLength);
 
-		List<RuntimeErrorConsumer> oldConsumers = List.of();
-		if (instance != null) {
-			instance.close();
-			oldConsumers = instance.consumers;
+		if (standardFilter == null) {
+			standardFilter = new RuntimeErrorFilter(errorLimits, warningsLimits);
+		} else {
+			standardFilter.setErrorFrameLimits(errorLimits);
+			standardFilter.setWarningFrameLimits(warningsLimits);
 		}
-		instance = new RuntimeErrorManager(Math.max((int) frameLength, 1), errorFrame, warningFrame);
-		oldConsumers.forEach(consumer -> instance.addConsumer(consumer));
 	}
 
-	private final Frame errorFrame, warningFrame;
 	private final Task task;
 
-	private final List<RuntimeErrorConsumer> consumers = new ArrayList<>();
+	private final Map<RuntimeErrorFilter, Set<RuntimeErrorConsumer>> filterMap = new HashMap<>();
 
 	/**
 	 * Creates a new error manager, which also creates its own frames.
@@ -78,48 +83,59 @@ public class RuntimeErrorManager implements Closeable {
 	 * Must be closed when no longer being used.
 	 *
 	 * @param frameLength The length of a frame in ticks.
-	 * @param errorLimits The limits to the error frame.
-	 * @param warningLimits The limits to the warning frame.
 	 */
-	public RuntimeErrorManager(int frameLength, FrameLimit errorLimits, FrameLimit warningLimits) {
-		errorFrame = new Frame(errorLimits);
-		warningFrame = new Frame(warningLimits);
+	public RuntimeErrorManager(long frameLength) {
 		task = new Task(Skript.getInstance(), frameLength, frameLength, true) {
 			@Override
 			public void run() {
-				consumers.forEach(consumer -> consumer.printFrameOutput(errorFrame.getFrameOutput(), Level.SEVERE));
-				errorFrame.nextFrame();
+				for (var entry : filterMap.entrySet()) {
+					RuntimeErrorFilter filter = entry.getKey();
+					if (filter == null)
+						continue;
+					Set<RuntimeErrorConsumer> consumers = entry.getValue();
 
-				consumers.forEach(consumer -> consumer.printFrameOutput(warningFrame.getFrameOutput(), Level.WARNING));
-				warningFrame.nextFrame();
+					Frame errorFrame = filter.getErrorFrame();
+					consumers.forEach(consumer -> consumer.printFrameOutput(errorFrame.getFrameOutput(), Level.SEVERE));
+					errorFrame.nextFrame();
+
+					Frame warningFrame = filter.getErrorFrame();
+					consumers.forEach(consumer -> consumer.printFrameOutput(warningFrame.getFrameOutput(), Level.WARNING));
+					warningFrame.nextFrame();
+				}
 			}
 		};
 	}
 
 	/**
-	 * Emits a warning or error depending on severity. Errors are passed to their respective {@link Frame}s for processing.
+	 * Emits a warning or error depending on severity.
 	 * @param error The error to emit.
 	 */
 	public void error(@NotNull RuntimeError error) {
-		// print if < limit
-		if ((error.level() == Level.SEVERE && errorFrame.add(error))
-			|| (error.level() == Level.WARNING && warningFrame.add(error))) {
-			consumers.forEach((consumer -> consumer.printError(error)));
+		for (var entry : filterMap.entrySet()) {
+			RuntimeErrorFilter filter = entry.getKey();
+			Set<RuntimeErrorConsumer> consumers = entry.getValue();
+			if (filter == null || filter.test(error)){
+				consumers.forEach((consumer -> consumer.printError(error)));
+			}
 		}
 	}
 
 	/**
 	 * @return The frame containing emitted errors.
+	 * @deprecated {@link RuntimeErrorFilter#getErrorFrame()}
 	 */
+	@Deprecated(since="INSERT VERSION", forRemoval = true)
 	public Frame getErrorFrame() {
-		return errorFrame;
+		return standardFilter.getErrorFrame();
 	}
 
 	/**
 	 * @return The frame containing emitted warnings.
+	 * @deprecated {@link RuntimeErrorFilter#getWarningFrame()}
 	 */
+	@Deprecated(since="INSERT VERSION", forRemoval = true)
 	public Frame getWarningFrame() {
-		return warningFrame;
+		return standardFilter.getWarningFrame();
 	}
 
 	/**
@@ -128,8 +144,8 @@ public class RuntimeErrorManager implements Closeable {
 	 * @param consumer The consumer to add.
 	 */
 	public void addConsumer(RuntimeErrorConsumer consumer) {
-		synchronized (consumers) {
-			consumers.add(consumer);
+		synchronized (filterMap) {
+			filterMap.computeIfAbsent(consumer.getFilter(), key -> new HashSet<>()).add(consumer);
 		}
 	}
 
@@ -139,8 +155,10 @@ public class RuntimeErrorManager implements Closeable {
 	 * @param newConsumers The {@link RuntimeErrorConsumer}s to add.
 	 */
 	public void addConsumers(RuntimeErrorConsumer... newConsumers) {
-		synchronized (consumers) {
-			consumers.addAll(Arrays.asList(newConsumers));
+		synchronized (filterMap) {
+			for (var consumer : newConsumers) {
+				filterMap.computeIfAbsent(consumer.getFilter(), key -> new HashSet<>()).add(consumer);
+			}
 		}
 	}
 
@@ -150,9 +168,19 @@ public class RuntimeErrorManager implements Closeable {
 	 * @return {@code true} If the {@code consumer} was removed.
 	 */
 	public boolean removeConsumer(RuntimeErrorConsumer consumer) {
-		synchronized (consumers) {
-			return consumers.remove(consumer);
+		synchronized (filterMap) {
+			var iterator = filterMap.entrySet().iterator();
+			while (iterator.hasNext()) {
+				var entry = iterator.next();
+				boolean removed = entry.getValue().remove(consumer);
+				if (entry.getValue().isEmpty()) {
+					iterator.remove();
+				}
+				if (removed)
+					return true;
+			}
 		}
+		return false;
 	}
 
 	/**
@@ -160,9 +188,10 @@ public class RuntimeErrorManager implements Closeable {
 	 * @return All {@link RuntimeErrorConsumer}s removed.
 	 */
 	public List<RuntimeErrorConsumer> removeAllConsumers() {
-		synchronized (consumers) {
-			List<RuntimeErrorConsumer> currentConsumers = List.copyOf(consumers);
-			consumers.clear();
+		synchronized (filterMap) {
+			List<RuntimeErrorConsumer> currentConsumers = new ArrayList<>();
+			for (var set : filterMap.values())
+				currentConsumers.addAll(set);
 			return currentConsumers;
 		}
 	}

--- a/src/test/skript/tests/syntaxes/expressions/ExprWorldBorderCenter.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprWorldBorderCenter.sk
@@ -36,3 +36,9 @@ test "worldborder center":
 
 	reset worldborder center of {_border}
 	assert worldborder center of {_border} is location(0, 0, 0, "world") with "failed to reset border center"
+
+	catch runtime errors:
+		loop 20 times:
+			set worldborder center of {_border} to location(2, 0, NaN value)
+		set worldborder damage amount of {_border} to infinity value
+	assert last caught runtime errors contains "World border damage amount cannot be infinite" with "Infinity damage value did not throw error"


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
RuntimeErrorManager enforced a standard filtering system for all consumers based on the values in config.sk. This meant that the runtime error catcher could not adequately catch errors, since they would be suppressed after reaching the limits. A per-consumer filtering system was needed.

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
Allows each consumer to provide its own filter, or null for no filter. Defaults to the standard config-driven filter.
REManager internally uses a filter->set<consumer> map to avoid giving a filter the same error twice.

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
Manual testing and edits to existing tests to ensure functionality.

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** #7921 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
