### PR TITLE
Add serializer for text components

### DIFF
--- a/src/main/java/org/skriptlang/skript/bukkit/text/TextModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/text/TextModule.java
@@ -1,18 +1,13 @@
 package org.skriptlang.skript.bukkit.text;
 
-import ch.njol.skript.classes.ClassInfo;
-import ch.njol.skript.classes.Parser;
-import ch.njol.skript.expressions.base.EventValueExpression;
-import ch.njol.skript.lang.ParseContext;
 import ch.njol.skript.registrations.Classes;
-import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
-import org.bukkit.command.CommandSender;
 import org.skriptlang.skript.addon.AddonModule;
 import org.skriptlang.skript.addon.HierarchicalAddonModule;
 import org.skriptlang.skript.addon.SkriptAddon;
 import org.skriptlang.skript.bukkit.text.elements.effects.*;
 import org.skriptlang.skript.bukkit.text.elements.expressions.*;
+import org.skriptlang.skript.bukkit.text.types.*;
 import org.skriptlang.skript.lang.arithmetic.Arithmetics;
 import org.skriptlang.skript.lang.arithmetic.Operator;
 import org.skriptlang.skript.lang.comparator.Comparators;
@@ -26,57 +21,8 @@ public class TextModule extends HierarchicalAddonModule {
 
 	@Override
 	public void initSelf(SkriptAddon addon) {
-		Classes.registerClass(new ClassInfo<>(Component.class, "textcomponent")
-			.user("text ?components?")
-			.name("Text Component")
-			.description("Text components are used to represent how text is displayed in Minecraft.",
-				"This includes colors, decorations, and more.")
-			.examples("\"<red><bold>This text is red and bold!\"")
-			.since("2.15")
-			.parser(new Parser<>() {
-				@Override
-				public boolean canParse(ParseContext context) {
-					return false;
-				}
-
-				@Override
-				public String toString(Component component, int flags) {
-					return TextComponentParser.instance().toString(component);
-				}
-
-				@Override
-				public String toVariableNameString(Component component) {
-					return "textcomponent:" + component;
-				}
-			}));
-
-		Classes.registerClass(new ClassInfo<>(Audience.class, "audience")
-			.user("audiences?")
-			.name("Audience")
-			.description("An audience is a receiver of media, such as individual players, the console, or groups of players (such as those on a team or in a world).")
-			.examples("send \"Hello world!\" to the player",
-				"send action bar \"ALERT! A horde of zombies has overrun the central village.\" to the world")
-			.since("2.15")
-			// note: CommandSender is purposefully used here as there may be many Audiences in a single event
-			// for example, there is a conflict in events with Player and World (e.g. all player events)
-			// we continue to use CommandSender for retaining existing behavior
-			.defaultExpression(new EventValueExpression<>(CommandSender.class))
-			.parser(new Parser<>() {
-				@Override
-				public boolean canParse(ParseContext context) {
-					return false;
-				}
-
-				@Override
-				public String toString(Audience audience, int flags) {
-					return "audience";
-				}
-
-				@Override
-				public String toVariableNameString(Audience audience) {
-					return "audience";
-				}
-			}));
+		Classes.registerClass(new TextComponentClassInfo());
+		Classes.registerClass(new AudienceClassInfo());
 
 		Converters.registerConverter(String.class, Component.class,
 			string -> TextComponentParser.instance().parseSafe(string));

--- a/src/main/java/org/skriptlang/skript/bukkit/text/types/AudienceClassInfo.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/text/types/AudienceClassInfo.java
@@ -1,0 +1,48 @@
+package org.skriptlang.skript.bukkit.text.types;
+
+import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.classes.Parser;
+import ch.njol.skript.expressions.base.EventValueExpression;
+import ch.njol.skript.lang.ParseContext;
+import net.kyori.adventure.audience.Audience;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+public final class AudienceClassInfo extends ClassInfo<Audience> {
+
+	public AudienceClassInfo() {
+		super(Audience.class, "audience");
+		this.user("audiences?")
+			.name("Audience")
+			.description("An audience is a receiver of media, such as individual players, the console, or groups of players (such as those on a team or in a world).")
+			.examples("send \"Hello world!\" to the player",
+				"send action bar \"ALERT! A horde of zombies has overrun the central village.\" to the world")
+			.since("2.15")
+			// note: CommandSender is purposefully used here as there may be many Audiences in a single event
+			// for example, there is a conflict in events with Player and World (e.g. all player events)
+			// we continue to use CommandSender for retaining existing behavior
+			.defaultExpression(new EventValueExpression<>(CommandSender.class))
+			.parser(new AudienceParser());
+	}
+
+	private static final class AudienceParser extends Parser<Audience> {
+
+		@Override
+		public boolean canParse(ParseContext context) {
+			return false;
+		}
+
+		@Override
+		public String toString(Audience audience, int flags) {
+			return "audience";
+		}
+
+		@Override
+		public String toVariableNameString(Audience audience) {
+			return "audience:" + audience.hashCode();
+		}
+
+	}
+
+}

--- a/src/main/java/org/skriptlang/skript/bukkit/text/types/TextComponentClassInfo.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/text/types/TextComponentClassInfo.java
@@ -1,0 +1,76 @@
+package org.skriptlang.skript.bukkit.text.types;
+
+import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.classes.Parser;
+import ch.njol.skript.classes.Serializer;
+import ch.njol.skript.lang.ParseContext;
+import ch.njol.yggdrasil.Fields;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.json.JSONComponentSerializer;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.io.StreamCorruptedException;
+
+@ApiStatus.Internal
+public final class TextComponentClassInfo extends ClassInfo<Component> {
+
+	public TextComponentClassInfo() {
+		super(Component.class, "textcomponent");
+		this.user("text ?components?")
+			.name("Text Component")
+			.description("Text components are used to represent how text is displayed in Minecraft.",
+				"This includes colors, decorations, and more.")
+			.examples("\"<red><bold>This text is red and bold!\"")
+			.since("2.15")
+			.parser(new TextComponentParser())
+			.serializer(new TextComponentSerializer());
+	}
+
+	private static final class TextComponentParser extends Parser<Component> {
+
+		@Override
+		public boolean canParse(ParseContext context) {
+			return false;
+		}
+
+		@Override
+		public String toString(Component component, int flags) {
+			return org.skriptlang.skript.bukkit.text.TextComponentParser.instance().toString(component);
+		}
+
+		@Override
+		public String toVariableNameString(Component component) {
+			return "textcomponent:" + component.hashCode();
+		}
+
+	}
+
+	static final class TextComponentSerializer extends Serializer<Component> {
+
+		@Override
+		public Fields serialize(Component component) {
+			return Fields.singletonObject("json", JSONComponentSerializer.json().serialize(component));
+		}
+
+		@Override
+		protected Component deserialize(Fields fields) throws StreamCorruptedException {
+			String json = fields.getObject("json", String.class);
+			if (json == null) {
+				throw new StreamCorruptedException();
+			}
+			return JSONComponentSerializer.json().deserialize(json);
+		}
+
+		@Override
+		public boolean mustSyncDeserialization() {
+			return false;
+		}
+
+		@Override
+		protected boolean canBeInstantiated() {
+			return false;
+		}
+
+	}
+
+}

--- a/src/test/java/org/skriptlang/skript/bukkit/text/types/TextComponentSerializationTest.java
+++ b/src/test/java/org/skriptlang/skript/bukkit/text/types/TextComponentSerializationTest.java
@@ -1,0 +1,27 @@
+package org.skriptlang.skript.bukkit.text.types;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextDecoration;
+import org.junit.Test;
+import org.skriptlang.skript.bukkit.text.types.TextComponentClassInfo.TextComponentSerializer;
+
+import java.io.StreamCorruptedException;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+public class TextComponentSerializationTest {
+
+	@Test
+	public void test() throws StreamCorruptedException {
+		TextComponentSerializer serializer = new TextComponentSerializer();
+		Component expected = Component.text("Hello ", Style.style(NamedTextColor.RED)
+				.decorations(Set.of(TextDecoration.values()), false).decoration(TextDecoration.BOLD, true))
+			.append(Component.text("world!", Style.style(NamedTextColor.BLUE, TextDecoration.BOLD.withState(false))));
+		Component deserialized = serializer.deserialize(serializer.serialize(expected));
+		assertEquals(expected, deserialized);
+	}
+
+}

--- a/src/test/skript/tests/bukkit/TextModule.sk
+++ b/src/test/skript/tests/bukkit/TextModule.sk
@@ -1,2 +1,8 @@
 test "component equality":
 	assert (formatted "<rainbow>Hello!") is (formatted "<rainbow>Hello!") with "components with virtual components failed comparison"
+
+test "component serialization":
+	# verify no warning
+	parse:
+		set {x} to line 1 of lore of {_item}
+	assert last parse logs are not set


### PR DESCRIPTION
### Problem
Users expect to be able to save text components in variables.

### Solution
I have added a serializer for text components. I pulled the ClassInfos out into their own classes for better organization. I also improved their toVariableString implementations.

### Testing Completed
I added tests to verify serialization.

### Supporting Information
n/a

---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
