### PR TITLE
Allow adding the same type to typed pdc lists instead of using the ar…

### DIFF
--- a/src/main/java/org/skriptlang/skript/bukkit/pdc/expressions/ExprPersistentData.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/pdc/expressions/ExprPersistentData.java
@@ -254,9 +254,14 @@ public class ExprPersistentData extends PropertyExpression<Object, Object> {
 					if (changer != null) {
 						yield changer.acceptChange(mode);
 					}
+					Class<?> changeType = type.getC();
+					if (plural)
+						changeType = changeType.arrayType();
 					if (mode == ChangeMode.SET) {
-						yield CollectionUtils.array(type.getC());
+						yield CollectionUtils.array(changeType);
 					} else if (mode == ChangeMode.ADD || mode == ChangeMode.REMOVE) {
+						if (plural)
+							yield CollectionUtils.array(changeType);
 						yield getArithmeticChangeTypes(type.getC(), mode, operation -> type.getC().isAssignableFrom(operation.returnType()));
 					}
 					yield null;


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
`add {item} to item list data tag "x" of y` would not work because the expr would only return arithmetic changers and items cannot be added to each other.

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
Uses the data type itself if the tag is a list and has a specified type, like adding 1 to {_list::*}.

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
Manual confirmation


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
