### PR TITLE
Fix HTML Documentation Generation

### DIFF
--- a/src/main/java/ch/njol/skript/doc/HTMLGenerator.java
+++ b/src/main/java/ch/njol/skript/doc/HTMLGenerator.java
@@ -15,6 +15,7 @@ import org.bukkit.event.Event;
 import org.bukkit.event.block.BlockCanBuildEvent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.bukkit.registration.BukkitSyntaxInfos;
 import org.skriptlang.skript.lang.entry.EntryData;
 import org.skriptlang.skript.lang.entry.EntryValidator;
 import org.skriptlang.skript.lang.structure.StructureInfo;
@@ -97,24 +98,24 @@ public class HTMLGenerator extends DocumentationGenerator {
 	/**
 	 * Sorts events alphabetically.
 	 */
-	private static class EventComparator implements Comparator<SkriptEventInfo<?>> {
+	private static class EventComparator implements Comparator<BukkitSyntaxInfos.Event<?>> {
 
 		public EventComparator() {}
 
 		@Override
-		public int compare(@Nullable SkriptEventInfo<?> o1, @Nullable SkriptEventInfo<?> o2) {
+		public int compare(@Nullable BukkitSyntaxInfos.Event<?> o1, @Nullable BukkitSyntaxInfos.Event<?> o2) {
 			// Nullness check
 			if (o1 == null || o2 == null) {
 				assert false;
 				throw new NullPointerException();
 			}
 
-			if (o1.getElementClass().getAnnotation(NoDoc.class) != null)
+			if (o1.type().getAnnotation(NoDoc.class) != null)
 				return 1;
-			else if (o2.getElementClass().getAnnotation(NoDoc.class) != null)
+			else if (o2.type().getAnnotation(NoDoc.class) != null)
 				return -1;
 
-			return o1.name.compareTo(o2.name);
+			return o1.name().compareTo(o2.name());
 		}
 
 	}
@@ -311,11 +312,11 @@ public class HTMLGenerator extends DocumentationGenerator {
 					}
 				}
 				if (genType.equals("events") || isDocsPage) {
-					List<SkriptEventInfo<?>> events = new ArrayList<>(Skript.getEvents());
+					List<BukkitSyntaxInfos.Event<?>> events = new ArrayList<>(Skript.instance().syntaxRegistry().syntaxes(BukkitSyntaxInfos.Event.KEY));
 					events.sort(eventComparator);
-					for (SkriptEventInfo<?> info : events) {
+					for (BukkitSyntaxInfos.Event<?> info : events) {
 						assert info != null;
-						if (info.getElementClass().getAnnotation(NoDoc.class) != null)
+						if (info.type().getAnnotation(NoDoc.class) != null)
 							continue;
 						generated.append(generateEvent(descTemp, info, generated.toString()));
 					}
@@ -584,7 +585,8 @@ public class HTMLGenerator extends DocumentationGenerator {
 		return desc;
 	}
 
-	private String generateEvent(String descTemp, SkriptEventInfo<?> info, @Nullable String page) {
+	private String generateEvent(String descTemp, BukkitSyntaxInfos.Event<?> modernInfo, @Nullable String page) {
+		SkriptEventInfo<?> info = (SkriptEventInfo<?>) SyntaxElementInfo.fromModern(modernInfo);
 		Class<?> c = info.getElementClass();
 		String desc;
 
@@ -631,7 +633,7 @@ public class HTMLGenerator extends DocumentationGenerator {
 		desc = desc.replace("${element.cancellable}", cancellable ? "Yes" : ""); // if not cancellable the section is hidden
 
 		// Documentation ID
-		desc = desc.replace("${element.id}", DocumentationIdProvider.getId(info));
+		desc = desc.replace("${element.id}", DocumentationIdProvider.getId(modernInfo));
 
 		// Events
 		Events events = c.getAnnotation(Events.class);


### PR DESCRIPTION
### Problem
I accidentally broke Event IDs for the HTMLGenerator in https://github.com/SkriptLang/Skript/pull/8339. This results in glitches/crashes on the live site (oops).

### Solution
I have updated HTMLGenerator to use the modern event info class. However, to avoid changing too much (and the effort given that this is only going to be used for so much longer), the legacy info class is still used most of the time in `generateEvent`.


### Testing Completed
https://docs.skriptlang.org/nightly/feature/fix-html-docs/docs.html


### Supporting Information
n/a


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
