### PR TITLE
Use piaee instead of piee

### DIFF
--- a/src/main/java/ch/njol/skript/SkriptEventHandler.java
+++ b/src/main/java/ch/njol/skript/SkriptEventHandler.java
@@ -65,13 +65,13 @@ public final class SkriptEventHandler {
 	 * @param event The event to find pairs from.
 	 * @return A List containing all Triggers registered under the provided Event class.
 	 */
-	private static List<Trigger> getTriggers(Class<? extends Event> event) {
+	private static Set<Trigger> getTriggers(Class<? extends Event> event) {
 		HandlerList eventHandlerList = getHandlerList(event);
 		assert eventHandlerList != null; // It had one at some point so this should remain true
 		return triggers.asMap().entrySet().stream()
 				.filter(entry -> entry.getKey().isAssignableFrom(event) && getHandlerList(entry.getKey()) == eventHandlerList)
 				.flatMap(entry -> entry.getValue().stream())
-				.collect(Collectors.toList()); // forces evaluation now and prevents us from having to call getTriggers again if very high logging is enabled
+				.collect(Collectors.toSet()); // forces evaluation now and prevents us from having to call getTriggers again if very high logging is enabled
 	}
 
 	/**
@@ -83,7 +83,7 @@ public final class SkriptEventHandler {
 	 */
 	private static void check(Event event, EventPriority priority) {
 		// get all triggers for this event, return if none
-		List<Trigger> triggers = getTriggers(event.getClass());
+		Set<Trigger> triggers = getTriggers(event.getClass());
 		if (triggers.isEmpty())
 			return;
 

--- a/src/main/java/ch/njol/skript/SkriptEventHandler.java
+++ b/src/main/java/ch/njol/skript/SkriptEventHandler.java
@@ -65,13 +65,14 @@ public final class SkriptEventHandler {
 	 * @param event The event to find pairs from.
 	 * @return A List containing all Triggers registered under the provided Event class.
 	 */
-	private static Set<Trigger> getTriggers(Class<? extends Event> event) {
+	private static List<Trigger> getTriggers(Class<? extends Event> event) {
 		HandlerList eventHandlerList = getHandlerList(event);
 		assert eventHandlerList != null; // It had one at some point so this should remain true
 		return triggers.asMap().entrySet().stream()
 				.filter(entry -> entry.getKey().isAssignableFrom(event) && getHandlerList(entry.getKey()) == eventHandlerList)
 				.flatMap(entry -> entry.getValue().stream())
-				.collect(Collectors.toSet()); // forces evaluation now and prevents us from having to call getTriggers again if very high logging is enabled
+				.distinct()
+				.collect(Collectors.toList()); // forces evaluation now and prevents us from having to call getTriggers again if very high logging is enabled
 	}
 
 	/**
@@ -83,7 +84,7 @@ public final class SkriptEventHandler {
 	 */
 	private static void check(Event event, EventPriority priority) {
 		// get all triggers for this event, return if none
-		Set<Trigger> triggers = getTriggers(event.getClass());
+		List<Trigger> triggers = getTriggers(event.getClass());
 		if (triggers.isEmpty())
 			return;
 

--- a/src/main/java/ch/njol/skript/events/EvtClick.java
+++ b/src/main/java/ch/njol/skript/events/EvtClick.java
@@ -30,7 +30,7 @@ import java.util.function.Predicate;
 
 public class EvtClick extends SkriptEvent {
 
-	// remove when 26.1.1 is the minimum supported version
+	// TODO: UNTIL MC 26.1.1
 	private final static boolean USE_OLD_PIAEE_BEHAVIOR = !Skript.isRunningMinecraft(26,1,1);
 
 	/**

--- a/src/main/java/ch/njol/skript/events/EvtClick.java
+++ b/src/main/java/ch/njol/skript/events/EvtClick.java
@@ -30,6 +30,7 @@ import java.util.function.Predicate;
 
 public class EvtClick extends SkriptEvent {
 
+	// remove when 26.1.1 is the minimum supported version
 	private final static boolean USE_OLD_PIAEE_BEHAVIOR = !Skript.isRunningMinecraft(26,1,1);
 
 	/**

--- a/src/main/java/ch/njol/skript/events/EvtClick.java
+++ b/src/main/java/ch/njol/skript/events/EvtClick.java
@@ -30,6 +30,8 @@ import java.util.function.Predicate;
 
 public class EvtClick extends SkriptEvent {
 
+	private final static boolean USE_OLD_PIAEE_BEHAVIOR = !Skript.isRunningMinecraft(26,1,1);
+
 	/**
 	 * Click types.
 	 */
@@ -111,19 +113,27 @@ public class EvtClick extends SkriptEvent {
 		if (event instanceof PlayerInteractEntityEvent interactEntityEvent) {
 			Entity clicked = interactEntityEvent.getRightClicked();
 
-			// Usually, don't handle these events
-			if (interactEntityEvent instanceof PlayerInteractAtEntityEvent) {
-				// But armor stands are an exception
-				// Later, there may be more exceptions...
-				if (!(clicked instanceof ArmorStand))
-					return false;
+			if (USE_OLD_PIAEE_BEHAVIOR) {
+				// Usually, don't handle these events
+				if (interactEntityEvent instanceof PlayerInteractAtEntityEvent) {
+					// But armor stands are an exception
+					// Later, there may be more exceptions...
+					if (!(clicked instanceof ArmorStand))
+						return false;
+				}
 			}
 
 			if (click == LEFT) // Lefts clicks on entities don't work
 				return false;
 
-			// PlayerInteractAtEntityEvent called only once for armor stands
-			if (!(event instanceof PlayerInteractAtEntityEvent)) {
+			if (USE_OLD_PIAEE_BEHAVIOR) {
+				// PlayerInteractAtEntityEvent called only once for armor stands
+				if (!(event instanceof PlayerInteractAtEntityEvent)) {
+					if (!interactTracker.checkEvent(interactEntityEvent.getPlayer(), interactEntityEvent, interactEntityEvent.getHand())) {
+						return false; // Not first event this tick
+					}
+				}
+			} else {
 				if (!interactTracker.checkEvent(interactEntityEvent.getPlayer(), interactEntityEvent, interactEntityEvent.getHand())) {
 					return false; // Not first event this tick
 				}


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
paper switched to calling PIAEE events instead of PIEE :(
This means our old handling of PIAEE which was based on it only being called spuriously (except armor stands) now screws us over.

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
Ensures the old PIAEE handling is shortcut and PIAEE is treated as the default PIEE event. Also ensure the SkriptEventHandler doesn't return the same trigger twice when getTriggers is called, since EvtClick registers for both PIEE and PIAEE. It may be possible for PIEE to be removed, but I want to keep the deduplication in general for future cases like this.

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** #8575 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
