### PR TITLE
Exclude syntax info's origin from its hash code

### DIFF
--- a/src/main/java/org/skriptlang/skript/registration/SyntaxInfoImpl.java
+++ b/src/main/java/org/skriptlang/skript/registration/SyntaxInfoImpl.java
@@ -127,7 +127,7 @@ class SyntaxInfoImpl<T extends SyntaxElement> implements SyntaxInfo<T> {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(origin(), type(), patterns(), priority());
+		return Objects.hash(type(), patterns(), priority());
 	}
 
 	@Override

--- a/src/test/java/org/skriptlang/skript/registration/SyntaxRegistryTest.java
+++ b/src/test/java/org/skriptlang/skript/registration/SyntaxRegistryTest.java
@@ -18,41 +18,6 @@ public class SyntaxRegistryTest {
 		return SyntaxRegistry.empty();
 	}
 
-	private static SyntaxRegistry originApplyingRegistry(Origin origin) {
-		return new SyntaxRegistry() {
-
-			private final SyntaxRegistry delegate = syntaxRegistry();
-
-			@Override
-			public @Unmodifiable <I extends SyntaxInfo<?>> Collection<I> syntaxes(Key<I> key) {
-				return delegate.syntaxes(key);
-			}
-
-			@Override
-			public <I extends SyntaxInfo<?>> void register(Key<I> key, I info) {
-				if (info.origin() == Origin.UNKNOWN)
-					//noinspection unchecked
-					info = (I) info.toBuilder().origin(origin).build();
-				delegate.register(key, info);
-			}
-
-			@Override
-			public void unregister(SyntaxInfo<?> info) {
-				delegate.unregister(info);
-			}
-
-			@Override
-			public <I extends SyntaxInfo<?>> void unregister(Key<I> key, I info) {
-				delegate.unregister(key, info);
-			}
-
-			@Override
-			public @Unmodifiable Collection<SyntaxInfo<?>> elements() {
-				return delegate.elements();
-			}
-		};
-	}
-
 	private static SyntaxInfo<?> info() {
 		return SyntaxInfo.builder(SyntaxElement.class)
 			.supplier(() -> {
@@ -156,9 +121,11 @@ public class SyntaxRegistryTest {
 		final Origin origin = EasyMock.mock(Origin.AddonOrigin.class);
 		EasyMock.expect(origin.name()).andStubReturn("TestOrigin");
 		EasyMock.replay(origin);
-		final SyntaxRegistry registry = originApplyingRegistry(origin);
+
+		final SyntaxRegistry registry = syntaxRegistry();
 		SyntaxInfo<?> info = info();
-		registry.register(key(), info);
+
+		registry.register(key(), info.toBuilder().origin(origin).build());
 		registry.unregister(key(), info);
 		assertTrue(registry.elements().isEmpty());
 	}

--- a/src/test/java/org/skriptlang/skript/registration/SyntaxRegistryTest.java
+++ b/src/test/java/org/skriptlang/skript/registration/SyntaxRegistryTest.java
@@ -1,9 +1,14 @@
 package org.skriptlang.skript.registration;
 
 import ch.njol.skript.lang.SyntaxElement;
+import org.easymock.EasyMock;
+import org.jetbrains.annotations.Unmodifiable;
 import org.junit.Test;
+import org.skriptlang.skript.docs.Origin;
 import org.skriptlang.skript.registration.SyntaxRegistry.Key;
 import org.skriptlang.skript.util.Priority;
+
+import java.util.Collection;
 
 import static org.junit.Assert.*;
 
@@ -11,6 +16,41 @@ public class SyntaxRegistryTest {
 
 	private static SyntaxRegistry syntaxRegistry() {
 		return SyntaxRegistry.empty();
+	}
+
+	private static SyntaxRegistry originApplyingRegistry(Origin origin) {
+		return new SyntaxRegistry() {
+
+			private final SyntaxRegistry delegate = syntaxRegistry();
+
+			@Override
+			public @Unmodifiable <I extends SyntaxInfo<?>> Collection<I> syntaxes(Key<I> key) {
+				return delegate.syntaxes(key);
+			}
+
+			@Override
+			public <I extends SyntaxInfo<?>> void register(Key<I> key, I info) {
+				if (info.origin() == Origin.UNKNOWN)
+					//noinspection unchecked
+					info = (I) info.toBuilder().origin(origin).build();
+				delegate.register(key, info);
+			}
+
+			@Override
+			public void unregister(SyntaxInfo<?> info) {
+				delegate.unregister(info);
+			}
+
+			@Override
+			public <I extends SyntaxInfo<?>> void unregister(Key<I> key, I info) {
+				delegate.unregister(key, info);
+			}
+
+			@Override
+			public @Unmodifiable Collection<SyntaxInfo<?>> elements() {
+				return delegate.elements();
+			}
+		};
 	}
 
 	private static SyntaxInfo<?> info() {
@@ -109,6 +149,18 @@ public class SyntaxRegistryTest {
 		assertThrows(UnsupportedOperationException.class, () -> unmodifiable.unregister(info));
 		assertFalse(registry.elements().contains(info));
 		assertFalse(unmodifiable.elements().contains(info));
+	}
+
+	@Test
+	public void testDifferentOriginUnregistration() {
+		final Origin origin = EasyMock.mock(Origin.AddonOrigin.class);
+		EasyMock.expect(origin.name()).andStubReturn("TestOrigin");
+		EasyMock.replay(origin);
+		final SyntaxRegistry registry = originApplyingRegistry(origin);
+		SyntaxInfo<?> info = info();
+		registry.register(key(), info);
+		registry.unregister(key(), info);
+		assertTrue(registry.elements().isEmpty());
 	}
 
 }

--- a/src/test/java/org/skriptlang/skript/registration/SyntaxRegistryTest.java
+++ b/src/test/java/org/skriptlang/skript/registration/SyntaxRegistryTest.java
@@ -2,13 +2,10 @@ package org.skriptlang.skript.registration;
 
 import ch.njol.skript.lang.SyntaxElement;
 import org.easymock.EasyMock;
-import org.jetbrains.annotations.Unmodifiable;
 import org.junit.Test;
 import org.skriptlang.skript.docs.Origin;
 import org.skriptlang.skript.registration.SyntaxRegistry.Key;
 import org.skriptlang.skript.util.Priority;
-
-import java.util.Collection;
 
 import static org.junit.Assert.*;
 


### PR DESCRIPTION
### Problem
When registering an element without defining its origin, Skript will automatically apply an origin to it pointing to the addon that registered it. That's extremely useful but unfortunately means that the syntax info that Skript registers isn't the same as the one provided by the addon, due to the origin being included in the hash code, thus having different hashes. Which in turn means that, when the addon tries to unregister the same info later on, Skript won't be able to find and unregister it.


### Solution
Exclude the origin from the hash, since it's not part of the syntax info's properties. Which also aligns with how the `equals` method is currently implemented. (origin is excluded)


### Testing Completed
Added a test case in `SyntaxRegistryTest.java` for unregistering elements with different origins


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
