### PR TITLE
Implement better function argument ordering parsing

### DIFF
--- a/src/main/java/org/skriptlang/skript/common/function/FunctionReferenceParser.java
+++ b/src/main/java/org/skriptlang/skript/common/function/FunctionReferenceParser.java
@@ -281,7 +281,7 @@ public record FunctionReferenceParser(ParseContext context, int flags) {
 						}
 						continue;
 					}
-					// find the next unnamed argument
+					// find the next named argument
 					String nextName = null;
 					for (int j = i + 1; j < arguments.length; j++) {
 						Argument<String> nextArgument = arguments[j];

--- a/src/main/java/org/skriptlang/skript/common/function/FunctionReferenceParser.java
+++ b/src/main/java/org/skriptlang/skript/common/function/FunctionReferenceParser.java
@@ -41,6 +41,7 @@ public record FunctionReferenceParser(ParseContext context, int flags) {
 	private final static Pattern FUNCTION_CALL_PATTERN =
 			Pattern.compile("(?<name>[\\p{IsAlphabetic}_][\\p{IsAlphabetic}\\d_]*)\\((?<args>.*)\\)");
 
+	private static final ArgsMessage UNEXPECTED_ARGUMENT = new ArgsMessage("functions.unexpected argument");
 	private static final ArgsMessage INVALID_ARGUMENT = new ArgsMessage("functions.invalid argument");
 
 	/**
@@ -323,7 +324,7 @@ public record FunctionReferenceParser(ParseContext context, int flags) {
 					}
 					// unable to find a slot for this argument
 					if (argument.name() != null) { // this was originally a named argument, error as if it is
-						Skript.error(Language.get("functions.unexpected argument"), argument.name());
+						Skript.error(UNEXPECTED_ARGUMENT.toString(argument.name()));
 					} else {
 						Skript.error(Language.get("functions.mixing named and unnamed arguments"));
 					}

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -238,3 +238,4 @@ functions:
 	ambiguous function call: Cannot determine which function named '%s' to call: '%s'. Try clarifying the type of the arguments using the 'value within' expression.
 	already assigned value to parameter: A value has already been assigned to parameter '%s'.
 	mixing named and unnamed arguments: Mixing named and unnamed arguments is not allowed unless the order of the arguments matches the order of the parameters.
+	invalid argument: Can't understand the argument for %s parameter '%s': %s.

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -239,3 +239,4 @@ functions:
 	already assigned value to parameter: A value has already been assigned to parameter '%s'.
 	mixing named and unnamed arguments: Mixing named and unnamed arguments is not allowed unless the order of the arguments matches the order of the parameters.
 	invalid argument: Can't understand the argument for %s parameter '%s': %s.
+	unexpected argument: The argument named '%s' is unexpected.

--- a/src/test/skript/tests/syntaxes/structures/StructFunction.sk
+++ b/src/test/skript/tests/syntaxes/structures/StructFunction.sk
@@ -157,6 +157,10 @@ test "named function arguments":
 		location(x: 1, y: 2, z: 3, pitch: 4, 5)
 	assert first element of last parse logs contains "Mixing named and unnamed arguments is not allowed"
 
+	parse:
+		location(x: 1, y: 2, z: 3, 4, world: "world", 5)
+	assert first element of last parse logs contains "Mixing named and unnamed arguments is not allowed"
+
 local function nfa_incorrect_list(ns: numbers):
 	stop
 

--- a/src/test/skript/tests/syntaxes/structures/StructFunction.sk
+++ b/src/test/skript/tests/syntaxes/structures/StructFunction.sk
@@ -134,11 +134,11 @@ test "named function arguments":
 
 	parse:
 		nfa(a: 1, b: 2, d: 2)
-	assert first element of last parse logs contains "The function nfa(a: integer, b: integer, d: integer) does not exist"
+	assert first element of last parse logs contains "Can't understand the argument for integer parameter 'c': d: 2"
 
 	parse:
 		nfa(a: 1, d: 2, b: 2)
-	assert first element of last parse logs contains "The function nfa(a: integer, d: integer, b: integer) does not exist"
+	assert first element of last parse logs contains "The argument named 'd' is unexpected"
 
 	parse:
 		nfa(a: 1, a: 2, c: 2)

--- a/src/test/skript/tests/syntaxes/structures/StructFunction.sk
+++ b/src/test/skript/tests/syntaxes/structures/StructFunction.sk
@@ -112,11 +112,11 @@ test "named function arguments":
 
 	parse:
 		assert nfa(a: 8, c: adghadhaherta, b: 2) = 7
-	assert first element of last parse logs contains "The function nfa(a: integer, c: ?, b: integer) does not exist"
+	assert first element of last parse logs contains "Can't understand the argument for integer parameter 'c': adghadhaherta"
 
 	parse:
 		assert nfa(8, c: 3, b: 2) = 7
-	assert first element of last parse logs contains "Mixing named and unnamed arguments is not allowed"
+	assert last parse logs is not set
 
 	parse:
 		assert nfa(c: 3, 2, a: 8) = 7
@@ -143,6 +143,19 @@ test "named function arguments":
 	parse:
 		nfa(a: 1, a: 2, c: 2)
 	assert first element of last parse logs contains "A value has already been assigned to parameter 'a'"
+
+	parse:
+		set {_loc} to location(x: 1, y: 2, z: 3, yaw: 4, 5)
+		assert pitch of {_loc} is 5
+	assert last parse logs is not set
+
+	parse:
+		location(x: 1, y: 2, z: 3, pitch: 5, yaw: 4)
+	assert last parse logs is not set
+
+	parse:
+		location(x: 1, y: 2, z: 3, pitch: 4, 5)
+	assert first element of last parse logs contains "Mixing named and unnamed arguments is not allowed"
 
 local function nfa_incorrect_list(ns: numbers):
 	stop


### PR DESCRIPTION
### Problem
Currently, the enhanced function argument parsing with named arguments is too restrictive when optional parameters exist. For example, the following function call errors for a somewhat unclear reason: `set {_loc} to location(x: 1, y: 1, z: 1, yaw: 1, pitch: 1)` (`Mixing named and unnamed arguments is not allowed unless the order of the arguments matches the order of the parameters.`). This error is because the `world` parameter must occur before the `yaw` parameter. However, given that it is optional. one would expect for this function call to work without issue.

### Solution
I have reworked the function argument parsing so that the user provided arguments are instead reworked into the order defined by the function signature. First, all named parameters are inserted into their respective positions. Then, the remaining unnamed arguments are inserted into the remaining positions. An unnamed parameter is only valid in its position if the named parameter it represents occurs before all named parameters that come after in the user's provided arguments.

For example, the following calls are now valid:
`location(1, 2, 3, pitch: 10, yaw: 5)` where `1`, `2`, and `3` represent `x`, `y`, and `z` respectively
`location(x: 1, y: 2, z: 3, yaw: 4, 5)` where `5` represents `pitch`
`location(x: 1, 2, z: 3) where `2` represents `y`.

Further, I fixed a mistake where failures to parse arguments as expressions would result in the default value being used. Instead, an error about the input being invalid for that parameter is now parsed.

### Testing Completed
I have added a few additional tests to `StructFunction.sk`

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->
n/a

---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
