### PR TITLE
Fix game effect names in docs

### DIFF
--- a/src/main/java/org/skriptlang/skript/bukkit/particles/GameEffect.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/particles/GameEffect.java
@@ -11,15 +11,17 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Arrays;
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * A class to hold metadata about {@link org.bukkit.Effect}s before playing.
  */
 public class GameEffect {
-
-	public static final EnumParser<Effect> ENUM_UTILS = new EnumParser<>(Effect.class, "game effect"); // exclude effects that require data
+	/**
+	 * Parser for game effects without data
+	 */
+	private static final GameEffectParser ENUM_PARSER = new GameEffectParser();
 
 	/**
 	 * The {@link Effect} that this object represents
@@ -45,7 +47,7 @@ public class GameEffect {
 	 * @return the parsed GameEffect, or null if the input is invalid
 	 */
 	public static GameEffect parse(String input) {
-		Effect effect = ENUM_UTILS.parse(input.toLowerCase(Locale.ENGLISH), ParseContext.DEFAULT);
+		Effect effect = ENUM_PARSER.parse(input.toLowerCase(Locale.ENGLISH), ParseContext.DEFAULT);
 		if (effect == null)
 			return null;
 		if (effect.getData() != null) {
@@ -116,7 +118,7 @@ public class GameEffect {
 	}
 
 	public String toString(int flags) {
-		return ENUM_UTILS.toString(getEffect(), flags);
+		return ENUM_PARSER.toString(getEffect(), flags);
 	}
 
 	@Override
@@ -125,18 +127,31 @@ public class GameEffect {
 	}
 
 	/**
-	 * A cached array of all effect names that do not require data.
-	 */
-	static final String[] namesWithoutData = Arrays.stream(Effect.values())
-			.filter(effect -> effect.getData() == null)
-			.map(Enum::name)
-			.toArray(String[]::new);
-
-	/**
 	 * @return an array of all effect names that do not require data.
 	 */
 	public static String[] getAllNamesWithoutData(){
-		return namesWithoutData.clone();
+		return ENUM_PARSER.getPatternsWithoutData();
+	}
+
+	/**
+	 * A custom {@link EnumParser} that excludes game effects with data from being parsed directly.
+	 */
+	private static class GameEffectParser extends EnumParser<Effect> {
+
+		public GameEffectParser() {
+			super(Effect.class, "game effect");
+		}
+
+		public String @NotNull [] getPatternsWithoutData() {
+			return parseMap.entrySet().stream()
+				.filter(entry -> {
+					Effect effect = entry.getValue();
+					return effect.getData() == null;
+				})
+				.map(Map.Entry::getKey)
+				.toArray(String[]::new);
+		}
+
 	}
 
 }


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
Game effects in docs were using the enum names.

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
Uses the actual enum parser names from the lang file instead, same method as how particles are handled.

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
