### PR TITLE
Fix getting java functions causing casting errors

### DIFF
--- a/src/main/java/ch/njol/skript/doc/Documentation.java
+++ b/src/main/java/ch/njol/skript/doc/Documentation.java
@@ -6,9 +6,7 @@ import ch.njol.skript.conditions.CondCompare;
 import ch.njol.skript.lang.ExpressionInfo;
 import ch.njol.skript.lang.SkriptEventInfo;
 import ch.njol.skript.lang.SyntaxElementInfo;
-import org.skriptlang.skript.common.function.DefaultFunction;
 import ch.njol.skript.lang.function.Functions;
-import ch.njol.skript.lang.function.JavaFunction;
 import ch.njol.skript.lang.function.Parameter;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.util.Utils;
@@ -153,7 +151,7 @@ public class Documentation {
 				"examples VARCHAR(2000) NOT NULL," +
 				"since VARCHAR(100) NOT NULL" +
 				");");
-		for (ch.njol.skript.lang.function.Function<?> func : Functions.getDefaultFunctions()) {
+		for (ch.njol.skript.lang.function.Function<?> func : Functions.getFunctions()) {
 			assert func != null;
 			insertFunction(pw, func);
 		}

--- a/src/main/java/ch/njol/skript/doc/DocumentationIdProvider.java
+++ b/src/main/java/ch/njol/skript/doc/DocumentationIdProvider.java
@@ -103,7 +103,7 @@ public class DocumentationIdProvider {
 	 * @return the documentation ID of the function
 	 */
 	public static String getId(Function<?> function) {
-		int collisionCount = calculateCollisionCount(Functions.getJavaFunctions().iterator(),
+		int collisionCount = calculateCollisionCount(Functions.getFunctions().iterator(),
 			javaFunction -> function.getName().equals(javaFunction.getName()),
 			javaFunction -> javaFunction == function);
 		return addCollisionSuffix(function.getName(), collisionCount);

--- a/src/main/java/ch/njol/skript/doc/HTMLGenerator.java
+++ b/src/main/java/ch/njol/skript/doc/HTMLGenerator.java
@@ -6,7 +6,6 @@ import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.lang.*;
 import ch.njol.skript.lang.function.Function;
 import ch.njol.skript.lang.function.Functions;
-import ch.njol.skript.lang.function.JavaFunction;
 import ch.njol.skript.registrations.Classes;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
@@ -18,7 +17,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.entry.EntryData;
 import org.skriptlang.skript.lang.entry.EntryValidator;
-import org.skriptlang.skript.common.function.DefaultFunction;
 import org.skriptlang.skript.lang.structure.StructureInfo;
 
 import java.io.File;
@@ -333,7 +331,7 @@ public class HTMLGenerator extends DocumentationGenerator {
 					}
 				}
 				if (genType.equals("functions") || isDocsPage) {
-					List<Function<?>> functions = new ArrayList<>(Functions.getDefaultFunctions());
+					List<Function<?>> functions = new ArrayList<>(Functions.getFunctions());
 					functions.sort(functionComparator);
 					for (Function<?> info : functions) {
 						assert info != null;

--- a/src/main/java/ch/njol/skript/doc/JSONGenerator.java
+++ b/src/main/java/ch/njol/skript/doc/JSONGenerator.java
@@ -503,7 +503,7 @@ public class JSONGenerator extends DocumentationGenerator {
 		jsonDocs.add("structures", generateStructureElementArray(source.syntaxRegistry().syntaxes(SyntaxRegistry.STRUCTURE)));
 		jsonDocs.add("sections", generateSyntaxElementArray(source.syntaxRegistry().syntaxes(SyntaxRegistry.SECTION)));
 		jsonDocs.add("types", generateClassInfoArray(Classes.getClassInfos().iterator()));
-		jsonDocs.add("functions", generateFunctionArray(Functions.getDefaultFunctions().iterator()));
+		jsonDocs.add("functions", generateFunctionArray(Functions.getFunctions().iterator()));
 
 		try {
 			Files.writeString(path, GSON.toJson(jsonDocs));

--- a/src/main/java/ch/njol/skript/lang/function/Functions.java
+++ b/src/main/java/ch/njol/skript/lang/function/Functions.java
@@ -16,6 +16,7 @@ import org.skriptlang.skript.common.function.DefaultFunction;
 import org.skriptlang.skript.lang.script.Script;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Static methods to work with functions.
@@ -445,13 +446,15 @@ public abstract class Functions {
 	}
 
 	/**
-	 * @deprecated Use {@link #getDefaultFunctions()} instead.
+	 * @deprecated Use {@link #getFunctions()} instead.
 	 */
-	@SuppressWarnings({"unchecked"})
 	@Deprecated(forRemoval = true, since = "INSERT VERSION")
 	public static Collection<JavaFunction<?>> getJavaFunctions() {
 		// We know there are only Java functions in that namespace
-		return (Collection<JavaFunction<?>>) (Object) javaNamespace.getFunctions();
+		return javaNamespace.getFunctions().stream()
+				.filter(it -> it instanceof JavaFunction<?>)
+				.map(it -> (JavaFunction<?>) it)
+				.collect(Collectors.toSet());
 	}
 
 	/**
@@ -459,7 +462,7 @@ public abstract class Functions {
 	 *
 	 * @return All {@link JavaFunction} or {@link DefaultFunction} functions.
 	 */
-	public static Collection<Function<?>> getDefaultFunctions() {
+	public static Collection<Function<?>> getFunctions() {
 		return javaNamespace.getFunctions();
 	}
 


### PR DESCRIPTION
### Problem
Fix `Functions#getJavaFunctions` causing casting errors on call.


### Solution
Makes sure that only `JavaFunction`s are returned when calling `getJavaFunctions`. This does not include `DefaultFunction`s, as `getFunctions` should be used.


### Testing Completed
Manual testing.


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
