### PR TITLE
Make event value registration check more lenient

### DIFF
--- a/src/main/java/ch/njol/skript/registrations/EventValues.java
+++ b/src/main/java/ch/njol/skript/registrations/EventValues.java
@@ -297,6 +297,7 @@ public class EventValues {
 		}
 
 		public static <E extends Event, T> EventValueInfo<E, T> fromModern(EventValue<E, T> eventValue) {
+			//noinspection unchecked
 			return new EventValueInfo<>(
 				eventValue.eventClass(),
 				eventValue.valueClass(),
@@ -314,7 +315,7 @@ public class EventValues {
 					})
 					.orElse(eventValue.converter()),
 				eventValue.excludedErrorMessage(),
-				eventValue.excludedEvents(),
+				eventValue.excludedEvents() != null ? eventValue.excludedEvents().toArray(new Class[0]) : null,
 				eventValue.time().value()
 			);
 		}

--- a/src/main/java/ch/njol/skript/registrations/EventValues.java
+++ b/src/main/java/ch/njol/skript/registrations/EventValues.java
@@ -315,7 +315,7 @@ public class EventValues {
 					})
 					.orElse(eventValue.converter()),
 				eventValue.excludedErrorMessage(),
-				eventValue.excludedEvents() != null ? eventValue.excludedEvents().toArray(new Class[0]) : null,
+				eventValue.excludedEvents().toArray(new Class[0]),
 				eventValue.time().value()
 			);
 		}

--- a/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/ConvertedEventValue.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/ConvertedEventValue.java
@@ -3,11 +3,13 @@ package org.skriptlang.skript.bukkit.lang.eventvalue;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 import org.skriptlang.skript.lang.converter.Converter;
 import org.skriptlang.skript.lang.converter.Converters;
 
 import java.lang.reflect.Array;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -124,7 +126,7 @@ record ConvertedEventValue<SourceEvent extends Event, ConvertedEvent extends Eve
 	}
 
 	@Override
-	public String @Nullable [] patterns() {
+	public @Nullable @Unmodifiable List<String> patterns() {
 		return source.patterns();
 	}
 
@@ -163,10 +165,6 @@ record ConvertedEventValue<SourceEvent extends Event, ConvertedEvent extends Eve
 		return source.changer(mode).map(changer -> (event, value) -> {
 			if (!source.eventClass().isAssignableFrom(event.getClass()))
 				return;
-			if (changer instanceof EventValue.NoValueChanger) {
-				changer.change(source.eventClass().cast(event), null);
-				return;
-			}
 			if (reverseConverter == null)
 				return;
 			SourceValue sourceValue = reverseConverter.convert(value);
@@ -181,14 +179,14 @@ record ConvertedEventValue<SourceEvent extends Event, ConvertedEvent extends Eve
 	}
 
 	@Override
-	public Class<? extends ConvertedEvent> @Nullable [] excludedEvents() {
-		Class<? extends SourceEvent>[] excludedEvents = source.excludedEvents();
+	public List<Class<? extends ConvertedEvent>> excludedEvents() {
+		List<Class<? extends SourceEvent>> excludedEvents = source.excludedEvents();
 		if (excludedEvents == null)
 			return null;
-		//noinspection unchecked
-		return Arrays.stream(excludedEvents)
+		//noinspection unchecked,rawtypes
+		return (List) excludedEvents.stream()
 			.filter(eventClass::isAssignableFrom)
-			.toArray(Class[]::new);
+			.toList();
 	}
 
 	@Override

--- a/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/ConvertedEventValue.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/ConvertedEventValue.java
@@ -197,6 +197,11 @@ record ConvertedEventValue<SourceEvent extends Event, ConvertedEvent extends Eve
 	}
 
 	@Override
+	public boolean matches(EventValue<?, ?> eventValue) {
+		return matches(eventValue.eventClass(), eventValue.valueClass(), eventValue.patterns());
+	}
+
+	@Override
 	public @Nullable <NewEvent extends Event, NewValue> EventValue<NewEvent, NewValue> getConverted(
 		Class<NewEvent> newEventClass,
 		Class<NewValue> newValueClass

--- a/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/ConvertedEventValue.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/ConvertedEventValue.java
@@ -8,9 +8,8 @@ import org.skriptlang.skript.lang.converter.Converter;
 import org.skriptlang.skript.lang.converter.Converters;
 
 import java.lang.reflect.Array;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
+import java.util.SequencedCollection;
 
 /**
  * An {@link EventValue} that is a converted version of another event value.
@@ -126,7 +125,7 @@ record ConvertedEventValue<SourceEvent extends Event, ConvertedEvent extends Eve
 	}
 
 	@Override
-	public @Nullable @Unmodifiable List<String> patterns() {
+	public @Unmodifiable SequencedCollection<String> patterns() {
 		return source.patterns();
 	}
 
@@ -179,12 +178,9 @@ record ConvertedEventValue<SourceEvent extends Event, ConvertedEvent extends Eve
 	}
 
 	@Override
-	public List<Class<? extends ConvertedEvent>> excludedEvents() {
-		List<Class<? extends SourceEvent>> excludedEvents = source.excludedEvents();
-		if (excludedEvents == null)
-			return null;
+	public @Unmodifiable SequencedCollection<Class<? extends ConvertedEvent>> excludedEvents() {
 		//noinspection unchecked,rawtypes
-		return (List) excludedEvents.stream()
+		return (SequencedCollection) source.excludedEvents().stream()
 			.filter(eventClass::isAssignableFrom)
 			.toList();
 	}

--- a/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/ConvertedEventValue.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/ConvertedEventValue.java
@@ -8,6 +8,7 @@ import org.skriptlang.skript.lang.converter.Converter;
 import org.skriptlang.skript.lang.converter.Converters;
 
 import java.lang.reflect.Array;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.SequencedCollection;
 
@@ -178,9 +179,9 @@ record ConvertedEventValue<SourceEvent extends Event, ConvertedEvent extends Eve
 	}
 
 	@Override
-	public @Unmodifiable SequencedCollection<Class<? extends ConvertedEvent>> excludedEvents() {
+	public @Unmodifiable Collection<Class<? extends ConvertedEvent>> excludedEvents() {
 		//noinspection unchecked,rawtypes
-		return (SequencedCollection) source.excludedEvents().stream()
+		return (Collection) source.excludedEvents().stream()
 			.filter(eventClass::isAssignableFrom)
 			.toList();
 	}

--- a/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValue.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValue.java
@@ -9,7 +9,9 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 import org.skriptlang.skript.lang.converter.Converter;
 
-import java.util.*;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.SequencedCollection;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 
@@ -74,7 +76,7 @@ public sealed interface EventValue<E extends Event, V> permits EventValueImpl, C
 	 * @return the patterns
 	 */
 	@Contract(pure = true)
-	@Nullable @Unmodifiable List<String> patterns();
+	@Unmodifiable SequencedCollection<String> patterns();
 
 	/**
 	 * Validates that this event value can be used in the provided event context.
@@ -140,10 +142,10 @@ public sealed interface EventValue<E extends Event, V> permits EventValueImpl, C
 	/**
 	 * Event types explicitly excluded from using this event value.
 	 *
-	 * @return a list of excluded event classes or {@code null} if none
+	 * @return a list of excluded event classes
 	 */
 	@Contract(pure = true)
-	@Nullable @Unmodifiable List<Class<? extends E>> excludedEvents();
+	@Unmodifiable SequencedCollection<Class<? extends E>> excludedEvents();
 
 	/**
 	 * An optional error message shown when this value is excluded for a matching event.
@@ -173,8 +175,8 @@ public sealed interface EventValue<E extends Event, V> permits EventValueImpl, C
 	 * @return {@code true} if they match
 	 */
 	@Contract(pure = true)
-	default boolean matches(Class<? extends Event> eventClass, Class<?> valueClass, Collection<String> patterns) {
-		return matches(eventClass, valueClass) && Objects.equals(patterns(), patterns);
+	default boolean matches(Class<? extends Event> eventClass, Class<?> valueClass, SequencedCollection<String> patterns) {
+		return matches(eventClass, valueClass) && patterns().equals(patterns);
 	}
 
 	/**

--- a/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValue.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValue.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 import org.skriptlang.skript.lang.converter.Converter;
 
-import java.util.Objects;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.SequencedCollection;
 import java.util.function.BiPredicate;
@@ -145,7 +145,7 @@ public sealed interface EventValue<E extends Event, V> permits EventValueImpl, C
 	 * @return a list of excluded event classes
 	 */
 	@Contract(pure = true)
-	@Unmodifiable SequencedCollection<Class<? extends E>> excludedEvents();
+	@Unmodifiable Collection<Class<? extends E>> excludedEvents();
 
 	/**
 	 * An optional error message shown when this value is excluded for a matching event.

--- a/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValue.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValue.java
@@ -149,9 +149,7 @@ public sealed interface EventValue<E extends Event, V> permits EventValueImpl, C
 	 * @param eventValue the event value to compare against
 	 * @return {@code true} if they match
 	 */
-	default boolean matches(EventValue<?, ?> eventValue) {
-		return matches(eventValue.eventClass(), eventValue.valueClass(), eventValue.patterns());
-	}
+	boolean matches(EventValue<?, ?> eventValue);
 
 	/**
 	 * Checks whether this event value matches the provided event class, value class,

--- a/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValue.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValue.java
@@ -6,10 +6,10 @@ import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 import org.skriptlang.skript.lang.converter.Converter;
 
-import java.util.Arrays;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 
@@ -57,6 +57,7 @@ public sealed interface EventValue<E extends Event, V> permits EventValueImpl, C
 	 *
 	 * @return the event type this event value is defined for
 	 */
+	@Contract(pure = true)
 	Class<E> eventClass();
 
 	/**
@@ -64,6 +65,7 @@ public sealed interface EventValue<E extends Event, V> permits EventValueImpl, C
 	 *
 	 * @return the value type
 	 */
+	@Contract(pure = true)
 	Class<V> valueClass();
 
 	/**
@@ -71,7 +73,8 @@ public sealed interface EventValue<E extends Event, V> permits EventValueImpl, C
 	 *
 	 * @return the patterns
 	 */
-	String @Nullable [] patterns();
+	@Contract(pure = true)
+	@Nullable @Unmodifiable List<String> patterns();
 
 	/**
 	 * Validates that this event value can be used in the provided event context.
@@ -88,6 +91,7 @@ public sealed interface EventValue<E extends Event, V> permits EventValueImpl, C
 	 * @param input the identifier provided by the user
 	 * @return {@code true} if the validation succeeds
 	 */
+	@Contract(pure = true)
 	boolean matchesInput(String input);
 
 	/**
@@ -96,6 +100,7 @@ public sealed interface EventValue<E extends Event, V> permits EventValueImpl, C
 	 * @param event the event instance
 	 * @return the value obtained from the event, which may be {@code null}
 	 */
+	@Contract(pure = true)
 	V get(E event);
 
 	/**
@@ -103,6 +108,7 @@ public sealed interface EventValue<E extends Event, V> permits EventValueImpl, C
 	 *
 	 * @return the converter
 	 */
+	@Contract(pure = true)
 	Converter<E, V> converter();
 
 	/**
@@ -111,6 +117,7 @@ public sealed interface EventValue<E extends Event, V> permits EventValueImpl, C
 	 * @param mode the change mode
 	 * @return {@code true} if a changer is supported
 	 */
+	@Contract(pure = true)
 	boolean hasChanger(ChangeMode mode);
 
 	/**
@@ -119,6 +126,7 @@ public sealed interface EventValue<E extends Event, V> permits EventValueImpl, C
 	 * @param mode the change mode
 	 * @return an {@link Optional} containing the changer if available
 	 */
+	@Contract(pure = true)
 	Optional<Changer<E, V>> changer(ChangeMode mode);
 
 	/**
@@ -126,20 +134,23 @@ public sealed interface EventValue<E extends Event, V> permits EventValueImpl, C
 	 *
 	 * @return the time state
 	 */
+	@Contract(pure = true)
 	Time time();
 
 	/**
 	 * Event types explicitly excluded from using this event value.
 	 *
-	 * @return an array of excluded event classes or {@code null} if none
+	 * @return a list of excluded event classes or {@code null} if none
 	 */
-	Class<? extends E> @Nullable [] excludedEvents();
+	@Contract(pure = true)
+	@Nullable @Unmodifiable List<Class<? extends E>> excludedEvents();
 
 	/**
 	 * An optional error message shown when this value is excluded for a matching event.
 	 *
 	 * @return the exclusion error message or {@code null}
 	 */
+	@Contract(pure = true)
 	@Nullable String excludedErrorMessage();
 
 	/**
@@ -149,6 +160,7 @@ public sealed interface EventValue<E extends Event, V> permits EventValueImpl, C
 	 * @param eventValue the event value to compare against
 	 * @return {@code true} if they match
 	 */
+	@Contract(pure = true)
 	boolean matches(EventValue<?, ?> eventValue);
 
 	/**
@@ -160,8 +172,9 @@ public sealed interface EventValue<E extends Event, V> permits EventValueImpl, C
 	 * @param patterns the patterns to compare against
 	 * @return {@code true} if they match
 	 */
-	default boolean matches(Class<? extends Event> eventClass, Class<?> valueClass, String[] patterns) {
-		return matches(eventClass, valueClass) && Arrays.equals(patterns(), patterns);
+	@Contract(pure = true)
+	default boolean matches(Class<? extends Event> eventClass, Class<?> valueClass, Collection<String> patterns) {
+		return matches(eventClass, valueClass) && Objects.equals(patterns(), patterns);
 	}
 
 	/**
@@ -171,6 +184,7 @@ public sealed interface EventValue<E extends Event, V> permits EventValueImpl, C
 	 * @param valueClass the value class to compare against
 	 * @return {@code true} if they match
 	 */
+	@Contract(pure = true)
 	default boolean matches(Class<? extends Event> eventClass, Class<?> valueClass) {
 		return eventClass().equals(eventClass) && valueClass().equals(valueClass);
 	}
@@ -314,37 +328,6 @@ public sealed interface EventValue<E extends Event, V> permits EventValueImpl, C
 		 * @param value the value to apply (may be {@code null} depending on mode)
 		 */
 		void change(E event, V value);
-
-	}
-
-	/**
-	 * A changer that does not require a value to be passed (e.g. for {@link ChangeMode#DELETE} or {@link ChangeMode#RESET}).
-	 *
-	 * @param <E> the event type
-	 * @param <V> the value type
-	 */
-	@FunctionalInterface
-	interface NoValueChanger<E extends Event, V> extends Changer<E, V> {
-
-		/**
-		 * Applies a change to the given event instance without a value.
-		 *
-		 * @param event the event instance
-		 */
-		void change(E event);
-
-		/**
-		 * {@inheritDoc}
-		 * <p>
-		 * This implementation ignores the provided value and calls {@link #change(Event)}.
-		 *
-		 * @param event the event instance
-		 * @param value the value (ignored)
-		 */
-		@Override
-		default void change(E event, V value) {
-			change(event);
-		}
 
 	}
 

--- a/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValueImpl.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValueImpl.java
@@ -70,14 +70,12 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 
 	@Override
 	public Validation validate(Class<?> event) {
-		if (excludedEvents != null) {
-			for (Class<? extends E> excludedEvent : excludedEvents) {
-				if (!excludedEvent.isAssignableFrom(event))
-					continue;
-				if (excludedErrorMessage != null)
-					Skript.error(excludedErrorMessage);
-				return Validation.ABORT;
-			}
+		for (Class<? extends E> excludedEvent : excludedEvents) {
+			if (!excludedEvent.isAssignableFrom(event))
+				continue;
+			if (excludedErrorMessage != null)
+				Skript.error(excludedErrorMessage);
+			return Validation.ABORT;
 		}
 		if (eventValidator == null)
 			return Validation.VALID;
@@ -97,7 +95,7 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 	private SkriptPattern[] compilePatterns() {
 		if (compiledPatterns != null)
 			return compiledPatterns;
-		compiledPatterns = patterns == null ? patternsFromType(valueClass) : patterns.stream()
+		compiledPatterns = patterns.isEmpty() ? patternsFromType(valueClass) : patterns.stream()
 			.map(PatternCompiler::compile)
 			.toArray(SkriptPattern[]::new);
 		return compiledPatterns;

--- a/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValueImpl.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValueImpl.java
@@ -27,6 +27,7 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 	private final Class<E> eventClass;
 	private final Class<V> valueClass;
 	private final String @Nullable [] patterns;
+	private final boolean hasCustomInputValidator;
 	private final @Nullable BiPredicate<String, ParseResult> inputValidator;
 	private final @Nullable Function<Class<?>, Validation> eventValidator;
 	private final Converter<E, V> converter;
@@ -37,28 +38,18 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 
 	private SkriptPattern[] compiledPatterns;
 
-	EventValueImpl(
-		Class<E> eventClass,
-		Class<V> valueClass,
-		String @Nullable [] patterns,
-		@Nullable BiPredicate<String, ParseResult> inputValidator,
-		@Nullable Function<Class<?>, Validation> eventValidator,
-		Converter<E, V> converter,
-		Map<ChangeMode, Changer<E, V>> changers,
-		Time time,
-		Class<? extends E> @Nullable [] excludedEvents,
-		@Nullable String excludedErrorMessage
-	) {
-		this.eventClass = eventClass;
-		this.valueClass = valueClass;
-		this.patterns = patterns;
-		this.inputValidator = inputValidator;
-		this.eventValidator = eventValidator;
-		this.converter = converter;
-		this.changers = changers;
-		this.time = time;
-		this.excludedEvents = excludedEvents;
-		this.excludedErrorMessage = excludedErrorMessage;
+	private EventValueImpl(BuilderImpl<E, V> builder) {
+		this.eventClass = builder.eventClass;
+		this.valueClass = builder.valueClass;
+		this.patterns = builder.patterns;
+		this.hasCustomInputValidator = builder.hasCustomInputValidator;
+		this.inputValidator = builder.inputValidator;
+		this.eventValidator = builder.eventValidator;
+		this.converter = builder.converter;
+		this.changers = builder.changers;
+		this.time = builder.time;
+		this.excludedEvents = builder.excludedEvents;
+		this.excludedErrorMessage = builder.excludedErrorMessage;
 	}
 
 	@Override
@@ -164,6 +155,16 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 	}
 
 	@Override
+	public boolean matches(EventValue<?, ?> eventValue) {
+		return matches(eventValue.eventClass(), eventValue.valueClass(), eventValue.patterns())
+			&& eventValue instanceof EventValueImpl<?,?> other
+			&& hasCustomInputValidator == other.hasCustomInputValidator
+			&& (!hasCustomInputValidator || inputValidator == other.inputValidator)
+			&& eventValidator == other.eventValidator
+			&& Arrays.equals(excludedEvents, other.excludedEvents);
+	}
+
+	@Override
 	public @Nullable <ConvertedEvent extends Event, ConvertedValue> EventValue<ConvertedEvent, ConvertedValue> getConverted(
 		Class<ConvertedEvent> newEventClass,
 		Class<ConvertedValue> newValueClass
@@ -197,6 +198,7 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 		private final Class<V> valueClass;
 		private final Map<ChangeMode, Changer<E, V>> changers = new EnumMap<>(ChangeMode.class);
 		private String @Nullable [] patterns;
+		private boolean hasCustomInputValidator;
 		private @Nullable BiPredicate<String, ParseResult> inputValidator;
 		private @Nullable Function<Class<?>, Validation> eventValidator;
 		private Converter<E, V> converter;
@@ -218,6 +220,7 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 		@Override
 		public Builder<E,V> inputValidator(BiPredicate<String, ParseResult> inputValidator) {
 			this.inputValidator = inputValidator;
+			hasCustomInputValidator = inputValidator != null;
 			return this;
 		}
 
@@ -272,18 +275,7 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 				}
 			}
 
-			return new EventValueImpl<>(
-				eventClass,
-				valueClass,
-				patterns,
-				inputValidator,
-				eventValidator,
-				converter,
-				changers,
-				time,
-				excludedEvents,
-				excludedErrorMessage
-			);
+			return new EventValueImpl<>(this);
 		}
 
 		private static <T, U> BiPredicate<T, U> combinePredicates(

--- a/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValueImpl.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValueImpl.java
@@ -34,7 +34,7 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 	private final Converter<E, V> converter;
 	private final Map<ChangeMode, Changer<E, V>> changers;
 	private final Time time;
-	private final SequencedCollection<Class<? extends E>> excludedEvents;
+	private final Collection<Class<? extends E>> excludedEvents;
 	private final @Nullable String excludedErrorMessage;
 
 	private SkriptPattern[] compiledPatterns;
@@ -146,7 +146,7 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 	}
 
 	@Override
-	public @Unmodifiable SequencedCollection<Class<? extends E>> excludedEvents() {
+	public @Unmodifiable Collection<Class<? extends E>> excludedEvents() {
 		return excludedEvents;
 	}
 
@@ -204,7 +204,7 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 		private @Nullable Function<Class<?>, Validation> eventValidator;
 		private Converter<E, V> converter;
 		private Time time = Time.NOW;
-		private SequencedCollection<Class<? extends E>> excludedEvents = Collections.emptyList();
+		private Collection<Class<? extends E>> excludedEvents = Collections.emptyList();
 		private @Nullable String excludedErrorMessage;
 
 		BuilderImpl(Class<E> eventClass, Class<V> valueClass) {
@@ -214,7 +214,7 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 
 		@Override
 		public Builder<E,V> patterns(String... patterns) {
-			this.patterns = List.of(patterns);
+			this.patterns = patterns != null ? List.of(patterns) : Collections.emptyList();
 			return this;
 		}
 
@@ -252,7 +252,7 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 		@Override
 		@SafeVarargs
 		public final Builder<E, V> excludes(Class<? extends E>... events) {
-			this.excludedEvents = List.of(events);
+			this.excludedEvents = events != null ? List.of(events) : Collections.emptyList();
 			return this;
 		}
 

--- a/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValueImpl.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValueImpl.java
@@ -13,6 +13,7 @@ import ch.njol.skript.util.Utils;
 import com.google.common.base.MoreObjects;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 import org.skriptlang.skript.lang.converter.Converter;
 
 import java.util.*;
@@ -26,14 +27,14 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 
 	private final Class<E> eventClass;
 	private final Class<V> valueClass;
-	private final String @Nullable [] patterns;
+	private final @Nullable List<String> patterns;
 	private final boolean hasCustomInputValidator;
 	private final @Nullable BiPredicate<String, ParseResult> inputValidator;
 	private final @Nullable Function<Class<?>, Validation> eventValidator;
 	private final Converter<E, V> converter;
 	private final Map<ChangeMode, Changer<E, V>> changers;
 	private final Time time;
-	private final Class<? extends E> @Nullable [] excludedEvents;
+	private final @Nullable List<Class<? extends E>> excludedEvents;
 	private final @Nullable String excludedErrorMessage;
 
 	private SkriptPattern[] compiledPatterns;
@@ -63,8 +64,8 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 	}
 
 	@Override
-	public String @Nullable [] patterns() {
-		return patterns != null ? patterns.clone() : null;
+	public @Nullable @Unmodifiable List<String> patterns() {
+		return patterns;
 	}
 
 	@Override
@@ -96,7 +97,7 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 	private SkriptPattern[] compilePatterns() {
 		if (compiledPatterns != null)
 			return compiledPatterns;
-		compiledPatterns = patterns == null ? patternsFromType(valueClass) : Arrays.stream(patterns)
+		compiledPatterns = patterns == null ? patternsFromType(valueClass) : patterns.stream()
 			.map(PatternCompiler::compile)
 			.toArray(SkriptPattern[]::new);
 		return compiledPatterns;
@@ -145,8 +146,8 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 	}
 
 	@Override
-	public Class<? extends E> @Nullable [] excludedEvents() {
-		return excludedEvents != null ? excludedEvents.clone() : null;
+	public @Nullable @Unmodifiable List<Class<? extends E>> excludedEvents() {
+		return excludedEvents;
 	}
 
 	@Override
@@ -161,7 +162,7 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 			&& hasCustomInputValidator == other.hasCustomInputValidator
 			&& (!hasCustomInputValidator || inputValidator == other.inputValidator)
 			&& eventValidator == other.eventValidator
-			&& Arrays.equals(excludedEvents, other.excludedEvents);
+			&& Objects.equals(excludedEvents, other.excludedEvents);
 	}
 
 	@Override
@@ -197,13 +198,13 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 		private final Class<E> eventClass;
 		private final Class<V> valueClass;
 		private final Map<ChangeMode, Changer<E, V>> changers = new EnumMap<>(ChangeMode.class);
-		private String @Nullable [] patterns;
+		private @Nullable List<String> patterns;
 		private boolean hasCustomInputValidator;
 		private @Nullable BiPredicate<String, ParseResult> inputValidator;
 		private @Nullable Function<Class<?>, Validation> eventValidator;
 		private Converter<E, V> converter;
 		private Time time = Time.NOW;
-		private Class<? extends E> @Nullable [] excludedEvents;
+		private @Nullable List<Class<? extends E>> excludedEvents;
 		private @Nullable String excludedErrorMessage;
 
 		BuilderImpl(Class<E> eventClass, Class<V> valueClass) {
@@ -213,7 +214,7 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 
 		@Override
 		public Builder<E,V> patterns(String... patterns) {
-			this.patterns = patterns;
+			this.patterns = patterns != null ? List.of(patterns) : null;
 			return this;
 		}
 
@@ -251,7 +252,7 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 		@Override
 		@SafeVarargs
 		public final Builder<E, V> excludes(Class<? extends E>... events) {
-			this.excludedEvents = events;
+			this.excludedEvents = events != null ? List.of(events) : null;
 			return this;
 		}
 

--- a/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValueImpl.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValueImpl.java
@@ -27,14 +27,14 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 
 	private final Class<E> eventClass;
 	private final Class<V> valueClass;
-	private final @Nullable List<String> patterns;
+	private final SequencedCollection<String> patterns;
 	private final boolean hasCustomInputValidator;
 	private final @Nullable BiPredicate<String, ParseResult> inputValidator;
 	private final @Nullable Function<Class<?>, Validation> eventValidator;
 	private final Converter<E, V> converter;
 	private final Map<ChangeMode, Changer<E, V>> changers;
 	private final Time time;
-	private final @Nullable List<Class<? extends E>> excludedEvents;
+	private final SequencedCollection<Class<? extends E>> excludedEvents;
 	private final @Nullable String excludedErrorMessage;
 
 	private SkriptPattern[] compiledPatterns;
@@ -64,7 +64,7 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 	}
 
 	@Override
-	public @Nullable @Unmodifiable List<String> patterns() {
+	public @Unmodifiable SequencedCollection<String> patterns() {
 		return patterns;
 	}
 
@@ -146,7 +146,7 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 	}
 
 	@Override
-	public @Nullable @Unmodifiable List<Class<? extends E>> excludedEvents() {
+	public @Unmodifiable SequencedCollection<Class<? extends E>> excludedEvents() {
 		return excludedEvents;
 	}
 
@@ -162,7 +162,7 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 			&& hasCustomInputValidator == other.hasCustomInputValidator
 			&& (!hasCustomInputValidator || inputValidator == other.inputValidator)
 			&& eventValidator == other.eventValidator
-			&& Objects.equals(excludedEvents, other.excludedEvents);
+			&& excludedEvents.equals(other.excludedEvents);
 	}
 
 	@Override
@@ -198,13 +198,13 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 		private final Class<E> eventClass;
 		private final Class<V> valueClass;
 		private final Map<ChangeMode, Changer<E, V>> changers = new EnumMap<>(ChangeMode.class);
-		private @Nullable List<String> patterns;
+		private SequencedCollection<String> patterns = Collections.emptyList();
 		private boolean hasCustomInputValidator;
 		private @Nullable BiPredicate<String, ParseResult> inputValidator;
 		private @Nullable Function<Class<?>, Validation> eventValidator;
 		private Converter<E, V> converter;
 		private Time time = Time.NOW;
-		private @Nullable List<Class<? extends E>> excludedEvents;
+		private SequencedCollection<Class<? extends E>> excludedEvents = Collections.emptyList();
 		private @Nullable String excludedErrorMessage;
 
 		BuilderImpl(Class<E> eventClass, Class<V> valueClass) {
@@ -214,7 +214,7 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 
 		@Override
 		public Builder<E,V> patterns(String... patterns) {
-			this.patterns = patterns != null ? List.of(patterns) : null;
+			this.patterns = List.of(patterns);
 			return this;
 		}
 
@@ -252,7 +252,7 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 		@Override
 		@SafeVarargs
 		public final Builder<E, V> excludes(Class<? extends E>... events) {
-			this.excludedEvents = events != null ? List.of(events) : null;
+			this.excludedEvents = List.of(events);
 			return this;
 		}
 

--- a/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValueRegistryImpl.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValueRegistryImpl.java
@@ -28,6 +28,9 @@ final class EventValueRegistryImpl implements EventValueRegistry {
 
 	@Override
 	public <E extends Event> void register(EventValue<E, ?> eventValue) {
+		Preconditions.checkNotNull(eventValue, "eventValue");
+		if (eventValue instanceof ConvertedEventValue)
+			throw new SkriptAPIException("Cannot register a converted event value: " + eventValue);
 		if (isRegistered(eventValue))
 			throw new SkriptAPIException(eventValue + " is already registered");
 		List<EventValue<?, ?>> eventValues = eventValues(eventValue.time());
@@ -45,8 +48,8 @@ final class EventValueRegistryImpl implements EventValueRegistry {
 
 	@Override
 	public boolean isRegistered(EventValue<?, ?> eventValue) {
-		for (EventValue<?, ?> eventValue2 : eventValues(eventValue.time())) {
-			if (eventValue.matches(eventValue2))
+		for (EventValue<?, ?> existing : eventValues(eventValue.time())) {
+			if (existing.matches(eventValue))
 				return true;
 		}
 		return false;


### PR DESCRIPTION
### Problem
When registering an event value, the registry doesn't take into account any special validation when checking if the event value is already registered. This falsely claims two event values with different validation as the same


### Solution
Include the input/event validation in the registration check


### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
