### PR TITLE
Lower implicit priority for syntaxes involving regular expressions

### DIFF
--- a/src/main/java/org/skriptlang/skript/registration/SyntaxInfoImpl.java
+++ b/src/main/java/org/skriptlang/skript/registration/SyntaxInfoImpl.java
@@ -34,6 +34,12 @@ class SyntaxInfoImpl<T extends SyntaxElement> implements SyntaxInfo<T> {
 						return SyntaxInfo.PATTERN_MATCHES_EVERYTHING;
 					}
 					priority = SyntaxInfo.COMBINED;
+				} else if (chars[i] == '<') {
+					if (i > 0 && chars[i - 1] == '\\') { // skip escaped angle brackets
+						continue;
+					}
+					// regular expression string
+					return SyntaxInfo.PATTERN_MATCHES_EVERYTHING;
 				}
 			}
 		}


### PR DESCRIPTION
### Problem
As documented by @TheLimeGlass in issue #8534, Skript prefers EffDoIf(ExprDefaultValue) over ExprTernary in situations where do-if should have lower priority. This is because EffDoIf does not declare its priority as `PATTERN_MATCHES_EVERYTHING` despite involving the regular expression `<.+>` in its pattern. The current implementation for calculating the implicit priority of a syntax does not take regular expressions into account, even though it could; `PATTERN_MATCHES_EVERYTHING` is intended precisely for syntaxes that have these kinds of regular expressions.

### Solution
A general solution is given. This PR adjusts the implicit priority calculation to automatically apply a priority of `PATTERN_MATCHES_EVERYTHING` to syntaxes that use regular expressions (have an angle bracket in one or more of their patterns). An additional conditional case is added to `estimatePriority` in `SyntaxInfoImpl`.


### Testing Completed
I verified that this change solves the issue documented in #8534, and does not break our tests (using `quickTest`). I've also used skUnity Docs to identify all syntaxes that have a pattern that includes a regular expression, and did not immediately see any patterns that could reasonably break because of these changes. A tab-separated list of all syntaxes documented on skUnity containing `&lt;` in their pattern (as retrieved from the skUnity Docs API) is given.[^1]

### Supporting Information
All skUnity syntaxes can be retrieved using an API key from the URL `https://api.skunity.com/v1/API_KEY_HERE/docs/getAllSyntax`. I used my own personal API key, which I found [on the skUnity Dashboard](https://skunity.com/dashboard/skunity-api).

---
**Completes:** #8534 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** [Discussion on the SkriptLang Discord](https://discord.com/channels/988998880794402856/1399497440918376469/1493295074564509927) <!-- Links to issues or discussions with related information -->
**AI assistance:** For creating the JQ pattern that exported syntax patterns containing `&lt;` from the skUnity `getAllSyntax` JSON <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->

[^1]: [regexful.csv on GitHub Gist](https://gist.github.com/bluelhf/da4364229e17202948f2ed4c4f569988)
