### PR TITLE
Fix missing call in GroupPatternElement stringification

### DIFF
--- a/src/main/java/ch/njol/skript/patterns/GroupPatternElement.java
+++ b/src/main/java/ch/njol/skript/patterns/GroupPatternElement.java
@@ -38,7 +38,7 @@ public class GroupPatternElement extends PatternElement {
 
 	@Override
 	public String toString(StringificationProperties properties) {
-		return "(" + patternElement + ")";
+		return "(" + patternElement.toFullString(properties) + ")";
 	}
 
 	@Override

--- a/src/test/java/ch/njol/skript/patterns/PatternCompilerTest.java
+++ b/src/test/java/ch/njol/skript/patterns/PatternCompilerTest.java
@@ -22,6 +22,8 @@ public class PatternCompilerTest {
 			.build();
 		assertEquals("hello [a:world]", PatternCompiler.compile("hello [a:world]").toString());
 		assertEquals("hello [world]", PatternCompiler.compile("hello [a:world]").toString(properties));
+		assertEquals("(a|b:b)", PatternCompiler.compile("(a|:b)").toString());
+		assertEquals("(a|b)", PatternCompiler.compile("(a|:b)").toString(properties));
 		assertEquals("hello [%-number%]", PatternCompiler.compile("hello [%-number%]").toString());
 		assertEquals("hello [%number%]", PatternCompiler.compile("hello [%-number%]").toString(properties));
 		assertEquals("hello [%number@1%]", PatternCompiler.compile("hello [%number@1%]").toString());


### PR DESCRIPTION
### Problem
In https://github.com/SkriptLang/Skript/pull/8391, GroupPatternElement was incorrectly implemented. The stringification properties were not passed along, resulting in default properties being used.

### Solution
I have updated the method to properly stringify the pattern element.

### Testing Completed
Updated the relevant JUnit Test to account for this case.

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
