### PR TITLE
Initial work on inner PDC  support

### DIFF
--- a/src/main/java/org/skriptlang/skript/bukkit/pdc/PDCModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/pdc/PDCModule.java
@@ -25,7 +25,8 @@ public class PDCModule extends HierarchicalAddonModule {
 	@Override
 	protected void initSelf(SkriptAddon addon) {
 		Classes.registerClass(new ClassInfo<>(PersistentDataContainer.class, "persistentdatacontainer")
-			.user("persistent ?data ?containers?") // TODO possible "pdc" option?!?!?
+			.user("(?:persistent ?)data ?container|pdc")
+			.name("Persistent Data Container")
 			.parser(new Parser<>() {
 				@Override
 				public boolean canParse(ParseContext context) {

--- a/src/main/java/org/skriptlang/skript/bukkit/pdc/PDCModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/pdc/PDCModule.java
@@ -1,12 +1,20 @@
 package org.skriptlang.skript.bukkit.pdc;
 
+import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.classes.Parser;
+import ch.njol.skript.lang.ParseContext;
+import ch.njol.skript.registrations.Classes;
+import org.bukkit.persistence.PersistentDataContainer;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.addon.AddonModule;
 import org.skriptlang.skript.addon.HierarchicalAddonModule;
 import org.skriptlang.skript.addon.SkriptAddon;
+import org.skriptlang.skript.bukkit.pdc.elements.SecEditContainer;
 import org.skriptlang.skript.bukkit.pdc.elements.conditions.CondHasPersistentDataTag;
 import org.skriptlang.skript.bukkit.pdc.elements.expressions.ExprAllPersistentDataKeys;
 import org.skriptlang.skript.bukkit.pdc.elements.expressions.ExprPersistentData;
+
+import java.io.IOException;
 
 public class PDCModule extends HierarchicalAddonModule {
 
@@ -15,11 +23,39 @@ public class PDCModule extends HierarchicalAddonModule {
 	}
 
 	@Override
+	protected void initSelf(SkriptAddon addon) {
+		Classes.registerClass(new ClassInfo<>(PersistentDataContainer.class, "persistentdatacontainer")
+			.user("persistent ?data ?containers?") // TODO possible "pdc" option?!?!?
+			.parser(new Parser<>() {
+				@Override
+				public boolean canParse(ParseContext context) {
+					return false;
+				}
+
+				@Override
+				public String toString(PersistentDataContainer o, int flags) {
+					try {
+						// I don't see any good way to do this
+						return new String(o.serializeToBytes());
+					} catch (IOException e) {
+						throw new RuntimeException(e);
+					}
+				}
+
+				@Override
+				public String toVariableNameString(PersistentDataContainer o) {
+					return toString(o, 0);
+				}
+			}));
+	}
+
+	@Override
 	protected void loadSelf(SkriptAddon addon) {
 		register(addon,
 			CondHasPersistentDataTag::register,
 			ExprAllPersistentDataKeys::register,
-			ExprPersistentData::register);
+			ExprPersistentData::register,
+			SecEditContainer::register);
 	}
 
 	@Override

--- a/src/main/java/org/skriptlang/skript/bukkit/pdc/PDCModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/pdc/PDCModule.java
@@ -25,7 +25,7 @@ public class PDCModule extends HierarchicalAddonModule {
 	@Override
 	protected void initSelf(SkriptAddon addon) {
 		Classes.registerClass(new ClassInfo<>(PersistentDataContainer.class, "persistentdatacontainer")
-			.user("(?:persistent ?)data ?container|pdc")
+			.user("(persistent ?)?data ?containers?|pdcs?")
 			.name("Persistent Data Container")
 			.parser(new Parser<>() {
 				@Override

--- a/src/main/java/org/skriptlang/skript/bukkit/pdc/PDCSerializer.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/pdc/PDCSerializer.java
@@ -47,7 +47,6 @@ public class PDCSerializer {
 		REPRESENTABLE_TYPES.put(Double.class, PersistentDataType.DOUBLE);
 		REPRESENTABLE_TYPES.put(Float.class, PersistentDataType.FLOAT);
 		REPRESENTABLE_TYPES.put(String.class, PersistentDataType.STRING);
-		REPRESENTABLE_TYPES.put(PersistentDataContainer.class, PersistentDataType.TAG_CONTAINER);
 	}
 
 	public static @Unmodifiable Collection<PersistentDataType<?, ?>> getRepresentablePDCTypes() {
@@ -78,9 +77,6 @@ public class PDCSerializer {
 		assert Bukkit.isPrimaryThread();
 
 		ClassInfo<?> classInfo = Classes.getSuperClassInfo(unserializedData.getClass());
-		if (classInfo.getCodeName().equals("persistentdatacontainer")) {
-			return (PersistentDataContainer) unserializedData;
-		}
 		if (classInfo.getSerializeAs() != null) {
 			classInfo = Classes.getExactClassInfo(classInfo.getSerializeAs());
 			if (classInfo == null) {
@@ -155,9 +151,6 @@ public class PDCSerializer {
 			throw new IllegalArgumentException("Cannot deserialize PDC because it has no type");
 		}
 		ClassInfo<?> classInfo = Classes.getClassInfo(typeName);
-		if (classInfo.getCodeName().equalsIgnoreCase("persistentdatacontainer")) {
-			return serializedData;
-		}
 		//noinspection unchecked
 		Serializer<Object> serializer = (Serializer<Object>) classInfo.getSerializer();
 		if (serializer == null) {

--- a/src/main/java/org/skriptlang/skript/bukkit/pdc/PDCSerializer.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/pdc/PDCSerializer.java
@@ -47,6 +47,7 @@ public class PDCSerializer {
 		REPRESENTABLE_TYPES.put(Double.class, PersistentDataType.DOUBLE);
 		REPRESENTABLE_TYPES.put(Float.class, PersistentDataType.FLOAT);
 		REPRESENTABLE_TYPES.put(String.class, PersistentDataType.STRING);
+		REPRESENTABLE_TYPES.put(PersistentDataContainer.class, PersistentDataType.TAG_CONTAINER);
 	}
 
 	public static @Unmodifiable Collection<PersistentDataType<?, ?>> getRepresentablePDCTypes() {
@@ -77,6 +78,9 @@ public class PDCSerializer {
 		assert Bukkit.isPrimaryThread();
 
 		ClassInfo<?> classInfo = Classes.getSuperClassInfo(unserializedData.getClass());
+		if (classInfo.getCodeName().equals("persistentdatacontainer")) {
+			return (PersistentDataContainer) unserializedData;
+		}
 		if (classInfo.getSerializeAs() != null) {
 			classInfo = Classes.getExactClassInfo(classInfo.getSerializeAs());
 			if (classInfo == null) {
@@ -151,6 +155,9 @@ public class PDCSerializer {
 			throw new IllegalArgumentException("Cannot deserialize PDC because it has no type");
 		}
 		ClassInfo<?> classInfo = Classes.getClassInfo(typeName);
+		if (classInfo.getCodeName().equalsIgnoreCase("persistentdatacontainer")) {
+			return serializedData;
+		}
 		//noinspection unchecked
 		Serializer<Object> serializer = (Serializer<Object>) classInfo.getSerializer();
 		if (serializer == null) {

--- a/src/main/java/org/skriptlang/skript/bukkit/pdc/PDCUtils.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/pdc/PDCUtils.java
@@ -64,6 +64,7 @@ public final class PDCUtils {
 	 */
 	public static void editPersistentDataContainer(Object holder, Consumer<PersistentDataContainer> consumer) {
 		switch (holder) {
+			case PersistentDataContainer container -> consumer.accept(container);
 			case PersistentDataHolder dataHolder -> consumer.accept(dataHolder.getPersistentDataContainer());
 			case ItemType itemType -> {
 				var meta = itemType.getItemMeta();

--- a/src/main/java/org/skriptlang/skript/bukkit/pdc/elements/SecEditContainer.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/pdc/elements/SecEditContainer.java
@@ -1,0 +1,115 @@
+package org.skriptlang.skript.bukkit.pdc.elements;
+
+import ch.njol.skript.bukkitutil.NamespacedUtils;
+import ch.njol.skript.config.SectionNode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Example;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Keywords;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.Section;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.Trigger;
+import ch.njol.skript.lang.TriggerItem;
+import ch.njol.skript.registrations.EventValues;
+import ch.njol.util.Kleenean;
+import org.bukkit.NamespacedKey;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.bukkit.pdc.PDCUtils;
+import org.skriptlang.skript.registration.SyntaxInfo;
+import org.skriptlang.skript.registration.SyntaxRegistry;
+
+import java.util.List;
+import java.util.Locale;
+
+@Name("Persistent Data Container Edit") // ?!??!
+@Description("") // IDEAS?
+@Examples("""
+	edit data container "my_stuff" of player's tool:
+		set data tag "health" of event-persistentdatacontainer to 1
+		set data tag "name" of event-persistentdatacontainer to "Some Name"
+	""")
+@Since("INSERT VERSION")
+@Keywords({"pdc", "persistent data container", "custom data", "nbt"})
+public class SecEditContainer extends Section {
+
+	private static class EditContainerEvent extends Event {
+
+		private final PersistentDataContainer container;
+
+		public EditContainerEvent(PersistentDataContainer container) {
+			this.container = container;
+		}
+
+		public PersistentDataContainer getContainer() {
+			return container;
+		}
+
+		@Override
+		public @NotNull HandlerList getHandlers() {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	public static void register(SyntaxRegistry registry) {
+		registry.register(SyntaxRegistry.SECTION, SyntaxInfo.builder(Section.class)
+			.addPatterns("edit data container %string% of %chunks/worlds/entities/blocks/itemtypes/offlineplayers/persistentdatacontainers%")
+			.supplier(SecEditContainer::new)
+			.build());
+
+		// I know you're not supposed to be here, but where SHOULD you go?
+		EventValues.registerEventValue(EditContainerEvent.class, PersistentDataContainer.class, EditContainerEvent::getContainer);
+	}
+
+	private Expression<String> key;
+	private Expression<?> targets;
+	private Trigger trigger;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
+		this.key = (Expression<String>) expressions[0];
+		this.targets = expressions[1];
+		this.trigger = loadCode(sectionNode, "edit data container section", EditContainerEvent.class);
+		return true;
+	}
+
+	@Override
+	protected @Nullable TriggerItem walk(Event event) {
+		String tagName = this.key.getSingle(event);
+		if (tagName == null)
+			return super.walk(event, false);
+
+		NamespacedKey key = NamespacedUtils.checkValidationAndSend(tagName.toLowerCase(Locale.ENGLISH), this);
+		if (key == null)
+			return super.walk(event, false);
+
+		for (Object target : this.targets.getArray(event)) {
+			PDCUtils.editPersistentDataContainer(target, pdc -> {
+				// Get or create new container
+				PersistentDataContainer container = pdc.getOrDefault(key, PersistentDataType.TAG_CONTAINER, pdc.getAdapterContext().newPersistentDataContainer());
+
+				// Walk and edit
+				EditContainerEvent editEvent = new EditContainerEvent(container);
+				Trigger.walk(this.trigger, editEvent);
+
+				// Pass back
+				pdc.set(key, PersistentDataType.TAG_CONTAINER, container);
+			});
+		}
+		return super.walk(event, false);
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "edit data container " + this.key.toString(event, debug) + " of " + this.targets.toString(event, debug);
+	}
+
+}

--- a/src/main/java/org/skriptlang/skript/bukkit/pdc/elements/SecEditContainer.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/pdc/elements/SecEditContainer.java
@@ -29,8 +29,14 @@ import org.skriptlang.skript.registration.SyntaxRegistry;
 import java.util.List;
 import java.util.Locale;
 
-@Name("Persistent Data Container Edit") // ?!??!
-@Description("Edit a Persistent Data Container within a supported object.") // IDEAS?
+@Name("Edit Sub Persistent Data Containers")
+@Description({
+	"Opens a data container that's stored inside another data container, so you can read or change its data tags.",
+	"You give the container a name (a key), and the section opens it for editing. If a container with that name doesn't exist yet, an empty one is created for you. When the section ends, your changes are saved back automatically — you don't need to do anything special to commit them.",
+	"Inside the section, use <code>event-pdcs</code> to refer to the container you're editing. From there, you can set, get, or delete data tags on it just like you would on any other container.",
+	"This is useful when you want to group related data together under one name instead of dumping everything into the top-level container.",
+	"Note that the key is automatically lowercased and namespaced, the same way other persistent data syntax handles keys."
+})
 @Examples("""
 	edit data container "my_stuff" of player's tool:
 		set data tag "health" of event-pdc to 1

--- a/src/main/java/org/skriptlang/skript/bukkit/pdc/elements/SecEditContainer.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/pdc/elements/SecEditContainer.java
@@ -30,11 +30,11 @@ import java.util.List;
 import java.util.Locale;
 
 @Name("Persistent Data Container Edit") // ?!??!
-@Description("") // IDEAS?
+@Description("Edit a Persistent Data Container within a supported object.") // IDEAS?
 @Examples("""
 	edit data container "my_stuff" of player's tool:
-		set data tag "health" of event-persistentdatacontainer to 1
-		set data tag "name" of event-persistentdatacontainer to "Some Name"
+		set data tag "health" of event-pdc to 1
+		set data tag "name" of event-pdc to "Some Name"
 	""")
 @Since("INSERT VERSION")
 @Keywords({"pdc", "persistent data container", "custom data", "nbt"})

--- a/src/main/java/org/skriptlang/skript/bukkit/pdc/elements/SecEditContainer.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/pdc/elements/SecEditContainer.java
@@ -30,13 +30,7 @@ import java.util.List;
 import java.util.Locale;
 
 @Name("Edit Sub Persistent Data Containers")
-@Description({
-	"Opens a data container that's stored inside another data container, so you can read or change its data tags.",
-	"You give the container a name (a key), and the section opens it for editing. If a container with that name doesn't exist yet, an empty one is created for you. When the section ends, your changes are saved back automatically — you don't need to do anything special to commit them.",
-	"Inside the section, use <code>event-pdcs</code> to refer to the container you're editing. From there, you can set, get, or delete data tags on it just like you would on any other container.",
-	"This is useful when you want to group related data together under one name instead of dumping everything into the top-level container.",
-	"Note that the key is automatically lowercased and namespaced, the same way other persistent data syntax handles keys."
-})
+@Description("Needs a description!")
 @Examples("""
 	edit data container "my_stuff" of player's tool:
 		set data tag "health" of event-pdc to 1

--- a/src/main/java/org/skriptlang/skript/bukkit/pdc/elements/expressions/ExprPersistentData.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/pdc/elements/expressions/ExprPersistentData.java
@@ -80,7 +80,7 @@ public class ExprPersistentData extends PropertyExpression<Object, Object> {
 			infoBuilder(
 				ExprPersistentData.class, Object.class,
 				"[persistent] [%-*classinfo%] [:list] data (value|tag) %string%",
-					"chunks/worlds/entities/blocks/itemtypes/offlineplayers",
+					"chunks/worlds/entities/blocks/itemtypes/offlineplayers/persistentdatacontainers",
 				false
 			)
 			.supplier(ExprPersistentData::new)

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -2902,6 +2902,7 @@ types:
 	directionalparticle: directional particle¦s @a
 	scalableparticle: scalable particle¦s @a
 	zombienautilusvariant: zombie nautilus variant¦s @a
+	persistentdatacontainer: persistent data container¦s @a
 
 	# Skript
 	weathertype: weather type¦s @a


### PR DESCRIPTION
### Problem
Currently Skript's PDC support only supports setting specific types.
It does not allow for editing inner containers.


### Solution
Added a section to allow editing inner containers.
This is greatly beneficial for organization.


### Testing Completed
None... why? Cause I forgot. I will do those.


### Supporting Information
Talked to Sovde on discord about this... I make base, he makes better. GO TEAM!


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
