### PR TITLE
Fix rare exception due to no function definition with multiple script loading threads

### DIFF
--- a/src/main/java/org/skriptlang/skript/common/function/FunctionReference.java
+++ b/src/main/java/org/skriptlang/skript/common/function/FunctionReference.java
@@ -32,6 +32,7 @@ public final class FunctionReference<T> implements Debuggable {
 	private final Signature<T> signature;
 	private final Argument<Expression<?>>[] arguments;
 
+	private boolean unloaded = false;
 	private Function<T> cachedFunction;
 	private LinkedHashMap<String, ArgInfo> cachedArguments;
 
@@ -40,9 +41,9 @@ public final class FunctionReference<T> implements Debuggable {
 	}
 
 	public FunctionReference(@Nullable String namespace,
-							 @NotNull String name,
-							 @NotNull Signature<T> signature,
-							 @NotNull Argument<Expression<?>>[] arguments) {
+	                         @NotNull String name,
+	                         @NotNull Signature<T> signature,
+	                         @NotNull Argument<Expression<?>>[] arguments) {
 		Preconditions.checkNotNull(name, "name cannot be null");
 		Preconditions.checkNotNull(signature, "signature cannot be null");
 		Preconditions.checkNotNull(arguments, "arguments cannot be null");
@@ -57,7 +58,7 @@ public final class FunctionReference<T> implements Debuggable {
 	 * Invalidate the cached function used in this reference.
 	 */
 	public void invalidateCache() {
-		cachedFunction = null;
+		unloaded = true;
 	}
 
 	/**
@@ -98,6 +99,20 @@ public final class FunctionReference<T> implements Debuggable {
 
 				// all good
 				cachedArguments.put(target.name(), new ArgInfo(converted, target.type(), target.modifiers()));
+			}
+		}
+
+		if (unloaded || cachedFunction == null) {
+			Class<?>[] parameters = Arrays.stream(signature.parameters().all())
+					.map(Parameter::type)
+					.toArray(Class[]::new);
+
+			Retrieval<ch.njol.skript.lang.function.Function<?>> retrieval = FunctionRegistry.getRegistry().getFunction(namespace, name, parameters);
+
+			if (retrieval.result() == RetrievalResult.EXACT) {
+				//noinspection unchecked
+				cachedFunction = (Function<T>) retrieval.retrieved();
+				unloaded = false;
 			}
 		}
 
@@ -225,19 +240,6 @@ public final class FunctionReference<T> implements Debuggable {
 	 * @return The function referred to by this reference.
 	 */
 	public Function<T> function() {
-		if (cachedFunction == null) {
-			Class<?>[] parameters = Arrays.stream(signature.parameters().all())
-					.map(Parameter::type)
-					.toArray(Class[]::new);
-
-			Retrieval<ch.njol.skript.lang.function.Function<?>> retrieval = FunctionRegistry.getRegistry().getFunction(namespace, name, parameters);
-
-			if (retrieval.result() == RetrievalResult.EXACT) {
-				//noinspection unchecked
-				cachedFunction = (Function<T>) retrieval.retrieved();
-			}
-		}
-
 		return cachedFunction;
 	}
 

--- a/src/main/java/org/skriptlang/skript/common/function/FunctionReference.java
+++ b/src/main/java/org/skriptlang/skript/common/function/FunctionReference.java
@@ -102,24 +102,6 @@ public final class FunctionReference<T> implements Debuggable {
 			}
 		}
 
-		if (unloaded || cachedFunction == null) {
-			Class<?>[] parameters = Arrays.stream(signature.parameters().all())
-					.map(Parameter::type)
-					.toArray(Class[]::new);
-
-			Retrieval<ch.njol.skript.lang.function.Function<?>> retrieval = FunctionRegistry.getRegistry().getFunction(namespace, name, parameters);
-
-			if (retrieval.result() == RetrievalResult.EXACT) {
-				//noinspection unchecked
-				cachedFunction = (Function<T>) retrieval.retrieved();
-				unloaded = false;
-			}
-
-			if (cachedFunction == null) {
-				return false;
-			}
-		}
-
 		signature.addCall(this);
 
 		return true;
@@ -244,6 +226,20 @@ public final class FunctionReference<T> implements Debuggable {
 	 * @return The function referred to by this reference.
 	 */
 	public Function<T> function() {
+		if (unloaded || cachedFunction == null) {
+			Class<?>[] parameters = Arrays.stream(signature.parameters().all())
+					.map(Parameter::type)
+					.toArray(Class[]::new);
+
+			Retrieval<ch.njol.skript.lang.function.Function<?>> retrieval = FunctionRegistry.getRegistry().getFunction(namespace, name, parameters);
+
+			if (retrieval.result() == RetrievalResult.EXACT) {
+				//noinspection unchecked
+				cachedFunction = (Function<T>) retrieval.retrieved();
+				unloaded = false;
+			}
+		}
+
 		return cachedFunction;
 	}
 

--- a/src/main/java/org/skriptlang/skript/common/function/FunctionReference.java
+++ b/src/main/java/org/skriptlang/skript/common/function/FunctionReference.java
@@ -114,6 +114,10 @@ public final class FunctionReference<T> implements Debuggable {
 				cachedFunction = (Function<T>) retrieval.retrieved();
 				unloaded = false;
 			}
+
+			if (cachedFunction == null) {
+				return false;
+			}
 		}
 
 		signature.addCall(this);


### PR DESCRIPTION
### Problem
In rare cases, reloading a script which used a function definition in a different script with multiple script loading threads would cause the function implementation to be undefined, which would cause an exception.


### Solution
Instead of setting the function implementation to null, now marks the function implementation to be unloaded. The function reference will continue to use the old implementation until a new one can be found. 


### Testing Completed
Spam `sk reload x` with 1 worker thread in config.


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** #8468 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
