### PR TITLE
Update EvtFurnaceTest.java

### DIFF
--- a/src/test/java/org/skriptlang/skript/test/tests/syntaxes/events/EvtFurnaceTest.java
+++ b/src/test/java/org/skriptlang/skript/test/tests/syntaxes/events/EvtFurnaceTest.java
@@ -1,9 +1,9 @@
 package org.skriptlang.skript.test.tests.syntaxes.events;
 
+import ch.njol.skript.Skript;
 import ch.njol.skript.test.runner.SkriptJUnitTest;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.FurnaceBurnEvent;
@@ -18,6 +18,8 @@ import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
 
 public class EvtFurnaceTest extends SkriptJUnitTest {
 
@@ -43,8 +45,17 @@ public class EvtFurnaceTest extends SkriptJUnitTest {
 		FurnaceBurnEvent burnEvent = new FurnaceBurnEvent(furnace, new ItemStack(Material.LAVA_BUCKET), 10);
 		FurnaceSmeltEvent smeltEvent = new FurnaceSmeltEvent(furnace, new ItemStack(Material.RAW_IRON), new ItemStack(Material.IRON_INGOT));
 		FurnaceStartSmeltEvent startEvent = new FurnaceStartSmeltEvent(furnace, new ItemStack(Material.RAW_GOLD), recipe);
-		FurnaceExtractEvent extractEvent = new FurnaceExtractEvent(easyMockPlayer, furnace, Material.COPPER_INGOT, 10, 20);
-
+		FurnaceExtractEvent extractEvent;
+		if (Skript.isRunningMinecraft(1, 21, 11)) {
+			extractEvent = new FurnaceExtractEvent(easyMockPlayer, furnace, new ItemStack(Material.COPPER_INGOT), 10, 20);
+		} else {
+			try {
+				extractEvent = FurnaceExtractEvent.class.getDeclaredConstructor(Player.class, Block.class, Material.class, int.class, int.class)
+											.newInstance(easyMockPlayer, furnace, Material.COPPER_INGOT, 10, 20);
+			} catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+				throw new RuntimeException(e);
+			}
+		}
 		Bukkit.getPluginManager().callEvent(burnEvent);
 		Bukkit.getPluginManager().callEvent(smeltEvent);
 		Bukkit.getPluginManager().callEvent(startEvent);


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
FurnaceExtractEvent's constructor switched from material to itemstack.

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
Bandaid fix for 1.21.11 but these are all deprecated and internal constructors we should be avoiding using in the future.

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
