### PR TITLE
Fix function parameter stringification

### DIFF
--- a/src/main/java/org/skriptlang/skript/common/function/DefaultFunctionImpl.java
+++ b/src/main/java/org/skriptlang/skript/common/function/DefaultFunctionImpl.java
@@ -310,15 +310,30 @@ final class DefaultFunctionImpl<T> extends ch.njol.skript.lang.function.Function
 
 		@Override
 		public @NotNull String toString() {
-			Noun exact = Classes.getSuperClassInfo(type).getName();
-			String typeName;
-			if (type.isArray()) {
-				typeName = exact.getPlural();
-			} else {
-				typeName = exact.getSingular();
+			StringJoiner joiner = new StringJoiner(" ");
+
+			joiner.add("%s:".formatted(name));
+
+			if (hasModifier(Modifier.OPTIONAL)) {
+				joiner.add("optional");
 			}
 
-			return "%s: %s".formatted(name, typeName);
+			Noun exact = Classes.getSuperClassInfo(type).getName();
+			if (type.isArray()) {
+				joiner.add(exact.getPlural());
+			} else {
+				joiner.add(exact.getSingular());
+			}
+
+			if (hasModifier(Modifier.RANGED)) {
+				RangedModifier<?> range = getModifier(RangedModifier.class);
+				joiner.add("between")
+						.add(range.getMin().toString())
+						.add("and")
+						.add(range.getMax().toString());
+			}
+
+			return joiner.toString();
 		}
 	}
 


### PR DESCRIPTION
### Problem
Function parameters were showing in the docs as the Java string representation, instead of the intended human-readable one.


### Solution
Implement toString.


### Testing Completed
**Before**
<img width="1257" height="621" alt="image" src="https://github.com/user-attachments/assets/2b34024d-600c-40b8-b5aa-6a21f8bf25d1" />
<img width="1257" height="451" alt="image" src="https://github.com/user-attachments/assets/fd345a60-ef24-43fd-8b45-3e4b9af09590" />

**After**
<img width="1257" height="394" alt="image" src="https://github.com/user-attachments/assets/99a92c1f-49ad-4502-8cfc-664c849c2ede" />
<img width="1257" height="451" alt="image" src="https://github.com/user-attachments/assets/7ca6152b-a23d-4c06-8c11-87e2675268ec" />

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
