### PR TITLE
Fix duplicate indices in ExprIndices

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprIndices.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprIndices.java
@@ -91,7 +91,7 @@ public class ExprIndices extends SimpleExpression<String> {
 			if (separator != -1)
 				keys[i] = keys[i].substring(0, keys[i].indexOf(Variable.SEPARATOR));
 		}
-		return keys;
+		return Arrays.stream(keys).distinct().toArray(String[]::new);
 	}
 
 	@Override

--- a/src/test/skript/tests/syntaxes/expressions/ExprIndices.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprIndices.sk
@@ -1,3 +1,11 @@
+test "indices":
+	set {_list::a} to 1
+	set {_list::b} to 2
+	set {_list::c::e} to 3
+	set {_list::c::f} to 4
+	assert size of indices of {_list::*} is 3
+	assert indices of {_list::*} is "a", "b" and "c"
+
 test "sorted indices":
 	assert indices of {single-var} is set to fail with "Should not be able to acquire indices of anything other than a list"
 	assert indices of wooden hoe is set to fail with "Should not be able to acquire indices of anything other than a list"


### PR DESCRIPTION
### Problem
Trying to get the indices of a list that has a sublist of multiple values, will return the index for that sublist multiple times.
```applescript
set {_list::sublist::*} to 1 and 2
broadcast indices of {_list::*} # 'sublist and sublist`
```


### Solution
Ensure all the keys returned by the expression are unique


### Testing Completed
`ExprIndices.sk` and manual testing


### Supporting Information
N/A


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
