### PR TITLE
Improve add syntax for lists by saving the last used index

### DIFF
--- a/src/main/java/ch/njol/skript/lang/Variable.java
+++ b/src/main/java/ch/njol/skript/lang/Variable.java
@@ -239,8 +239,8 @@ public class Variable<T> implements Expression<T>, KeyReceiverExpression<T>, Key
 					infos[i] = Classes.getSuperClassInfo(types[i]);
 				}
 				ClassInfo<?>[] hintInfos = hints.stream()
-					.map(Classes::getSuperClassInfo)
-					.toArray(ClassInfo[]::new);
+						.map(Classes::getSuperClassInfo)
+						.toArray(ClassInfo[]::new);
 				String isTypes = Utils.a(Classes.toString(hintInfos, false));
 				String notTypes = Utils.a(Classes.toString(infos, false));
 				Skript.error("Expected variable '{_" + variableString.toString(null) + "}' to be " + notTypes + ", but it is " + isTypes);

--- a/src/main/java/ch/njol/skript/lang/Variable.java
+++ b/src/main/java/ch/njol/skript/lang/Variable.java
@@ -511,7 +511,7 @@ public class Variable<T> implements Expression<T>, KeyReceiverExpression<T>, Key
 						setIndex(event, index, null);
 					}
 				}
-				lastUsedIndex = -1;
+				lastElementAddedIndex = -1;
 				set(event, null);
 				break;
 			case SET:
@@ -580,7 +580,7 @@ public class Variable<T> implements Expression<T>, KeyReceiverExpression<T>, Key
 							assert index != null;
 							setIndex(event, index, null);
 						}
-						lastUsedIndex = -1;
+						lastElementAddedIndex = -1;
 					} else if (mode == ChangeMode.REMOVE_ALL) {
 						if (map == null)
 							return;
@@ -595,11 +595,11 @@ public class Variable<T> implements Expression<T>, KeyReceiverExpression<T>, Key
 							assert index != null;
 							setIndex(event, index, null);
 						}
-						lastUsedIndex = -1;
+						lastElementAddedIndex = -1;
 					} else {
 						assert mode == ChangeMode.ADD;
 						int i = 1;
-						if (lastUsedIndex != -1) i = lastUsedIndex+1;
+						if (lastElementAddedIndex != -1) i = lastElementAddedIndex+1;
 						for (Object value : delta) {
 							if (map != null) {
 								if (map.containsKey("" + i)) { // to ensure the expensive map.keySet() is used as little as possible
@@ -609,7 +609,7 @@ public class Variable<T> implements Expression<T>, KeyReceiverExpression<T>, Key
 								}
 							}
 							setIndex(event, "" + i, value);
-							lastUsedIndex = i;
+							lastElementAddedIndex = i;
 							i++;
 						}
 					}

--- a/src/main/java/ch/njol/skript/lang/Variable.java
+++ b/src/main/java/ch/njol/skript/lang/Variable.java
@@ -72,7 +72,7 @@ public class Variable<T> implements Expression<T>, KeyReceiverExpression<T>, Key
 
 	private ListProvider listProvider = new ShallowListProvider();
 
-	private int lastUsedIndex = -1; // Used for the "add" syntax in lists
+	private int lastElementAddedIndex = -1;
 
 	@SuppressWarnings("unchecked")
 	private Variable(VariableString name, Class<? extends T>[] types, boolean local, boolean ephemeral, boolean list, @Nullable Variable<?> source) {

--- a/src/main/java/ch/njol/skript/lang/Variable.java
+++ b/src/main/java/ch/njol/skript/lang/Variable.java
@@ -72,6 +72,8 @@ public class Variable<T> implements Expression<T>, KeyReceiverExpression<T>, Key
 
 	private ListProvider listProvider = new ShallowListProvider();
 
+	private int lastUsedIndex = -1; // Used for the "add" syntax in lists
+
 	@SuppressWarnings("unchecked")
 	private Variable(VariableString name, Class<? extends T>[] types, boolean local, boolean ephemeral, boolean list, @Nullable Variable<?> source) {
 		assert types.length > 0;
@@ -237,8 +239,8 @@ public class Variable<T> implements Expression<T>, KeyReceiverExpression<T>, Key
 					infos[i] = Classes.getSuperClassInfo(types[i]);
 				}
 				ClassInfo<?>[] hintInfos = hints.stream()
-						.map(Classes::getSuperClassInfo)
-						.toArray(ClassInfo[]::new);
+					.map(Classes::getSuperClassInfo)
+					.toArray(ClassInfo[]::new);
 				String isTypes = Utils.a(Classes.toString(hintInfos, false));
 				String notTypes = Utils.a(Classes.toString(infos, false));
 				Skript.error("Expected variable '{_" + variableString.toString(null) + "}' to be " + notTypes + ", but it is " + isTypes);
@@ -509,7 +511,7 @@ public class Variable<T> implements Expression<T>, KeyReceiverExpression<T>, Key
 						setIndex(event, index, null);
 					}
 				}
-
+				lastUsedIndex = -1;
 				set(event, null);
 				break;
 			case SET:
@@ -578,6 +580,7 @@ public class Variable<T> implements Expression<T>, KeyReceiverExpression<T>, Key
 							assert index != null;
 							setIndex(event, index, null);
 						}
+						lastUsedIndex = -1;
 					} else if (mode == ChangeMode.REMOVE_ALL) {
 						if (map == null)
 							return;
@@ -592,14 +595,21 @@ public class Variable<T> implements Expression<T>, KeyReceiverExpression<T>, Key
 							assert index != null;
 							setIndex(event, index, null);
 						}
+						lastUsedIndex = -1;
 					} else {
 						assert mode == ChangeMode.ADD;
 						int i = 1;
+						if (lastUsedIndex != -1) i = lastUsedIndex+1;
 						for (Object value : delta) {
-							if (map != null)
-								while (map.containsKey("" + i))
-									i++;
+							if (map != null) {
+								if (map.containsKey("" + i)) { // to ensure the expensive map.keySet() is used as little as possible
+									HashSet<String> keys = new HashSet<>(map.keySet());
+									while (keys.contains("" + i))
+										i++;
+								}
+							}
 							setIndex(event, "" + i, value);
+							lastUsedIndex = i;
 							i++;
 						}
 					}


### PR DESCRIPTION
### Problem
Adding to lists has been slow due to an O(N) lookup happening every single time a value is added. This means adding N values to a list separately is O(N²), while adding them all at the same time is O(N). This problem is also described in #891 


### Solution
I (somewhat) solved this problem in 2 ways:
1: Replaced repeated TreeMap.containsKey() calls with HashSet.contains() calls 
2: Saving the last used index during an add operation. If another operation is done that could cause a gap in the list, the saved index is reset. This means the O(N) lookup will only happen once a gap can occur or when the server restarts.

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
quickTest was completed succesfully. I tested if gaps in lists would get filled and the performance of the code in #891 (the performance is now pretty much the same for setting and adding, adding might even be faster (though I doubt it))

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:**: #891 
**Related:** #891 
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->

p.s. I think some sort of auto formatter ran and removed a double tab around line 242