### PR TITLE
Optimize looping reversed lists

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprElement.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprElement.java
@@ -1,14 +1,14 @@
 package ch.njol.skript.expressions;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.SkriptAPIException;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
-import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.Literal;
+import ch.njol.skript.lang.*;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.simplification.SimplifiedLiteral;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.skript.registrations.Feature;
 import ch.njol.skript.util.LiteralUtils;
@@ -16,16 +16,20 @@ import ch.njol.skript.util.Patterns;
 import ch.njol.util.Kleenean;
 import ch.njol.util.StringUtils;
 import ch.njol.util.coll.CollectionUtils;
+import ch.njol.util.coll.iterator.EmptyIterator;
 import com.google.common.collect.Iterators;
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.function.TriFunction;
 import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import ch.njol.skript.lang.simplification.SimplifiedLiteral;
 import org.skriptlang.skript.lang.util.SkriptQueue;
 
 import java.lang.reflect.Array;
-import java.util.Iterator;
+import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 @Name("Elements")
 @Description({
@@ -43,7 +47,7 @@ import java.util.concurrent.ThreadLocalRandom;
 	"broadcast the first 3 elements in {queue}"
 })
 @Since("2.0, 2.7 (relative to last element), 2.8.0 (range of elements)")
-public class ExprElement<T> extends SimpleExpression<T> {
+public class ExprElement<T> extends SimpleExpression<T> implements KeyProviderExpression<T> {
 
 	private static final Patterns<ElementType[]> PATTERNS = new Patterns<>(new Object[][]{
 		{"[the] (first|1:last) element [out] of %objects%", new ElementType[] {ElementType.FIRST_ELEMENT, ElementType.LAST_ELEMENT}},
@@ -65,114 +69,160 @@ public class ExprElement<T> extends SimpleExpression<T> {
 	}
 
 	private enum ElementType {
-		FIRST_ELEMENT,
-		LAST_ELEMENT,
-		FIRST_X_ELEMENTS,
-		LAST_X_ELEMENTS,
-		RANDOM,
-		ORDINAL,
-		TAIL_END_ORDINAL,
-		RANGE
+		FIRST_ELEMENT(iterator -> Iterators.limit(iterator, 1)),
+		LAST_ELEMENT(iterator -> Iterators.singletonIterator(Iterators.getLast(iterator))),
+		FIRST_X_ELEMENTS(Iterators::limit),
+		LAST_X_ELEMENTS((iterator, index) -> {
+			Object[] array = Iterators.toArray(iterator, Object.class);
+			index = Math.min(index, array.length);
+			return Iterators.forArray(CollectionUtils.subarray(array, array.length - index, array.length));
+		}),
+		RANDOM(iterator -> {
+			Object[] array = Iterators.toArray(iterator, Object.class);
+			if (array.length == 0)
+				return EmptyIterator.get();
+			Object element = CollectionUtils.getRandom(array);
+			return Iterators.singletonIterator(element);
+		}),
+		ORDINAL((iterator, index) -> {
+			Iterators.advance(iterator, index - 1);
+			if (!iterator.hasNext())
+				return EmptyIterator.get();
+			return Iterators.singletonIterator(iterator.next());
+		}),
+		TAIL_END_ORDINAL((iterator, index) -> {
+			Object[] array = Iterators.toArray(iterator, Object.class);
+			if (index > array.length)
+				return EmptyIterator.get();
+			return Iterators.singletonIterator(array[array.length - index]);
+		}),
+		RANGE((iterator, startIndex, endIndex) -> {
+			boolean reverse = startIndex > endIndex;
+			int from = Math.max(Math.min(startIndex, endIndex) - 1, 0);
+			int to = Math.max(Math.max(startIndex, endIndex), 0);
+			if (reverse) {
+				Object[] array = Iterators.toArray(iterator, Object.class);
+				Object[] elements = CollectionUtils.subarray(array, from, to);
+				ArrayUtils.reverse(elements);
+				return Iterators.forArray(elements);
+			}
+			Iterators.advance(iterator, from);
+			return Iterators.limit(iterator, to - from);
+		});
+
+		private final TriFunction<Iterator<?>, Integer, Integer, Iterator<?>> function;
+
+		ElementType(Function<Iterator<?>, Iterator<?>> function) {
+			this.function = (it, start, end) -> function.apply(it);
+		}
+
+		ElementType(BiFunction<Iterator<?>, Integer, Iterator<?>> function) {
+			this.function = (it, start, end) -> function.apply(it, start);
+		}
+
+		ElementType(TriFunction<Iterator<?>, Integer, Integer, Iterator<?>> function) {
+			this.function = function;
+		}
+
+		public <T> Iterator<T> apply(Iterator<T> iterator, int startIndex, int endIndex) {
+			//noinspection unchecked
+			return (Iterator<T>) function.apply(iterator, startIndex, endIndex);
+		}
+
 	}
+
+	private final Map<Event, List<String>> cache = new WeakHashMap<>();
 
 	private Expression<? extends T> expr;
 	private	@Nullable Expression<Integer> startIndex, endIndex;
 	private ElementType type;
 	private boolean queue;
+	private boolean keyed;
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
 		ElementType[] types = PATTERNS.getInfo(matchedPattern);
 		this.queue = matchedPattern > 4;
 		if (queue && !this.getParser().hasExperiment(Feature.QUEUES))
 			return false;
 		if (queue) {
-			this.expr = (Expression<T>) exprs[exprs.length - 1];
+			this.expr = (Expression<T>) expressions[expressions.length - 1];
 		} else {
-			this.expr = LiteralUtils.defendExpression(exprs[exprs.length - 1]);
+			this.expr = LiteralUtils.defendExpression(expressions[expressions.length - 1]);
 		}
 		switch (type = types[parseResult.mark]) {
 			case RANGE:
-				endIndex = (Expression<Integer>) exprs[1];
+				endIndex = (Expression<Integer>) expressions[1];
 			case FIRST_X_ELEMENTS, LAST_X_ELEMENTS, ORDINAL, TAIL_END_ORDINAL:
-				startIndex = (Expression<Integer>) exprs[0];
+				startIndex = (Expression<Integer>) expressions[0];
 				break;
 			default:
 				startIndex = null;
 				break;
 		}
+		this.keyed = KeyProviderExpression.canReturnKeys(this.expr);
 		return queue || LiteralUtils.canInitSafely(expr);
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	protected T @Nullable [] get(Event event) {
 		if (queue)
 			return this.getFromQueue(event);
+		if (keyed) {
+			KeyedValue.UnzippedKeyValues<T> unzipped = KeyedValue.unzip(keyedIterator(event));
+			cache.put(event, unzipped.keys());
+			//noinspection unchecked
+			T[] empty = (T[]) Array.newInstance(getReturnType(), 0);
+			return unzipped.values().toArray(empty);
+		}
+		Iterator<? extends T> iterator = iterator(event);
+		assert iterator != null;
+		//noinspection unchecked
+		return Iterators.toArray(iterator, (Class<T>) getReturnType());
+	}
+
+	@Override
+	public @NotNull String @NotNull [] getArrayKeys(Event event) throws IllegalStateException {
+		if (!keyed)
+			throw new UnsupportedOperationException();
+		if (!cache.containsKey(event))
+			throw new SkriptAPIException("Cannot call getArrayKeys() before calling getArray() or getAll()");
+		return cache.remove(event).toArray(new String[0]);
+	}
+
+	@Override
+	public @Nullable Iterator<? extends T> iterator(Event event) {
+		if (queue)
+			return Optional.ofNullable(getFromQueue(event)).map(Iterators::forArray).orElse(null);
 		Iterator<? extends T> iterator = expr.iterator(event);
+		return transformIterator(event, iterator);
+	}
+
+	@Override
+	public Iterator<KeyedValue<T>> keyedIterator(Event event) {
+		if (!keyed)
+			throw new UnsupportedOperationException();
+		//noinspection unchecked
+		Iterator<KeyedValue<T>> iterator = ((KeyProviderExpression<T>) expr).keyedIterator(event);
+		return transformIterator(event, iterator);
+	}
+
+	private <A> Iterator<A> transformIterator(Event event, @Nullable Iterator<A> iterator) {
 		if (iterator == null || !iterator.hasNext())
-			return null;
-		T element = null;
-		Class<T> returnType = (Class<T>) getReturnType();
-		int startIndex = 0, endIndex = 0;
+			return EmptyIterator.get();
+		Integer startIndex = 0, endIndex = 0;
 		if (this.startIndex != null) {
-			Integer integer = this.startIndex.getSingle(event);
-			if (integer == null)
-				return null;
-			startIndex = integer;
-			if (startIndex <= 0 && type != ElementType.RANGE)
-				return null;
+			startIndex = this.startIndex.getSingle(event);
+			if (startIndex == null || startIndex <= 0 && type != ElementType.RANGE)
+				return EmptyIterator.get();
 		}
 		if (this.endIndex != null) {
-			Integer integer = this.endIndex.getSingle(event);
-			if (integer == null)
-				return null;
-			endIndex = integer;
+			endIndex = this.endIndex.getSingle(event);
+			if (endIndex == null)
+				return EmptyIterator.get();
 		}
-		T[] elementArray;
-		switch (type) {
-			case FIRST_ELEMENT:
-				element = iterator.next();
-				break;
-			case LAST_ELEMENT:
-				element = Iterators.getLast(iterator);
-				break;
-			case RANDOM:
-				element = CollectionUtils.getRandom(Iterators.toArray(iterator, returnType));
-				break;
-			case ORDINAL:
-				Iterators.advance(iterator, startIndex - 1);
-				if (!iterator.hasNext())
-					return null;
-				element = iterator.next();
-				break;
-			case TAIL_END_ORDINAL:
-				elementArray = Iterators.toArray(iterator, returnType);
-				if (startIndex > elementArray.length)
-					return null;
-				element = elementArray[elementArray.length - startIndex];
-				break;
-			case FIRST_X_ELEMENTS:
-				return Iterators.toArray(Iterators.limit(iterator, startIndex), returnType);
-			case LAST_X_ELEMENTS:
-				elementArray = Iterators.toArray(iterator, returnType);
-				startIndex = Math.min(startIndex, elementArray.length);
-				return CollectionUtils.subarray(elementArray, elementArray.length - startIndex, elementArray.length);
-			case RANGE:
-				elementArray = Iterators.toArray(iterator, returnType);
-				boolean reverse = startIndex > endIndex;
-				int from = Math.min(startIndex, endIndex) - 1;
-				int to = Math.max(startIndex, endIndex);
-				T[] elements = CollectionUtils.subarray(elementArray, from, to);
-				if (reverse)
-					ArrayUtils.reverse(elements);
-				return elements;
-		}
-		//noinspection unchecked
-		elementArray = (T[]) Array.newInstance(getReturnType(), 1);
-		elementArray[0] = element;
-		return elementArray;
+		return type.apply(iterator, startIndex, endIndex);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -207,6 +257,20 @@ public class ExprElement<T> extends SimpleExpression<T> {
 				yield elements;
 			}
 		};
+	}
+
+	@Override
+	public boolean canReturnKeys() {
+		if (!keyed)
+			return false;
+		return ((KeyProviderExpression<?>) expr).canReturnKeys();
+	}
+
+	@Override
+	public boolean areKeysRecommended() {
+		if (!keyed)
+			return false;
+		return ((KeyProviderExpression<?>) expr).areKeysRecommended();
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprReversedList.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprReversedList.java
@@ -18,6 +18,10 @@ import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
 
 @Name("Reversed List")
 @Description("Reverses given list.")
@@ -58,6 +62,24 @@ public class ExprReversedList extends SimpleExpression<Object> {
 		System.arraycopy(inputArray, 0, array, 0, inputArray.length);
 		reverse(array);
 		return array;
+	}
+
+	@Override
+	public @Nullable Iterator<?> iterator(Event event) {
+		List<?> list = Arrays.asList(this.list.getArray(event).clone());
+		return new Iterator<>() {
+			private final ListIterator<?> listIterator = list.listIterator(list.size());
+
+			@Override
+			public boolean hasNext() {
+				return listIterator.hasPrevious();
+			}
+
+			@Override
+			public Object next() {
+				return listIterator.previous();
+			}
+		};
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprReversedList.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprReversedList.java
@@ -17,7 +17,6 @@ import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 
-import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -57,16 +56,14 @@ public class ExprReversedList extends SimpleExpression<Object> {
 	@Override
 	@Nullable
 	protected Object[] get(Event e) {
-		Object[] inputArray = list.getArray(e).clone();
-		Object[] array = (Object[]) Array.newInstance(getReturnType(), inputArray.length);
-		System.arraycopy(inputArray, 0, array, 0, inputArray.length);
+		Object[] array = list.getArray(e);
 		reverse(array);
 		return array;
 	}
 
 	@Override
 	public @Nullable Iterator<?> iterator(Event event) {
-		List<?> list = Arrays.asList(this.list.getArray(event).clone());
+		List<?> list = Arrays.asList(this.list.getArray(event));
 		return new Iterator<>() {
 			private final ListIterator<?> listIterator = list.listIterator(list.size());
 

--- a/src/test/skript/tests/syntaxes/expressions/ExprElement.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprElement.sk
@@ -24,3 +24,17 @@ test "ExprElement":
 	assert elements from 5 to 5 of {_list::*} is not set with "Incorrect elements from 5 to 5"
 	assert elements from 1 to 1 of {_list::*} is "foo" with "Incorrect elements from 1 to 1"
 	assert (first element out of (5 and 6)) + 5 is 10 with "Incorrect return type"
+
+test "keyed ExprElement":
+	set {_list::a} to "foo"
+	set {_list::b} to "bar"
+	set {_list::c} to "foobar"
+	set {_other::*} to first 2 elements of keyed {_list::*}
+	assert {_other::a} is "foo"
+	assert {_other::b} is "bar"
+
+	loop last 2 elements of keyed {_list::*}:
+		if loop-counter is 1:
+			assert loop-value is "bar"
+		if loop-counter is 2:
+			assert loop-value is "foobar"

--- a/src/test/skript/tests/syntaxes/expressions/ExprReversedList.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprReversedList.sk
@@ -1,0 +1,11 @@
+test "reversed":
+	set {_list::*} to 1, 2, 3, 4 and 5
+	set {_size} to size of {_list::*}
+	set {_reversed::*} to reversed {_list::*}
+	assert size of {_reversed::*} is {_size}
+
+	loop {_size} times:
+		assert {_list::%loop-counter%} is {_reversed::%{_size} - loop-counter + 1%}
+
+	loop reversed {_list::*}:
+		assert loop-value is {_reversed::%loop-counter%}


### PR DESCRIPTION
### Problem
When looping trying to loop in reverse, Skript constructs a whole new array in reverse order then loops it


### Solution
Implement the `iterator` method for ExprReversedList that iterates over the array in reverse order without constructing a new array


### Testing Completed
`ExprReversedList.sk` and manual testing


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
