### PR TITLE
move addDelayedEvent to trigger after the delay finishes

### DIFF
--- a/src/main/java/ch/njol/skript/effects/Delay.java
+++ b/src/main/java/ch/njol/skript/effects/Delay.java
@@ -68,7 +68,6 @@ public class Delay extends Effect {
 		long start = Skript.debug() ? System.nanoTime() : 0;
 		TriggerItem next = getNext();
 		if (next != null && Skript.getInstance().isEnabled()) { // See https://github.com/SkriptLang/Skript/issues/3702
-			addDelayedEvent(event);
 
 			Timespan duration = this.duration.getSingle(event);
 			if (duration == null)
@@ -78,6 +77,7 @@ public class Delay extends Effect {
 			Object localVars = Variables.removeLocals(event);
 			
 			Bukkit.getScheduler().scheduleSyncDelayedTask(Skript.getInstance(), () -> {
+				addDelayedEvent(event);
 				Skript.debug(getIndentation() + "... continuing after " + (System.nanoTime() - start) / 1_000_000_000. + "s");
 
 				// Re-set local variables

--- a/src/main/java/ch/njol/skript/effects/EffTeleport.java
+++ b/src/main/java/ch/njol/skript/effects/EffTeleport.java
@@ -132,11 +132,11 @@ public class EffTeleport extends Effect {
 		}
 
 		final Location fixed = location;
-		Delay.addDelayedEvent(event);
 		Object localVars = Variables.removeLocals(event);
 
 		// This will either fetch the chunk instantly if on Spigot or already loaded or fetch it async if on Paper.
 		PaperLib.getChunkAtAsync(location).thenAccept(chunk -> {
+			Delay.addDelayedEvent(event);
 			// The following is now on the main thread
 			SkriptTeleportFlag[] teleportFlags = this.teleportFlags == null ? null : this.teleportFlags.getArray(event);
 			for (Entity entity : entityArray) {

--- a/src/main/java/ch/njol/skript/effects/IndeterminateDelay.java
+++ b/src/main/java/ch/njol/skript/effects/IndeterminateDelay.java
@@ -23,7 +23,6 @@ public class IndeterminateDelay extends Delay {
 		TriggerItem next = getNext();
 
 		if (next != null && Skript.getInstance().isEnabled()) { // See https://github.com/SkriptLang/Skript/issues/3702
-			Delay.addDelayedEvent(event);
 			Timespan duration = this.duration.getSingle(event);
 			if (duration == null)
 				return null;
@@ -32,6 +31,7 @@ public class IndeterminateDelay extends Delay {
 			Object localVars = Variables.removeLocals(event);
 			
 			Bukkit.getScheduler().scheduleSyncDelayedTask(Skript.getInstance(), () -> {
+				Delay.addDelayedEvent(event);
 				Skript.debug(getIndentation() + "... continuing after " + (System.nanoTime() - start) / 1_000_000_000. + "s");
 
 				// Re-set local variables

--- a/src/main/java/ch/njol/skript/util/AsyncEffect.java
+++ b/src/main/java/ch/njol/skript/util/AsyncEffect.java
@@ -27,14 +27,14 @@ public abstract class AsyncEffect extends Effect {
 	@Nullable
 	protected TriggerItem walk(Event e) {
 		debug(e, true);
-		
-		Delay.addDelayedEvent(e); // Mark this event as delayed
+
 		Object localVars = Variables.removeLocals(e); // Back up local variables
 
 		if (!Skript.getInstance().isEnabled()) // See https://github.com/SkriptLang/Skript/issues/3702
 			return null;
 
 		Bukkit.getScheduler().runTaskAsynchronously(Skript.getInstance(), () -> {
+			Delay.addDelayedEvent(e); // Mark this event as delayed
 			// Re-set local variables
 			if (localVars != null)
 				Variables.setLocalVariables(e, localVars);


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
Delays would trigger isDelayed as soon as they scheduled the delayed task, rather than when the delayed task begins. Since isDelayed cannot differentiate between Triggers, this meant that one trigger could schedule a delay and a second, undelayed, trigger would think it was delayed too!

```
on jump:
  send isDelayed # sends false
  wait 1 tick # adds to DELAYED
  send isDelayed # sends true

on jump:
  send isDelayed # uh oh, this ran after the first event, so the event's already in DELAYED! returns TRUE
  wait 1 tick
  send isDelayed # sends true
```

This PR does NOT fix this issue! It simply mitigates the issue so that the user isn't impacted by it. The delay api still needs to be updated when proper runtime context is implemented.

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
Moving the addDelayedEvent call to after the delay is complete ensures that non-delayed code can run as normal, but still ensures delayed code is ran as delayed code. I believe this is safe, but if anyone can think up a counterexample please comment it.

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
Manual testing confirms this functions properly, but I did not do a comprehensive check of behaviors. Automated tests can't handle delays so this can't be tested automatically.


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** #8298 <!-- Links to issues or discussions with related information -->
