### PR TITLE
Add missing language entries

### DIFF
--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -98,6 +98,8 @@ enchantments:
 	density: Density
 	breach: Breach
 	wind_burst: Wind Burst
+	# 1.21.11
+	lunge: Lunge
 
 # -- Potion Effect Types --
 potion effect types:
@@ -148,6 +150,9 @@ potion effect types:
 	weaving: weaving
 	trial_omen: trial omen
 	oozing: oozing
+
+	# 1.21.11
+	breath_of_the_nautilus: breath of the nautilus
 
 potion effect type categories:
 	beneficial: beneficial
@@ -1929,6 +1934,7 @@ spawn reasons:
 	enchantment: enchantment
 	rehydration: rehydration, rehydrated
 	build_coppergolem: build copper golem, built copper golem
+	reanimate: reanimate
 
 # -- Respawn Reasons --
 respawn reasons:
@@ -2125,6 +2131,8 @@ potion causes:
 	villager_trade: villager trade
 	patrol_captain: pillager captain, patrol captain
 	wither_rose: wither rose infliction
+	# 1.21.11
+	nautilus: nautilus
 
 # -- Potion Actions --
 potion actions:
@@ -2353,6 +2361,7 @@ entity effect:
 	sniffer_dig: sniffer dig sound effect # only if the sniffer is already in search/dig state
 	armadillo_peek: armadillo peek animation
 	shake: creaking shake animation
+	hit: kinetic weapon hit effect
 	
 	
 	hurt_drown: drown damage effect
@@ -2744,6 +2753,7 @@ damage types:
 	player_attack: player attack
 	player_explosion: player explosion
 	sonic_boom: sonic boom
+	spear: spear
 	spit: spit, llama spit
 	stalagmite: stalagmite
 	starve: starve
@@ -2885,6 +2895,7 @@ types:
 	gameeffect: game effect¦s @a
 	entityeffect: entity effect¦s @an
 	particle: particle¦s @a
+	bukkitparticle: bukkit particle¦s @a
 	convergingparticle: converging particle¦s @a
 	directionalparticle: directional particle¦s @a
 	scalableparticle: scalable particle¦s @a


### PR DESCRIPTION
### Problem
There are missing language entries for the features added in 1.21.11. We need to formally define them so that they may be properly/fully used in scripts.


### Solution
Adds definitions for these missing entries in default.lang (based on startup warnings).


### Testing Completed
No new tests were added as there are no explicitly new features being added.


### Supporting Information
n/a


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
