### PR TITLE
Fix ExprHash internal error when MD5 is used

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprHash.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHash.java
@@ -51,11 +51,8 @@ public class ExprHash extends PropertyExpression<String, String> {
 		String algorithm = parseResult.tags.get(0).toUpperCase(Locale.ENGLISH);
 		try {
 			digest = MessageDigest.getInstance(algorithm);
-			if (algorithm.equals("MD5")) {
-				try {
-					if (!getParser().getCurrentScript().suppressesWarning(ScriptWarning.DEPRECATED_SYNTAX))
-						Skript.warning("MD5 is not secure and shouldn't be used if a cryptographically secure hashing algorithm is required.");
-				} catch (Exception e) {}
+			if (algorithm.equals("MD5") && getParser().isActive() && !getParser().getCurrentScript().suppressesWarning(ScriptWarning.DEPRECATED_SYNTAX)) {
+				Skript.warning("MD5 is not secure and shouldn't be used if a cryptographically secure hashing algorithm is required.");
 			}
 			return true;
 		} catch (NoSuchAlgorithmException e) {

--- a/src/main/java/ch/njol/skript/expressions/ExprHash.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHash.java
@@ -7,6 +7,7 @@ import java.util.HexFormat;
 import java.util.Locale;
 
 import ch.njol.skript.doc.*;
+import ch.njol.skript.lang.parser.ParserInstance;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 
@@ -51,7 +52,8 @@ public class ExprHash extends PropertyExpression<String, String> {
 		String algorithm = parseResult.tags.get(0).toUpperCase(Locale.ENGLISH);
 		try {
 			digest = MessageDigest.getInstance(algorithm);
-			if (algorithm.equals("MD5") && getParser().isActive() && !getParser().getCurrentScript().suppressesWarning(ScriptWarning.DEPRECATED_SYNTAX)) {
+			ParserInstance parser = getParser();
+			if (algorithm.equals("MD5") && parser.isActive() && !parser.getCurrentScript().suppressesWarning(ScriptWarning.DEPRECATED_SYNTAX)) {
 				Skript.warning("MD5 is not secure and shouldn't be used if a cryptographically secure hashing algorithm is required.");
 			}
 			return true;

--- a/src/main/java/ch/njol/skript/expressions/ExprHash.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHash.java
@@ -51,8 +51,11 @@ public class ExprHash extends PropertyExpression<String, String> {
 		String algorithm = parseResult.tags.get(0).toUpperCase(Locale.ENGLISH);
 		try {
 			digest = MessageDigest.getInstance(algorithm);
-			if (algorithm.equals("MD5") && !getParser().getCurrentScript().suppressesWarning(ScriptWarning.DEPRECATED_SYNTAX)) {
-				Skript.warning("MD5 is not secure and shouldn't be used if a cryptographically secure hashing algorithm is required.");
+			if (algorithm.equals("MD5")) {
+				try {
+					if (!getParser().getCurrentScript().suppressesWarning(ScriptWarning.DEPRECATED_SYNTAX))
+						Skript.warning("MD5 is not secure and shouldn't be used if a cryptographically secure hashing algorithm is required.");
+				} catch (Exception e) {}
 			}
 			return true;
 		} catch (NoSuchAlgorithmException e) {


### PR DESCRIPTION
Added exception handling for MD5 warning suppression.

### Problem
https://github.com/SkriptLang/Skript/issues/8474 (Error was caused by trying to give the warning, regards with @bluelhf)


### Solution
Adopted the recommended fix by @APickledWalrus https://github.com/SkriptLang/Skript/issues/8474#issuecomment-3988702580


### Testing Completed
<img width="595" height="166" alt="image" src="https://github.com/user-attachments/assets/b10547e9-678c-45c1-866a-3fc710014224" />



### Supporting Information


---
**Completes:** https://github.com/SkriptLang/Skript/issues/8474
**Related:** none
**AI assistance:** none
