### PR TITLE
Fix missing name for invalid arguments

### DIFF
--- a/src/main/java/org/skriptlang/skript/common/function/FunctionReferenceParser.java
+++ b/src/main/java/org/skriptlang/skript/common/function/FunctionReferenceParser.java
@@ -245,7 +245,7 @@ public record FunctionReferenceParser(ParseContext context, int flags) {
 						}
 					}
 				} else if (index < arguments.length) { // if there are no named arguments, simply take the next provided one
-					argument = arguments[index];
+					argument = new Argument<>(ArgumentType.UNNAMED, entry.getKey(), arguments[index].value());
 				}
 				if (argument == null) { // could not resolve an argument, use a placeholder
 					argument = new Argument<>(ArgumentType.UNNAMED, entry.getKey(), null);

--- a/src/main/java/org/skriptlang/skript/common/function/FunctionReferenceParser.java
+++ b/src/main/java/org/skriptlang/skript/common/function/FunctionReferenceParser.java
@@ -641,7 +641,7 @@ public record FunctionReferenceParser(ParseContext context, int flags) {
 			Expression<?> expression = parser.parseExpression(targetData.type());
 			if (expression == null) {
 				logHandler.printError(INVALID_ARGUMENT.toString(
-					Classes.getSuperClassInfo(targetData.type()).getName().getSingular(), argument.name(), argument.value()
+					argument.name(), Classes.getSuperClassInfo(targetData.type()).getName().getSingular(), argument.value()
 				));
 			}
 			return expression;

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -238,7 +238,7 @@ functions:
 	ambiguous function call: Cannot determine which function named '%s' to call: '%s'. Try clarifying the type of the arguments using the 'value within' expression.
 	already assigned value to parameter: A value has already been assigned to parameter '%s'.
 	mixing named and unnamed arguments: Mixing named and unnamed arguments is not allowed unless the order of the arguments matches the order of the parameters.
-	invalid argument: Can't understand the argument for %s parameter '%s': %s.
+	invalid argument: Can't understand the argument for the %s parameter '%s': %s.
 	unexpected argument: The argument named '%s' is unexpected.
 	unknown function: The function %s(%s) does not exist.
 	potential signature: Did you mean to use the function '%s'?

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -238,7 +238,7 @@ functions:
 	ambiguous function call: Cannot determine which function named '%s' to call: '%s'. Try clarifying the type of the arguments using the 'value within' expression.
 	already assigned value to parameter: A value has already been assigned to parameter '%s'.
 	mixing named and unnamed arguments: Mixing named and unnamed arguments is not allowed unless the order of the arguments matches the order of the parameters.
-	invalid argument: Can't understand the argument for the %s parameter '%s': %s.
+	invalid argument: Can't understand the argument for the parameter '%s' with type '%s': %s.
 	unexpected argument: The argument named '%s' is unexpected.
 	unknown function: The function %s(%s) does not exist.
 	potential signature: Did you mean to use the function '%s'?

--- a/src/test/skript/tests/syntaxes/structures/StructFunction.sk
+++ b/src/test/skript/tests/syntaxes/structures/StructFunction.sk
@@ -80,6 +80,18 @@ test "function structure arguments":
 		argument_test_list(1, (2, 3))
 	assert last parse logs contain "The function argument_test_list(integer, integers) does not exist"
 
+	parse:
+		argument_test(1 if {_x} is 1, else 2, 3)
+	assert last parse logs is "The function argument_test(?, ?, integer) does not exist. Did you mean to use the function 'local argument_test(x: integer, y: integer)'?"
+
+	parse:
+		argument_test((1 if {_x} is 1, else 2), 3)
+	assert last parse logs is not set
+
+	parse:
+		location(1, 1, 1, 1, 1)
+	assert last parse logs is "Can't understand the argument for the world parameter 'world': 1."
+
 local function argument_default(x: int, y: int = 2) -> int:
     return {_x} + {_y}
 
@@ -112,7 +124,7 @@ test "named function arguments":
 
 	parse:
 		assert nfa(a: 8, c: adghadhaherta, b: 2) = 7
-	assert first element of last parse logs contains "Can't understand the argument for integer parameter 'c': adghadhaherta"
+	assert last parse logs is "Can't understand the argument for the integer parameter 'c': adghadhaherta."
 
 	parse:
 		assert nfa(8, c: 3, b: 2) = 7
@@ -134,7 +146,7 @@ test "named function arguments":
 
 	parse:
 		nfa(a: 1, b: 2, d: 2)
-	assert first element of last parse logs contains "Can't understand the argument for integer parameter 'c': d: 2"
+	assert last parse logs is "Can't understand the argument for the integer parameter 'c': d: 2."
 
 	parse:
 		nfa(a: 1, d: 2, b: 2)
@@ -160,14 +172,6 @@ test "named function arguments":
 	parse:
 		location(x: 1, y: 2, z: 3, 4, world: "world", 5)
 	assert first element of last parse logs contains "Mixing named and unnamed arguments is not allowed"
-
-	parse:
-		nfa(1 if {_x} is 1, else 2, 3, 4)
-	assert last parse logs is "The function nfa(?, ?, integer, integer) does not exist. Did you mean to use the function 'local nfa(a: integer, b: integer, c: integer)'?"
-
-	parse:
-		nfa((1 if {_x} is 1, else 2), 3, 4)
-	assert last parse logs is not set
 
 local function nfa_incorrect_list(ns: numbers):
 	stop

--- a/src/test/skript/tests/syntaxes/structures/StructFunction.sk
+++ b/src/test/skript/tests/syntaxes/structures/StructFunction.sk
@@ -90,7 +90,7 @@ test "function structure arguments":
 
 	parse:
 		location(1, 1, 1, 1, 1)
-	assert last parse logs is "Can't understand the argument for the world parameter 'world': 1."
+	assert last parse logs is "Can't understand the argument for the parameter 'world' with type 'world': 1."
 
 local function argument_default(x: int, y: int = 2) -> int:
     return {_x} + {_y}
@@ -124,7 +124,7 @@ test "named function arguments":
 
 	parse:
 		assert nfa(a: 8, c: adghadhaherta, b: 2) = 7
-	assert last parse logs is "Can't understand the argument for the integer parameter 'c': adghadhaherta."
+	assert last parse logs is "Can't understand the argument for the parameter 'c' with type 'integer': adghadhaherta."
 
 	parse:
 		assert nfa(8, c: 3, b: 2) = 7
@@ -146,7 +146,7 @@ test "named function arguments":
 
 	parse:
 		nfa(a: 1, b: 2, d: 2)
-	assert last parse logs is "Can't understand the argument for the integer parameter 'c': d: 2."
+	assert last parse logs is "Can't understand the argument for the parameter 'c' with type 'integer': d: 2."
 
 	parse:
 		nfa(a: 1, d: 2, b: 2)


### PR DESCRIPTION
### Problem
In some cases, the name of an invalid function argument was not properly carried. For example, given the call `location(1, 1, 1, 100, 100`, the error message is `Can't understand the argument for world parameter 'null': 100.`


### Solution
When passing arguments through, they are instead recreated with the expected parameter name. I have also tweaked the existing error message.


### Testing Completed
I have added an additional test to confirm that the correct parameter name is now printed as expected.

### Supporting Information
n/a

---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
