### PR TITLE
Paper 26.1 Support

### DIFF
--- a/.github/workflows/java-25-builds.yml
+++ b/.github/workflows/java-25-builds.yml
@@ -1,0 +1,47 @@
+name: Java 25 CI
+
+on:
+    push:
+        branches:
+            - master
+            - 'dev/**'
+    pull_request:
+
+jobs:
+    prepare:
+        name: Parallelize Tests
+        if: "! contains(toJSON(github.event.commits.*.message), '[ci skip]')"
+        uses: ./.github/workflows/parallelize-tests.yml
+        with:
+            environments: 26.1
+            java_version: 25
+            parallel_jobs: 3
+
+    build:
+        name: ${{ matrix.display }}
+        needs: prepare
+        runs-on: ubuntu-latest
+        strategy:
+            matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  submodules: recursive
+            - name: validate gradle wrapper
+              uses: gradle/actions/wrapper-validation@v6
+            - name: Set up JDK 25
+              uses: actions/setup-java@v5
+              with:
+                  java-version: '25'
+                  distribution: 'adopt'
+                  cache: gradle
+            - name: Grant execute permission for gradlew
+              run: chmod +x gradlew
+            - name: Build Skript and run test scripts
+              run: ./gradlew clean customTest -PtestEnvs="${{ matrix.envs }}" -PtestEnvJavaVersion=25
+            - name: Upload Nightly Build
+              uses: actions/upload-artifact@v6
+              if: success() && matrix.id == 1
+              with:
+                  name: skript-nightly
+                  path: build/libs/*

--- a/.github/workflows/java-25-builds.yml
+++ b/.github/workflows/java-25-builds.yml
@@ -13,7 +13,7 @@ jobs:
         if: "! contains(toJSON(github.event.commits.*.message), '[ci skip]')"
         uses: ./.github/workflows/parallelize-tests.yml
         with:
-            environments: 26.1
+            environments: 26.1.1
             java_version: 25
             parallel_jobs: 3
 

--- a/.github/workflows/junit-25-builds.yml
+++ b/.github/workflows/junit-25-builds.yml
@@ -1,0 +1,41 @@
+name: JUnit 25
+
+on:
+    push:
+        branches:
+            - master
+            - 'dev/**'
+    pull_request:
+
+jobs:
+    prepare:
+        name: Parallelize Tests
+        if: "! contains(toJSON(github.event.commits.*.message), '[ci skip]')"
+        uses: ./.github/workflows/parallelize-tests.yml
+        with:
+            environments: 26.1
+            java_version: 25
+            parallel_jobs: 3
+
+    build:
+        name: ${{ matrix.display }}
+        needs: prepare
+        runs-on: ubuntu-latest
+        strategy:
+            matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  submodules: recursive
+            - name: validate gradle wrapper
+              uses: gradle/actions/wrapper-validation@v6
+            - name: Set up JDK 25
+              uses: actions/setup-java@v5
+              with:
+                  java-version: '25'
+                  distribution: 'adopt'
+                  cache: gradle
+            - name: Grant execute permission for gradlew
+              run: chmod +x gradlew
+            - name: Build Skript and run test scripts
+              run: ./gradlew clean customTest -PtestEnvs="${{ matrix.envs }}" -PtestEnvJavaVersion=25 -Pjunit=true

--- a/.github/workflows/junit-25-builds.yml
+++ b/.github/workflows/junit-25-builds.yml
@@ -13,7 +13,7 @@ jobs:
         if: "! contains(toJSON(github.event.commits.*.message), '[ci skip]')"
         uses: ./.github/workflows/parallelize-tests.yml
         with:
-            environments: 26.1
+            environments: 26.1.1
             java_version: 25
             parallel_jobs: 3
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 	shadow group: 'io.papermc', name: 'paperlib', version: '1.0.8'
 	shadow group: 'org.bstats', name: 'bstats-bukkit', version: '3.1.0'
 
-	implementation group: 'io.papermc.paper', name: 'paper-api', version: '1.21.11-R0.1-SNAPSHOT'
+	implementation group: 'io.papermc.paper', name: 'paper-api', version: '26.1.1.build.+'
 	implementation group: 'com.google.code.findbugs', name: 'findbugs', version: '3.0.1'
 
 	// bundled with Minecraft 1.19.4+ for display entity transforms
@@ -257,8 +257,10 @@ def latestJUnitJava = latestJava
 
 java {
     toolchain.languageVersion.set(JavaLanguageVersion.of(latestJava))
-	sourceCompatibility = oldestJava
-	targetCompatibility = oldestJava
+}
+
+tasks.withType(JavaCompile).configureEach {
+	options.compilerArgs += ['-source', '' + oldestJava, '-target', '' + oldestJava]
 }
 
 compileJava.options.encoding = 'UTF-8'

--- a/build.gradle
+++ b/build.gradle
@@ -246,9 +246,10 @@ void createTestTask(String name, String desc, String environments, int javaVersi
 }
 
 def java21 = 21
+def java25 = 25
 
 def env = project.testEnv + ".json"
-def latestJava = java21
+def latestJava = java25
 def oldestJava = java21
 
 def latestJUnitEnv = env
@@ -268,6 +269,7 @@ String environments = 'src/test/skript/environments/';
 int envJava = project.property('testEnvJavaVersion') == null ? latestJava : Integer.parseInt(project.property('testEnvJavaVersion') as String)
 createTestTask('quickTest', 'Runs tests on one environment being the latest supported Java and Minecraft.', environments + env, latestJava, 0)
 createTestTask('skriptTestJava21', 'Runs tests on all Java 21 environments.', environments + 'java21', java21, 0)
+createTestTask('skriptTestJava25', 'Runs tests on all Java 25 environments.', environments + 'java25', java25, 0)
 createTestTask('skriptTestDev', 'Runs testing server and uses \'system.in\' for command input, stop server to finish.', environments + env, envJava, 0, Modifiers.DEV_MODE, Modifiers.DEBUG)
 createTestTask('skriptProfile', 'Starts the testing server with JProfiler support.', environments + env, latestJava, -1, Modifiers.PROFILE)
 createTestTask('genNightlyDocs', 'Generates the Skript documentation website html files.', environments + env, envJava, 0, Modifiers.GEN_NIGHTLY_DOCS)
@@ -279,6 +281,7 @@ tasks.register('skriptTest') {
 
 createTestTask('JUnitQuick', 'Runs JUnit tests on one environment being the latest supported Java and Minecraft.', environments + latestJUnitEnv, latestJUnitJava, 0, Modifiers.JUNIT)
 createTestTask('JUnitJava21', 'Runs JUnit tests on all Java 21 environments.', environments + 'java21', java21, 0, Modifiers.JUNIT)
+createTestTask('JUnitJava25', 'Runs JUnit tests on all Java 25 environments.', environments + 'java25', java25, 0, Modifiers.JUNIT)
 tasks.register('JUnit') {
 	description = 'Runs JUnit tests on all environments.'
 	dependsOn JUnitJava21

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ groupid=ch.njol
 name=skript
 version=2.15.0-pre1
 jarName=Skript.jar
-testEnv=java21/paper-1.21.11
-testEnvJavaVersion=21
+testEnv=java25/paper-26.1
+testEnvJavaVersion=25

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ groupid=ch.njol
 name=skript
 version=2.15.0-pre1
 jarName=Skript.jar
-testEnv=java25/paper-26.1
+testEnv=java25/paper-26.1.1
 testEnvJavaVersion=25

--- a/src/main/java/ch/njol/skript/aliases/Aliases.java
+++ b/src/main/java/ch/njol/skript/aliases/Aliases.java
@@ -3,6 +3,7 @@ package ch.njol.skript.aliases;
 import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptAddon;
 import ch.njol.skript.SkriptConfig;
+import ch.njol.skript.bukkitutil.ItemUtils;
 import ch.njol.skript.config.Config;
 import ch.njol.skript.config.Node;
 import ch.njol.skript.config.SectionNode;
@@ -18,6 +19,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
+import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.script.Script;
 
@@ -399,6 +401,10 @@ public abstract class Aliases {
 	 * The returned value is true if the loading was successful, false otherwise.
 	 */
 	public static CompletableFuture<Boolean> loadAsync() {
+		// Argument provider service will not load correctly if that load occurs from another thread
+		// Make a call now to force it to load
+		// See https://github.com/PaperMC/Paper/pull/12829
+		ItemUtils.applyComponentData(ItemStack.empty(), "[]");
 		return CompletableFuture.supplyAsync(() -> {
 			try {
 				long start = System.currentTimeMillis();

--- a/src/main/java/ch/njol/skript/aliases/Aliases.java
+++ b/src/main/java/ch/njol/skript/aliases/Aliases.java
@@ -34,7 +34,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public abstract class Aliases {
-	static final boolean USING_ITEM_COMPONENTS = Skript.isRunningMinecraft(1, 20, 5);
 
 	private static final AliasesProvider provider = createProvider(10000, null);
 	private static final AliasesParser parser = createParser(provider);

--- a/src/main/java/ch/njol/skript/aliases/AliasesParser.java
+++ b/src/main/java/ch/njol/skript/aliases/AliasesParser.java
@@ -201,12 +201,9 @@ public class AliasesParser {
 				json = item.substring(firstBracket, jsonEndIndex + 1);
 				id = id + item.substring(jsonEndIndex + 2); // essentially rips out json part
 			}
-			if (Aliases.USING_ITEM_COMPONENTS) {
-				json = "[" + json.substring(1, json.length() - 1) + "]"; // replace brackets (not json :))
-				tags = Collections.singletonMap("components", json);
-			} else {
-				tags = provider.parseMojangson(json);
-			}
+			// add component data
+			json = "[" + json.substring(1, json.length() - 1) + "]"; // replace brackets (not json :))
+			tags = Collections.singletonMap("components", json);
 		}
 		
 		// Separate block state from id

--- a/src/main/java/ch/njol/skript/aliases/AliasesProvider.java
+++ b/src/main/java/ch/njol/skript/aliases/AliasesProvider.java
@@ -95,18 +95,10 @@ public class AliasesProvider {
 			return flags;
 
 		// Apply random tags using JSON
-		if (Aliases.USING_ITEM_COMPONENTS) {
-			String components = (String) tags.get("components"); // only components are supported for modifying a stack
-			assert components != null;
-			// for modifyItemStack to work, you have to include an item id ... e.g. "minecraft:dirt[<components>]"
-			// just to be safe we use the same one as the provided stack
-			components = stack.getType().getKey() + components;
-			BukkitUnsafe.modifyItemStack(stack, components);
-		} else {
-			String json = gson.toJson(tags);
-			assert json != null;
-			BukkitUnsafe.modifyItemStack(stack, json);
-		}
+		String components = (String) tags.get("components"); // only components are supported for modifying a stack
+		assert components != null;
+		ItemUtils.applyComponentData(stack, components);
+
 		flags |= ItemFlags.CHANGED_TAGS;
 
 		return flags;

--- a/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/ItemUtils.java
@@ -4,6 +4,9 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.util.slot.Slot;
 import com.destroystokyo.paper.profile.PlayerProfile;
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
@@ -36,6 +39,26 @@ public class ItemUtils {
 	public static final boolean CAN_CREATE_PLAYER_PROFILE = Skript.methodExists(Bukkit.class, "createPlayerProfile", UUID.class, String.class);
 	// paper does not do texture lookups by default
 	public static final boolean REQUIRES_TEXTURE_LOOKUP = Skript.classExists("com.destroystokyo.paper.profile.PlayerProfile") && Skript.isRunningMinecraft(1, 19, 4);
+
+	/**
+	 * Applies string format of component data to an item stack.
+	 * <b>Note: This overwrites the entire {@link ItemMeta} of the item.</b>
+	 * @param itemStack The item stack to apply data to.
+	 * @param data The data to apply.
+	 *  This data is expected to be in the format used by the Brigadier item stack parser.
+	 *  For example {@code [{minecraft:potion_contents={"potion":"minecraft:invisibility"}}]}
+	 */
+	public static void applyComponentData(ItemStack itemStack, String data) {
+		// need to include item id: "minecraft:dirt[<components>]"
+		// use the same one as the stack to be safe (likely needed for obtaining correct item meta)
+		data = itemStack.getType().getKey() + data;
+		try {
+			ItemStack parsed = ArgumentTypes.itemStack().parse(new StringReader(data));
+			itemStack.setItemMeta(parsed.getItemMeta());
+		} catch (CommandSyntaxException e) {
+			throw Skript.exception(e, "Failed to apply component data to ItemStack");
+		}
+	}
 
 	/**
 	 * Gets damage/durability of an item, or 0 if it does not have damage.

--- a/src/test/skript/environments/java25/paper-26.1.1.json
+++ b/src/test/skript/environments/java25/paper-26.1.1.json
@@ -1,11 +1,11 @@
 {
-	"name": "paper-1.21.11",
+	"name": "paper-26.1.1",
 	"resources": [
 		{"source": "server.properties.generic", "target": "server.properties"}
 	],
 	"paperDownloads": [
 		{
-			"version": "1.21.11",
+			"version": "26.1.1",
 			"target": "paperclip.jar"
 		}
 	],

--- a/src/test/skript/environments/java25/paper-26.1.json
+++ b/src/test/skript/environments/java25/paper-26.1.json
@@ -1,0 +1,17 @@
+{
+	"name": "paper-1.21.11",
+	"resources": [
+		{"source": "server.properties.generic", "target": "server.properties"}
+	],
+	"paperDownloads": [
+		{
+			"version": "1.21.11",
+			"target": "paperclip.jar"
+		}
+	],
+	"skriptTarget": "plugins/Skript.jar",
+	"commandLine": [
+		"-Dcom.mojang.eula.agree=true",
+		"-jar", "paperclip.jar", "--nogui"
+	]
+}


### PR DESCRIPTION
### Problem
Skript is not currently working on Paper's 26.1 development branch due to changes within BukkitUnsafe. Paper 26.1 also requires Java 25, which we will need to update to.


### Solution
This PR updates Skript to build with Java 25. Java 21 is still supported (meaning no newer features can be used).

I've also reworked how aliases applies item component data (the cause of Skript not running). Rather than use BukkitUnsafe, we can instead use Brigadier's ItemStack parser, exposed by Paper (which is essentially what the BukkitUnsafe method does anyways). This is the more stable (and likely recommended) approach.

### Testing Completed
Added 26.1.1 testing environment.


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
