### PR TITLE
Add playtime alias for ExprTimePlayed

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprTimePlayed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTimePlayed.java
@@ -26,7 +26,8 @@ import org.jetbrains.annotations.Nullable;
 	"if player's time played is greater than 10 minutes:",
 	"\tgive player a diamond sword",
 	"",
-	"set player's time played to 0 seconds"
+	"set player's time played to 0 seconds",
+	"set player's playtime to 0 seconds"
 })
 @RequiredPlugins("MC 1.15+ (offline players)")
 @Since("2.5, 2.7 (offline players)")
@@ -35,7 +36,7 @@ public class ExprTimePlayed extends SimplePropertyExpression<OfflinePlayer, Time
 	private static final boolean IS_OFFLINE_SUPPORTED = Skript.methodExists(OfflinePlayer.class, "getStatistic", Statistic.class);
 
 	static {
-		register(ExprTimePlayed.class, Timespan.class, "time played", "offlineplayers");
+		register(ExprTimePlayed.class, Timespan.class, "(time played|play[ ]time)", "offlineplayers");
 	}
 	
 	@Nullable
@@ -43,7 +44,7 @@ public class ExprTimePlayed extends SimplePropertyExpression<OfflinePlayer, Time
 	public Timespan convert(OfflinePlayer offlinePlayer) {
 		return getTimePlayed(offlinePlayer);
 	}
-	
+
 	@Nullable
 	@Override
 	public Class<?>[] acceptChange(ChangeMode mode) {


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
https://github.com/SkriptLang/Skript/issues/5914

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
`"time played"` -> `"(time played|play[ ]time)"`

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
No test scripts as there isn't really an easy way to test for a player's time played. I tested it manually via effect commands, screenshot is attached below.

<img width="868" height="145" alt="Capture" src="https://github.com/user-attachments/assets/c1a13722-fdd6-4893-8c4e-fc408a3346a9" />

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** https://github.com/SkriptLang/Skript/issues/5914 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->