### PR TITLE
Enable errors in Region converter during parsing

### DIFF
--- a/src/main/java/ch/njol/skript/hooks/regions/classes/Region.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/classes/Region.java
@@ -7,6 +7,7 @@ import ch.njol.skript.classes.YggdrasilSerializer;
 import ch.njol.skript.hooks.regions.RegionsPlugin;
 import ch.njol.skript.lang.ParseContext;
 import ch.njol.skript.lang.VariableString;
+import ch.njol.skript.lang.parser.ParserInstance;
 import ch.njol.skript.registrations.Classes;
 import org.skriptlang.skript.lang.converter.Converters;
 import ch.njol.yggdrasil.YggdrasilSerializable.YggdrasilExtendedSerializable;
@@ -78,7 +79,7 @@ public abstract class Region implements YggdrasilExtendedSerializable {
 						return true;
 					}
 				}));
-		Converters.registerConverter(String.class, Region.class, s -> Region.parse(s, false));
+		Converters.registerConverter(String.class, Region.class, s -> Region.parse(s, ParserInstance.get().isActive()));
 	}
 
 	@Nullable


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
Errors involving missing or duplicate regions were exceedingly hard to debug due to no specific error messages being sent. The parser has errors, but the converter does not and the converter was being used.

This is because there are mainfarm regions in 2 separate worlds, but you'd never know that.
<img width="938" height="134" alt="image" src="https://github.com/user-attachments/assets/f0c0a9a4-c34d-4392-8134-ed1bb2eb6d07" />


### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
Enables errors in the converter when the parser instance is active:
<img width="691" height="131" alt="image" src="https://github.com/user-attachments/assets/017d1e23-7d52-4b0c-b62d-da01e5982a62" />
<img width="660" height="161" alt="image" src="https://github.com/user-attachments/assets/f8f0253d-0de7-4814-9f67-1074e71cef7d" />


### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
Manual testing. I confirmed this only errors during parsing and not otherwise, including on load.


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
