### PR TITLE
Warn for duplicate event value registration

### DIFF
--- a/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValueRegistryImpl.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValueRegistryImpl.java
@@ -32,7 +32,7 @@ final class EventValueRegistryImpl implements EventValueRegistry {
 		if (eventValue instanceof ConvertedEventValue)
 			throw new SkriptAPIException("Cannot register a converted event value: " + eventValue);
 		if (isRegistered(eventValue))
-			throw new SkriptAPIException(eventValue + " is already registered");
+			Skript.warning(eventValue + " is already registered.");
 		List<EventValue<?, ?>> eventValues = eventValues(eventValue.time());
 		eventValues.add(eventValue);
 		eventValuesCache.clear();

--- a/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValueRegistryImpl.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValueRegistryImpl.java
@@ -31,8 +31,10 @@ final class EventValueRegistryImpl implements EventValueRegistry {
 		Preconditions.checkNotNull(eventValue, "eventValue");
 		if (eventValue instanceof ConvertedEventValue)
 			throw new SkriptAPIException("Cannot register a converted event value: " + eventValue);
-		if (isRegistered(eventValue))
+		if (isRegistered(eventValue)) {
 			Skript.warning(eventValue + " is already registered.");
+			return;
+		}
 		List<EventValue<?, ?>> eventValues = eventValues(eventValue.time());
 		eventValues.add(eventValue);
 		eventValuesCache.clear();


### PR DESCRIPTION
### Problem
Attempting to register an already registered event value, would throw an exception, breaking backwards compatibility with several addons. This issue is more prominent than I anticipated when I made the event value registry.

### Solution
Replace the exception with a warning and skip registration

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
