### PR TITLE
Add `--recurse-submodules` to `git clone` in contribution guide

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -80,7 +80,7 @@ We welcome contributions from everyone. To get started, please fork the reposito
 and clone it to your local machine. If you are unfamiliar with Git, please refer to the
 [Git documentation](https://git-scm.com/learn).
 ```
-git clone https://github.com/SkriptLang/Skript
+git clone https://github.com/SkriptLang/Skript --recurse-submodules
 ```
 
 Create a new branch for your changes. Use a descriptive name for the branch,


### PR DESCRIPTION
This PR updates the `git clone` command in the contribution guide to include the `--recurse-submodules` option so aliases are included when building Skript

### Problem
When following the guide, builds of Skript would not include aliases and Skript would print a stack trace on load

### Solution
`--recurse-submodules` clones `skript-aliases` as well so they are included when building


### Testing Completed
Ran `skriptTestDev` with repositories cloned with and without `--recurse-submodules` and verified they did not and did contain aliases respectively


### Supporting Information
Would probably also be useful to document usage of `skriptTestDev`, as it's very useful when testing your changes

---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none
**AI assistance:** GitHub Copilot made a template commit message automatically, because I guess that's something it does now? Anyway the template sucked so I didn't use that