### PR TITLE
Replaced reflection with LambdaMetafactory when creating new SyntaxElement instances

### DIFF
--- a/src/main/java/org/skriptlang/skript/registration/SyntaxInfoImpl.java
+++ b/src/main/java/org/skriptlang/skript/registration/SyntaxInfoImpl.java
@@ -113,8 +113,10 @@ class SyntaxInfoImpl<T extends SyntaxElement> implements SyntaxInfo<T> {
 
 	@Override
 	public T instance() {
-		if (providedSupplier != null) return providedSupplier.get();
-		if (generatedSupplier != null) return generatedSupplier.get();
+		if (providedSupplier != null)
+			return providedSupplier.get();
+		if (generatedSupplier != null)
+			return generatedSupplier.get();
 		try {
 			generatedSupplier = instanceSupplier(type());
 		} catch (Throwable e) {


### PR DESCRIPTION
### Problem & Solution
This PR improves SyntaxInfo implementation for cases when no supplier for the SyntaxElement is provided.
Before, each time a new instance was created, constructor was resolved and invoked.

This is now changed; first time the SyntaxInfo#instance is called, CallSite for the constructor is created and
is invoked through a Supplier. If #instance() is called repeatedly the LambdaMetafactory approach
is faster (close to direct calls). It should be beneficial for users who often reload large script files.
For one-off calls it is generally slower because the LambdaMetafactory setup is costly but the quickTest performs the same as before on my machine so I think it shouldn't really be noticeable.

### Testing Completed
built-in test

---
**Completes:** none
**Related:** none
**AI assistance:** none
