### PR TITLE
Allow wait/halt to be used as a section

### DIFF
--- a/src/main/java/ch/njol/skript/effects/Delay.java
+++ b/src/main/java/ch/njol/skript/effects/Delay.java
@@ -1,11 +1,12 @@
 package ch.njol.skript.effects;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
-import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.EffectSection;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -20,29 +21,47 @@ import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.WeakHashMap;
 
 @Name("Delay")
-@Description("Delays the script's execution by a given timespan. Please note that delays are not persistent, e.g. trying to create a tempban script with <code>ban player → wait 7 days → unban player</code> will not work if you restart your server anytime within these 7 days. You also have to be careful even when using small delays!")
+@Description({
+	"Delays the script's execution by a given timespan.",
+	"",
+	"When used as an effect, all code after the <code>wait</code> runs once the delay elapses. The whole trigger pauses.",
+	"",
+	"When used as a section, only the section body is deferred. Code after the section continues immediately, and the body runs on the same event once the delay elapses. This is useful for scheduling follow-up work without blocking the rest of the trigger.",
+	"",
+	"Note that delays are not persistent. For example, <code>ban player → wait 7 days → unban player</code> will not resume if the server restarts during the delay.",
+	"",
+	"Inside a section body, outer <code>loop-value</code>s are not available because the body is parsed as a separate trigger. Event values (like <code>player</code>) still work. If you need a variable's value from before the delay, copy it to a local variable &mdash; local variables are snapshotted when the section is scheduled."
+})
 @Example("wait 2 minutes")
 @Example("halt for 5 minecraft hours")
 @Example("wait a tick")
-@Since("1.4")
-public class Delay extends Effect {
+@Example("""
+	# Section form: outer continues immediately, body runs 3 seconds later.
+	send "hello" to player
+	wait 3 seconds:
+		send "...and goodbye" to player
+	""")
+@Since("1.4, 2.15")
+public class Delay extends EffectSection {
 
 	static {
-		Skript.registerEffect(Delay.class, "(wait|halt) [for] %timespan%");
+		Skript.registerSection(Delay.class, "(wait|halt) [for] %timespan%");
 	}
 
 	@SuppressWarnings("NotNullFieldNotInitialized")
 	protected Expression<Timespan> duration;
 
+	private @Nullable Trigger trigger;
+
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
-	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-		getParser().setHasDelayBefore(Kleenean.TRUE);
-
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult,
+						@Nullable SectionNode sectionNode, @Nullable List<TriggerItem> triggerItems) {
 		duration = (Expression<Timespan>) exprs[0];
 		if (duration instanceof Literal) { // If we can, do sanity check for delays
 			Timespan timespan = ((Literal<Timespan>) duration).getSingle();
@@ -56,51 +75,89 @@ public class Delay extends Effect {
 			}
 		}
 
+		if (hasSection()) {
+			assert sectionNode != null;
+			// Parse the body under the outer event context so event values still resolve inside it.
+			// Locals are isolated at runtime via the swap dance in walk().
+			Class<? extends Event>[] outerEvents = getParser().getCurrentEvents();
+			Runnable beforeLoading = () -> getParser().setHasDelayBefore(Kleenean.TRUE);
+			trigger = loadCode(sectionNode, "wait", beforeLoading, null, outerEvents);
+			// Outer trigger is NOT delayed - code after the section runs immediately.
+			return trigger != null;
+		}
+
+		getParser().setHasDelayBefore(Kleenean.TRUE);
 		return true;
 	}
 
 	@Override
-	@Nullable
-	protected TriggerItem walk(Event event) {
+	protected @Nullable TriggerItem walk(Event event) {
 		debug(event, true);
 		long start = Skript.debug() ? System.nanoTime() : 0;
-		TriggerItem next = getNext();
-		if (next != null && Skript.getInstance().isEnabled()) { // See https://github.com/SkriptLang/Skript/issues/3702
 
-			Timespan duration = this.duration.getSingle(event);
-			if (duration == null)
-				return null;
+		if (!Skript.getInstance().isEnabled()) // See https://github.com/SkriptLang/Skript/issues/3702
+			return trigger != null ? super.walk(event, false) : null;
+
+		Timespan duration = this.duration.getSingle(event);
+		if (duration == null)
+			return trigger != null ? super.walk(event, false) : null;
+
+		long ticks = Math.max(duration.getAs(Timespan.TimePeriod.TICK), 1);
+
+		if (trigger != null) {
 			
-			// Back up local variables
+			Object snapshot = Variables.copyLocalVariables(event);
+			Trigger body = trigger;
+			Bukkit.getScheduler().scheduleSyncDelayedTask(Skript.getInstance(), () -> {
+				Skript.debug(getIndentation() + "... running delayed section after " + (System.nanoTime() - start) / 1_000_000_000. + "s");
+
+				
+				Object outerLocals = Variables.removeLocals(event);
+				if (snapshot != null)
+					Variables.setLocalVariables(event, snapshot);
+
+				Object timing = null;
+				if (SkriptTimings.enabled()) {
+					Trigger parentTrigger = getTrigger();
+					if (parentTrigger != null)
+						timing = SkriptTimings.start(parentTrigger.getDebugLabel());
+				}
+				try {
+					TriggerItem.walk(body, event);
+				} finally {
+					Variables.setLocalVariables(event, outerLocals);
+					SkriptTimings.stop(timing);
+				}
+			}, ticks);
+			return super.walk(event, false);
+		}
+
+		
+		TriggerItem next = getNext();
+		if (next != null) {
 			Object localVars = Variables.removeLocals(event);
-			
+
 			Bukkit.getScheduler().scheduleSyncDelayedTask(Skript.getInstance(), () -> {
 				addDelayedEvent(event);
 				Skript.debug(getIndentation() + "... continuing after " + (System.nanoTime() - start) / 1_000_000_000. + "s");
 
-				// Re-set local variables
 				if (localVars != null)
 					Variables.setLocalVariables(event, localVars);
 
-				Object timing = null; // Timings reference must be kept so that it can be stopped after TriggerItem execution
-				if (SkriptTimings.enabled()) { // getTrigger call is not free, do it only if we must
-					Trigger trigger = getTrigger();
-					if (trigger != null)
-						timing = SkriptTimings.start(trigger.getDebugLabel());
+				Object timing = null;
+				if (SkriptTimings.enabled()) {
+					Trigger parentTrigger = getTrigger();
+					if (parentTrigger != null)
+						timing = SkriptTimings.start(parentTrigger.getDebugLabel());
 				}
 
 				TriggerItem.walk(next, event);
-				Variables.removeLocals(event); // Clean up local vars, we may be exiting now
+				Variables.removeLocals(event);
 
-				SkriptTimings.stop(timing); // Stop timing if it was even started
-			}, Math.max(duration.getAs(Timespan.TimePeriod.TICK), 1)); // Minimum delay is one tick, less than it is useless!
+				SkriptTimings.stop(timing);
+			}, ticks);
 		}
 		return null;
-	}
-
-	@Override
-	protected void execute(Event event) {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/src/main/java/ch/njol/skript/effects/Delay.java
+++ b/src/main/java/ch/njol/skript/effects/Delay.java
@@ -102,7 +102,7 @@ public class Delay extends EffectSection {
 		if (duration == null)
 			return trigger != null ? super.walk(event, false) : null;
 
-		long ticks = Math.max(duration.getAs(Timespan.TimePeriod.TICK), 1);
+		long ticks = Math.max(duration.getAs(Timespan.TimePeriod.TICK), 1); // Minimum delay is one tick, less than it is useless!
 
 		if (trigger != null) {
 			
@@ -126,7 +126,7 @@ public class Delay extends EffectSection {
 					TriggerItem.walk(body, event);
 				} finally {
 					Variables.setLocalVariables(event, outerLocals);
-					SkriptTimings.stop(timing);
+					SkriptTimings.stop(timing); // Stop timing if it was even started
 				}
 			}, ticks);
 			return super.walk(event, false);
@@ -152,7 +152,7 @@ public class Delay extends EffectSection {
 				}
 
 				TriggerItem.walk(next, event);
-				Variables.removeLocals(event);
+				Variables.removeLocals(event); // Clean up local vars, we may be exiting now
 
 				SkriptTimings.stop(timing);
 			}, ticks);


### PR DESCRIPTION
### Problem
`wait` / `halt` only work as effects today, they block the entire trigger until the delay elapses. There is no way in Skript to schedule a block of code to run later while the rest of the trigger continues immediately.

### Solution
Convert `Delay` from `Effect` to `EffectSection` and register it with `Skript.registerSection` using the same `(wait|halt) [for] %timespan%` pattern. The parser dispatches to the effect form when there's no body and the section form when there is. Both forms live in one class.

- **Effect form:** behavior unchanged. Same `hasDelayBefore=TRUE`, same local-variable handling, same scheduler call, same `addDelayedEvent` tracking. Existing scripts are not affected.
- **Section form:** body is parsed as a separate trigger under the outer event classes, with `hasDelayBefore=TRUE` set in `beforeLoading` so nested delays inside the body parse correctly. At runtime, `walk()` snapshots outer locals with `Variables.copyLocalVariables`, schedules a sync task, and inside the callback swaps locals (save current outer then install snapshot then walk body then restore outer) so body mutations don't leak into the outer trigger. Outer is not marked delayed, code after the section runs immediately.


### Testing Completed
Manual in game testing on a Paper server covering:
```applescript
command /test1:
    trigger:
        broadcast "A"
        wait 1 second:
            broadcast "B"
            wait 2 seconds:
                broadcast "C"
            broadcast "D"
            wait 1 second
            broadcast "E"
        broadcast "F"
# expect: A, F, (1s) B, D, (2s) E, (3s) C


command /test2:
    trigger:
        set {_shared} to "outer"
        loop 3 times:
            set {_i} to loop-number
            wait 1 second:
                set {_shared} to "body-%{_i}%"
                broadcast "iter %{_i}% shared=%{_shared}% %unix timestamp of now%"
        wait 2 seconds
        broadcast "done shared=%{_shared}% %unix timestamp of now%"
# expect: (1s) 3 messages "iter 1..3" each with correct number and shared=body-N, (3s after start) done shared=outer


command /test3:
    trigger:
        broadcast "1"
        wait 2 seconds
        broadcast "2"
# expect: 1, (2s) 2 — effect form unchanged
```

```
> test1
[19:04:44 INFO]: A
[19:04:44 INFO]: F
[19:04:45 INFO]: B
[19:04:45 INFO]: D
[19:04:46 INFO]: E
[19:04:47 INFO]: C
> test2
[19:04:50 INFO]: iter 1 shared=body-1 1776272690.29
[19:04:50 INFO]: iter 2 shared=body-2 1776272690.29
[19:04:50 INFO]: iter 3 shared=body-3 1776272690.29
[19:04:51 INFO]: done shared=outer 1776272691.29
> test3
[19:04:53 INFO]: 1
[19:04:55 INFO]: 2
```

No skript test files added in this PR `wait` / `halt` do not currently have test scripts under `src/test/skript/tests/` and adding the first ones for this feature felt out of scope. Happy to add them in a follow up if sovde (only him) want them here.


### Supporting Information
This PR was made by eult :) 

---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** Claude Opus 4.6, Used to help me writing the walk method, tests and rewrite the description