### PR TITLE
Fix effect section errors getting overridden

### DIFF
--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -1064,15 +1064,34 @@ public class ScriptLoader {
 
 					if (item != null)
 						break find_section;
-					Collection<LogEntry> errors = handler.getErrors();
 
 					// restore the failure log if:
 					// 1. there are no errors from the statement parse
 					// 2. the error message is the default one from the statement parse
 					// 3. the backup log contains a message about the section being claimed
-					if (errors.isEmpty()
-						|| errors.iterator().next().getMessage().contains("Can't understand this condition/effect:")
-						|| backup.getErrors().iterator().next().getMessage().contains("tried to claim the current section, but it was already claimed by")
+					// 4. the backup log contains an explicit error and the error message is about no syntax managing the section
+					if (!handler.hasErrors()) {
+						handler.restore(backup);
+						continue;
+					}
+
+					LogEntry errorEntry = handler.getFirstError();
+					assert errorEntry != null;
+					String error = errorEntry.getMessage();
+
+					if (error.contains("Can't understand this condition/effect:")) {
+						handler.restore(backup);
+						continue;
+					}
+
+					LogEntry backupErrorEntry = backup.getFirstError();
+					if (backupErrorEntry == null)
+						continue;
+					String backupError = backupErrorEntry.getMessage();
+
+					if (backupError.contains("tried to claim the current section, but it was already claimed by")
+						|| (!backupError.contains("Can't understand this section: ")
+						&& error.contains("is a valid statement but cannot function as a section (:) because there is no syntax in the line to manage it."))
 					) {
 						handler.restore(backup);
 					}

--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -1069,7 +1069,7 @@ public class ScriptLoader {
 					// 1. there are no errors from the statement parse
 					// 2. the error message is the default one from the statement parse
 					// 3. the backup log contains a message about the section being claimed
-					// 4. the backup log contains an explicit error and the error message is about no syntax managing the section
+					// 4. the backup log contains an explicit error and the current error message is about no syntax managing the section
 					if (!handler.hasErrors()) {
 						handler.restore(backup);
 						continue;

--- a/src/main/java/ch/njol/skript/test/runner/EffSecErrorWhenSection.java
+++ b/src/main/java/ch/njol/skript/test/runner/EffSecErrorWhenSection.java
@@ -1,0 +1,49 @@
+package ch.njol.skript.test.runner;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.config.SectionNode;
+import ch.njol.skript.doc.NoDoc;
+import ch.njol.skript.lang.*;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+@NoDoc
+public class EffSecErrorWhenSection extends EffectSection {
+
+	static {
+		if (TestMode.ENABLED)
+			Skript.registerSection(EffSecErrorWhenSection.class, "error [%-*string%] when using [a] section");
+	}
+
+	private @Nullable Literal<String> error;
+
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult, @Nullable SectionNode sectionNode, @Nullable List<TriggerItem> triggerItems) {
+		//noinspection unchecked
+		error = expressions.length == 1 ? (Literal<String>) expressions[0] : null;
+		if (sectionNode != null) {
+			if (error != null)
+				Skript.error(error.getSingle());
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	protected @Nullable TriggerItem walk(Event event) {
+		return super.walk(event, false);
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		SyntaxStringBuilder builder = new SyntaxStringBuilder(event, debug);
+		builder.append("error");
+		builder.appendIf(error != null, error);
+		builder.append("when using a section");
+		return builder.toString();
+	}
+
+}

--- a/src/main/java/ch/njol/skript/test/runner/EffSecErrorWhenSection.java
+++ b/src/main/java/ch/njol/skript/test/runner/EffSecErrorWhenSection.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.doc.NoDoc;
 import ch.njol.skript.lang.*;
+import ch.njol.skript.util.LiteralUtils;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
@@ -15,21 +16,23 @@ public class EffSecErrorWhenSection extends EffectSection {
 
 	static {
 		if (TestMode.ENABLED)
-			Skript.registerSection(EffSecErrorWhenSection.class, "error [%-*string%] when using [a] section");
+			Skript.registerSection(EffSecErrorWhenSection.class, "error [%-*string%] when using [a] section [with %-object%]");
 	}
 
 	private @Nullable Literal<String> error;
+	private @Nullable Expression<?> with;
 
 	@Override
 	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult, @Nullable SectionNode sectionNode, @Nullable List<TriggerItem> triggerItems) {
 		//noinspection unchecked
-		error = expressions.length == 1 ? (Literal<String>) expressions[0] : null;
+		error = (Literal<String>) expressions[0];
+		with = LiteralUtils.defendExpression(expressions[1]);
 		if (sectionNode != null) {
 			if (error != null)
 				Skript.error(error.getSingle());
 			return false;
 		}
-		return true;
+		return with == null || LiteralUtils.canInitSafely(with);
 	}
 
 	@Override
@@ -43,6 +46,7 @@ public class EffSecErrorWhenSection extends EffectSection {
 		builder.append("error");
 		builder.appendIf(error != null, error);
 		builder.append("when using a section");
+		builder.appendIf(with != null, "with", with);
 		return builder.toString();
 	}
 

--- a/src/main/java/ch/njol/skript/test/runner/ExprSecErroringSectionExpression.java
+++ b/src/main/java/ch/njol/skript/test/runner/ExprSecErroringSectionExpression.java
@@ -1,0 +1,52 @@
+package ch.njol.skript.test.runner;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.config.SectionNode;
+import ch.njol.skript.doc.NoDoc;
+import ch.njol.skript.expressions.base.SectionExpression;
+import ch.njol.skript.lang.*;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+@NoDoc
+public class ExprSecErroringSectionExpression extends SectionExpression<Object> {
+
+	static {
+		if (TestMode.ENABLED)
+			Skript.registerExpression(ExprSecErroringSectionExpression.class, Object.class, ExpressionType.SIMPLE, "erroring section expression");
+	}
+
+	@Override
+	public boolean init(Expression<?>[] expressions, int pattern, Kleenean delayed, ParseResult result, @Nullable SectionNode node, @Nullable List<TriggerItem> triggerItems) {
+		if (node != null) {
+			Skript.error("erroring section expression");
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	protected Object @Nullable [] get(Event event) {
+		return new Object[0];
+	}
+
+	@Override
+	public boolean isSingle() {
+		return true;
+	}
+
+	@Override
+	public Class<?> getReturnType() {
+		return Object.class;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "test";
+	}
+
+}

--- a/src/test/skript/tests/misc/effect section error.sk
+++ b/src/test/skript/tests/misc/effect section error.sk
@@ -1,0 +1,10 @@
+test "effect section error":
+	parse:
+		error "foobar" when using a section:
+			abc
+	assert parse logs contain "foobar" with "EffectSection's error got overridden by its effect counterpart"
+
+	parse:
+		error when using a section:
+			abc
+	assert "%parse logs%" contains "is a valid statement but cannot function as a section (:) because there is no syntax in the line to manage it." with "Default error was overridden"

--- a/src/test/skript/tests/misc/effect section error.sk
+++ b/src/test/skript/tests/misc/effect section error.sk
@@ -8,3 +8,9 @@ test "effect section error":
 		error when using a section:
 			abc
 	assert "%parse logs%" contains "is a valid statement but cannot function as a section (:) because there is no syntax in the line to manage it." with "Default error was overridden"
+
+	parse:
+		error "foobar" when using a section with erroring section expression:
+			abc
+	assert "%parse logs%" doesn't contain "foobar" with "EffectSection overrode SectionExpression's error"
+	assert "%parse logs%" contains "erroring section expression" with "Erroring section expression didn't error"


### PR DESCRIPTION
### Problem
When the section element of an EffectSection errors, but the effect element of it succeeds and later errors due to no syntaxes claiming the section. The user logged errors get overridden by a generic "X is a valid statement but cannot function as a section (:) because there is no syntax in the line to manage it." error.


### Solution
Only override the section's error if it doesn't include an explicitly logged error by the user.


### Testing Completed
`effect section error.sk` and manual testing.


### Supporting Information
Quick rundown of what happens:
```
erroring effect section:
    ...
```

1. tries to parse the effect section as a section -> succeeds
2. tries to call init -> fails with explicit error
3. tries to parse the effect on its own -> succeeds
4. tries to see if any expression claimed the section -> fails
5. prints can't claim section (overrides explicit error)

---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
