### PR TITLE
Fix sign indexing

### DIFF
--- a/src/main/java/ch/njol/skript/patterns/TypePatternElement.java
+++ b/src/main/java/ch/njol/skript/patterns/TypePatternElement.java
@@ -132,7 +132,6 @@ public class TypePatternElement extends PatternElement {
 					}
 					// time states need to match and be valid
 					if (!applyTimeState(expression)) {
-						loopLog.printError();
 						return null;
 					}
 

--- a/src/main/java/org/skriptlang/skript/bukkit/block/sign/elements/expressions/ExprSignText.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/block/sign/elements/expressions/ExprSignText.java
@@ -58,12 +58,25 @@ public class ExprSignText extends SimpleExpression<Component> {
 		block = (Expression<Block>) exprs[exprs.length - 1];
 		return true;
 	}
-	
+
+	private Integer getLine(Event event) {
+		Integer line = this.line.getSingle(event);
+		if (line == null) {
+			return null;
+		}
+		if (line < 1 || line > 4) {
+			error("Signs only have lines from 1 to 4, but tried to obtain line " + line);
+			return null;
+		}
+		line--; // we accept 1-indexed, convert to 0-indexed
+		return line;
+	}
+
 	@Override
 	protected Component[] get(Event event) {
-		Integer line = this.line.getSingle(event);
-		if (line == null || line < 0 || line > 3) {
-			return new Component[0];
+		Integer line = getLine(event);
+		if (line == null) {
+			return null;
 		}
 		if (getTime() >= 0 && block.isDefault() && event instanceof SignChangeEvent signEvent && !Delay.isDelayed(event)) {
 			return new Component[]{signEvent.line(line)};
@@ -86,8 +99,8 @@ public class ExprSignText extends SimpleExpression<Component> {
 
 	@Override
 	public void change(Event event, Object @Nullable [] delta, ChangeMode mode) {
-		Integer line = this.line.getSingle(event);
-		if (line == null || line < 0 || line > 3) {
+		Integer line = getLine(event);
+		if (line == null) {
 			return;
 		}
 

--- a/src/main/java/org/skriptlang/skript/bukkit/block/sign/elements/expressions/ExprSignText.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/block/sign/elements/expressions/ExprSignText.java
@@ -59,14 +59,14 @@ public class ExprSignText extends SimpleExpression<Component> {
 		return true;
 	}
 
-	private Integer getLine(Event event) {
+	private int getLine(Event event) {
 		Integer line = this.line.getSingle(event);
 		if (line == null) {
-			return null;
+			return -1;
 		}
 		if (line < 1 || line > 4) {
 			error("Signs only have lines from 1 to 4, but tried to obtain line " + line);
-			return null;
+			return -1;
 		}
 		line--; // we accept 1-indexed, convert to 0-indexed
 		return line;
@@ -74,9 +74,9 @@ public class ExprSignText extends SimpleExpression<Component> {
 
 	@Override
 	protected Component[] get(Event event) {
-		Integer line = getLine(event);
-		if (line == null) {
-			return null;
+		int line = getLine(event);
+		if (line == -1) {
+			return new Component[0];
 		}
 		if (getTime() >= 0 && block.isDefault() && event instanceof SignChangeEvent signEvent && !Delay.isDelayed(event)) {
 			return new Component[]{signEvent.line(line)};
@@ -99,8 +99,8 @@ public class ExprSignText extends SimpleExpression<Component> {
 
 	@Override
 	public void change(Event event, Object @Nullable [] delta, ChangeMode mode) {
-		Integer line = getLine(event);
-		if (line == null) {
+		int line = getLine(event);
+		if (line == -1) {
 			return;
 		}
 

--- a/src/test/skript/tests/bukkit/block/sign/ExprSignText.sk
+++ b/src/test/skript/tests/bukkit/block/sign/ExprSignText.sk
@@ -1,0 +1,22 @@
+using error catching
+
+test "ExprSignText":
+	# test setting/getting
+	set {_old_block} to event-block
+	set {_old_block_below} to block below event-block
+	set block below event-block to dirt
+	set block at event-block to oak sign
+
+	loop 4 times:
+		set line loop-number of event-block to "%loop-number%"
+		assert line loop-number of event-block is "%loop-number%" with "setting line %loop-number% did not work"
+
+	set block at event-block to {_old_block}
+	set block below event-block to {_old_block_below}
+
+	# test invalid line for get/set
+	catch runtime errors:
+		set {_x} to line 0 of {_sign}
+		set line 5 of {_sign} to "5"
+	assert last caught runtime errors contains "Signs only have lines from 1 to 4, but tried to obtain line 0"
+	assert last caught runtime errors contains "Signs only have lines from 1 to 4, but tried to obtain line 5"


### PR DESCRIPTION
### Problem
As described in #8577, there is a regression in 2.15 causing signs to now be 0-indexed rather than 1-indexed.


### Solution
I added a small utility method to handle adjusting the line. I also added runtime errors for out of range inputs.

There is an additional bug fix in TypePatternElement for a log handler error that was being printed. `loopLog.printError()` was being called before `exprLog` was stopped. The solution was to simply remove the call as it will be handled in one of the `finally` blocks further down.


### Testing Completed
I added a test for getting/setting for valid/invalid inputs.


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:**
- #8577 
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
