### PR TITLE
Add pull alias in EffPush

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffPush.java
+++ b/src/main/java/ch/njol/skript/effects/EffPush.java
@@ -30,7 +30,7 @@ public class EffPush extends Effect {
 
 	static {
 		Skript.registerEffect(EffPush.class,
-			"(push|thrust) %entities% [along] %direction% [(at|with) [a] (speed|velocity|force) [of] %-number%]",
+			"(push|thrust|pull) %entities% [along] %direction% [(at|with) [a] (speed|velocity|force) [of] %-number%]",
 			"(push|thrust|pull) %entities% (towards|away:away from) %location% [(at|with) [a] (speed|velocity|force) [of] %-number%]");
 	}
 

--- a/src/test/skript/tests/syntaxes/effects/EffPush.sk
+++ b/src/test/skript/tests/syntaxes/effects/EffPush.sk
@@ -21,4 +21,7 @@ test "pushing and pulling":
 	push {_e} along vector(-2,-1,-1)
 	assert {_e}'s velocity is vector(0,0,0) with "pig's velocity after push was wrong"
 
+	pull {_e} along vector(-2,-1,-1)
+	assert {_e}'s velocity is not vector(0,0,0) with "pull syntax works"
+
 	delete entity within {_e}


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
https://skripthub.net/docs/?id=1135 
The examples from the doc showed `pull player along vector(1,1,1) at speed 1.5` when pull wasn't a syntax for that effect

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
`(push|thrust)` -> `(push|thrust|pull)`

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
Tested manually in game & added 2 lines on `EffPush.sk`
<img width="1161" height="110" alt="image" src="https://github.com/user-attachments/assets/eba8a01b-00e1-40f1-9de0-2d1d323bb4e9" />

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
