### PR TITLE
Use @Example annotations instead of @Examples

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondAllayCanDuplicate.java
+++ b/src/main/java/ch/njol/skript/conditions/CondAllayCanDuplicate.java
@@ -2,7 +2,7 @@ package ch.njol.skript.conditions;
 
 import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import org.bukkit.entity.Allay;
@@ -10,10 +10,10 @@ import org.bukkit.entity.LivingEntity;
 
 @Name("Allay Can Duplicate")
 @Description("Checks to see if an allay is able to duplicate naturally.")
-@Examples({
-	"if last spawned allay can duplicate:",
-		"\tdisallow last spawned to duplicate"
-})
+@Example("""
+	if last spawned allay can duplicate:
+		disallow last spawned to duplicate
+	""")
 @Since("2.11")
 public class CondAllayCanDuplicate extends PropertyCondition<LivingEntity> {
 

--- a/src/main/java/ch/njol/skript/conditions/CondAlphanumeric.java
+++ b/src/main/java/ch/njol/skript/conditions/CondAlphanumeric.java
@@ -16,8 +16,10 @@ import ch.njol.util.Kleenean;
 
 @Name("Alphanumeric")
 @Description({"Checks if the given string is alphanumeric."})
-@Examples({"if the argument is not alphanumeric:",
-		"	send \"Invalid name!\""})
+@Examples("""
+	if the argument is not alphanumeric:
+		send "Invalid name!"
+	""")
 @Since("2.4")
 public class CondAlphanumeric extends Condition {
 	

--- a/src/main/java/ch/njol/skript/conditions/CondAlphanumeric.java
+++ b/src/main/java/ch/njol/skript/conditions/CondAlphanumeric.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.Nullable;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Condition;
@@ -16,7 +16,7 @@ import ch.njol.util.Kleenean;
 
 @Name("Alphanumeric")
 @Description({"Checks if the given string is alphanumeric."})
-@Examples("""
+@Example("""
 	if the argument is not alphanumeric:
 		send "Invalid name!"
 	""")

--- a/src/main/java/ch/njol/skript/conditions/CondIsCharged.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsCharged.java
@@ -2,7 +2,7 @@ package ch.njol.skript.conditions;
 
 import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import org.bukkit.entity.Creeper;
@@ -12,10 +12,10 @@ import org.bukkit.entity.WitherSkull;
 
 @Name("Is Charged")
 @Description("Checks if a creeper, wither, or wither skull is charged (powered).")
-@Examples({
-	"if the last spawned creeper is charged:",
-		"\tbroadcast \"A charged creeper is at %location of last spawned creeper%\""
-})
+@Example("""
+	if the last spawned creeper is charged:
+		broadcast "A charged creeper is at %location of last spawned creeper%"
+	""")
 @Since("2.5, 2.10 (withers, wither skulls)")
 public class CondIsCharged extends PropertyCondition<Entity> {
 

--- a/src/main/java/ch/njol/skript/conditions/CondIsSwimming.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsSwimming.java
@@ -2,11 +2,12 @@ package ch.njol.skript.conditions;
 
 import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.*;
+import ch.njol.skript.doc.Example;
 import org.bukkit.entity.LivingEntity;
 
 @Name("Is Swimming")
 @Description("Checks whether a living entity is swimming.")
-@Examples("player is swimming")
+@Example("player is swimming")
 @Since("2.3")
 public class CondIsSwimming extends PropertyCondition<LivingEntity> {
 	

--- a/src/main/java/ch/njol/skript/conditions/CondScriptLoaded.java
+++ b/src/main/java/ch/njol/skript/conditions/CondScriptLoaded.java
@@ -4,7 +4,7 @@ import ch.njol.skript.ScriptLoader;
 import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptCommand;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Condition;
@@ -20,10 +20,8 @@ import java.io.File;
 
 @Name("Is Script Loaded")
 @Description("Check if the current script, or another script, is currently loaded.")
-@Examples({
-	"script is loaded",
-	"script \"example.sk\" is loaded"
-})
+@Example("script is loaded")
+@Example("script \"example.sk\" is loaded")
 @Since("2.2-dev31")
 public class CondScriptLoaded extends Condition {
 

--- a/src/main/java/ch/njol/skript/effects/EffApplyBoneMeal.java
+++ b/src/main/java/ch/njol/skript/effects/EffApplyBoneMeal.java
@@ -2,7 +2,7 @@ package ch.njol.skript.effects;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.RequiredPlugins;
 import ch.njol.skript.doc.Since;
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("Apply Bone Meal")
 @Description("Applies bone meal to a crop, sapling, or composter")
-@Examples("apply 3 bone meal to event-block")
+@Example("apply 3 bone meal to event-block")
 @RequiredPlugins("MC 1.16.2+")
 @Since("2.8.0")
 public class EffApplyBoneMeal extends Effect {

--- a/src/main/java/ch/njol/skript/effects/EffBreakNaturally.java
+++ b/src/main/java/ch/njol/skript/effects/EffBreakNaturally.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.Nullable;
 import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
@@ -20,9 +20,18 @@ import ch.njol.util.Kleenean;
 @Description({"Breaks the block and spawns items as if a player had mined it",
 		"\nYou can add a tool, which will spawn items based on how that tool would break the block ",
 		"(ie: When using a hand to break stone, it drops nothing, whereas with a pickaxe it drops cobblestone)"})
-@Examples({"on right click:", "\tbreak clicked block naturally",
-		"loop blocks in radius 10 around player:", "\tbreak loop-block using player's tool",
-		"loop blocks in radius 10 around player:", "\tbreak loop-block naturally using diamond pickaxe"})
+@Example("""
+	on right click:
+		break clicked block naturally
+	""")
+@Example("""
+	loop blocks in radius 10 around player:
+		break loop-block using player's tool
+	""")
+@Example("""
+	loop blocks in radius 10 around player:
+		break loop-block naturally using diamond pickaxe
+	""")
 @Since("2.4")
 public class EffBreakNaturally extends Effect {
 	

--- a/src/main/java/ch/njol/skript/effects/EffCharge.java
+++ b/src/main/java/ch/njol/skript/effects/EffCharge.java
@@ -2,7 +2,7 @@ package ch.njol.skript.effects;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
@@ -17,10 +17,10 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("Charge Entity")
 @Description("Charges or uncharges a creeper or wither skull. A creeper is charged when it has been struck by lightning.")
-@Examples({
-	"on spawn of creeper:",
-		"\tcharge the event-entity"
-})
+@Example("""
+	on spawn of creeper:
+		charge the event-entity
+	""")
 @Since("2.5, 2.10 (wither skulls)")
 public class EffCharge extends Effect {
 

--- a/src/main/java/ch/njol/skript/effects/EffColorItems.java
+++ b/src/main/java/ch/njol/skript/effects/EffColorItems.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.Nullable;
 import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
@@ -27,8 +27,8 @@ import ch.njol.util.coll.CollectionUtils;
 		"You can also use RGB codes if you feel limited with the 16 default colors. " +
 		"RGB codes are three numbers from 0 to 255 in the order <code>(red, green, blue)</code>, where <code>(0,0,0)</code> is black and <code>(255,255,255)</code> is white. " +
 		"Armor is colorable for all Minecraft versions. With Minecraft 1.11 or newer you can also color potions and maps. Note that the colors might not look exactly how you'd expect.")
-@Examples({"dye player's helmet blue",
-		"color the player's tool red"})
+@Example("dye player's helmet blue")
+@Example("color the player's tool red")
 @Since("2.0, 2.2-dev26 (maps and potions)")
 public class EffColorItems extends Effect {
 	

--- a/src/main/java/ch/njol/skript/effects/EffForceAttack.java
+++ b/src/main/java/ch/njol/skript/effects/EffForceAttack.java
@@ -7,7 +7,7 @@ import org.jetbrains.annotations.Nullable;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.RequiredPlugins;
 import ch.njol.skript.doc.Since;
@@ -18,8 +18,10 @@ import ch.njol.util.Kleenean;
 
 @Name("Force Attack")
 @Description("Makes a living entity attack an entity with a melee attack.")
-@Examples({"spawn a wolf at player's location",
-	"make last spawned wolf attack player"})
+@Example("""
+	spawn a wolf at player's location
+	make last spawned wolf attack player
+	""")
 @Since("2.5.1")
 @RequiredPlugins("Minecraft 1.15.2+")
 public class EffForceAttack extends Effect {
@@ -29,7 +31,7 @@ public class EffForceAttack extends Effect {
 			"make %livingentities% attack %entity%",
 			"force %livingentities% to attack %entity%");
 	}
-	
+
 	@SuppressWarnings("null")
 	private Expression<LivingEntity> entities;
 	@SuppressWarnings("null")
@@ -52,7 +54,7 @@ public class EffForceAttack extends Effect {
 			}
 		}
 	}
-	
+
 	@Override
 	public String toString(@Nullable Event e, boolean debug) {
 		return "make " + entities.toString(e, debug) + " attack " + target.toString(e, debug);

--- a/src/main/java/ch/njol/skript/effects/EffGoatRam.java
+++ b/src/main/java/ch/njol/skript/effects/EffGoatRam.java
@@ -16,7 +16,7 @@ import org.jetbrains.annotations.Nullable;
 	"Make a goat ram an entity.",
 	"Ramming does have a cooldown and currently no way to change it."
 })
-@Examples("make all goats ram player")
+@Example("make all goats ram player")
 @RequiredPlugins("Paper")
 @Since("2.11")
 public class EffGoatRam extends Effect {

--- a/src/main/java/ch/njol/skript/effects/EffHandedness.java
+++ b/src/main/java/ch/njol/skript/effects/EffHandedness.java
@@ -2,7 +2,7 @@ package ch.njol.skript.effects;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.RequiredPlugins;
 import ch.njol.skript.doc.Since;
@@ -17,12 +17,11 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("Handedness")
 @Description("Make mobs left or right-handed. This does not affect players.")
-@Examples({
-	"spawn skeleton at spawn of world \"world\":",
-		"\tmake entity left handed",
-	"",
-	"make all zombies in radius 10 of player right handed"
-})
+@Example("""
+	spawn skeleton at spawn of world "world":
+		make entity left handed
+	""")
+@Example("make all zombies in radius 10 of player right handed")
 @Since("2.8.0")
 @RequiredPlugins("Paper 1.17.1+")
 public class EffHandedness extends Effect {

--- a/src/main/java/ch/njol/skript/effects/EffIncendiary.java
+++ b/src/main/java/ch/njol/skript/effects/EffIncendiary.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.Nullable;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
@@ -19,8 +19,10 @@ import ch.njol.util.Kleenean;
 
 @Name("Make Incendiary")
 @Description("Sets if an entity's explosion will leave behind fire. This effect is also usable in an explosion prime event.")
-@Examples({"on explosion prime:",
-			"\tmake the explosion fiery"})
+@Example("""
+	on explosion prime:
+		make the explosion fiery
+	""")
 @Since("2.5")
 public class EffIncendiary extends Effect {
 

--- a/src/main/java/ch/njol/skript/effects/EffInvulnerability.java
+++ b/src/main/java/ch/njol/skript/effects/EffInvulnerability.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.Nullable;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
@@ -16,7 +16,7 @@ import ch.njol.util.Kleenean;
 
 @Name("Make Invulnerable")
 @Description("Makes an entity invulnerable/not invulnerable.")
-@Examples("make target entity invulnerable")
+@Example("make target entity invulnerable")
 @Since("2.5")
 public class EffInvulnerability extends Effect {
 	

--- a/src/main/java/ch/njol/skript/effects/EffLoadServerIcon.java
+++ b/src/main/java/ch/njol/skript/effects/EffLoadServerIcon.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.Nullable;
 import ch.njol.skript.ScriptLoader;
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.RequiredPlugins;
 import ch.njol.skript.doc.Since;
@@ -25,14 +25,16 @@ import ch.njol.util.Kleenean;
 @Description({"Loads server icons from the given files. You can get the loaded icon using the",
 		"<a href='#ExprLastLoadedServerIcon'>last loaded server icon</a> expression.",
 		"Please note that the image must be 64x64 and the file path starts from the server folder.",})
-@Examples({"on load:",
-		"	clear {server-icons::*}",
-		"	loop 5 times:",
-		"		load server icon from file \"icons/%loop-number%.png\"",
-		"		add the last loaded server icon to {server-icons::*}",
-		"",
-		"on server list ping:",
-		"	set the icon to a random server icon out of {server-icons::*}"})
+@Example("""
+	on load:
+		clear {server-icons::*}
+		loop 5 times:
+			load server icon from file "icons/%loop-number%.png"
+			add the last loaded server icon to {server-icons::*}
+
+	on server list ping:
+		set the icon to a random server icon out of {server-icons::*}
+	""")
 @Since("2.3")
 @RequiredPlugins("Paper 1.12.2 or newer")
 public class EffLoadServerIcon extends AsyncEffect {

--- a/src/main/java/ch/njol/skript/effects/EffLog.java
+++ b/src/main/java/ch/njol/skript/effects/EffLog.java
@@ -16,7 +16,7 @@ import org.jetbrains.annotations.Nullable;
 import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptConfig;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
@@ -31,14 +31,21 @@ import ch.njol.util.Kleenean;
 @Name("Log")
 @Description({"Writes text into a .log file. Skript will write these files to /plugins/Skript/logs.",
 		"NB: Using 'server.log' as the log file will write to the default server log. Omitting the log file altogether will log the message as '[Skript] [&lt;script&gt;.sk] &lt;message&gt;' in the server log."})
-@Examples({
-	"on join:",
-		"\tlog \"%player% has just joined the server!\"",
-	"on world change:",
-		"\tlog \"Someone just went to %event-world%!\" to file \"worldlog/worlds.log\"",
-	"on command:",
-		"\tlog \"%player% just executed %full command%!\" to file \"server/commands.log\" with a severity of warning"
-})
+@Example("""
+	# Broadcast on join
+	on join:
+		log "%player% has just joined the server!"
+	""")
+@Example("""
+	# Log world changes
+	on world change:
+		log "Someone just went to %event-world%!" to file "worldlog/worlds.log"
+	""")
+@Example("""
+	# Log commands with severity
+	on command:
+		log "%player% just executed %full command%!" to file "server/commands.log" with a severity of warning
+	""")
 @Since("2.0, 2.9.0 (severities)")
 public class EffLog extends Effect {
 	static {

--- a/src/main/java/ch/njol/skript/effects/EffLog.java
+++ b/src/main/java/ch/njol/skript/effects/EffLog.java
@@ -32,17 +32,14 @@ import ch.njol.util.Kleenean;
 @Description({"Writes text into a .log file. Skript will write these files to /plugins/Skript/logs.",
 		"NB: Using 'server.log' as the log file will write to the default server log. Omitting the log file altogether will log the message as '[Skript] [&lt;script&gt;.sk] &lt;message&gt;' in the server log."})
 @Example("""
-	# Broadcast on join
 	on join:
 		log "%player% has just joined the server!"
 	""")
 @Example("""
-	# Log world changes
 	on world change:
 		log "Someone just went to %event-world%!" to file "worldlog/worlds.log"
 	""")
 @Example("""
-	# Log commands with severity
 	on command:
 		log "%player% just executed %full command%!" to file "server/commands.log" with a severity of warning
 	""")

--- a/src/main/java/ch/njol/skript/effects/EffMessage.java
+++ b/src/main/java/ch/njol/skript/effects/EffMessage.java
@@ -30,14 +30,18 @@ import java.util.UUID;
 		"Adding an optional sender allows the messages to be sent as if a specific player sent them.",
 		"This is useful with Minecraft 1.16.4's new chat ignore system, in which players can choose to ignore other players,",
 		"but for this to work, the message needs to be sent from a player."})
-@Examples({"message \"A wild %player% appeared!\"",
-		"message \"This message is a distraction. Mwahaha!\"",
-		"send \"Your kill streak is %{kill streak::%uuid of player%}%.\" to player",
-		"if the targeted entity exists:",
-		"\tmessage \"You're currently looking at a %type of the targeted entity%!\"",
-		"on chat:",
-		"\tcancel event",
-		"\tsend \"[%player%] >> %message%\" to all players from player"})
+@Example("message \"A wild %player% appeared!\"")
+@Example("message \"This message is a distraction. Mwahaha!\"")
+@Example("send \"Your kill streak is %{kill streak::%uuid of player%}%\" to player")
+@Example("""
+		if the targeted entity exists:
+			message "You're currently looking at a %type of the targeted entity%!"
+		""")
+@Example("""
+		on chat:
+			cancel event
+			send "[%player%] >> %message%" to all players from player
+		""")
 @RequiredPlugins("Minecraft 1.16.4+ for optional sender")
 @Since("1.0, 2.2-dev26 (advanced features), 2.5.2 (optional sender), 2.6 (sending objects)")
 public class EffMessage extends Effect {

--- a/src/main/java/ch/njol/skript/effects/EffOpenBook.java
+++ b/src/main/java/ch/njol/skript/effects/EffOpenBook.java
@@ -10,7 +10,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.Aliases;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.RequiredPlugins;
 import ch.njol.skript.doc.Since;
@@ -21,7 +21,7 @@ import ch.njol.util.Kleenean;
 
 @Name("Open Book")
 @Description("Opens a written book to a player.")
-@Examples("open book player's tool to player")
+@Example("open book player's tool to player")
 @RequiredPlugins("Minecraft 1.14.2+")
 @Since("2.5.1")
 public class EffOpenBook extends Effect {

--- a/src/main/java/ch/njol/skript/effects/EffPlaySound.java
+++ b/src/main/java/ch/njol/skript/effects/EffPlaySound.java
@@ -37,12 +37,10 @@ import java.util.OptionalLong;
 	"",
 	"Please note that sound names can get changed in any Minecraft or Spigot version, or even removed from Minecraft itself.",
 })
-@Examples({
-	"play sound \"block.note_block.pling\"",
-	"play sound \"entity.experience_orb.pickup\" with volume 0.5 to the player",
-	"play sound \"custom.music.1\" in jukebox category at {speakerBlock}",
-	"play sound \"BLOCK_AMETHYST_BLOCK_RESONATE\" with seed 1 on target entity for the player #1.20.1+"
-})
+@Example("play sound \"block.note_block.pling\"")
+@Example("play sound \"entity.experience_orb.pickup\" with volume 0.5 to the player")
+@Example("play sound \"custom.music.1\" in jukebox category at {speakerBlock}")
+@Example("play sound \"BLOCK_AMETHYST_BLOCK_RESONATE\" with seed 1 on target entity for the player #1.20.1+")
 @RequiredPlugins("Minecraft 1.18.1+ (entity emitters), Paper 1.19.4+ or Adventure API 4.12.0+ (sound seed)")
 @Since("2.2-dev28, 2.4 (sound categories), 2.9 (sound seed & entity emitter)")
 public class EffPlaySound extends Effect {

--- a/src/main/java/ch/njol/skript/effects/EffRing.java
+++ b/src/main/java/ch/njol/skript/effects/EffRing.java
@@ -2,7 +2,7 @@ package ch.njol.skript.effects;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.RequiredPlugins;
 import ch.njol.skript.doc.Since;
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.Nullable;
 	"A bell can only ring in two directions, and the direction is determined by which way the bell is facing.",
 	"By default, the bell will ring in the direction it is facing.",
 })
-@Examples({"make player ring target-block"})
+@Example("make player ring target-block")
 @RequiredPlugins("Spigot 1.19.4+")
 @Since("2.9.0")
 public class EffRing extends Effect {

--- a/src/main/java/ch/njol/skript/effects/EffRun.java
+++ b/src/main/java/ch/njol/skript/effects/EffRun.java
@@ -16,11 +16,11 @@ import org.skriptlang.skript.util.Executable;
 
 @Name("Run (Experimental)")
 @Description("Executes a task (a function). Any returned result is discarded.")
-@Examples({
-		"set {_function} to the function named \"myFunction\"",
-		"run {_function}",
-		"run {_function} with arguments {_things::*}",
-})
+@Example("""
+	set {_function} to the function named "myFunction"
+	run {_function}
+	run {_function} with arguments {_things::*}
+	""")
 @Since("2.10")
 @Keywords({"run", "execute", "reflection", "function"})
 @SuppressWarnings({"rawtypes", "unchecked"})

--- a/src/main/java/ch/njol/skript/effects/EffStopServer.java
+++ b/src/main/java/ch/njol/skript/effects/EffStopServer.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.Nullable;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
@@ -17,7 +17,8 @@ import ch.njol.util.Kleenean;
 
 @Name("Stop Server")
 @Description("Stops or restarts the server. If restart is used when the restart-script spigot.yml option isn't defined, the server will stop instead.")
-@Examples({"stop the server", "restart server"})
+@Example("stop the server")
+@Example("restart server")
 @Since("2.5")
 public class EffStopServer extends Effect {
 	

--- a/src/main/java/ch/njol/skript/effects/EffToggle.java
+++ b/src/main/java/ch/njol/skript/effects/EffToggle.java
@@ -31,8 +31,10 @@ import ch.njol.util.Kleenean;
 		projectile is arrow
 		toggle the block at the arrow
 	""")
-@Example("# With booleans")
-@Example("toggle gravity of player")
+@Example("""
+	# With booleans
+	toggle gravity of player
+	""")
 @Since("1.4, 2.12 (booleans)")
 public class EffToggle extends Effect {
 

--- a/src/main/java/ch/njol/skript/effects/EffToggle.java
+++ b/src/main/java/ch/njol/skript/effects/EffToggle.java
@@ -14,7 +14,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.classes.Changer.ChangerUtils;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
@@ -25,14 +25,14 @@ import ch.njol.util.Kleenean;
 
 @Name("Toggle")
 @Description("Toggle the state of a block or boolean.")
-@Examples({"# use arrows to toggle switches, doors, etc.",
-		"on projectile hit:",
-		"\tprojectile is arrow",
-		"\ttoggle the block at the arrow",
-		"",
-		"# With booleans",
-		"toggle gravity of player"
-})
+@Example("""
+	# use arrows to toggle switches, doors, etc.
+	on projectile hit:
+		projectile is arrow
+		toggle the block at the arrow
+	""")
+@Example("# With booleans")
+@Example("toggle gravity of player")
 @Since("1.4, 2.12 (booleans)")
 public class EffToggle extends Effect {
 

--- a/src/main/java/ch/njol/skript/effects/EffWakeupSleep.java
+++ b/src/main/java/ch/njol/skript/effects/EffWakeupSleep.java
@@ -3,7 +3,7 @@ package ch.njol.skript.effects;
 import ch.njol.skript.Skript;
 import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
@@ -27,13 +27,11 @@ import org.jetbrains.annotations.Nullable;
 		+ "Does not work if the location of the bed is not in the world the player is currently in.",
 	"Using 'without spawn location update' will make players wake up without setting their spawn location to the bed."
 })
-@Examples({
-	"make {_fox} go to sleep",
-	"make {_bat} stop sleeping",
-	"make {_villager} start sleeping at location(0, 0, 0)",
-	"make player go to sleep at location(0, 0, 0) with force",
-	"make player wake up without spawn location update"
-})
+@Example("make {_fox} go to sleep")
+@Example("make {_bat} stop sleeping")
+@Example("make {_villager} start sleeping at location(0, 0, 0)")
+@Example("make player go to sleep at location(0, 0, 0) with force")
+@Example("make player wake up without spawn location update")
 @Since("2.11")
 public class EffWakeupSleep extends Effect {
 

--- a/src/main/java/ch/njol/skript/expressions/ExprAffectedEntities.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAffectedEntities.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.Nullable;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
@@ -23,10 +23,12 @@ import ch.njol.util.Kleenean;
 
 @Name("Affected Entities")
 @Description("The affected entities in the <a href='#aoe_cloud_effect'>area cloud effect</a> event.")
-@Examples({"on area cloud effect:",
-		"\tloop affected entities:",
-		"\t\tif loop-value is a player:",
-		"\t\t\tsend \"WARNING: you've step on an area effect cloud!\" to loop-value"})
+@Example("""
+	on area cloud effect:
+		loop affected entities:
+			if loop-value is a player:
+				send "WARNING: you've step on an area effect cloud!" to loop-value
+	""")
 @Since("2.4")
 public class ExprAffectedEntities extends SimpleExpression<LivingEntity> {
 

--- a/src/main/java/ch/njol/skript/expressions/ExprAllCommands.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAllCommands.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.Nullable;
 import ch.njol.skript.Skript;
 import ch.njol.skript.command.Commands;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
@@ -17,8 +17,8 @@ import ch.njol.util.Kleenean;
 
 @Name("All commands")
 @Description("Returns all registered commands or all script commands.")
-@Examples({"send \"Number of all commands: %size of all commands%\"",
-	"send \"Number of all script commands: %size of all script commands%\""})
+@Example("send \"Number of all commands: %size of all commands%\"")
+@Example("send \"Number of all script commands: %size of all script commands%\"")
 @Since("2.6")
 public class ExprAllCommands extends SimpleExpression<String> {
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprArrowKnockbackStrength.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprArrowKnockbackStrength.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.Nullable;
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
@@ -17,9 +17,11 @@ import ch.njol.util.coll.CollectionUtils;
 
 @Name("Arrow Knockback Strength")
 @Description("An arrow's knockback strength.")
-@Examples({"on shoot:",
-	"\tevent-projectile is an arrow",
-	"\tset arrow knockback strength of event-projectile to 10"})
+@Example("""
+	on shoot:
+		event-projectile is an arrow
+		set arrow knockback strength of event-projectile to 10
+	""")
 @Since("2.5.1")
 public class ExprArrowKnockbackStrength extends SimplePropertyExpression<Projectile, Long> {
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprBookTitle.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBookTitle.java
@@ -3,7 +3,7 @@ package ch.njol.skript.expressions;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
@@ -14,8 +14,10 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("Book Title")
 @Description("The title of a book.")
-@Examples({"on book sign:",
-			"\tmessage \"Book Title: %title of event-item%\""})
+@Example("""
+	on book sign:
+		message "Book Title: %title of event-item%"
+	""")
 @Since("2.2-dev31")
 public class ExprBookTitle extends SimplePropertyExpression<ItemType, String> {
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprBreakSpeed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprBreakSpeed.java
@@ -2,7 +2,7 @@ package ch.njol.skript.expressions;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.RequiredPlugins;
 import ch.njol.skript.doc.Since;
@@ -25,11 +25,11 @@ import java.util.ArrayList;
 	"breaking the block each tick. When the total breaking progress reaches 1.0, the block is broken. Note that the " +
 	"break speed can change in the course of breaking a block, e.g. if a potion effect is applied or expires, or the " +
 	"player jumps/enters water.")
-@Examples({
-	"on left click using diamond pickaxe:",
-		"\tevent-block is set",
-		"\tsend \"Break Speed: %break speed for player%\" to player"
-})
+@Example("""
+	on left click using diamond pickaxe:
+		event-block is set
+		send "Break Speed: %break speed for player%" to player
+	""")
 @Since("2.7")
 @RequiredPlugins("1.17+")
 public class ExprBreakSpeed extends SimpleExpression<Float> {

--- a/src/main/java/ch/njol/skript/expressions/ExprCharges.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCharges.java
@@ -4,7 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.RequiredPlugins;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
@@ -23,7 +23,7 @@ import static java.lang.Math.min;
 
 @Name("Respawn Anchor Charges")
 @Description("The charges of a respawn anchor.")
-@Examples({"set the charges of event-block to 3"})
+@Example("set the charges of event-block to 3")
 @RequiredPlugins("Minecraft 1.16+")
 @Since("2.7")
 public class ExprCharges extends SimplePropertyExpression<Block, Integer> {

--- a/src/main/java/ch/njol/skript/expressions/ExprClicked.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprClicked.java
@@ -19,7 +19,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Events;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.entity.EntityData;
@@ -35,11 +35,11 @@ import ch.njol.util.coll.CollectionUtils;
 
 @Name("Clicked Block/Entity/Inventory/Slot")
 @Description("The clicked block, entity, inventory, inventory slot, inventory click type or inventory action.")
-@Examples({
-	"message \"You clicked on a %type of clicked entity%!\"",
-	"if the clicked block is a chest:",
-		"\tshow the inventory of the clicked block to the player"
-})
+@Example("""
+	message "You clicked on a %type of clicked entity%!"
+	if the clicked block is a chest:
+		show the inventory of the clicked block to the player
+	""")
 @Since("1.0, 2.2-dev35 (more clickable things)")
 @Events({"click", "inventory click"})
 public class ExprClicked extends SimpleExpression<Object> {

--- a/src/main/java/ch/njol/skript/expressions/ExprCoordinate.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprCoordinate.java
@@ -3,7 +3,7 @@ package ch.njol.skript.expressions;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
@@ -21,8 +21,10 @@ import ch.njol.skript.lang.simplification.SimplifiedLiteral;
  */
 @Name("Coordinate")
 @Description("Represents a given coordinate of a location. ")
-@Examples({"player's y-coordinate is smaller than 40:",
-		"	message \"Watch out for lava!\""})
+@Example("""
+	player's y-coordinate is smaller than 40:
+		message "Watch out for lava!"
+	""")
 @Since("1.4.3")
 public class ExprCoordinate extends SimplePropertyExpression<Location, Number> {
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprDamage.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDamage.java
@@ -11,7 +11,7 @@ import ch.njol.skript.bukkitutil.HealthUtils;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Events;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
@@ -28,13 +28,15 @@ import ch.njol.util.coll.CollectionUtils;
 	"For entity damage events, possibly ignoring armour, criticals and/or enchantments (remember that in Skript '1' is one full heart, not half a heart).",
 	"For items, it's the amount of durability damage the item will be taking."
 })
-@Examples({
-	"on item damage:",
-		"\tevent-item is any tool",
-		"\tclear damage # unbreakable tools as the damage will be 0",
-	"on damage:",
-		"\tincrease the damage by 2"
-})
+@Example("""
+	on item damage:
+		event-item is any tool
+		clear damage # unbreakable tools as the damage will be 0
+	""")
+@Example("""
+	on damage:
+		increase the damage by 2
+	""")
 @Since("1.3.5, 2.8.0 (item damage event)")
 @Events({"Damage", "Vehicle Damage", "Item Damage"})
 public class ExprDamage extends SimpleExpression<Number> {

--- a/src/main/java/ch/njol/skript/expressions/ExprDamageCause.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDamageCause.java
@@ -3,7 +3,7 @@ package ch.njol.skript.expressions;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.EventValueExpression;
@@ -11,7 +11,7 @@ import ch.njol.skript.registrations.EventValues;
 
 @Name("Damage Cause")
 @Description("The <a href='#damagecause'>damage cause</a> of a damage event. Please click on the link for more information.")
-@Examples("damage cause is lava, fire or burning")
+@Example("damage cause is lava, fire or burning")
 @Since("2.0")
 public class ExprDamageCause extends EventValueExpression<DamageCause> {
 

--- a/src/main/java/ch/njol/skript/expressions/ExprDequeuedQueue.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDequeuedQueue.java
@@ -2,7 +2,7 @@ package ch.njol.skript.expressions;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
@@ -23,12 +23,11 @@ import org.skriptlang.skript.lang.util.SkriptQueue;
 	The order of the list will be the same as the order of the elements in the queue.
 	If a list variable is set to this, it will use numerical indices.
 	The original queue will not be changed.""")
-@Examples({
-	"""
-		set {queue} to a new queue
-		add "hello" and "there" to {queue}
-		set {list::*} to dequeued {queue}"""
-})
+@Example("""
+	set {queue} to a new queue
+	add "hello" and "there" to {queue}
+	set {list::*} to dequeued {queue}
+	""")
 @Since("2.10 (experimental)")
 public class ExprDequeuedQueue extends SimpleExpression<Object> implements QueueExperimentSyntax {
 

--- a/src/main/java/ch/njol/skript/expressions/ExprEnchantmentLevel.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEnchantmentLevel.java
@@ -4,7 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
@@ -22,8 +22,10 @@ import java.util.stream.Stream;
 
 @Name("Enchantment Level")
 @Description("The level of a particular <a href='#enchantment'>enchantment</a> on an item.")
-@Examples({"player's tool is a sword of sharpness:",
-	"\tmessage \"You have a sword of sharpness %level of sharpness of the player's tool% equipped\""})
+@Example("""
+	player's tool is a sword of sharpness:
+		message "You have a sword of sharpness %level of sharpness of the player's tool% equipped"
+	""")
 @Since("2.0")
 public class ExprEnchantmentLevel extends SimpleExpression<Long> {
 

--- a/src/main/java/ch/njol/skript/expressions/ExprHostname.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHostname.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.Nullable;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
@@ -17,10 +17,11 @@ import ch.njol.util.Kleenean;
 
 @Name("Hostname")
 @Description("The hostname used by the connecting player to connect to the server in a <a href='#connect'>connect</a> event.")
-@Examples({
-		"on connect:",
-		"\thostname is \"testers.example.com\"",
-		"\tsend \"Welcome back tester!\""})
+@Example("""
+	on connect:
+		hostname is "testers.example.com"
+		send "Welcome back tester!"
+	""")
 @Since("2.6.1")
 public class ExprHostname extends SimpleExpression<String> {
 

--- a/src/main/java/ch/njol/skript/expressions/ExprIP.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprIP.java
@@ -26,8 +26,10 @@ import ch.njol.util.coll.CollectionUtils;
 @Name("IP")
 @Description("The IP address of a player, or the connected player in a <a href='#connect'>connect</a> event, " +
 		"or the pinger in a <a href='#server_list_ping'>server list ping</a> event.")
-@Example("ban the IP address of the player")
-@Example("broadcast \"Banned the IP %IP of player%\"")
+@Example("""
+	ban the IP address of the player")
+	broadcast "Banned the IP %IP of player%"
+	""")
 @Example("""
 	on connect:
 		log "[%now%] %player% (%ip%) is connected to the server."

--- a/src/main/java/ch/njol/skript/expressions/ExprIP.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprIP.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.Nullable;
 import com.destroystokyo.paper.event.server.PaperServerListPingEvent;
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
@@ -26,14 +26,16 @@ import ch.njol.util.coll.CollectionUtils;
 @Name("IP")
 @Description("The IP address of a player, or the connected player in a <a href='#connect'>connect</a> event, " +
 		"or the pinger in a <a href='#server_list_ping'>server list ping</a> event.")
-@Examples({"ban the IP address of the player",
-		"broadcast \"Banned the IP %IP of player%\"",
-		"",
-		"on connect:",
-		"\tlog \"[%now%] %player% (%ip%) is connected to the server.\"",
-		"",
-		"on server list ping:",
-		"\tsend \"%IP-address%\" to the console"})
+@Example("ban the IP address of the player")
+@Example("broadcast \"Banned the IP %IP of player%\"")
+@Example("""
+	on connect:
+		log "[%now%] %player% (%ip%) is connected to the server."
+	""")
+@Example("""
+	on server list ping:
+		send "%IP-address%" to the console
+	""")
 @Since("1.4, 2.2-dev26 (when used in connect event), 2.3 (when used in server list ping event)")
 public class ExprIP extends SimpleExpression<String> {
 

--- a/src/main/java/ch/njol/skript/expressions/ExprLastSpawnedEntity.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLastSpawnedEntity.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.Nullable;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.effects.EffDrop;
@@ -31,16 +31,20 @@ import ch.njol.util.Kleenean;
 @Description("Holds the entity that was spawned most recently with the spawn effect (section), dropped with the <a href='../effects/#EffDrop'>drop effect</a>, shot with the <a href='../effects/#EffShoot'>shoot effect</a> or created with the <a href='../effects/#EffLightning'>lightning effect</a>. " +
 		"Please note that even though you can spawn multiple mobs simultaneously (e.g. with 'spawn 5 creepers'), only the last spawned mob is saved and can be used. " +
 		"If you spawn an entity, shoot a projectile and drop an item you can however access all them together.")
-@Examples({
-	"spawn a priest",
-	"set {healer::%spawned priest%} to true",
-	"shoot an arrow from the last spawned entity",
-	"ignite the shot projectile",
-	"drop a diamond sword",
-	"push last dropped item upwards",
-	"teleport player to last struck lightning",
-	"delete last launched firework"
-})
+@Example("""
+	spawn a priest
+	set {healer::%spawned priest%} to true
+	""")
+@Example("""
+	shoot an arrow from the last spawned entity
+	ignite the shot projectile
+	""")
+@Example("""
+	drop a diamond sword
+	push last dropped item upwards
+	""")
+@Example("teleport player to last struck lightning")
+@Example("delete last launched firework")
 @Since("1.3 (spawned entity), 2.0 (shot entity), 2.2-dev26 (dropped item), 2.7 (struck lightning, firework)")
 public class ExprLastSpawnedEntity extends SimpleExpression<Entity> {
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprLoopIteration.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLoopIteration.java
@@ -2,7 +2,7 @@ package ch.njol.skript.expressions;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
@@ -18,17 +18,18 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("Loop Iteration")
 @Description("Returns the loop's current iteration count (for both normal and while loops).")
-@Examples({
-	"while player is online:",
-	"\tgive player 1 stone",
-	"\twait 5 ticks",
-	"\tif loop-counter > 30:",
-	"\t\tstop loop",
-	"",
-	"loop {top-balances::*}:",
-	"\tif loop-iteration <= 10:",
-	"\t\tbroadcast \"#%loop-iteration% %loop-index% has $%loop-value%\"",
-})
+@Example("""
+	while player is online:
+		give player 1 stone
+		wait 5 ticks
+		if loop-counter > 30:
+			stop loop
+	""")
+@Example("""
+	loop {top-balances::*}:
+		if loop-iteration <= 10:
+			broadcast "#%loop-iteration% %loop-index% has $%loop-value%"
+	""")
 @Since("2.8.0")
 public class ExprLoopIteration extends SimpleExpression<Long> {
 

--- a/src/main/java/ch/njol/skript/expressions/ExprMaxHealth.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprMaxHealth.java
@@ -9,7 +9,7 @@ import ch.njol.skript.bukkitutil.HealthUtils;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Events;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
@@ -19,10 +19,14 @@ import ch.njol.skript.expressions.base.SimplePropertyExpression;
  */
 @Name("Max Health")
 @Description("The maximum health of an entity, e.g. 10 for a player.")
-@Examples({"on join:",
-		"	set the maximum health of the player to 100",
-		"spawn a giant",
-		"set the last spawned entity's max health to 1000"})
+@Example("""
+	on join:
+		set the maximum health of the player to 100
+	""")
+@Example("""
+	spawn a giant
+	set the last spawned entity's max health to 1000
+	""")
 @Since("2.0")
 @Events({"damage", "death"})
 public class ExprMaxHealth extends SimplePropertyExpression<LivingEntity, Number> {

--- a/src/main/java/ch/njol/skript/expressions/ExprMaxItemUseTime.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprMaxItemUseTime.java
@@ -13,10 +13,10 @@ import org.jetbrains.annotations.Nullable;
 	"E.g. it takes 1.6 seconds to drink a potion, or 1.4 seconds to load an unenchanted crossbow.",
 	"Some items, like bows and shields, do not have a limit to their use. They will return 1 hour."
 })
-@Examples({
-	"on right click:",
-		"\tbroadcast max usage duration of player's tool"
-})
+@Example("""
+	on right click:
+		broadcast max usage duration of player's tool
+	""")
 @Since("2.8.0")
 @RequiredPlugins("Paper")
 public class ExprMaxItemUseTime extends SimplePropertyExpression<ItemStack, Timespan> {

--- a/src/main/java/ch/njol/skript/expressions/ExprMaxMinecartSpeed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprMaxMinecartSpeed.java
@@ -7,7 +7,7 @@ import org.jetbrains.annotations.Nullable;
 
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
@@ -15,8 +15,10 @@ import ch.njol.util.coll.CollectionUtils;
 
 @Name("Max Minecart Speed")
 @Description("The maximum speed of a minecart.")
-@Examples({"on right click on minecart:",
-	"\tset max minecart speed of event-entity to 1"})
+@Example("""
+	on right click on minecart:
+		set max minecart speed of event-entity to 1
+	""")
 @Since("2.5.1")
 public class ExprMaxMinecartSpeed extends SimplePropertyExpression<Entity, Number> {
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprSkull.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSkull.java
@@ -7,17 +7,15 @@ import org.jetbrains.annotations.Nullable;
 
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
 
 @Name("Player Skull")
 @Description("Gets a skull item representing a player. Skulls for other entities are provided by the aliases.")
-@Examples({
-	"give the victim's skull to the attacker",
-	"set the block at the entity to the entity's skull"
-})
+@Example("give the victim's skull to the attacker")
+@Example("set the block at the entity to the entity's skull")
 @Since("2.0")
 public class ExprSkull extends SimplePropertyExpression<OfflinePlayer, ItemType> {
 

--- a/src/main/java/ch/njol/skript/expressions/ExprSlotIndex.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSlotIndex.java
@@ -6,7 +6,7 @@ import ch.njol.util.Kleenean;
 import org.jetbrains.annotations.Nullable;
 
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
@@ -23,14 +23,15 @@ import ch.njol.skript.util.slot.SlotWithIndex;
 	"",
 	"Raw index of slot is unique for the view, see <a href=\"https://wiki.vg/Inventory\">Minecraft Wiki</a>",
 })
-@Examples({
-	"if index of event-slot is 10:",
-	"\tsend \"You bought a pie!\"",
-	"",
-	"if display name of player's top inventory is \"Custom Menu\": # 3 rows inventory",
-	"\tif raw index of event-slot > 27: # outside custom inventory",
-	"\t\tcancel event",
-})
+@Example("""
+	if index of event-slot is 10:
+		send "You bought a pie!"
+	""")
+@Example("""
+	if display name of player's top inventory is "Custom Menu": # 3 rows inventory
+		if raw index of event-slot > 27: # outside custom inventory
+			cancel event
+	""")
 @Since("2.2-dev35, 2.8.0 (raw index)")
 public class ExprSlotIndex extends SimplePropertyExpression<Slot, Long> {
 	

--- a/src/main/java/ch/njol/skript/expressions/ExprSpectatorTarget.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSpectatorTarget.java
@@ -2,7 +2,7 @@ package ch.njol.skript.expressions;
 
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
@@ -20,7 +20,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.classes.data.DefaultChangers;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.RequiredPlugins;
 import ch.njol.skript.doc.Since;
@@ -35,14 +35,15 @@ import ch.njol.util.coll.CollectionUtils;
 
 @Name("Spectator Target")
 @Description("Grabs the spectator target entity of the players.")
-@Examples({
-	"on player start spectating of player:",
-		"\tmessage \"&c%spectator target% currently has %{game::kills::%spectator target%}% kills!\" to the player",
-	"",
-	"on player stop spectating:",
-		"\tpast spectator target was a zombie",
-		"\tset spectator target to the nearest skeleton"
-})
+@Example("""
+	on player start spectating of player:
+		message "&c%spectator target% currently has %{game::kills::%spectator target%}% kills!" to the player
+	""")
+@Example("""
+	on player stop spectating:
+		past spectator target was a zombie
+		set spectator target to the nearest skeleton
+	""")
 @RequiredPlugins("Paper")
 @Since("2.4-alpha4, 2.7 (Paper Spectator Event)")
 public class ExprSpectatorTarget extends SimpleExpression<Entity> {

--- a/src/main/java/ch/njol/skript/expressions/ExprTargetedBlock.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTargetedBlock.java
@@ -4,7 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptConfig;
 import ch.njol.skript.bukkitutil.ItemUtils;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.PropertyExpression;
@@ -22,16 +22,14 @@ import org.jetbrains.annotations.Nullable;
 	"The block at the crosshair. This regards all blocks that are not air as fully solid, e.g. torches will be like a solid stone block for this expression.",
 	"The actual target block will regard the actual hit box of the block."
 })
-@Examples({
-	"set target block of player to stone",
-	"set target block of player to oak_stairs[waterlogged=true]",
-	"break target block of player using player's tool",
-	"give player 1 of type of target block",
-	"teleport player to location above target block",
-	"kill all entities in radius 3 around target block of player",
-	"set {_block} to actual target block of player",
-	"break actual target block of player"
-})
+@Example("set target block of player to stone")
+@Example("set target block of player to oak_stairs[waterlogged=true]")
+@Example("break target block of player using player's tool")
+@Example("give player 1 of type of target block")
+@Example("teleport player to location above target block")
+@Example("kill all entities in radius 3 around target block of player")
+@Example("set {_block} to actual target block of player")
+@Example("break actual target block of player")
 @Since("1.0, 2.9.0 (actual/exact)")
 public class ExprTargetedBlock extends PropertyExpression<LivingEntity, Block> {
 

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorDotProduct.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorDotProduct.java
@@ -7,7 +7,7 @@ import org.jetbrains.annotations.Nullable;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
@@ -20,7 +20,7 @@ import ch.njol.skript.lang.simplification.SimplifiedLiteral;
 
 @Name("Vectors - Dot Product")
 @Description("Gets the dot product between two vectors.")
-@Examples("set {_dot} to {_v1} dot {_v2}")
+@Example("set {_dot} to {_v1} dot {_v2}")
 @Since("2.2-dev28")
 public class ExprVectorDotProduct extends SimpleExpression<Number> {
 

--- a/src/main/java/ch/njol/skript/expressions/ExprWeather.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprWeather.java
@@ -25,12 +25,10 @@ import org.jetbrains.annotations.Nullable;
 	"Clearing or resetting the weather of a player will make the player's weather match the weather of the world.",
 	"Clearing or resetting the weather of a world will make the weather clear."
 })
-@Examples({
-	"set weather to clear",
-	"weather in \"world\" is rainy",
-	"reset custom weather of player",
-	"set weather of player to clear"
-})
+@Example("set weather to clear")
+@Example("weather in \"world\" is rainy")
+@Example("reset custom weather of player")
+@Example("set weather of player to clear")
 @Since("1.0")
 @Events("weather change")
 public class ExprWeather extends PropertyExpression<Object, WeatherType> {

--- a/src/main/java/ch/njol/skript/sections/EffSecShoot.java
+++ b/src/main/java/ch/njol/skript/sections/EffSecShoot.java
@@ -3,7 +3,7 @@ package ch.njol.skript.sections;
 import ch.njol.skript.Skript;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.entity.EntityData;
@@ -35,11 +35,11 @@ import java.util.function.Consumer;
 
 @Name("Shoot")
 @Description("Shoots a projectile (or any other entity) from a given entity or location.")
-@Examples({
-	"shoot arrow from all players at speed 2",
-	"shoot a pig from all players:",
-		"\tadd event-entity to {_projectiles::*}"
-})
+@Example("shoot arrow from all players at speed 2")
+@Example("""
+	shoot a pig from all players:
+		add event-entity to {_projectiles::*}
+	""")
 @Since("2.10")
 public class EffSecShoot extends EffectSection {
 

--- a/src/main/java/ch/njol/skript/sections/EffSecSpawn.java
+++ b/src/main/java/ch/njol/skript/sections/EffSecSpawn.java
@@ -38,15 +38,16 @@ import java.util.function.Consumer;
 	"",
 	"Note that when spawning an entity via entity snapshots, the code within the section will not run instantaneously as compared to spawning normally (via 'a zombie')."
 })
-@Examples({
-	"spawn 3 creepers at the targeted block",
-	"spawn a ghast 5 meters above the player",
-	"spawn a zombie at the player:",
-		"\tset name of the zombie to \"\"",
-	"",
-	"spawn a block display of a ladder[waterlogged=true] at location above player:",
-		"\tset billboard of event-display to center # allows the display to rotate around the center axis"
-})
+@Example("spawn 3 creepers at the targeted block")
+@Example("spawn a ghast 5 meters above the player")
+@Example("""
+	spawn a zombie at the player:
+		set name of the zombie to ""
+	""")
+@Example("""
+	spawn a block display of a ladder[waterlogged=true] at location above player:
+		set billboard of event-display to center # allows the display to rotate around the center axis
+	""")
 @RequiredPlugins("Minecraft 1.20.2+ (entity snapshots)")
 @Since("1.0, 2.6.1 (with section), 2.8.6 (dropped items), 2.10 (entity snapshots)")
 public class EffSecSpawn extends EffectSection {

--- a/src/main/java/ch/njol/skript/sections/SecConditional.java
+++ b/src/main/java/ch/njol/skript/sections/SecConditional.java
@@ -5,7 +5,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.config.Node;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.*;
@@ -39,20 +39,18 @@ import java.util.List;
 	"else parse if: another special case of 'else if' condition that its code will not be parsed if all previous chained " +
 		"conditionals weren't executed, and its condition is true",
 })
-@Examples({
-	"if player's health is greater than or equal to 4:",
-	"\tsend \"Your health is okay so far but be careful!\"",
-	"",
-	"else if player's health is greater than 2:",
-	"\tsend \"You need to heal ASAP, your health is very low!\"",
-	"",
-	"else: # Less than 2 hearts",
-	"\tsend \"You are about to DIE if you don't heal NOW. You have only %player's health% heart(s)!\"",
-	"",
-	"parse if plugin \"SomePluginName\" is enabled: # parse if %condition%",
-	"\t# This code will only be executed if the condition used is met otherwise Skript will not parse this section therefore will not give any errors/info about this section",
-	""
-})
+@Example("""
+	if player's health is greater than or equal to 4:
+		send "Your health is okay so far but be careful!"
+	else if player's health is greater than 2:
+		send "You need to heal ASAP, your health is very low!"
+	else: # Less than 2 hearts
+		send "You are about to DIE if you don't heal NOW. You have only %player's health% heart(s)!"
+	""")
+@Example("""
+	parse if plugin "SomePluginName" is enabled: # parse if %condition%
+		# This code will only be executed if the condition used is met otherwise Skript will not parse this section therefore will not give any errors/info about this section
+	""")
 @Since("1.0")
 public class SecConditional extends Section {
 

--- a/src/main/java/ch/njol/skript/sections/SecFor.java
+++ b/src/main/java/ch/njol/skript/sections/SecFor.java
@@ -5,7 +5,7 @@ import ch.njol.skript.SkriptAPIException;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.*;
@@ -33,22 +33,26 @@ import java.util.List;
 	
 	When looping a simple (non-indexed) set of values, e.g. all players, the index will be the loop counter number."""
 )
-@Examples({
-	"for each {_player} in players:",
-	"\tsend \"Hello %{_player}%!\" to {_player}",
-	"",
-	"loop {_item} in {list of items::*}:",
-	"\tbroadcast {_item}'s name",
-	"",
-	"for each key {_index} in {list of items::*}:",
-	"\tbroadcast {_index}",
-	"",
-	"loop key {_index} and value {_value} in {list of items::*}:",
-	"\tbroadcast \"%{_index}% = %{_value}%\"",
-	"",
-	"for each {_index}, {_value} in {my list::*}:",
-	"\tbroadcast \"%{_index}% = %{_value}%\"",
-})
+@Example("""
+	for each {_player} in players:
+		send "Hello %{_player}%!" to {_player}
+	""")
+@Example("""
+	loop {_item} in {list of items::*}:
+		broadcast {_item}'s name
+	""")
+@Example("""
+	for each key {_index} in {list of items::*}:
+		broadcast {_index}
+	""")
+@Example("""
+	loop key {_index} and value {_value} in {list of items::*}:
+		broadcast "%{_index}% = %{_value}%"
+	""")
+@Example("""
+	for each {_index}, {_value} in {my list::*}:
+		broadcast "%{_index}% = %{_value}%"
+	""")
 @Since("2.10")
 public class SecFor extends SecLoop implements SimpleExperimentalSyntax {
 

--- a/src/main/java/ch/njol/skript/sections/SecLoop.java
+++ b/src/main/java/ch/njol/skript/sections/SecLoop.java
@@ -4,7 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptAPIException;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.*;
@@ -42,30 +42,34 @@ import java.util.*;
 		"the loop. <code>loop-value</code> is the value of the currently looped variable, and <code>loop-index</code> " +
 		"is the last part of the variable's name (the part where the list variable has its asterisk *)."
 })
-@Examples({
-	"loop all players:",
-		"\tsend \"Hello %loop-player%!\" to loop-player",
-	"",
-	"loop items in player's inventory:",
-		"\tif loop-item is dirt:",
-			"\t\tset loop-item to air",
-	"",
-	"loop 10 times:",
-		"\tsend title \"%11 - loop-value%\" and subtitle \"seconds left until the game begins\" to player for 1 second # 10, 9, 8 etc.",
-		"\twait 1 second",
-	"",
-	"loop {Coins::*}:",
-		"\tset {Coins::%loop-index%} to loop-value + 5 # Same as \"add 5 to {Coins::%loop-index%}\" where loop-index is the uuid of " +
-		"the player and loop-value is the number of coins for the player",
-	"",
-	"loop shuffled (integers between 0 and 8):",
-		"\tif all:",
-			"\t\tprevious loop-value = 1",
-			"\t\tloop-value = 4",
-			"\t\tnext loop-value = 8",
-		"\tthen:",
-			"\t\t kill all players"
-})
+@Example("""
+	loop all players:
+		send "Hello %loop-player%!" to loop-player
+	""")
+@Example("""
+	loop items in player's inventory:
+		if loop-item is dirt:
+			set loop-item to air
+	""")
+@Example("""
+	loop 10 times:
+		send title "%11 - loop-value%" and subtitle "seconds left until the game begins" to player for 1 second # 10, 9, 8 etc.
+		wait 1 second
+	""")
+@Example("""
+	loop {Coins::*}:
+		set {Coins::%loop-index%} to loop-value + 5 # Same as "add 5 to {Coins::%loop-index%}" where loop-index is the uuid of " +
+		"the player and loop-value is the number of coins for the player
+	""")
+@Example("""
+	loop shuffled (integers between 0 and 8):
+		if all:
+			previous loop-value = 1
+			loop-value = 4
+			next loop-value = 8
+		then:
+			kill all players
+	""")
 @Since("1.0")
 public class SecLoop extends LoopSection {
 

--- a/src/main/java/ch/njol/skript/sections/SecWhile.java
+++ b/src/main/java/ch/njol/skript/sections/SecWhile.java
@@ -3,7 +3,7 @@ package ch.njol.skript.sections;
 import ch.njol.skript.Skript;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.*;
@@ -16,22 +16,24 @@ import java.util.List;
 
 @Name("While Loop")
 @Description("While Loop sections are loops that will just keep repeating as long as a condition is met.")
-@Examples({
-	"while size of all players < 5:",
-	"\tsend \"More players are needed to begin the adventure\" to all players",
-	"\twait 5 seconds",
-	"",
-	"set {_counter} to 1",
-	"do while {_counter} > 1: # false but will increase {_counter} by 1 then get out",
-	"\tadd 1 to {_counter}",
-	"",
-	"# Be careful when using while loops with conditions that are almost ",
-	"# always true for a long time without using 'wait %timespan%' inside it, ",
-	"# otherwise it will probably hang and crash your server.",
-	"while player is online:",
-	"\tgive player 1 dirt",
-	"\twait 1 second # without using a delay effect the server will crash",
-})
+@Example("""
+	while size of all players < 5:
+		send "More players are needed to begin the adventure" to all players
+		wait 5 seconds
+	""")
+@Example("""
+	set {_counter} to 1
+	do while {_counter} > 1: # false but will increase {_counter} by 1 then get out
+		add 1 to {_counter}
+	""")
+@Example("""
+	# Be careful when using while loops with conditions that are almost
+	# always true for a long time without using 'wait %timespan%' inside it,
+	# otherwise it will probably hang and crash your server.
+	while player is online:
+		give player 1 dirt
+		wait 1 second # without using a delay effect the server will crash
+	""")
 @Since("2.0, 2.6 (do while)")
 public class SecWhile extends LoopSection {
 

--- a/src/main/java/ch/njol/skript/structures/StructAliases.java
+++ b/src/main/java/ch/njol/skript/structures/StructAliases.java
@@ -5,7 +5,7 @@ import ch.njol.skript.aliases.Aliases;
 import ch.njol.skript.aliases.ScriptAliases;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Literal;
@@ -18,11 +18,12 @@ import org.skriptlang.skript.lang.structure.Structure;
 
 @Name("Aliases")
 @Description("Used for registering custom aliases for a script.")
-@Examples({
-	"aliases:",
-	"\tblacklisted items = TNT, bedrock, obsidian, mob spawner, lava, lava bucket",
-	"\tshiny swords = golden sword, iron sword, diamond sword"
-})
+@Example("""
+	# Example aliases for a script
+	aliases:
+		blacklisted items = TNT, bedrock, obsidian, mob spawner, lava, lava bucket
+		shiny swords = golden sword, iron sword, diamond sword
+	""")
 @Since("1.0")
 public class StructAliases extends Structure {
 

--- a/src/main/java/ch/njol/skript/structures/StructCommand.java
+++ b/src/main/java/ch/njol/skript/structures/StructCommand.java
@@ -12,7 +12,7 @@ import ch.njol.skript.command.ScriptCommand;
 import ch.njol.skript.command.ScriptCommandEvent;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Literal;
@@ -46,20 +46,20 @@ import java.util.regex.Pattern;
 
 @Name("Command")
 @Description("Used for registering custom commands.")
-@Examples({
-	"command /broadcast <string>:",
-	"\tusage: A command for broadcasting a message to all players.",
-	"\tpermission: skript.command.broadcast",
-	"\tpermission message: You don't have permission to broadcast messages",
-	"\taliases: /bc",
-	"\texecutable by: players and console",
-	"\tcooldown: 15 seconds",
-	"\tcooldown message: You last broadcast a message %elapsed time% ago. You can broadcast another message in %remaining time%.",
-	"\tcooldown bypass: skript.command.broadcast.admin",
-	"\tcooldown storage: {cooldown::%player%}",
-	"\ttrigger:",
-	"\t\tbroadcast the argument"
-})
+@Example("""
+	command /broadcast <string>:
+		usage: A command for broadcasting a message to all players.
+		permission: skript.command.broadcast
+		permission message: You don't have permission to broadcast messages
+		aliases: /bc
+		executable by: players and console
+		cooldown: 15 seconds
+		cooldown message: You last broadcast a message %elapsed time% ago. You can broadcast another message in %remaining time%.
+		cooldown bypass: skript.command.broadcast.admin
+		cooldown storage: {cooldown::%player%}
+		trigger:
+			broadcast the argument
+	""")
 @Since("1.0")
 public class StructCommand extends Structure {
 

--- a/src/main/java/org/skriptlang/skript/bukkit/breeding/elements/CondCanAge.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/breeding/elements/CondCanAge.java
@@ -2,7 +2,7 @@ package org.skriptlang.skript.bukkit.breeding.elements;
 
 import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import org.bukkit.entity.Breedable;
@@ -10,11 +10,11 @@ import org.bukkit.entity.LivingEntity;
 
 @Name("Can Age")
 @Description("Checks whether or not an entity will be able to age/grow up.")
-@Examples({
-	"on breeding:",
-		"\tentity can't age",
-		"\tbroadcast \"An immortal has been born!\" to player"
-})
+@Example("""
+	on breeding:
+		entity can't age
+		broadcast "An immortal has been born!" to player
+	""")
 @Since("2.10")
 public class CondCanAge extends PropertyCondition<LivingEntity> {
 

--- a/src/main/java/org/skriptlang/skript/bukkit/breeding/elements/CondCanBreed.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/breeding/elements/CondCanBreed.java
@@ -2,7 +2,7 @@ package org.skriptlang.skript.bukkit.breeding.elements;
 
 import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import org.bukkit.entity.Breedable;
@@ -10,11 +10,11 @@ import org.bukkit.entity.LivingEntity;
 
 @Name("Can Breed")
 @Description("Checks whether or not a living entity can be bred.")
-@Examples({
-	"on right click on living entity:",
-		"\tevent-entity can't breed",
-		"\tsend \"Turns out %event-entity% is not breedable. Must be a Skript user!\" to player"
-})
+@Example("""
+	on right click on living entity:
+		event-entity can't breed
+		send "Turns out %event-entity% is not breedable. Must be a Skript user!" to player
+	""")
 @Since("2.10")
 public class CondCanBreed extends PropertyCondition<LivingEntity> {
 

--- a/src/main/java/org/skriptlang/skript/bukkit/breeding/elements/CondIsAdult.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/breeding/elements/CondIsAdult.java
@@ -2,7 +2,7 @@ package org.skriptlang.skript.bukkit.breeding.elements;
 
 import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import org.bukkit.entity.Ageable;
@@ -10,11 +10,11 @@ import org.bukkit.entity.LivingEntity;
 
 @Name("Is Adult")
 @Description("Checks whether or not a living entity is an adult.")
-@Examples({
-	"on drink:",
-		"\tevent-entity is not an adult",
-		"\tkill event-entity"
-})
+@Example("""
+	on drink:
+		event-entity is not an adult
+		kill event-entity
+	""")
 @Since("2.10")
 public class CondIsAdult extends PropertyCondition<LivingEntity> {
 

--- a/src/main/java/org/skriptlang/skript/bukkit/breeding/elements/CondIsBaby.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/breeding/elements/CondIsBaby.java
@@ -2,7 +2,7 @@ package org.skriptlang.skript.bukkit.breeding.elements;
 
 import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import org.bukkit.entity.Ageable;
@@ -10,11 +10,11 @@ import org.bukkit.entity.LivingEntity;
 
 @Name("Is Baby")
 @Description("Checks whether or not a living entity is a baby.")
-@Examples({
-	"on drink:",
-		"\tevent-entity is a baby",
-		"\tkill event-entity"
-})
+@Example("""
+	on drink:
+		event-entity is a baby
+		kill event-entity
+	""")
 @Since("2.10")
 public class CondIsBaby extends PropertyCondition<LivingEntity> {
 

--- a/src/main/java/org/skriptlang/skript/bukkit/breeding/elements/CondIsInLove.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/breeding/elements/CondIsInLove.java
@@ -2,7 +2,7 @@ package org.skriptlang.skript.bukkit.breeding.elements;
 
 import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import org.bukkit.entity.Animals;
@@ -10,11 +10,11 @@ import org.bukkit.entity.LivingEntity;
 
 @Name("Is In Love")
 @Description("Checks whether or not a living entity is in love.")
-@Examples({
-	"on spawn of living entity:",
-		"\tif entity is in love:",
-			"broadcast \"That was quick!\""
-})
+@Example("""
+	on spawn of living entity:
+		if entity is in love:
+			broadcast "That was quick!"
+	""")
 @Since("2.10")
 public class CondIsInLove extends PropertyCondition<LivingEntity> {
 

--- a/src/main/java/org/skriptlang/skript/bukkit/breeding/elements/EffAllowAging.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/breeding/elements/EffAllowAging.java
@@ -2,7 +2,7 @@ package org.skriptlang.skript.bukkit.breeding.elements;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
@@ -16,10 +16,10 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("Allow Aging")
 @Description("Sets whether or not living entities will be able to age.")
-@Examples({
-	"on spawn of animal:",
-		"\tallow aging of entity"
-})
+@Example("""
+	on spawn of animal:
+		allow aging of entity
+	""")
 @Since("2.10")
 public class EffAllowAging extends Effect {
 

--- a/src/main/java/org/skriptlang/skript/bukkit/breeding/elements/EffBreedable.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/breeding/elements/EffBreedable.java
@@ -2,7 +2,7 @@ package org.skriptlang.skript.bukkit.breeding.elements;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
@@ -16,10 +16,10 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("Make Breedable")
 @Description("Sets whether or not entities will be able to breed. Only works on animals.")
-@Examples({
-	"on spawn of animal:",
-		"\tmake entity unbreedable"
-})
+@Example("""
+	on spawn of animal:
+		make entity unbreedable
+	""")
 @Since("2.10")
 public class EffBreedable extends Effect {
 

--- a/src/main/java/org/skriptlang/skript/bukkit/breeding/elements/EffMakeAdultOrBaby.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/breeding/elements/EffMakeAdultOrBaby.java
@@ -2,7 +2,7 @@ package org.skriptlang.skript.bukkit.breeding.elements;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
@@ -16,11 +16,11 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("Make Adult/Baby")
 @Description("Force a animal to become an adult or baby.")
-@Examples({
-	"on spawn of mob:",
-	"\tentity is not an adult",
-	"\tmake entity an adult",
-})
+@Example("""
+	on spawn of mob:
+		entity is not an adult
+		make entity an adult
+	""")
 @Since("2.10")
 public class EffMakeAdultOrBaby extends Effect {
 

--- a/src/main/java/org/skriptlang/skript/bukkit/breeding/elements/ExprBreedingFamily.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/breeding/elements/ExprBreedingFamily.java
@@ -2,7 +2,7 @@ package org.skriptlang.skript.bukkit.breeding.elements;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
@@ -17,11 +17,10 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("Breeding Family")
 @Description("Represents family members within a breeding event.")
-@Examples({
-	"on breeding:",
-		"\tsend \"When a %breeding mother% and %breeding father% love each other very much, " +
-		"they make a %bred offspring%\" to breeder"
-})
+@Example("""
+	on breeding:
+		send "When a %breeding mother% and %breeding father% love each other very much, they make a %bred offspring%" to breeder
+	""")
 @Since("2.10")
 public class ExprBreedingFamily extends SimpleExpression<LivingEntity> {
 

--- a/src/main/java/org/skriptlang/skript/bukkit/breeding/elements/ExprLoveTime.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/breeding/elements/ExprLoveTime.java
@@ -2,7 +2,7 @@ package org.skriptlang.skript.bukkit.breeding.elements;
 
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
@@ -19,10 +19,10 @@ import org.jetbrains.annotations.Nullable;
 	"Using a value of 30 seconds is equivalent to using an item to breed them.",
 	"Only works on animals that can be bred and returns '0 seconds' for animals that can't be bred."
 })
-@Examples({
-	"on right click:",
-		"\tsend \"%event-entity% has been in love for %love time of event-entity% more than you!\" to player"
-})
+@Example("""
+	on right click:
+		send "%event-entity% has been in love for %love time of event-entity% more than you!" to player
+	""")
 @Since("2.10")
 public class ExprLoveTime extends SimplePropertyExpression<LivingEntity, Timespan> {
 

--- a/src/main/java/org/skriptlang/skript/bukkit/displays/text/CondTextDisplayHasDropShadow.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/displays/text/CondTextDisplayHasDropShadow.java
@@ -3,7 +3,7 @@ package org.skriptlang.skript.bukkit.displays.text;
 import ch.njol.skript.Skript;
 import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
@@ -14,10 +14,10 @@ import org.bukkit.entity.TextDisplay;
 
 @Name("Text Display Has Drop Shadow")
 @Description("Returns whether the text of a display has drop shadow applied.")
-@Examples({
-	"if {_display} has drop shadow:",
-		"\tremove drop shadow from the text of {_display}"
-})
+@Example("""
+	if {_display} has drop shadow:
+		remove drop shadow from the text of {_display}
+	""")
 @Since("2.10")
 public class CondTextDisplayHasDropShadow extends PropertyCondition<Display> {
 

--- a/src/main/java/org/skriptlang/skript/bukkit/displays/text/CondTextDisplaySeeThroughBlocks.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/displays/text/CondTextDisplaySeeThroughBlocks.java
@@ -2,7 +2,7 @@ package org.skriptlang.skript.bukkit.displays.text;
 
 import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import org.bukkit.entity.Display;
@@ -10,10 +10,10 @@ import org.bukkit.entity.TextDisplay;
 
 @Name("Text Display Visible Through Blocks")
 @Description("Returns whether text displays can be seen through blocks or not.")
-@Examples({
-	"if last spawned text display is visible through walls:",
-		"\tprevent last spawned text display from being visible through walls"
-})
+@Example("""
+	if last spawned text display is visible through walls:
+		prevent last spawned text display from being visible through walls
+	""")
 @Since("2.10")
 public class CondTextDisplaySeeThroughBlocks extends PropertyCondition<Display> {
 

--- a/src/main/java/org/skriptlang/skript/bukkit/displays/text/EffTextDisplayDropShadow.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/displays/text/EffTextDisplayDropShadow.java
@@ -2,7 +2,7 @@ package org.skriptlang.skript.bukkit.displays.text;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
@@ -16,11 +16,11 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("Text Display Drop Shadow")
 @Description("Applies or removes drop shadow from the displayed text on a text display.")
-@Examples({
-	"apply drop shadow to last spawned text display",
-	"if {_display} has drop shadow:",
-		"\tremove drop shadow from the text of {_display}"
-})
+@Example("""
+	apply drop shadow to last spawned text display
+	if {_display} has drop shadow:
+		remove drop shadow from the text of {_display}
+""")
 @Since("2.10")
 public class EffTextDisplayDropShadow extends Effect {
 

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/CondFishingLure.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/CondFishingLure.java
@@ -12,11 +12,11 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("Fishing Lure Applied")
 @Description("Checks if the lure enchantment is applied to the current fishing event.")
-@Examples({
-	"on fishing line cast:",
-		"\tif lure enchantment bonus is applied:",
-			"\t\tcancel event"
-})
+@Example("""
+	on fishing line cast:
+		if lure enchantment bonus is applied:
+			cancel event
+	""")
 @Events("Fishing")
 @Since("2.10")
 public class CondFishingLure extends Condition {

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/CondIsInOpenWater.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/CondIsInOpenWater.java
@@ -11,11 +11,11 @@ import org.bukkit.entity.FishHook;
 	"Open water is defined by a 5x4x5 area of water, air and lily pads. " +
 	"If in open water, treasure items may be caught."
 })
-@Examples({
-	"on fish catch:",
-		"\tif fish hook is in open water:",
-			"\t\tsend \"You will catch a shark soon!\""
-})
+@Example("""
+	on fish catch:
+		if fish hook is in open water:
+			send "You will catch a shark soon!"
+	""")
 @Events("Fishing")
 @Since("2.10")
 public class CondIsInOpenWater extends PropertyCondition<Entity> {

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/EffFishingLure.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/EffFishingLure.java
@@ -12,10 +12,10 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("Apply Fishing Lure")
 @Description("Sets whether the lure enchantment should be applied, which reduces the wait time.")
-@Examples({
-	"on fishing line cast:",
-		"\tapply lure enchantment bonus"
-})
+@Example("""
+	on fishing line cast:
+		apply lure enchantment bonus
+	""")
 @Events("Fishing")
 @Since("2.10")
 public class EffFishingLure extends Effect {

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/EffPullHookedEntity.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/EffPullHookedEntity.java
@@ -12,10 +12,10 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("Pull In Hooked Entity")
 @Description("Pull the hooked entity to the player.")
-@Examples({
-	"on fishing state of caught entity:",
-		"\tpull in hooked entity"
-})
+@Example("""
+	on fishing state of caught entity:
+		pull in hooked entity
+	""")
 @Events("Fishing")
 @Since("2.10")
 public class EffPullHookedEntity extends Effect {

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/EvtBucketEntity.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/EvtBucketEntity.java
@@ -2,7 +2,7 @@ package org.skriptlang.skript.bukkit.fishing.elements;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.entity.EntityData;
@@ -24,10 +24,10 @@ import java.util.List;
 
 @Name("Bucket Catch Entity")
 @Description("Called when a player catches an entity in a bucket.")
-@Examples({
-	"on bucket catch of a puffer fish:",
-		"\tsend \"You caught a fish with a %future event-item%!\" to player"
-})
+@Example("""
+	on bucket catch of a puffer fish:
+		send "You caught a fish with a %future event-item%!" to player
+	""")
 @Since("2.10")
 public class EvtBucketEntity extends SkriptEvent {
 

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/ExprFishingApproachAngle.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/ExprFishingApproachAngle.java
@@ -19,14 +19,14 @@ import org.jetbrains.annotations.Nullable;
 	"The angle is in degrees, with 0 being positive Z, 90 being negative X, 180 being negative Z, and 270 being positive X.",
 	"By default, returns a value between 0 and 360 degrees."
 })
-@Examples({
-	"on fish approach:",
-		"\tif any:",
-			"\t\tmaximum fishing approach angle is bigger than 300.5 degrees",
-			"\t\tmin fishing approach angle is smaller than 59.5 degrees",
-		"\tthen:",
-			"\t\tcancel event"
-})
+@Example("""
+	on fish approach:
+		if any:
+			maximum fishing approach angle is bigger than 300.5 degrees
+			min fishing approach angle is smaller than 59.5 degrees
+		then:
+			cancel event
+	""")
 @Events("Fishing")
 @Since("2.10")
 public class ExprFishingApproachAngle extends SimpleExpression<Float> {

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/ExprFishingBiteTime.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/ExprFishingBiteTime.java
@@ -19,10 +19,10 @@ import org.jetbrains.annotations.Nullable;
 	"Returns the time it takes a fish to bite the fishing hook, after it started approaching the hook.",
 	"May return a timespan of 0 seconds. If modifying the value, it should be at least 1 tick.",
 })
-@Examples({
-	"on fish approach:",
-		"\tset fishing bite time to 5 seconds",
-})
+@Example("""
+	on fish approach:
+		set fishing bite time to 5 seconds
+	""")
 @RequiredPlugins("Paper 1.20.6")
 @Events("Fishing")
 @Since("2.10")

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/ExprFishingHook.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/ExprFishingHook.java
@@ -9,11 +9,11 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("Fishing Hook")
 @Description("The <a href='#entity'>fishing hook</a> in a fishing event.")
-@Examples({
-	"on fish line cast:",
-		"\twait a second",
-		"\tteleport player to fishing hook"
-})
+@Example("""
+	on fish line cast:
+		wait a second
+		teleport player to fishing hook
+	""")
 @Events("Fishing")
 @Since("2.10")
 public class ExprFishingHook extends EventValueExpression<Entity> {

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/ExprFishingHookEntity.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/ExprFishingHookEntity.java
@@ -18,11 +18,11 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("Fishing Hooked Entity")
 @Description("Returns the hooked entity in the hooked event.")
-@Examples({
-	"on entity hooked:",
-		"\tif hooked entity is a player:",
-			"\t\tteleport hooked entity to player",
-})
+@Example("""
+	on entity hooked:
+		if hooked entity is a player:
+			teleport hooked entity to player
+	""")
 @Events("Fishing")
 @Since("2.10")
 public class ExprFishingHookEntity extends SimpleExpression<Entity> {

--- a/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/ExprFishingWaitTime.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/fishing/elements/ExprFishingWaitTime.java
@@ -19,11 +19,11 @@ import org.jetbrains.annotations.Nullable;
 	"Returns the minimum and/or maximum waiting time of the fishing hook. ",
 	"Default minimum value is 5 seconds and maximum is 30 seconds, before lure is applied."
 })
-@Examples({
-	"on fishing line cast:",
-		"\tset min fish waiting time to 10 seconds",
-		"\tset max fishing waiting time to 20 seconds",
-})
+@Example("""
+	on fishing line cast:
+		set min fish waiting time to 10 seconds
+		set max fishing waiting time to 20 seconds
+	""")
 @Events("Fishing")
 @Since("2.10")
 public class ExprFishingWaitTime extends SimpleExpression<Timespan> {

--- a/src/main/java/org/skriptlang/skript/bukkit/furnace/elements/ExprFurnaceEventItems.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/furnace/elements/ExprFurnaceEventItems.java
@@ -25,18 +25,24 @@ import org.jetbrains.annotations.Nullable;
 	"Represents the different items in furnace events.",
 	"Only 'smelting item' can be changed."
 })
-@Examples({
-	"on furnace smelt:",
-		"\tbroadcast smelted item",
-		"\t# Or 'result'",
-	"on furnace extract:",
-		"\tbroadcast extracted item",
-	"on fuel burn:",
-		"\tbroadcast burned fuel",
-	"on smelting start:",
-		"\tbroadcast smelting item",
-		"\tclear smelting item"
-})
+@Example("""
+	on furnace smelt:
+		broadcast smelted item
+		# Or 'result'
+	""")
+@Example("""
+	on furnace extract:
+		broadcast extracted item
+	""")
+@Example("""
+	on fuel burn:
+		broadcast burned fuel
+	""")
+@Example("""
+	on smelting start:
+		broadcast smelting item
+		clear smelting item
+	""")
 @Events({"smelt", "fuel burn", "smelting start", "furnace extract"})
 @Since("2.10")
 public class ExprFurnaceEventItems extends PropertyExpression<Block, ItemStack> {

--- a/src/main/java/org/skriptlang/skript/bukkit/furnace/elements/ExprFurnaceSlot.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/furnace/elements/ExprFurnaceSlot.java
@@ -3,7 +3,7 @@ package org.skriptlang.skript.bukkit.furnace.elements;
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Events;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.effects.Delay;
@@ -38,14 +38,14 @@ import java.util.List;
 @Description({
 	"A slot of a furnace, i.e. either the ore, fuel or result slot."
 })
-@Examples({
-	"set the fuel slot of the clicked block to a lava bucket",
-	"set the block's ore slot to 64 iron ore",
-	"clear the result slot of the block",
-	"on smelt:",
-		"\tif the fuel slot is charcoal:",
-			"\t\tadd 5 seconds to the burn time"
-})
+@Example("set the fuel slot of the clicked block to a lava bucket")
+@Example("set the block's ore slot to 64 iron ore")
+@Example("clear the result slot of the block")
+@Example("""
+	on smelt:
+		if the fuel slot is charcoal:
+			add 5 seconds to the burn time
+	""")
 @Events({"smelt", "fuel burn"})
 @Since("1.0, 2.8.0 (syntax rework)")
 public class ExprFurnaceSlot extends SimpleExpression<Slot> {

--- a/src/main/java/org/skriptlang/skript/bukkit/furnace/elements/ExprFurnaceTime.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/furnace/elements/ExprFurnaceTime.java
@@ -35,14 +35,14 @@ import java.util.function.Supplier;
 	"<li>burn time: The amount of time left for the current fuel until consumption of another fuel item.</li>",
 	"</ul>"
 })
-@Examples({
-	"set the cooking time of {_block} to 10",
-	"set the total cooking time of {_block} to 50",
-	"set the fuel burning time of {_block} to 100",
-	"on smelt:",
-		"\tif the fuel slot is charcoal:",
-			"\t\tadd 5 seconds to the fuel burn time"
-})
+@Example("set the cooking time of {_block} to 10")
+@Example("set the total cooking time of {_block} to 50")
+@Example("set the fuel burning time of {_block} to 100")
+@Example("""
+	on smelt:
+		if the fuel slot is charcoal:
+			add 5 seconds to the fuel burn time
+	""")
 @Since("2.10")
 public class ExprFurnaceTime extends PropertyExpression<Block, Timespan> {
 

--- a/src/main/java/org/skriptlang/skript/bukkit/input/elements/conditions/CondIsPressingKey.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/input/elements/conditions/CondIsPressingKey.java
@@ -18,11 +18,11 @@ import org.skriptlang.skript.bukkit.input.InputKey;
 
 @Name("Is Pressing Key")
 @Description("Checks if a player is pressing a certain input key.")
-@Examples({
-	"on player input:",
-	"\tif player is pressing forward movement key:",
-		"\t\tsend \"You are moving forward!\""
-})
+@Example("""
+	on player input:
+		if player is pressing forward movement key:
+			send "You are moving forward!"
+	""")
 @Since("2.10")
 @Keywords({"press", "input"})
 @RequiredPlugins("Minecraft 1.21.2+")

--- a/src/main/java/org/skriptlang/skript/bukkit/input/elements/expressions/ExprCurrentInputKeys.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/input/elements/expressions/ExprCurrentInputKeys.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 @Name("Player Input Keys")
 @Description("Get the current input keys of a player.")
-@Examples("broadcast \"%player% is pressing %current input keys of player%\"")
+@Example("broadcast \"%player% is pressing %current input keys of player%\"")
 @Since("2.10")
 @RequiredPlugins("Minecraft 1.21.2+")
 public class ExprCurrentInputKeys extends PropertyExpression<Player, InputKey> {

--- a/src/main/java/org/skriptlang/skript/bukkit/misc/effects/EffRotate.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/misc/effects/EffRotate.java
@@ -2,7 +2,7 @@ package org.skriptlang.skript.bukkit.misc.effects;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
@@ -39,12 +39,10 @@ import java.util.Locale;
 	"The same applies to rotations by all three axes at once. " +
 	"In addition, rotating around all three axes of a quaternion/display at once will rotate in ZYX order, meaning the Z rotation will be applied first and the X rotation last."
 })
-@Examples({
-	"rotate {_quaternion} around x axis by 10 degrees",
-	"rotate last spawned block display around y axis by 10 degrees",
-	"rotate {_vector} around vector(1, 1, 1) by 45",
-	"rotate {_quaternion} by x 45, y 90, z 135"
-})
+@Example("rotate {_quaternion} around x axis by 10 degrees")
+@Example("rotate last spawned block display around y axis by 10 degrees")
+@Example("rotate {_vector} around vector(1, 1, 1) by 45")
+@Example("rotate {_quaternion} by x 45, y 90, z 135")
 @Since("2.2-dev28, 2.10 (quaternions, displays)")
 public class EffRotate extends Effect {
 

--- a/src/main/java/org/skriptlang/skript/bukkit/misc/expressions/ExprItemOfEntity.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/misc/expressions/ExprItemOfEntity.java
@@ -1,7 +1,7 @@
 package org.skriptlang.skript.bukkit.misc.expressions;
 
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
@@ -24,11 +24,8 @@ import org.jetbrains.annotations.Nullable;
 	"For throwable projectiles (snowballs, enderpearls etc.) or item displays, it gets the displayed item.",
 	"Other entities do not have items associated with them."
 })
-@Examples({
-	"item of event-entity",
-	"",
-	"set the item inside of event-entity to a diamond sword named \"Example\""
-})
+@Example("item of event-entity")
+@Example("set the item inside of event-entity to a diamond sword named \"Example\"")
 @Since("2.2-dev35, 2.2-dev36 (improved), 2.5.2 (throwable projectiles), 2.10 (item displays)")
 public class ExprItemOfEntity extends SimplePropertyExpression<Entity, Slot> {
 

--- a/src/main/java/org/skriptlang/skript/bukkit/misc/expressions/ExprQuaternionAxisAngle.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/misc/expressions/ExprQuaternionAxisAngle.java
@@ -4,7 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
@@ -27,13 +27,11 @@ import ch.njol.skript.lang.simplification.SimplifiedLiteral;
 	"All quaternions can be represented by a rotation of some amount around some axis, so this expression provides " +
 	"the ability to get that angle/axis."
 })
-@Examples({
-	"set {_quaternion} to axisAngle(45, vector(1, 2, 3))",
-	"send rotation axis of {_quaternion} # 1, 2, 3",
-	"send rotation angle of {_quaternion} # 45",
-	"set rotation angle of {_quaternion} to 135",
-	"set rotation axis of {_quaternion} to vector(0, 1, 0)"
-})
+@Example("set {_quaternion} to axisAngle(45, vector(1, 2, 3))")
+@Example("send rotation axis of {_quaternion} # 1, 2, 3")
+@Example("send rotation angle of {_quaternion} # 45")
+@Example("set rotation angle of {_quaternion} to 135")
+@Example("set rotation axis of {_quaternion} to vector(0, 1, 0)")
 @Since("2.10")
 public class ExprQuaternionAxisAngle extends SimplePropertyExpression<Quaternionf, Object> {
 

--- a/src/main/java/org/skriptlang/skript/bukkit/misc/expressions/ExprRotate.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/misc/expressions/ExprRotate.java
@@ -2,7 +2,7 @@ package org.skriptlang.skript.bukkit.misc.expressions;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
@@ -38,11 +38,9 @@ import java.util.Objects;
 	"The same applies to rotations by all three axes at once. " +
 	"In addition, rotating around all three axes of a quaternion/display at once will rotate in ZYX order, meaning the Z rotation will be applied first and the X rotation last."
 })
-@Examples({
-	"set {_new} to {_quaternion} rotated around x axis by 10 degrees",
-	"set {_new} to {_vector} rotated around vector(1, 1, 1) by 45",
-	"set {_new} to {_quaternion} rotated by x 45, y 90, z 135"
-})
+@Example("set {_new} to {_quaternion} rotated around x axis by 10 degrees")
+@Example("set {_new} to {_vector} rotated around vector(1, 1, 1) by 45")
+@Example("set {_new} to {_quaternion} rotated by x 45, y 90, z 135")
 @Since("2.10")
 public class ExprRotate extends SimpleExpression<Object> {
 

--- a/src/main/java/org/skriptlang/skript/bukkit/misc/expressions/ExprTextOf.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/misc/expressions/ExprTextOf.java
@@ -8,7 +8,7 @@ import ch.njol.skript.ServerPlatform;
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
@@ -23,7 +23,7 @@ import net.md_5.bungee.api.chat.BaseComponent;
 	"Returns or changes the <a href='#string'>text/string</a> of <a href='#display'>displays</a>.",
 	"Note that currently you can only use Skript chat codes when running Paper."
 })
-@Examples("set text of the last spawned text display to \"example\"")
+@Example("set text of the last spawned text display to \"example\"")
 @Since("2.10")
 public class ExprTextOf extends SimplePropertyExpression<Object, String> {
 

--- a/src/main/java/org/skriptlang/skript/bukkit/tags/elements/CondIsTagged.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/tags/elements/CondIsTagged.java
@@ -4,7 +4,7 @@ import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.conditions.base.PropertyCondition.PropertyType;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Keywords;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
@@ -23,12 +23,11 @@ import org.skriptlang.skript.bukkit.tags.TagModule;
 @Description({
 	"Checks whether an item, block, entity, or entitydata is tagged with the given tag."
 })
-@Examples({
-	"if player's tool is tagged with minecraft tag \"enchantable/sharp_weapon\":",
-		"\tenchant player's tool with sharpness 1",
-	"",
-	"if all logs are tagged with tag \"minecraft:logs\""
-})
+@Example("""
+	if player's tool is tagged with minecraft tag "enchantable/sharp_weapon":
+		enchant player's tool with sharpness 1
+	""")
+@Example("if all logs are tagged with tag \"minecraft:logs\"")
 @Since("2.10")
 @Keywords({"blocks", "minecraft tag", "type", "category"})
 public class CondIsTagged extends Condition {

--- a/src/main/java/org/skriptlang/skript/bukkit/tags/elements/EffRegisterTag.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/tags/elements/EffRegisterTag.java
@@ -3,7 +3,7 @@ package org.skriptlang.skript.bukkit.tags.elements;
 import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Keywords;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
@@ -45,15 +45,14 @@ import java.util.regex.Pattern;
 	"Please note that two tags can share a name if they are of different types. Registering a new tag of the same " +
 	"name and type will overwrite the existing tag. Tags will reset on server shutdown."
 })
-@Examples({
-	"register a new custom entity tag named \"fish\" using cod, salmon, tropical fish, and pufferfish",
-	"register an item tag named \"skript:wasp_weapons/swords\" containing diamond sword and netherite sword",
-	"register block tag named \"pokey\" containing sweet berry bush and bamboo sapling",
-	"",
-	"on player move:",
-		"\tblock at player is tagged as tag \"skript:pokey\"",
-		"\tdamage the player by 1 heart"
-})
+@Example("register a new custom entity tag named \"fish\" using cod, salmon, tropical fish, and pufferfish")
+@Example("register an item tag named \"skript:wasp_weapons/swords\" containing diamond sword and netherite sword")
+@Example("register block tag named \"pokey\" containing sweet berry bush and bamboo sapling")
+@Example("""
+	on player move:
+		block at player is tagged as tag "skript:pokey"
+		damage the player by 1 heart
+	""")
 @Since("2.10")
 @Keywords({"blocks", "minecraft tag", "type", "category"})
 public class EffRegisterTag extends Effect {

--- a/src/main/java/org/skriptlang/skript/bukkit/tags/elements/ExprTag.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/tags/elements/ExprTag.java
@@ -30,16 +30,14 @@ import java.util.List;
 		"and `custom tag` will look in the \"skript\" namespace for custom tags you've registered.",
 		"You can also filter by tag types using \"item\", \"block\", or \"entity\"."
 })
-@Examples({
-		"minecraft tag \"dirt\" # minecraft:dirt",
-		"paper tag \"doors\" # paper:doors",
-		"tag \"skript:custom_dirt\" # skript:custom_dirt",
-		"custom tag \"dirt\" # skript:dirt",
-		"datapack block tag \"dirt\" # minecraft:dirt",
-		"datapack tag \"my_pack:custom_dirt\" # my_pack:custom_dirt",
-		"tag \"minecraft:mineable/pickaxe\" # minecraft:mineable/pickaxe",
-		"custom item tag \"blood_magic_sk/can_sacrifice_with\" # skript:blood_magic_sk/can_sacrifice_with"
-})
+@Example("minecraft tag \"dirt\" # minecraft:dirt")
+@Example("paper tag \"doors\" # paper:doors")
+@Example("tag \"skript:custom_dirt\" # skript:custom_dirt")
+@Example("custom tag \"dirt\" # skript:dirt")
+@Example("datapack block tag \"dirt\" # minecraft:dirt")
+@Example("datapack tag \"my_pack:custom_dirt\" # my_pack:custom_dirt")
+@Example("tag \"minecraft:mineable/pickaxe\" # minecraft:mineable/pickaxe")
+@Example("custom item tag \"blood_magic_sk/can_sacrifice_with\" # skript:blood_magic_sk/can_sacrifice_with")
 @Since("2.10")
 @RequiredPlugins("Paper (paper tags)")
 @Keywords({"blocks", "minecraft tag", "type", "category"})

--- a/src/main/java/org/skriptlang/skript/bukkit/tags/elements/ExprTagContents.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/tags/elements/ExprTagContents.java
@@ -29,10 +29,8 @@ import java.util.stream.Stream;
 		"For item and block tags, this will return items. For entity tags, " +
 		"it will return entity datas (a creeper, a zombie)."
 })
-@Examples({
-		"broadcast tag values of minecraft tag \"dirt\"",
-		"broadcast (first element of player's tool's block tags)'s tag contents"
-})
+@Example("broadcast tag values of minecraft tag \"dirt\"")
+@Example("broadcast (first element of player's tool's block tags)'s tag contents")
 @Since("2.10")
 @Keywords({"blocks", "minecraft tag", "type", "category"})
 public class ExprTagContents extends SimpleExpression<Object> {

--- a/src/main/java/org/skriptlang/skript/bukkit/tags/elements/ExprTagsOfType.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/tags/elements/ExprTagsOfType.java
@@ -2,7 +2,7 @@ package org.skriptlang.skript.bukkit.tags.elements;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Keywords;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.RequiredPlugins;
@@ -33,11 +33,9 @@ import java.util.TreeSet;
 		"and `custom tag` will look in the \"skript\" namespace for custom tags you've registered.",
 	"You can also filter by tag types using \"item\", \"block\", or \"entity\"."
 })
-@Examples({
-	"broadcast minecraft tags",
-	"send paper entity tags",
-	"broadcast all block tags"
-})
+@Example("broadcast minecraft tags")
+@Example("send paper entity tags")
+@Example("broadcast all block tags")
 @Since("2.10")
 @RequiredPlugins("Paper (paper tags)")
 @Keywords({"blocks", "minecraft tag", "type", "category"})


### PR DESCRIPTION
Previously at #8222, closed because PR was ahead base.

This PR moves many syntaxes to use `@Example`-annotations instead of `@Examples`. The goal of this PR is to move all Skript syntaxes towards the new repeatable annotations. This results in cleaner generated JSON, with unambiguous data when multiple examples are present.

> [!Warning]
> This pull request was, due to its scale and simplicity, made in large part using agentic Copilot. Copilot has proven to be quite bad at tasks like programming and understanding language, and mistakes are expected.

### Testing Completed
I have generated the docs and looked for errors as well as verified every example by hand.
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->

### Note about line endings
End-of-line characters are not present when examples are defined in a single line. We should consider adapting `JSONGenerator` to insert an end-of-line character at the end of each example if it is missing. This way, all examples consist of POSIX-compliant 'lines', which always end in an end-of-line character.

## State of draft
There are over 400 syntaxes that are yet to be edited, and existing ones need a more thorough review.