### PR TITLE
Fix function parameters with default value as list causing error

### DIFF
--- a/src/main/java/ch/njol/skript/lang/function/ScriptFunction.java
+++ b/src/main/java/ch/njol/skript/lang/function/ScriptFunction.java
@@ -61,12 +61,22 @@ public class ScriptFunction<T> extends Function<T> implements ReturnHandler<T> {
 			Object[] val = params[i];
 			if (parameter.single && val.length > 0) {
 				Variables.setVariable(parameter.name, val[0], event, true);
-			} else {
-				for (Object value : val) {
-					KeyedValue<?> keyedValue = (KeyedValue<?>) value;
-					Variables.setVariable(parameter.name + "::" + keyedValue.key(), keyedValue.value(), event, true);
-				}
+				continue;
 			}
+
+			int count = 0;
+			for (Object value : val) {
+				if (value instanceof KeyedValue<?> keyedValue) {
+					Variables.setVariable(parameter.name + "::" + keyedValue.key(), keyedValue.value(), event, true);
+					continue;
+				}
+
+				// backup for if the passed argument is not a keyed value.
+				// an example of this is passing `xs: integers = (1, 2)` as a parameter.
+				Variables.setVariable(parameter.name + "::" + count, value, event, true);
+				count++;
+			}
+
 		}
 
 		trigger.execute(event);

--- a/src/test/skript/tests/regressions/8220-function-list-default-value.sk
+++ b/src/test/skript/tests/regressions/8220-function-list-default-value.sk
@@ -1,0 +1,9 @@
+function test(xs: integers = (1, 7)) :: integers:
+    return {_xs::*}
+
+test "8220 function has list default value":
+    set {_xs::*} to test()
+
+    assert size of {_xs::*} = 2
+    assert {_xs::1} = 1
+    assert {_xs::2} = 7


### PR DESCRIPTION
### Problem
Function parameters with a default value as a list cause errors.

```
function test(xs: integers = (1, 7)) :: integers:
    return {_xs::*}
```

This would error as `(1, 7)` is not a `KeyedValue`, while `ScriptFunction` expects that every argument that is a list or array is a `KeyedValue`.

### Solution
Adds a backup for setting the variable in case the passed argument has multiple elements (any array or list), but is not a `KeyedValue`. All values with multiple elements should still be passed as a `KeyedValue` by any API.


### Testing Completed
Added test file.


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** #8220 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
