### PR TITLE
Fix ExprTagsOf NPE

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprStringColor.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprStringColor.java
@@ -161,7 +161,9 @@ public class ExprStringColor extends PropertyExpression<String, Object> {
 		}
 		if (selectedState == StringColor.LAST) {
 			colors.clear();
-			colors.add(last);
+			if (last != null) {
+				colors.add(last);
+			}
 		}
 		return colors;
 	}

--- a/src/main/java/ch/njol/skript/expressions/base/PropertyExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/PropertyExpression.java
@@ -1,6 +1,7 @@
 package ch.njol.skript.expressions.base;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.SkriptAPIException;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -194,6 +195,14 @@ public abstract class PropertyExpression<F, T> extends SimpleExpression<T> {
 	@Override
 	public final T[] getAll(Event event) {
 		T[] result = get(event, expr.getAll(event));
+		if (result == null) {
+			throw new SkriptAPIException("PropertyExpression must not return a null array");
+		}
+		for (T t : result) {
+			if (t == null) {
+				throw new SkriptAPIException("PropertyExpression must not return an array containing null elements");
+			}
+		}
 		return Arrays.copyOf(result, result.length);
 	}
 

--- a/src/main/java/org/skriptlang/skript/bukkit/tags/elements/ExprTagsOf.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/tags/elements/ExprTagsOf.java
@@ -57,11 +57,11 @@ public class ExprTagsOf extends PropertyExpression<Object, Tag> {
 	@Override
 	protected Tag<?> @Nullable [] get(Event event, Object @NotNull [] source) {
 		if (source.length == 0)
-			return null;
+			return new Tag[0];
 		boolean isAny = (source[0] instanceof ItemType itemType && !itemType.isAll());
 		Keyed[] values = TagModule.getKeyed(source[0]);
 		if (values == null)
-			return null;
+			return new Tag[0];
 		// choose single material if it's something like `any log`
 		if (isAny) {
 			ThreadLocalRandom random = ThreadLocalRandom.current();
@@ -110,7 +110,7 @@ public class ExprTagsOf extends PropertyExpression<Object, Tag> {
 	@Override
 	public String toString(@Nullable Event event, boolean debug) {
 		String registry = types.length > 1 ? "" : " " + types[0].toString();
-		return  origin.toString(datapackOnly) + registry + " tags of " + getExpr().toString(event, debug);
+		return origin.toString(datapackOnly) + registry + " tags of " + getExpr().toString(event, debug);
 	}
 
 }

--- a/src/test/skript/tests/syntaxes/expressions/ExprFilter.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprFilter.sk
@@ -19,4 +19,4 @@ test "where filter":
 test "input conversion":
 	set {_strings::*} to "test1", "test2", "test3" and "4test"
 	assert size of ({_strings::*} where [the first 4 characters of string input is "test"]) is 3 with "input was not correctly casted"
-	assert size of ({_strings::*} where [the last string color of string input is not set]) is 0 with "input was not correctly casted"
+	assert size of ({_strings::*} where [the last string color of string input is not set]) is 4 with "input was not correctly casted"


### PR DESCRIPTION
### Problem
ExprTagsOf returns null in get(), which causes an NPE in PropertyExpression getAll()


### Solution
Force non-null rule on PropertyExpression and return an empty array in ExprTagsOf


### Testing Completed
Manual testing


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** #8494  <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
