### PR TITLE
Remove deprecated block data methods

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -275,7 +275,6 @@ public final class BukkitEventValues {
 		EventValues.registerEventValue(PlayerBucketFillEvent.class, Block.class, event -> {
 			BlockState state = event.getBlockClicked().getState();
 			state.setType(Material.AIR);
-			state.setRawData((byte) 0);
 			return new BlockStateBlock(state, true);
 		}, TIME_FUTURE);
 		EventValues.registerEventValue(PlayerBucketEmptyEvent.class, Block.class,
@@ -283,7 +282,6 @@ public final class BukkitEventValues {
 		EventValues.registerEventValue(PlayerBucketEmptyEvent.class, Block.class, event -> {
 			BlockState state = event.getBlockClicked().getRelative(event.getBlockFace()).getState();
 			state.setType(event.getBucket() == Material.WATER_BUCKET ? Material.WATER : Material.LAVA);
-			state.setRawData((byte) 0);
 			return new BlockStateBlock(state, true);
 		});
 		// PlayerDropItemEvent


### PR DESCRIPTION
### Problem
Buckets are my worst nightmare. When emptying or filling a bucket, Skript will attempt to set block data on it via a method that has been deprecated since 1.6.2. ONE POINT SIX. that's like. at least fifty versions behind what is currently the minimum version.
Since this method is so old, it's no longer natively supported by CraftBukkit, and instead initializes CraftLegacy. Since this happens the first time (in a session) the bucket is filled or emptied, CraftLegacy is not initialized on startup, but rather when this happens, and it causes anywhere from 5 to 30 seconds of lag.

tl;dr legacy bucket methods are causing lag during runtime


### Solution
just nuke it lmao


### Testing Completed
I have NO idea what script was causing this, but when I added the patched version to the server it was fixed. If this needs further testing let me know and I'll do some more extensive testing.


---
**Completes:** #6968, #7560, <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** #6641 
