### PR TITLE
Properly parse exprsecs in function calls

### DIFF
--- a/src/main/java/ch/njol/skript/lang/Statement.java
+++ b/src/main/java/ch/njol/skript/lang/Statement.java
@@ -30,7 +30,13 @@ public abstract class Statement extends TriggerItem implements SyntaxElement {
 
 	public static @Nullable Statement parse(String input, @Nullable String defaultError, @Nullable SectionNode node, @Nullable List<TriggerItem> items) {
 		try (ParseLogHandler log = SkriptLogger.startParseLogHandler()) {
-			EffFunctionCall functionCall = EffFunctionCall.parse(input);
+			Section.SectionContext sectionContext = ParserInstance.get().getData(Section.SectionContext.class);
+			EffFunctionCall functionCall;
+			if (node != null) {
+				functionCall = sectionContext.modify(node, items, () -> EffFunctionCall.parse(input));
+			} else {
+				functionCall = EffFunctionCall.parse(input);
+			}
 			if (functionCall != null) {
 				log.printLog();
 				return functionCall;
@@ -49,7 +55,6 @@ public abstract class Statement extends TriggerItem implements SyntaxElement {
 
 			Statement statement;
 			var iterator = Skript.instance().syntaxRegistry().syntaxes(org.skriptlang.skript.registration.SyntaxRegistry.STATEMENT).iterator();
-			Section.SectionContext sectionContext = ParserInstance.get().getData(Section.SectionContext.class);
 			if (node != null) {
 				var wrappedIterator = new Iterator<>() {
 					@Override

--- a/src/test/skript/tests/regressions/8199-parse exprsecs in function args.sk
+++ b/src/test/skript/tests/regressions/8199-parse exprsecs in function args.sk
@@ -1,0 +1,6 @@
+local function f(x: worldborder):
+	assert worldborder warning time of {_x} is 1 second with "Failed to modify worldborder before calling function. Check Statement.parse() for sectioncontext handling."
+
+test "load expr secs in functions":
+    f(a worldborder):
+        set worldborder warning time to 20 ticks


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
Having a section expression in a function call would not properly claim the section, leading to the section never running:
```
function f(x: worldborder):
    broadcast "%worldborder warning time of {_x}%"

load:
    f(a worldborder):
        set worldborder warning time to 20 ticks
```
would broadcast 15 seconds, not 1 second.

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
Modifies sectioncontext when parsing EffFunctionCall, so the expr sec can properly claim the section.

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
Added a regression test.

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
