### PR TITLE
Patches for Component-related issues

### DIFF
--- a/src/main/java/ch/njol/skript/classes/Changer.java
+++ b/src/main/java/ch/njol/skript/classes/Changer.java
@@ -1,7 +1,11 @@
 package ch.njol.skript.classes;
 
+import ch.njol.skript.expressions.base.WrapperExpression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
 import com.google.common.base.Preconditions;
 import org.bukkit.event.Event;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -10,8 +14,11 @@ import ch.njol.skript.lang.Expression;
 import org.skriptlang.skript.lang.arithmetic.Arithmetics;
 import org.skriptlang.skript.lang.arithmetic.OperationInfo;
 import org.skriptlang.skript.lang.arithmetic.Operator;
+import org.skriptlang.skript.lang.converter.Converters;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 /**
@@ -82,6 +89,77 @@ public interface Changer<T> {
 			}
 
 			return acceptsChangeTypes(validTypes, types);
+		}
+
+		/**
+		 * Tests whether an expression accepts changes of a certain type.
+		 * If multiple types are given it test for whether any of the types is accepted.
+		 * This method goes further than {@link #acceptsChange(Expression, ChangeMode, Class[])} by considering
+		 *  {@link Converters} and attempting to convert {@code expression} to accept at least one of {@code types}.
+		 *
+		 * @param expression The expression to test (and potentially convert)
+		 * @param mode The ChangeMode to use in the test
+		 * @param types The types to test for
+		 * @return {@code expression} (or a conversion of it) that allows {@link #change(Object[], Object[], ChangeMode)}
+		 *  to be called with one of {@code types} (as a delta value).
+		 *  Returns {@code null} if no such conversion of {@code expression} exists.
+		 */
+		@ApiStatus.Internal
+		public static @Nullable <T> Expression<T> acceptsChangeWithConverters(@NotNull Expression<T> expression, ChangeMode mode, Class<?>... types) {
+			Class<?>[] validTypes = expression.acceptChange(mode);
+			if (validTypes == null)
+				return null;
+
+			for (int i = 0; i < validTypes.length; i++) {
+				if (validTypes[i].isArray()) {
+					validTypes[i] = validTypes[i].getComponentType();
+				}
+			}
+
+			if (acceptsChangeTypes(validTypes, types)) {
+				return expression;
+			}
+
+			for (Class<?> type : types) {
+				if (Converters.converterExists(type, validTypes)) {
+					class ChangeWrapper extends WrapperExpression<T> {
+						public ChangeWrapper(Expression<T> expression) {
+							super(expression);
+						}
+
+						@Override
+						public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+							throw new UnsupportedOperationException();
+						}
+
+						@Override
+						public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+							super.change(event, Converters.convert(delta, validTypes, Object.class), mode);
+						}
+
+						@Override
+						public <R> void changeInPlace(Event event, Function<T, R> changeFunction, boolean getAll) {
+							T[] values = getAll ? getAll(event) : getArray(event);
+							if (values.length == 0)
+								return;
+
+							List<R> newValues = new ArrayList<>();
+							for (T value : values) {
+								newValues.add(changeFunction.apply(value));
+							}
+							change(event, newValues.toArray(), ChangeMode.SET);
+						}
+
+						@Override
+						public String toString(@Nullable Event event, boolean debug) {
+							return getExpr().toString(event, debug);
+						}
+					}
+					return new ChangeWrapper(expression);
+				}
+			}
+
+			return null;
 		}
 
 		/**

--- a/src/main/java/ch/njol/skript/effects/EffReplace.java
+++ b/src/main/java/ch/njol/skript/effects/EffReplace.java
@@ -70,9 +70,13 @@ public class EffReplace extends Effect {
 		replaceFirst = parseResult.hasTag("first");
 		replaceRegex = matchedPattern == 2 || matchedPattern == 3;
 
-		if (replaceString && !ChangerUtils.acceptsChange(haystack, ChangeMode.SET, String.class)) {
-			Skript.error(haystack + " cannot be changed and can thus not have parts replaced");
-			return false;
+		if (replaceString) {
+			Expression<?> newHaystack = ChangerUtils.acceptsChangeWithConverters(haystack, ChangeMode.SET, String.class);
+			if (newHaystack == null) {
+				Skript.error(haystack.toString(null, Skript.debug()) + " cannot be changed to a text and can thus not have parts replaced");
+				return false;
+			}
+			haystack = newHaystack;
 		}
 
 		if (SkriptConfig.caseSensitive.value() || parseResult.hasTag("case")) {

--- a/src/main/java/ch/njol/skript/expressions/base/WrapperExpression.java
+++ b/src/main/java/ch/njol/skript/expressions/base/WrapperExpression.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Iterator;
 
 /**
- * Represents an expression which is a wrapper of another one. Remember to set the wrapped expression in the constructor ({@link #WrapperExpression(SimpleExpression)})
+ * Represents an expression which is a wrapper of another one. Remember to set the wrapped expression in the constructor ({@link #WrapperExpression(Expression)})
  * or with {@link #setExpr(Expression)} in {@link SyntaxElement#init(Expression[], int, Kleenean, ParseResult) init()}.<br/>
  * If you override {@link #get(Event)} you must override {@link #iterator(Event)} as well.
  * 
@@ -27,7 +27,7 @@ public abstract class WrapperExpression<T> extends SimpleExpression<T> {
 	@SuppressWarnings("null")
 	protected WrapperExpression() {}
 
-	public WrapperExpression(SimpleExpression<? extends T> expr) {
+	public WrapperExpression(Expression<? extends T> expr) {
 		this.expr = expr;
 	}
 

--- a/src/main/java/ch/njol/skript/util/slot/InventorySlot.java
+++ b/src/main/java/ch/njol/skript/util/slot/InventorySlot.java
@@ -58,7 +58,7 @@ public class InventorySlot extends SlotWithIndex {
 		if (index == -999) //Non-existent slot, e.g. Outside GUI
 			return null;
 		ItemStack item = inventory.getItem(index);
-		return item == null  ? new ItemStack(Material.AIR, 1) : item.clone();
+		return item == null  ? new ItemStack(Material.AIR, 1) : item;
 	}
 
 	@Override

--- a/src/main/java/org/skriptlang/skript/bukkit/text/TextModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/text/TextModule.java
@@ -21,7 +21,7 @@ public class TextModule extends HierarchicalAddonModule {
 
 	@Override
 	public void initSelf(SkriptAddon addon) {
-		Classes.registerClass(new TextComponentClassInfo());
+		Classes.registerClass(new TextComponentClassInfo(addon));
 		Classes.registerClass(new AudienceClassInfo());
 
 		Converters.registerConverter(String.class, Component.class,

--- a/src/main/java/org/skriptlang/skript/bukkit/text/types/TextComponentClassInfo.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/text/types/TextComponentClassInfo.java
@@ -1,9 +1,11 @@
 package org.skriptlang.skript.bukkit.text.types;
 
+import ch.njol.skript.SkriptConfig;
 import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.classes.Parser;
 import ch.njol.skript.classes.Serializer;
 import ch.njol.skript.lang.ParseContext;
+import ch.njol.util.StringUtils;
 import ch.njol.yggdrasil.Fields;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.json.JSONComponentSerializer;
@@ -35,7 +37,7 @@ public final class TextComponentClassInfo extends ClassInfo<Component> {
 					@Override
 					public boolean contains(Component container, Component element) {
 						var parser = org.skriptlang.skript.bukkit.text.TextComponentParser.instance();
-						return parser.toString(container).contains(parser.toString(element));
+						return StringUtils.contains(parser.toString(container), parser.toString(element), SkriptConfig.caseSensitive.value());
 					}
 
 					@Override

--- a/src/main/java/org/skriptlang/skript/bukkit/text/types/TextComponentClassInfo.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/text/types/TextComponentClassInfo.java
@@ -8,13 +8,17 @@ import ch.njol.yggdrasil.Fields;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.json.JSONComponentSerializer;
 import org.jetbrains.annotations.ApiStatus;
+import org.skriptlang.skript.addon.SkriptAddon;
+import org.skriptlang.skript.bukkit.text.TextComponentParser;
+import org.skriptlang.skript.lang.properties.Property;
+import org.skriptlang.skript.lang.properties.handlers.ContainsHandler;
 
 import java.io.StreamCorruptedException;
 
 @ApiStatus.Internal
 public final class TextComponentClassInfo extends ClassInfo<Component> {
 
-	public TextComponentClassInfo() {
+	public TextComponentClassInfo(SkriptAddon addon) {
 		super(Component.class, "textcomponent");
 		this.user("text ?components?")
 			.name("Text Component")
@@ -23,7 +27,24 @@ public final class TextComponentClassInfo extends ClassInfo<Component> {
 			.examples("\"<red><bold>This text is red and bold!\"")
 			.since("2.15")
 			.parser(new TextComponentParser())
-			.serializer(new TextComponentSerializer());
+			.serializer(new TextComponentSerializer())
+			.property(Property.CONTAINS,
+				"Components can contain other components.",
+				addon,
+				new ContainsHandler<Component, Component>() {
+					@Override
+					public boolean contains(Component container, Component element) {
+						var parser = org.skriptlang.skript.bukkit.text.TextComponentParser.instance();
+						return parser.toString(container).contains(parser.toString(element));
+					}
+
+					@Override
+					public Class<? extends Component>[] elementTypes() {
+						//noinspection unchecked
+						return new Class[]{Component.class};
+					}
+				}
+			);
 	}
 
 	private static final class TextComponentParser extends Parser<Component> {

--- a/src/test/skript/tests/bukkit/TextModule.sk
+++ b/src/test/skript/tests/bukkit/TextModule.sk
@@ -6,3 +6,7 @@ test "component serialization":
 	parse:
 		set {x} to line 1 of lore of {_item}
 	assert last parse logs are not set
+
+test "component contains":
+	set {_item} to a dirt block with lore "<red>Hello world!"
+	assert last element of lore of {_item} contains "<red>Hello"

--- a/src/test/skript/tests/regressions/8584-adding lore to slot.sk
+++ b/src/test/skript/tests/regressions/8584-adding lore to slot.sk
@@ -1,0 +1,5 @@
+test "regression 8584 - adding lore to slot":
+	set {_inv} to a new chest inventory named "Testing Chest"
+	set slot 0 of {_inv} to a book
+	add "Hello world!" to lore of (slot 0 of {_inv})
+	assert lore of (slot 0 of {_inv}) is "Hello world!"

--- a/src/test/skript/tests/regressions/8599-using string based operations on component syntaxes.sk
+++ b/src/test/skript/tests/regressions/8599-using string based operations on component syntaxes.sk
@@ -1,0 +1,4 @@
+test "regression 8599 - using string based operations on component syntaxes":
+	set {_item} to a dirt block named "Dirty Dirt"
+	replace all "Dirt" with "Dirty Dirt" in the name of {_item}
+	assert the name of {_item} is "Dirty Dirty Dirty Dirt"


### PR DESCRIPTION
### Problem
There are several regressions related to 2.15's Adventure migration, specifically around String/Component syntaxes.


### Solution
1. Fixes an issue where contains behavior was lost. Solution was for Component to support CONTAINS property. String-based comparison approach seems kind of sketchy, but also is currently popular. Might be worth discussing different handling in the future.
2. Fixes (some) Slots not working with ExprLore. InventorySlot currently clones the ItemStack returned by `getItem()`. This is the **only** slot implementation to do this. It has been like this since it was created (13 years ago). I have removed this - we can see whether any issues pop up.
3. Adds slightly questionable support for Component-based expressions to EffReplace through conversion support for the haystack expression. API method is internal for now, as I'm a bit unsure about this approach. I think it would be better for EffReplace to make use of the Property API, but that is a far more intensive solution. This one should work "good enough" for now.


### Testing Completed
Added a test for each fix.


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:**
- https://github.com/SkriptLang/Skript/issues/8584
- https://github.com/SkriptLang/Skript/issues/8599
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
