### PR TITLE
Fix SectionNode claiming edge cases

### DIFF
--- a/src/main/java/ch/njol/skript/lang/EffectSection.java
+++ b/src/main/java/ch/njol/skript/lang/EffectSection.java
@@ -23,6 +23,10 @@ import java.util.List;
  */
 public abstract class EffectSection extends Section {
 
+	static {
+		ParserInstance.registerData(EffectSectionContext.class, EffectSectionContext::new);
+	}
+
 	private boolean hasSection;
 
 	public boolean hasSection() {
@@ -34,10 +38,23 @@ public abstract class EffectSection extends Section {
 	 */
 	@Override
 	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		SectionContext sectionContext = getParser().getData(SectionContext.class);
+		ParserInstance parser = getParser();
+		SectionContext sectionContext = parser.getData(SectionContext.class);
+		EffectSectionContext effectSectionContext = parser.getData(EffectSectionContext.class);
+		SectionNode sectionNode = sectionContext.sectionNode;
+		if (!effectSectionContext.isNodeForEffectSection) {
+			sectionContext.sectionNode = null;
+		}
+
 		//noinspection ConstantConditions - For an EffectSection, it may be null
 		hasSection = sectionContext.sectionNode != null;
-		return super.init(expressions, matchedPattern, isDelayed, parseResult);
+		boolean result = super.init(expressions, matchedPattern, isDelayed, parseResult);
+
+		if (!effectSectionContext.isNodeForEffectSection) {
+			sectionContext.sectionNode = sectionNode;
+		}
+
+		return result;
 	}
 
 	@Override
@@ -52,15 +69,48 @@ public abstract class EffectSection extends Section {
 	 * Similar to {@link Section#parse(String, String, SectionNode, List)}, but will only attempt to parse from other {@link EffectSection}s.
 	 */
 	public static @Nullable EffectSection parse(String input, @Nullable String defaultError, @Nullable SectionNode sectionNode, @Nullable List<TriggerItem> triggerItems) {
-		SectionContext sectionContext = ParserInstance.get().getData(SectionContext.class);
+		return parse(input, defaultError, sectionNode, true,  triggerItems);
+	}
 
-		return sectionContext.modify(sectionNode, triggerItems, () -> {
+	/**
+	 * Similar to {@link Section#parse(String, String, SectionNode, List)}, but will only attempt to parse from other {@link EffectSection}s.
+	 * @param isNodeForEffectSection Whether {@code sectionNode} can be {@link SectionContext#claim(SyntaxElement)}-ed by the parsed EffectSection.
+	 */
+	public static @Nullable EffectSection parse(String input, @Nullable String defaultError, SectionNode sectionNode, boolean isNodeForEffectSection, List<TriggerItem> triggerItems) {
+		ParserInstance parser = ParserInstance.get();
+		SectionContext sectionContext = parser.getData(SectionContext.class);
+		EffectSectionContext effectSectionContext = parser.getData(EffectSectionContext.class);
+		boolean wasNodeForEffectSection = effectSectionContext.isNodeForEffectSection;
+		effectSectionContext.isNodeForEffectSection = isNodeForEffectSection;
+
+		EffectSection effectSection = sectionContext.modify(sectionNode, triggerItems, () -> {
 			var iterator = Skript.instance().syntaxRegistry().syntaxes(org.skriptlang.skript.registration.SyntaxRegistry.SECTION).stream()
-					.filter(info -> EffectSection.class.isAssignableFrom(info.type()))
-					.iterator();
+				.filter(info -> EffectSection.class.isAssignableFrom(info.type()))
+				.iterator();
 			//noinspection unchecked,rawtypes
-			return (EffectSection) SkriptParser.parse(input, (Iterator) iterator, defaultError);
+			EffectSection parsed = (EffectSection) SkriptParser.parse(input, (Iterator) iterator, defaultError);
+			if (parsed != null && sectionNode != null && !sectionContext.claimed()) {
+				Skript.error("The line '" + input + "' is a valid statement but cannot function as a section (:) because there is no syntax in the line to manage it.");
+				return null;
+			}
+			return parsed;
 		});
+
+		effectSectionContext.isNodeForEffectSection = wasNodeForEffectSection;
+		return effectSection;
+	}
+
+	private static class EffectSectionContext extends ParserInstance.Data {
+
+		/**
+		 * Whether the {@link SectionContext#sectionNode} can be used by the initializing {@link EffectSection}.
+		 */
+		public boolean isNodeForEffectSection = true;
+
+		public EffectSectionContext(ParserInstance parserInstance) {
+			super(parserInstance);
+		}
+
 	}
 
 }

--- a/src/main/java/ch/njol/skript/lang/Statement.java
+++ b/src/main/java/ch/njol/skript/lang/Statement.java
@@ -33,7 +33,14 @@ public abstract class Statement extends TriggerItem implements SyntaxElement {
 			Section.SectionContext sectionContext = ParserInstance.get().getData(Section.SectionContext.class);
 			EffFunctionCall functionCall;
 			if (node != null) {
-				functionCall = sectionContext.modify(node, items, () -> EffFunctionCall.parse(input));
+				functionCall = sectionContext.modify(node, items, () -> {
+					EffFunctionCall parsed = EffFunctionCall.parse(input);
+					if (parsed != null && !sectionContext.claimed()) {
+						Skript.error("The line '" + input + "' is a valid function call but cannot function as a section (:) because there is no parameter to manage it.");
+						return null;
+					}
+					return parsed;
+				});
 			} else {
 				functionCall = EffFunctionCall.parse(input);
 			}
@@ -46,7 +53,7 @@ public abstract class Statement extends TriggerItem implements SyntaxElement {
 			}
 			log.clear();
 
-			EffectSection section = EffectSection.parse(input, null, null, items);
+			EffectSection section = EffectSection.parse(input, null, node, false, items);
 			if (section != null) {
 				log.printLog();
 				return new EffectSectionEffect(section);

--- a/src/test/skript/tests/regressions/8199-parse exprsecs in function args.sk
+++ b/src/test/skript/tests/regressions/8199-parse exprsecs in function args.sk
@@ -4,3 +4,9 @@ local function f(x: worldborder):
 test "load expr secs in functions":
     f(a worldborder):
         set worldborder warning time to 20 ticks
+
+    # ensure it fails for unclaimed sections
+    parse:
+        f({_null}):
+            stop
+    assert first element of last parse logs contains "is a valid function call but cannot function as a section" with "failed to correctly error for unclaimed section"


### PR DESCRIPTION
### Problem
There are some edge cases with SectionNode claiming related to Functions and EffectSections. Currently, functions can always be used with sections, even if no parameter claims the section. This results in random unparsed code. EffectSections also do not properly work with ExpressionSections. The "sectionNode" of the SectionContext is always null, meaning there is nothing to claim (even if one is present). This can result in unclaimed/unparsed code.


### Solution
#### For Functions
I simply added a check similar to the one performed below for Statement that ensures the Section has been claimed. I tweaked the error message to better fit functions. It does not currently attempt to try parsing as an EffectSection or Statement. This is partly due to the logging setup, and I believe that syntax conflicting with function calls is not currently supported anyways.

#### For EffectSections
I added a new `EffectSection#parse` override that supports specifying whether the `sectionNode` parameter can be claimed by the parsed EffectSection. This uses an internal ParserInstance context for passing this information around.

### Testing Completed
A test for the Function edge case was added.


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
