### PR TITLE
Fix ExprArithmetic's number return types

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/arithmetic/ExprArithmetic.java
+++ b/src/main/java/ch/njol/skript/expressions/arithmetic/ExprArithmetic.java
@@ -13,6 +13,7 @@ import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.UnparsedLiteral;
 import ch.njol.skript.lang.parser.ParsingStack;
+import ch.njol.skript.lang.simplification.SimplifiedLiteral;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.util.LiteralUtils;
@@ -24,7 +25,6 @@ import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.arithmetic.Arithmetics;
 import org.skriptlang.skript.lang.arithmetic.OperationInfo;
 import org.skriptlang.skript.lang.arithmetic.Operator;
-import ch.njol.skript.lang.simplification.SimplifiedLiteral;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
@@ -42,8 +42,6 @@ import java.util.List;
 @Since("1.4.2")
 @SuppressWarnings("null")
 public class ExprArithmetic<L, R, T> extends SimpleExpression<T> {
-
-	private static final Class<?>[] INTEGER_CLASSES = {Long.class, Integer.class, Short.class, Byte.class};
 
 	private record PatternInfo(Operator operator, boolean leftGrouped, boolean rightGrouped) {
 	}
@@ -245,21 +243,6 @@ public class ExprArithmetic<L, R, T> extends SimpleExpression<T> {
 			if (operationInfo == null) // we error if we couldn't find an operation between the two types
 				return error(firstClass, secondClass);
 			returnType = operationInfo.returnType();
-		}
-
-		// ensure proper return types for numerical operations
-		if (Number.class.isAssignableFrom(returnType)) {
-			if (operator == Operator.DIVISION || operator == Operator.EXPONENTIATION) {
-				returnType = (Class<? extends T>) Double.class;
-			} else {
-				boolean firstIsInt = false;
-				boolean secondIsInt = false;
-				for (Class<?> i : INTEGER_CLASSES) {
-					firstIsInt |= i.isAssignableFrom(first.getReturnType());
-					secondIsInt |= i.isAssignableFrom(second.getReturnType());
-				}
-				returnType = (Class<? extends T>) (firstIsInt && secondIsInt ? Long.class : Double.class);
-			}
 		}
 
 		/*

--- a/src/test/skript/tests/regressions/8456-exprarithmetic number return type.sk
+++ b/src/test/skript/tests/regressions/8456-exprarithmetic number return type.sk
@@ -1,0 +1,4 @@
+test "exprarithmetic number return types":
+	set {_num} to 1
+	set {_nums::*} to ({_num} + 1) and ({_num} + 1)
+	assert {_nums::*} is (2 and 2)


### PR DESCRIPTION
### Problem
ExprArithmetic wrongly assumes that its return type is a double if one of the operands is not an integer. Which is not true in the case of a variable containing an integer value, causing a mismatch between the claimed return type (a double) and the actual returned value (a long)


### Solution
Remove the logic that makes said assumption entirely.


### Testing Completed
manual testing, regression test


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
