### PR TITLE
Fix legacy formatting code support

### DIFF
--- a/src/main/java/ch/njol/skript/command/Commands.java
+++ b/src/main/java/ch/njol/skript/command/Commands.java
@@ -181,23 +181,25 @@ public abstract class Commands {
 				Effect effect = Effect.parse(command, null);
 				parserInstance.deleteCurrentEvent();
 
+				TextComponentParser textParser = TextComponentParser.instance();
 				if (effect != null) {
 					log.clear(); // ignore warnings and stuff
 					log.printLog();
 					if (!effectCommand.isCancelled()) {
-						sender.sendRichMessage("<gray>Executing '" + TextComponentParser.instance().escape(command) + "'");
+						sender.sendMessage(textParser.parse("<gray>Executing '" + textParser.escape(command) + "'"));
 						if (SkriptConfig.logEffectCommands.value() && !(sender instanceof ConsoleCommandSender))
-							Skript.info(sender.getName() + " issued effect command: " + TextComponentParser.instance().escape(command));
+							Skript.info(sender.getName() + " issued effect command: " + textParser.escape(command));
 						TriggerItem.walk(effect, effectCommand);
 						Variables.removeLocals(effectCommand);
 					} else {
-						sender.sendRichMessage("<red>Your effect command '" + TextComponentParser.instance().escape(command) + "' was cancelled.");
+						sender.sendMessage(textParser.parse("<red>Your effect command '" + textParser.escape(command) + "' was cancelled."));
 					}
 				} else {
 					if (sender == Bukkit.getConsoleSender()) // log as SEVERE instead of INFO like printErrors below
-						SkriptLogger.LOGGER.severe("Error in: " + TextComponentParser.instance().escape(command));
+						// No need to escape command here, logger will do it
+						SkriptLogger.LOGGER.severe("Error in: " + command);
 					else
-						sender.sendRichMessage("<red>Error in: <gray>" + TextComponentParser.instance().escape(command));
+						sender.sendMessage(textParser.parse("<red>Error in: <gray>" + textParser.escape(command)));
 					// TODO errors likely need to be escaped too
 					log.printErrors(sender, "(No specific information is available)");
 				}

--- a/src/main/java/org/skriptlang/skript/bukkit/text/TextComponentParser.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/text/TextComponentParser.java
@@ -127,7 +127,7 @@ public final class TextComponentParser {
 	 * A pattern for matching legacy hex codes ({@code &x&1&2&3&4&5&6}).
 	 * It also matches all preceding backslashes to determine whether the supposed tag is escaped.
 	 */
-	static final Pattern LEGACY_CODE_PATTERN = Pattern.compile("(\\\\*)([&§][a-f0-9])");
+	static final Pattern LEGACY_CODE_PATTERN = Pattern.compile("(\\\\*)([&§][a-f0-9klomnr])");
 
 	static {
 		INSTANCE = new TextComponentParser();

--- a/src/test/java/org/skriptlang/skript/bukkit/text/TextComponentParserTest.java
+++ b/src/test/java/org/skriptlang/skript/bukkit/text/TextComponentParserTest.java
@@ -4,6 +4,8 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.ChatColor;
 import org.junit.Test;
 
 import java.util.Set;
@@ -58,6 +60,12 @@ public class TextComponentParserTest {
 		assertEquals(parser.parse("<#123456>hello"), parser.parse("&x&1&2&3&4&5&6hello"));
 		assertEquals(Component.text("&chello"), parser.parse("\\&chello"));
 		assertEquals(Component.text("&x&1&2&3&4&5&6hello"), parser.parse("&x\\&1\\&2\\&3\\&4\\&5\\&6hello"));
+
+		//noinspection deprecation - yes i know
+		for (ChatColor color : ChatColor.values()) {
+			String message = "&" + color.getChar() + "hello";
+			assertEquals(LegacyComponentSerializer.legacyAmpersand().deserialize(message), parser.parse(message));
+		}
 	}
 
 	@Test


### PR DESCRIPTION
### Problem
#8589 broke support for legacy formatting codes (&l, &o, etc). I forgot to include them in the regular expression.

### Solution
Adds them to the regular expression.
Also fixes an issue with invalid escaping in effect command messages.


### Testing Completed
Added at test to verify that all legacy codes parse.

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
