### PR TITLE
Text parsing fixes

### DIFF
--- a/src/main/java/org/skriptlang/skript/bukkit/text/TextComponentParser.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/text/TextComponentParser.java
@@ -1,7 +1,6 @@
 package org.skriptlang.skript.bukkit.text;
 
 import ch.njol.skript.registrations.Classes;
-import ch.njol.util.StringUtils;
 import ch.njol.util.coll.CollectionUtils;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextReplacementConfig;
@@ -21,7 +20,6 @@ import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.adventure.text.minimessage.tag.standard.StandardTags;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
-import org.bukkit.ChatColor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -35,6 +33,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -118,6 +118,18 @@ public final class TextComponentParser {
 	 * For example, {@code <dark red>}.
 	 */
 	private static final Pattern MULTI_WORD_COLOR_PATTERN = Pattern.compile("(\\\\*)<([a-zA-Z]+ [a-zA-Z]+)>");
+
+	/**
+	 * A pattern for matching legacy hex codes ({@code &x&1&2&3&4&5&6}).
+	 * It also matches all preceding backslashes to determine whether the supposed tag is escaped.
+	 */
+	static final Pattern LEGACY_CODE_PATTERN = Pattern.compile("(\\\\*)([&§][a-f0-9])");
+
+	/**
+	 * A pattern for matching standard legacy codes ({@code &1}).
+	 * It also matches all preceding backslashes to determine whether the supposed tag is escaped.
+	 */
+	static final Pattern LEGACY_HEX_PATTERN = Pattern.compile("(\\\\*)([&§]x(?:[&§]x){6})");
 
 	static {
 		INSTANCE = new TextComponentParser();
@@ -444,17 +456,16 @@ public final class TextComponentParser {
 	public String reformatText(String text) {
 		// TODO improve...
 		// replace spaces with underscores for simple tags
-		text = StringUtils.replaceAll(text, MULTI_WORD_COLOR_PATTERN, matcher -> {
-			if (matcher.group(1).length() % 2 == 1) { // tag is escaped
-				return Matcher.quoteReplacement(matcher.group());
+		text = MULTI_WORD_COLOR_PATTERN.matcher(text).replaceAll(result -> {
+			if (result.group(1).length() % 2 == 1) { // tag is escaped
+				return Matcher.quoteReplacement(result.group());
 			}
-			String mappedTag = matcher.group(2).replace(" ", "_");
+			String mappedTag = result.group(2).replace(" ", "_");
 			if (simplePlaceholders.containsKey(mappedTag) || StandardTags.color().has(mappedTag)) { // only replace if it makes a valid tag
-				return Matcher.quoteReplacement(matcher.group(1) + "<" + mappedTag + ">");
+				return Matcher.quoteReplacement(result.group(1) + "<" + mappedTag + ">");
 			}
-			return Matcher.quoteReplacement(matcher.group());
+			return Matcher.quoteReplacement(result.group());
 		});
-		assert text != null;
 
 		// legacy compatibility, transform color codes into tags
 		text = TextComponentUtils.replaceLegacyFormattingCodes(text);
@@ -471,24 +482,14 @@ public final class TextComponentParser {
 	public String escape(String string) {
 		// legacy compatibility, escape color codes
 		if (string.contains("&") || string.contains("§")) {
-			StringBuilder reconstructedString = new StringBuilder();
-			char[] messageChars = string.toCharArray();
-			for (int i = 0; i < messageChars.length; i++) {
-				char current = messageChars[i];
-				char next = (i + 1 != messageChars.length) ? messageChars[i + 1] : ' ';
-				boolean isCode = (current == '&' || current == '§') && (i == 0 || messageChars[i - 1] != '\\');
-				if (isCode && next == 'x' && i + 13 <= messageChars.length) { // assume hex -> &x&1&2&3&4&5&6
-					reconstructedString.append('\\');
-					for (int i2 = i; i2 < i + 14; i2++) { // append the rest of the hex code, don't escape these symbols
-						reconstructedString.append(messageChars[i2]);
-					}
-					i += 13; // skip to the end
-				} else if (isCode && ChatColor.getByChar(next) != null) {
-					reconstructedString.append('\\');
+			Function<MatchResult, String> replacer = result -> {
+				if (result.group(1).length() % 2 == 1) { // tag is already escaped
+					return Matcher.quoteReplacement(result.group());
 				}
-				reconstructedString.append(current);
-			}
-			string = reconstructedString.toString();
+				return Matcher.quoteReplacement('\\' + result.group());
+			};
+			string = LEGACY_HEX_PATTERN.matcher(string).replaceAll(replacer);
+			string = LEGACY_CODE_PATTERN.matcher(string).replaceAll(replacer);
 		}
 		return parser.escapeTags(string);
 	}

--- a/src/main/java/org/skriptlang/skript/bukkit/text/TextComponentParser.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/text/TextComponentParser.java
@@ -118,6 +118,12 @@ public final class TextComponentParser {
 	private static final Pattern MULTI_WORD_COLOR_PATTERN = Pattern.compile("(\\\\*)<([a-zA-Z]+ [a-zA-Z]+)>");
 
 	/**
+	 * A pattern for matching double hashtag hex color tags ({@code <##123456>}).
+	 * It also matches all preceding backslashes to determine whether the supposed tag is escaped.
+	 */
+	private static final Pattern LEGACY_DOUBLE_HASHTAG_PATTERN = Pattern.compile("(\\\\*)<(##[a-f0-9]{6})>");
+
+	/**
 	 * A pattern for matching legacy hex codes ({@code &x&1&2&3&4&5&6}).
 	 * It also matches all preceding backslashes to determine whether the supposed tag is escaped.
 	 */
@@ -459,6 +465,17 @@ public final class TextComponentParser {
 			return Matcher.quoteReplacement(result.group());
 		});
 
+		text = LEGACY_DOUBLE_HASHTAG_PATTERN.matcher(text).replaceAll(result -> {
+			if (result.group(1).length() % 2 == 1) { // tag is escaped
+				return Matcher.quoteReplacement(result.group());
+			}
+			String mappedTag = result.group(2).substring(1);
+			if (StandardTags.color().has(mappedTag)) {
+				return Matcher.quoteReplacement("<" + mappedTag + ">");
+			}
+			return Matcher.quoteReplacement(result.group());
+		});
+
 		// legacy compatibility, transform color codes into tags
 		text = TextComponentUtils.replaceLegacyFormattingCodes(text);
 
@@ -481,6 +498,16 @@ public final class TextComponentParser {
 				return Matcher.quoteReplacement('\\' + result.group());
 			});
 		}
+		string = LEGACY_DOUBLE_HASHTAG_PATTERN.matcher(string).replaceAll(result -> {
+			if (result.group(1).length() % 2 == 1) { // tag is escaped
+				return Matcher.quoteReplacement(result.group());
+			}
+			String mappedTag = result.group(2).substring(1);
+			if (StandardTags.color().has(mappedTag)) {
+				return Matcher.quoteReplacement("\\<#" + mappedTag) + ">";
+			}
+			return Matcher.quoteReplacement(result.group());
+		});
 		return parser.escapeTags(string);
 	}
 

--- a/src/main/java/org/skriptlang/skript/bukkit/text/TextComponentParser.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/text/TextComponentParser.java
@@ -33,8 +33,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -124,12 +122,6 @@ public final class TextComponentParser {
 	 * It also matches all preceding backslashes to determine whether the supposed tag is escaped.
 	 */
 	static final Pattern LEGACY_CODE_PATTERN = Pattern.compile("(\\\\*)([&§][a-f0-9])");
-
-	/**
-	 * A pattern for matching standard legacy codes ({@code &1}).
-	 * It also matches all preceding backslashes to determine whether the supposed tag is escaped.
-	 */
-	static final Pattern LEGACY_HEX_PATTERN = Pattern.compile("(\\\\*)([&§]x(?:[&§]x){6})");
 
 	static {
 		INSTANCE = new TextComponentParser();
@@ -482,14 +474,12 @@ public final class TextComponentParser {
 	public String escape(String string) {
 		// legacy compatibility, escape color codes
 		if (string.contains("&") || string.contains("§")) {
-			Function<MatchResult, String> replacer = result -> {
+			string = LEGACY_CODE_PATTERN.matcher(string).replaceAll(result -> {
 				if (result.group(1).length() % 2 == 1) { // tag is already escaped
 					return Matcher.quoteReplacement(result.group());
 				}
 				return Matcher.quoteReplacement('\\' + result.group());
-			};
-			string = LEGACY_HEX_PATTERN.matcher(string).replaceAll(replacer);
-			string = LEGACY_CODE_PATTERN.matcher(string).replaceAll(replacer);
+			});
 		}
 		return parser.escapeTags(string);
 	}

--- a/src/main/java/org/skriptlang/skript/bukkit/text/TextComponentUtils.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/text/TextComponentUtils.java
@@ -13,6 +13,7 @@ import org.skriptlang.skript.lang.converter.Converters;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Matcher;
 
 /**
  * Utilities for working with {@link Component}s.
@@ -77,43 +78,42 @@ public final class TextComponentUtils {
 	 * @return Reformatted {@code text}.
 	 */
 	public static String replaceLegacyFormattingCodes(String text) {
-		char[] chars = text.toCharArray();
-		boolean hasLegacyFormatting = false;
-		for (char ch : chars) {
-			if (ch == '&' || ch == '§') {
-				hasLegacyFormatting = true;
-				break;
-			}
-		}
-		if (!hasLegacyFormatting) {
+		if (!text.contains("&") && !text.contains("§")) {
 			return text;
 		}
 
-		StringBuilder reconstructedMessage = new StringBuilder();
-		for (int i = 0; i < chars.length; i++) {
-			char current = chars[i];
-			char next = (i + 1 != chars.length) ? chars[i + 1] : ' ';
-			boolean isCode = (current == '&' || current == '§') && (i == 0 || chars[i - 1] != '\\');
-			if (isCode && next == 'x' && i + 13 <= chars.length) { // try to parse as hex -> &x&1&2&3&4&5&6
-				reconstructedMessage.append("<#");
-				for (int i2 = i + 3; i2 < i + 14; i2 += 2) { // isolate the specific numbers
-					reconstructedMessage.append(chars[i2]);
-				}
-				reconstructedMessage.append('>');
-				i += 13; // skip to the end
-			} else if (isCode) {
-				ChatColor color = ChatColor.getByChar(next);
-				if (color != null) { // this is a valid code
-					reconstructedMessage.append('<').append(color.asBungee().getName()).append('>');
-					i++; // skip to the end
-				} else { // not a valid color :(
-					reconstructedMessage.append(current);
-				}
-			} else {
-				reconstructedMessage.append(current);
+		text = TextComponentParser.LEGACY_HEX_PATTERN.matcher(text).replaceAll(result -> {
+			String backslashes = result.group(1);
+			if (backslashes.length() % 2 == 1) { // tag is escaped
+				return Matcher.quoteReplacement(result.group().substring(1));
+			} else if (!backslashes.isEmpty()) {
+				backslashes = backslashes.substring(1);
 			}
-		}
-		return reconstructedMessage.toString();
+			String hex = result.group(2);
+			StringBuilder replacement = new StringBuilder(backslashes);
+			replacement.append("<#");
+			for (int i = 3; i <= 13; i += 2) { // isolate the specific numbers
+				replacement.append(hex.charAt(i));
+			}
+			replacement.append('>');
+			return Matcher.quoteReplacement(replacement.toString());
+		});
+
+		text = TextComponentParser.LEGACY_CODE_PATTERN.matcher(text).replaceAll(result -> {
+			String backslashes = result.group(1);
+			if (backslashes.length() % 2 == 1) { // tag is escaped
+				return Matcher.quoteReplacement(result.group().substring(1));
+			} else if (!backslashes.isEmpty()) {
+				backslashes = backslashes.substring(1);
+			}
+			StringBuilder replacement = new StringBuilder(backslashes);
+			ChatColor color = ChatColor.getByChar(result.group(2).charAt(1));
+			assert color != null;
+			replacement.append('<').append(color.asBungee().getName()).append('>');
+			return Matcher.quoteReplacement(replacement.toString());
+		});
+
+		return text;
 	}
 
 	/**

--- a/src/main/java/org/skriptlang/skript/bukkit/text/TextComponentUtils.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/text/TextComponentUtils.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Utilities for working with {@link Component}s.
@@ -73,6 +74,12 @@ public final class TextComponentUtils {
 	}
 
 	/**
+	 * A pattern for matching standard legacy codes ({@code &1}).
+	 * It also matches all preceding backslashes to determine whether the supposed tag is escaped.
+	 */
+	private static final Pattern LEGACY_HEX_PATTERN = Pattern.compile("[&§]x(?:[&§][a-f0-9]){6}");
+
+	/**
 	 * Replaces all legacy formatting codes in a string with {@link net.kyori.adventure.text.minimessage.MiniMessage} equivalents.
 	 * @param text The string to reformat.
 	 * @return Reformatted {@code text}.
@@ -82,15 +89,9 @@ public final class TextComponentUtils {
 			return text;
 		}
 
-		text = TextComponentParser.LEGACY_HEX_PATTERN.matcher(text).replaceAll(result -> {
-			String backslashes = result.group(1);
-			if (backslashes.length() % 2 == 1) { // tag is escaped
-				return Matcher.quoteReplacement(result.group().substring(1));
-			} else if (!backslashes.isEmpty()) {
-				backslashes = backslashes.substring(1);
-			}
-			String hex = result.group(2);
-			StringBuilder replacement = new StringBuilder(backslashes);
+		text = LEGACY_HEX_PATTERN.matcher(text).replaceAll(result -> {
+			String hex = result.group();
+			StringBuilder replacement = new StringBuilder();
 			replacement.append("<#");
 			for (int i = 3; i <= 13; i += 2) { // isolate the specific numbers
 				replacement.append(hex.charAt(i));

--- a/src/test/java/org/skriptlang/skript/bukkit/text/TextComponentParserTest.java
+++ b/src/test/java/org/skriptlang/skript/bukkit/text/TextComponentParserTest.java
@@ -67,4 +67,11 @@ public class TextComponentParserTest {
 		assertEquals("&x\\&1\\&2\\&3\\&4\\&5\\&6hello &x", parser.escape("&x&1&2&3&4&5&6hello &x"));
 	}
 
+	@Test
+	public void testLegacyDoubleHashtag() {
+		TextComponentParser parser = new TextComponentParser();
+		assertEquals(parser.parse("<#123456>hello"), parser.parse("<##123456>hello"));
+		assertEquals("\\<##123456>hello", parser.escape("<##123456>hello"));
+	}
+
 }

--- a/src/test/java/org/skriptlang/skript/bukkit/text/TextComponentParserTest.java
+++ b/src/test/java/org/skriptlang/skript/bukkit/text/TextComponentParserTest.java
@@ -51,4 +51,20 @@ public class TextComponentParserTest {
 		assertEquals(expected, parsed);
 	}
 
+	@Test
+	public void testLegacy() {
+		TextComponentParser parser = new TextComponentParser();
+		assertEquals(parser.parse("<red>hello"), parser.parse("&chello"));
+		assertEquals(parser.parse("<#123456>hello"), parser.parse("&x&1&2&3&4&5&6hello"));
+		assertEquals(Component.text("&chello"), parser.parse("\\&chello"));
+		assertEquals(Component.text("&x&1&2&3&4&5&6hello"), parser.parse("&x\\&1\\&2\\&3\\&4\\&5\\&6hello"));
+	}
+
+	@Test
+	public void testLegacyEscaping() {
+		TextComponentParser parser = new TextComponentParser();
+		assertEquals("\\&chello", parser.escape("&chello"));
+		assertEquals("&x\\&1\\&2\\&3\\&4\\&5\\&6hello &x", parser.escape("&x&1&2&3&4&5&6hello &x"));
+	}
+
 }

--- a/src/test/java/org/skriptlang/skript/bukkit/text/TextComponentUtilsTest.java
+++ b/src/test/java/org/skriptlang/skript/bukkit/text/TextComponentUtilsTest.java
@@ -1,0 +1,22 @@
+package org.skriptlang.skript.bukkit.text;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+import static org.skriptlang.skript.bukkit.text.TextComponentUtils.replaceLegacyFormattingCodes;
+
+public class TextComponentUtilsTest {
+
+	@Test
+	public void testReplaceLegacyFormattingCodes() {
+		// validate code escaping
+		assertEquals("<red>Hello!", replaceLegacyFormattingCodes("&cHello!"));
+		assertEquals("&cHello!", replaceLegacyFormattingCodes("\\&cHello!"));
+		assertEquals("\\<red>Hello!", replaceLegacyFormattingCodes("\\\\&cHello!"));
+		assertEquals("\\\\&cHello!", replaceLegacyFormattingCodes("\\\\\\&cHello!"));
+		// validate internal metacharacter escaping
+		assertEquals("<red>You have $10", replaceLegacyFormattingCodes("&cYou have $10"));
+	}
+
+}

--- a/src/test/java/org/skriptlang/skript/bukkit/text/TextComponentUtilsTest.java
+++ b/src/test/java/org/skriptlang/skript/bukkit/text/TextComponentUtilsTest.java
@@ -15,6 +15,8 @@ public class TextComponentUtilsTest {
 		assertEquals("&cHello!", replaceLegacyFormattingCodes("\\&cHello!"));
 		assertEquals("\\<red>Hello!", replaceLegacyFormattingCodes("\\\\&cHello!"));
 		assertEquals("\\\\&cHello!", replaceLegacyFormattingCodes("\\\\\\&cHello!"));
+		assertEquals("<#123456>Hello!", replaceLegacyFormattingCodes("&x&1&2&3&4&5&6Hello!"));
+		assertEquals("<#123456><red>Hello!", replaceLegacyFormattingCodes("&x&1&2&3&4&5&6&cHello!"));
 		// validate internal metacharacter escaping
 		assertEquals("<red>You have $10", replaceLegacyFormattingCodes("&cYou have $10"));
 	}


### PR DESCRIPTION
### Problem
There are several regressions introduced by the Adventure migration:
- Double hashtag hex codes no longer work (`<##123456>`)
- Escaping behavior is very inconsistent (escape characters for legacy formatting aren't removed during parsing)

### Solution
My good friend Regular Expression has returned to bring order to the string parsing.

Unfortunately, MiniMessage does not accept tags with two leading `##` so this has to be manually handled. It is done so similarly to multi world color tags (`<dark red>`).

I've also rewritten escaping and conversion of legacy codes/hex codes. The pattern makes it easier to handle escaped tags and adds better validation to what we convert.

### Testing Completed
I added multiple JUnit regression tests.


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:**
- https://github.com/SkriptLang/Skript/issues/8566
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
