### PR TITLE
Display registered addons on BStats

### DIFF
--- a/src/main/java/org/skriptlang/skript/bukkit/SkriptMetrics.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/SkriptMetrics.java
@@ -10,11 +10,14 @@ import ch.njol.skript.util.chat.ChatMessages;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 import org.bstats.bukkit.Metrics;
+import org.bstats.charts.AdvancedPie;
 import org.bstats.charts.DrilldownPie;
 import org.bstats.charts.SimplePie;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.addon.SkriptAddon;
 
 import java.text.SimpleDateFormat;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -33,6 +36,9 @@ public class SkriptMetrics {
 
 		// sets up the old charts to prevent data splitting due to various user version
 		setupLegacyMetrics(metrics);
+
+		// addon registration
+		setupAddonCharts(metrics);
 
 		// add custom version charts for easier reading:
 		metrics.addCustomChart(new DrilldownPie("drilldownPluginVersion", () -> {
@@ -187,6 +193,21 @@ public class SkriptMetrics {
 			isDefaultMap(SkriptConfig.longParseTimeWarningThreshold, "disabled")
 		));
 	}
+
+	/**
+	 * Helper to set up addon-related charts
+	 * @param metrics The Metrics object to which charts will be added.
+	 */
+	private static void setupAddonCharts(Metrics metrics) {
+		metrics.addCustomChart(new AdvancedPie("registeredAddons", () -> {
+			Map<String,Integer> addons = new HashMap<>();
+			for (SkriptAddon addon : Skript.getAddons()) {
+				addons.put(addon.name(), 1);
+			}
+			return addons;
+		}));
+	}
+
 
 	/**
 	 * Helper method to set up legacy charts (pre 2.9.2)


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
Accurate information about what addons are in use could assist in making decisions about api changes and what challenges users face that they use addons to overcome.

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
Adds a pie chart to BStats that displays the names of the registered addons on each server. An example is live on the skript bstats page: https://bstats.org/plugin/bukkit/Skript/722. 

#### Possible downsides: 
- Addon developers may intentionally not included bstats and not wish to have their addon publicly counted
- Possible promotion of competition between addons as far as user counts

#### Possible upsides:
- Better knowledge of popular addon usage - one source of truth, not reliant on addon devs adding bstats.
- Identification of weaknesses in Skript that may be effective targets for improvement
- Possible use by resource/docs websites to order addons by usage for better user experience

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
N/A

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->
Currently based on feature but can be changed to patch after 2.13.

---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
