### PR TITLE
Base default values for attributes on the entity's defaults, not the global ones.

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprEntityAttribute.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprEntityAttribute.java
@@ -93,7 +93,9 @@ public class ExprEntityAttribute extends PropertyExpression<Entity, Number> {
 						instance.setBaseValue(0);
 						break;
 					case RESET:
-						instance.setBaseValue(instance.getDefaultValue());
+						AttributeInstance defaultValue = entity.getType().getDefaultAttributes().getAttribute(attribute);
+						if (defaultValue != null)
+							instance.setBaseValue(defaultValue.getBaseValue());
 						break;
 					case REMOVE:
 						instance.setBaseValue(instance.getBaseValue() - deltaValue);


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
Resetting a player's walk speed would use the global attribute default of 0.7 rather than the player entity type default of 0.1. This may apply to many more attribute defaults.

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
Uses the entity type's getDefaultAttributes to determine the base attribute value, as is intended by Paper API. See the clarification and deprecation of the method we currently use here: https://github.com/PaperMC/Paper/issues/13343

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
Manual confirmation.


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** #8097 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
