### PR TITLE
Deprecate boolean expressions

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprAI.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprAI.java
@@ -1,5 +1,9 @@
 package ch.njol.skript.expressions;
 
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
@@ -16,10 +20,17 @@ import ch.njol.util.coll.CollectionUtils;
 @Description("Returns whether an entity has AI.")
 @Example("set artificial intelligence of target entity to false")
 @Since("2.5")
+@Deprecated(since = "INSERT VERSION", forRemoval = true)
 public class ExprAI extends SimplePropertyExpression<LivingEntity, Boolean> {
 	
 	static {
 		register(ExprAI.class, Boolean.class, "(ai|artificial intelligence)", "livingentities");
+	}
+
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+        Skript.warning("This expression is deprecated. Consider using the AI effect instead.");
+		return super.init(expressions, matchedPattern, isDelayed, parseResult);
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprGlowing.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprGlowing.java
@@ -1,5 +1,9 @@
 package ch.njol.skript.expressions;
 
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
@@ -15,10 +19,17 @@ import ch.njol.skript.expressions.base.SimplePropertyExpression;
 @Description("Indicates if targeted entity is glowing (new 1.9 effect) or not. Glowing entities can be seen through walls.")
 @Example("set glowing of player to true")
 @Since("2.2-dev18")
+@Deprecated(since = "INSERT VERSION", forRemoval = true)
 public class ExprGlowing extends SimplePropertyExpression<Entity, Boolean> {
 	
 	static {
 		register(ExprGlowing.class, Boolean.class, "glowing", "entities");
+	}
+
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+        Skript.warning("This expression is deprecated. Consider using the glowing effect instead.");
+		return super.init(expressions, matchedPattern, isDelayed, parseResult);
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprGravity.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprGravity.java
@@ -1,5 +1,8 @@
 package ch.njol.skript.expressions;
 
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
@@ -16,10 +19,17 @@ import ch.njol.skript.expressions.base.SimplePropertyExpression;
 @Description("If entity is affected by gravity or not, i.e. if it has Minecraft 1.10+ NoGravity flag.")
 @Example("set gravity of player off")
 @Since("2.2-dev21")
+@Deprecated(since = "INSERT VERSION", forRemoval = true)
 public class ExprGravity extends SimplePropertyExpression<Entity, Boolean> {
 	
 	static {
 		register(ExprGravity.class, Boolean.class, "gravity", "entities");
+	}
+
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+        Skript.warning("This expression is deprecated. Consider using the gravity effect instead.");
+		return super.init(expressions, matchedPattern, isDelayed, parseResult);
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprProjectileCriticalState.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprProjectileCriticalState.java
@@ -1,5 +1,8 @@
 package ch.njol.skript.expressions;
 
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
 import org.bukkit.entity.AbstractArrow;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Projectile;
@@ -23,12 +26,19 @@ import ch.njol.util.coll.CollectionUtils;
 		set projectile critical mode of event-projectile to true
 	""")
 @Since("2.5.1")
+@Deprecated(since = "INSERT VERSION", forRemoval = true)
 public class ExprProjectileCriticalState extends SimplePropertyExpression<Projectile, Boolean> {
 	
 	private static final boolean abstractArrowExists = Skript.classExists("org.bukkit.entity.AbstractArrow");
 	
 	static {
 		register(ExprProjectileCriticalState.class, Boolean.class, "(projectile|arrow) critical (state|ability|mode)", "projectiles");
+	}
+
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+        Skript.warning("This expression is deprecated. Consider using the projectile critical state effect instead.");
+		return super.init(expressions, matchedPattern, isDelayed, parseResult);
 	}
 	
 	@Nullable

--- a/src/main/java/org/skriptlang/skript/bukkit/entity/EntityModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/entity/EntityModule.java
@@ -7,6 +7,12 @@ import org.skriptlang.skript.addon.AddonModule;
 import org.skriptlang.skript.addon.HierarchicalAddonModule;
 import org.skriptlang.skript.addon.SkriptAddon;
 import org.skriptlang.skript.bukkit.entity.displays.DisplayModule;
+import org.skriptlang.skript.bukkit.entity.elements.conditions.CondIsGlowing;
+import org.skriptlang.skript.bukkit.entity.elements.conditions.CondProjectileIsCritical;
+import org.skriptlang.skript.bukkit.entity.elements.effects.EffAI;
+import org.skriptlang.skript.bukkit.entity.elements.effects.EffGlowing;
+import org.skriptlang.skript.bukkit.entity.elements.effects.EffGravity;
+import org.skriptlang.skript.bukkit.entity.elements.effects.EffProjectileCriticalState;
 import org.skriptlang.skript.bukkit.entity.interactions.InteractionModule;
 import org.skriptlang.skript.bukkit.entity.elements.expressions.ExprDeathMessage;
 import org.skriptlang.skript.bukkit.entity.entitydata.NautilusData;
@@ -38,6 +44,14 @@ public class EntityModule extends HierarchicalAddonModule {
 		}
 
 		register(addon,
+			CondIsGlowing::register,
+			CondProjectileIsCritical::register,
+
+			EffAI::register,
+			EffGlowing::register,
+			EffGravity::register,
+			EffProjectileCriticalState::register,
+
 			ExprDeathMessage::register
 		);
 	}

--- a/src/main/java/org/skriptlang/skript/bukkit/entity/elements/conditions/CondIsGlowing.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/entity/elements/conditions/CondIsGlowing.java
@@ -1,0 +1,45 @@
+package org.skriptlang.skript.bukkit.entity.elements.conditions;
+
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.doc.*;
+import org.bukkit.entity.Entity;
+import org.skriptlang.skript.registration.SyntaxRegistry;
+
+@Name("Is Glowing")
+@Description("Checks whether or not a living entity is glowing.")
+@Example("""
+	command /glow:
+		trigger:
+			if player is glowing:
+				make player stop glowing
+			else:
+				make player glow
+	""")
+@Since("INSERT VERSION")
+public class CondIsGlowing extends PropertyCondition<Entity> {
+
+	public static void register(SyntaxRegistry registry) {
+		registry.register(
+			SyntaxRegistry.CONDITION,
+			infoBuilder(
+				CondIsGlowing.class,
+				PropertyType.BE,
+				"glowing",
+				"entities"
+			)
+				.supplier(CondIsGlowing::new)
+				.build()
+		);
+	}
+
+	@Override
+	public boolean check(Entity entity) {
+		return entity.isGlowing();
+	}
+
+	@Override
+	protected String getPropertyName() {
+		return "glowing";
+	}
+
+}

--- a/src/main/java/org/skriptlang/skript/bukkit/entity/elements/conditions/CondProjectileIsCritical.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/entity/elements/conditions/CondProjectileIsCritical.java
@@ -1,0 +1,58 @@
+package org.skriptlang.skript.bukkit.entity.elements.conditions;
+
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Example;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
+import org.bukkit.entity.AbstractArrow;
+import org.bukkit.entity.Projectile;
+import org.skriptlang.skript.log.runtime.RuntimeErrorProducer;
+import org.skriptlang.skript.registration.SyntaxInfo;
+import org.skriptlang.skript.registration.SyntaxRegistry;
+
+@Name("Projectile Is Critical")
+@Description("Checks whether or not a projectile is in critical state. As of now this only applies to arrows and tridents.")
+@Example("""
+	on shoot:
+		if event-projectile is not in projectile critical state:
+			enable projectile critical state of event-projectile
+	""")
+@Since("INSERT VERSION")
+public class CondProjectileIsCritical extends PropertyCondition<Projectile> implements RuntimeErrorProducer {
+
+	public static void register(SyntaxRegistry registry) {
+		registry.register(
+			SyntaxRegistry.CONDITION,
+			SyntaxInfo.builder(CondProjectileIsCritical.class)
+				.addPatterns(
+					"%projectile% is in (projectile|arrow) critical (state|mode)",
+					"%projectile% (is not|isn't) in (projectile|arrow) critical (state|mode)")
+				.supplier(CondProjectileIsCritical::new)
+				.build()
+		);
+	}
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		setNegated(matchedPattern == 1);
+		return super.init(exprs, matchedPattern, isDelayed, parseResult);
+	}
+
+	@Override
+	public boolean check(Projectile projectile) {
+		if (projectile instanceof AbstractArrow abstractArrow) {
+			return abstractArrow.isCritical();
+		}
+		warning("This projectile is not supported. This only applies to arrows and tridents.");
+		return false;
+	}
+
+	protected String getPropertyName() {
+		return "projectile critical state";
+	}
+
+}

--- a/src/main/java/org/skriptlang/skript/bukkit/entity/elements/effects/EffAI.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/entity/elements/effects/EffAI.java
@@ -1,0 +1,65 @@
+package org.skriptlang.skript.bukkit.entity.elements.effects;
+
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Example;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SyntaxStringBuilder;
+import ch.njol.util.Kleenean;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.registration.SyntaxInfo;
+import org.skriptlang.skript.registration.SyntaxRegistry;
+
+@Name("Entity AI")
+@Description("Change whether an entity has AI.")
+@Example("enable artificial intelligence of target entity")
+@Example("disable ai of last spawned entity")
+@Since("INSERT VERSION")
+public class EffAI extends Effect {
+
+	public static void register(SyntaxRegistry registry) {
+		registry.register(
+			SyntaxRegistry.EFFECT,
+			SyntaxInfo.builder(EffAI.class)
+				.addPatterns(
+					"(enable|:disable) (ai|artificial intelligence) of %livingentities%",
+					"(enable|:disable) %livingentities%'s (ai|artificial intelligence)"
+				)
+				.supplier(EffAI::new)
+				.build()
+		);
+	}
+
+	private Expression<LivingEntity> entities;
+	private boolean negated;
+
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		//noinspection unchecked
+		entities = (Expression<LivingEntity>) expressions[0];
+		negated = parseResult.hasTag("disable");
+		return true;
+	}
+
+	@Override
+	protected void execute(Event event) {
+		for (LivingEntity entity : entities.getArray(event)) {
+			entity.setAI(!negated);
+		}
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return new SyntaxStringBuilder(event, debug)
+			.appendIf(!negated, "enable")
+			.appendIf(negated, "disable")
+			.append("ai of", entities)
+			.toString();
+	}
+
+}

--- a/src/main/java/org/skriptlang/skript/bukkit/entity/elements/effects/EffGlowing.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/entity/elements/effects/EffGlowing.java
@@ -1,0 +1,65 @@
+package org.skriptlang.skript.bukkit.entity.elements.effects;
+
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Example;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SyntaxStringBuilder;
+import ch.njol.util.Kleenean;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.registration.SyntaxInfo;
+import org.skriptlang.skript.registration.SyntaxRegistry;
+
+@Name("Entity Glow")
+@Description("Change whether an entity is glowing.")
+@Example("make target entity glow")
+@Example("make player stop glowing")
+@Since("INSERT VERSION")
+public class EffGlowing extends Effect {
+
+	public static void register(SyntaxRegistry registry) {
+		registry.register(
+			SyntaxRegistry.EFFECT,
+			SyntaxInfo.builder(EffGlowing.class)
+				.addPatterns(
+					"make %entities% [negate:not] glow",
+					"make %entities% (negate:stop|start) glowing"
+				)
+				.supplier(EffGlowing::new)
+				.build()
+		);
+	}
+
+	private Expression<LivingEntity> entities;
+	private boolean negated;
+
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		//noinspection unchecked
+		entities = (Expression<LivingEntity>) expressions[0];
+		negated = parseResult.hasTag("negate");
+		return true;
+	}
+
+	@Override
+	protected void execute(Event event) {
+		for (LivingEntity entity : entities.getArray(event)) {
+			entity.setGlowing(!negated);
+		}
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return new SyntaxStringBuilder(event, debug)
+			.append("make", entities)
+			.appendIf(negated, "not")
+			.append("glow")
+			.toString();
+	}
+
+}

--- a/src/main/java/org/skriptlang/skript/bukkit/entity/elements/effects/EffGravity.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/entity/elements/effects/EffGravity.java
@@ -1,0 +1,65 @@
+package org.skriptlang.skript.bukkit.entity.elements.effects;
+
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Example;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SyntaxStringBuilder;
+import ch.njol.util.Kleenean;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.registration.SyntaxInfo;
+import org.skriptlang.skript.registration.SyntaxRegistry;
+
+@Name("Entity Gravity")
+@Description("Change whether an entity is affected by gravity.")
+@Example("enable gravity of target entity")
+@Example("disable last spawned entity's gravity")
+@Since("INSERT VERSION")
+public class EffGravity extends Effect {
+
+	public static void register(SyntaxRegistry registry) {
+		registry.register(
+			SyntaxRegistry.EFFECT,
+			SyntaxInfo.builder(EffGravity.class)
+				.addPatterns(
+					"(enable|:disable) (gravity) of %entities%",
+					"(enable|:disable) %entities%'s (gravity)"
+				)
+				.supplier(EffGravity::new)
+				.build()
+		);
+	}
+
+	private Expression<LivingEntity> entities;
+	private boolean negated;
+
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		//noinspection unchecked
+		entities = (Expression<LivingEntity>) expressions[0];
+		negated = parseResult.hasTag("disable");
+		return true;
+	}
+
+	@Override
+	protected void execute(Event event) {
+		for (LivingEntity entity : entities.getArray(event)) {
+			entity.setGravity(!negated);
+		}
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return new SyntaxStringBuilder(event, debug)
+			.appendIf(!negated, "enable")
+			.appendIf(negated, "disable")
+			.append("gravity of", entities)
+			.toString();
+	}
+
+}

--- a/src/main/java/org/skriptlang/skript/bukkit/entity/elements/effects/EffGravity.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/entity/elements/effects/EffGravity.java
@@ -9,7 +9,7 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.SyntaxStringBuilder;
 import ch.njol.util.Kleenean;
-import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.registration.SyntaxInfo;
@@ -35,20 +35,20 @@ public class EffGravity extends Effect {
 		);
 	}
 
-	private Expression<LivingEntity> entities;
+	private Expression<Entity> entities;
 	private boolean negated;
 
 	@Override
 	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
 		//noinspection unchecked
-		entities = (Expression<LivingEntity>) expressions[0];
+		entities = (Expression<Entity>) expressions[0];
 		negated = parseResult.hasTag("disable");
 		return true;
 	}
 
 	@Override
 	protected void execute(Event event) {
-		for (LivingEntity entity : entities.getArray(event)) {
+		for (Entity entity : entities.getArray(event)) {
 			entity.setGravity(!negated);
 		}
 	}

--- a/src/main/java/org/skriptlang/skript/bukkit/entity/elements/effects/EffProjectileCriticalState.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/entity/elements/effects/EffProjectileCriticalState.java
@@ -1,0 +1,70 @@
+package org.skriptlang.skript.bukkit.entity.elements.effects;
+
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Example;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SyntaxStringBuilder;
+import ch.njol.util.Kleenean;
+import org.bukkit.entity.AbstractArrow;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.registration.SyntaxInfo;
+import org.skriptlang.skript.registration.SyntaxRegistry;
+
+@Name("Projectile Critical State")
+@Description("Change whether a projectile is in its critical state. As of now this only applies to arrows and tridents.")
+@Example("""
+	on shoot:
+		enable projectile critical state of event-projectile
+	""")
+@Since("INSERT VERSION")
+public class EffProjectileCriticalState extends Effect {
+
+	public static void register(SyntaxRegistry registry) {
+		registry.register(
+			SyntaxRegistry.EFFECT,
+			SyntaxInfo.builder(EffProjectileCriticalState.class)
+				.addPatterns(
+					"(enable|:disable) (projectile|arrow) critical (state|mode) of %projectiles%",
+					"(enable|:disable) %projectiles%'s (projectile|arrow) critical (state|mode)"
+				)
+				.supplier(EffProjectileCriticalState::new)
+				.build()
+		);
+	}
+
+	private Expression<Projectile> projectiles;
+	private boolean negated;
+
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		//noinspection unchecked
+		projectiles = (Expression<Projectile>) expressions[0];
+		negated = parseResult.hasTag("disable");
+		return true;
+	}
+
+	@Override
+	protected void execute(Event event) {
+		for (Projectile projectile : projectiles.getArray(event)) {
+			if (projectile instanceof AbstractArrow abstractArrow) {
+				abstractArrow.setCritical(!negated);
+			}
+		}
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return new SyntaxStringBuilder(event, debug)
+			.appendIf(!negated, "enable")
+			.appendIf(negated, "disable")
+			.append("projectile critical state", projectiles)
+			.toString();
+	}
+
+}

--- a/src/main/java/org/skriptlang/skript/bukkit/entity/elements/effects/EffProjectileCriticalState.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/entity/elements/effects/EffProjectileCriticalState.java
@@ -13,6 +13,7 @@ import org.bukkit.entity.AbstractArrow;
 import org.bukkit.entity.Projectile;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.log.runtime.RuntimeErrorProducer;
 import org.skriptlang.skript.registration.SyntaxInfo;
 import org.skriptlang.skript.registration.SyntaxRegistry;
 
@@ -23,7 +24,7 @@ import org.skriptlang.skript.registration.SyntaxRegistry;
 		enable projectile critical state of event-projectile
 	""")
 @Since("INSERT VERSION")
-public class EffProjectileCriticalState extends Effect {
+public class EffProjectileCriticalState extends Effect implements RuntimeErrorProducer {
 
 	public static void register(SyntaxRegistry registry) {
 		registry.register(
@@ -54,6 +55,8 @@ public class EffProjectileCriticalState extends Effect {
 		for (Projectile projectile : projectiles.getArray(event)) {
 			if (projectile instanceof AbstractArrow abstractArrow) {
 				abstractArrow.setCritical(!negated);
+			} else {
+				warning("This projectile is not supported. This only applies to arrows and tridents.");
 			}
 		}
 	}


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
We have moved away from Boolean Expressions in favor of effect+condition pairs.

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
I looked through the expressions to find boolean expressions which could be deprecated and replaced. I then created effects and conditions to replace the functionality of the deprecated expressions.

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
Tests will be coming soon. I wanted to get opinions on the rest of the code first.

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->

- ExprAI: Created effect
- ExprFlightMode: Already has effect + condition
- ExprGlidingState: #8588 
- ExprGlowing: Created effect and condition
- ExprGravity: Created effect
- ExprProjectileCriticalState: Creates effect + condition

Please let me know if I missed any or if some of these don't count. 

---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
