### PR TITLE
Clone values at function boundary

### DIFF
--- a/src/main/java/org/skriptlang/skript/common/function/FunctionReference.java
+++ b/src/main/java/org/skriptlang/skript/common/function/FunctionReference.java
@@ -147,17 +147,17 @@ public final class FunctionReference<T> implements Debuggable {
 			return null;
 		}
 
-		LinkedHashMap<String, Object> args = new LinkedHashMap<>();
+		SequencedMap<String, Object> args = new LinkedHashMap<>();
 		cachedArguments.forEach((k, v) -> {
 			if (v.modifiers().contains(Modifier.KEYED)) {
-				args.put(k, evaluateKeyed(v.expression(), event));
+				args.put(k, Classes.clone(evaluateKeyed(v.expression(), event)));
 				return;
 			}
 
 			if (!v.type().isArray()) {
-				args.put(k, v.expression().getSingle(event));
+				args.put(k, Classes.clone(v.expression().getSingle(event)));
 			} else {
-				args.put(k, v.expression().getArray(event));
+				args.put(k, Classes.clone(v.expression().getArray(event)));
 			}
 		});
 

--- a/src/test/skript/tests/syntaxes/structures/StructFunction.sk
+++ b/src/test/skript/tests/syntaxes/structures/StructFunction.sk
@@ -16,6 +16,9 @@ local function bar() :: boolean:
 local function _blob() :: string:
 	return "blub"
 
+local function mutate(v: vector) :: vector:
+	add 1 to x of {_v}
+
 test "functions":
 	assert foo() is true with "function return type failed"
 	assert local() is not 1 with "global function parsed before local function"
@@ -208,3 +211,8 @@ test "duplicate keys in function arguments":
 	set {_a::foo} to "first"
 	set {_b::foo} to "second"
 	assert duplicate_keys_test(keyed {_a::*}, keyed {_b::*}) is "first"
+
+test "clone objects at function boundary":
+	set {_vector} to vector(0, 0, 0)
+	mutate({_vector})
+	assert {_vector} is vector(0, 0, 0) with "Values aren't cloned at function boundary"


### PR DESCRIPTION
### Problem
After the functions rework, the arguments passed to a function were no longer cloned, causing functions to be able to mutate objects from completely different triggers. This is not intended as Skript has always passed arguments by value rather than by reference.


### Solution
Clone values before passing them to functions


### Testing Completed
`StructFunction.sk` and manual testing


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** #8450 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
