### PR TITLE
Fix SIOOBE with ExprStringColor

### DIFF
--- a/src/main/java/org/skriptlang/skript/bukkit/text/elements/expressions/ExprStringColor.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/text/elements/expressions/ExprStringColor.java
@@ -136,7 +136,7 @@ public class ExprStringColor extends PropertyExpression<String, Object> {
 					continue;
 				}
 				String tag = string.substring(index + 1, end);
-				if (tag.charAt(0) == '#') { // should be a hex
+				if (!tag.isEmpty() && tag.charAt(0) == '#') { // should be a hex
 					tag = tag.substring(1);
 					int tagLength = tag.length();
 					if (tagLength != 6 && tagLength != 8) { // malformed hex format

--- a/src/main/java/org/skriptlang/skript/bukkit/text/elements/expressions/ExprStringColor.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/text/elements/expressions/ExprStringColor.java
@@ -136,7 +136,10 @@ public class ExprStringColor extends PropertyExpression<String, Object> {
 					continue;
 				}
 				String tag = string.substring(index + 1, end);
-				if (!tag.isEmpty() && tag.charAt(0) == '#') { // should be a hex
+				if (tag.isEmpty()) { // malformed (empty tag)
+					continue;
+				}
+				if (tag.charAt(0) == '#') { // should be a hex
 					tag = tag.substring(1);
 					int tagLength = tag.length();
 					if (tagLength != 6 && tagLength != 8) { // malformed hex format

--- a/src/test/skript/tests/regressions/8550-string colours sioobe.sk
+++ b/src/test/skript/tests/regressions/8550-string colours sioobe.sk
@@ -1,0 +1,3 @@
+test "empty tags with colours of string expression":
+	# throws exception if not fixed
+	set {_} to string colour of "<>"


### PR DESCRIPTION
### Problem
`string colors of "<>"` causes StringIndexOutOfBoundsException

### Solution
Added `String#isEmpty()` call to the relevant line, along with a regression test


### Testing Completed
Verified the regression test fails on commit fa0e5e16d but passes on commit cc8d7e082 (which introduces the fix)


---
**Completes:** #8550 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
