### PR TITLE
fix: correct StructureType comparator to compare s1 vs s2

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/DefaultComparators.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultComparators.java
@@ -449,7 +449,7 @@ public class DefaultComparators {
 		Comparators.registerComparator(StructureType.class, StructureType.class, new Comparator<StructureType, StructureType>() {
 			@Override
 			public Relation compare(StructureType s1, StructureType s2) {
-				return Relation.get(CollectionUtils.containsAll(s2.getTypes(), s2.getTypes()));
+				return Relation.get(CollectionUtils.containsAll(s1.getTypes(), s2.getTypes()));
 			}
 
 			@Override


### PR DESCRIPTION
## Summary

Fix the StructureType comparator in `DefaultComparators.java` to correctly compare `s1` vs `s2` instead of comparing `s2` against itself.

### Bug
```java
// Before (incorrect - compared s2 to itself)
return Relation.get(CollectionUtils.containsAll(s2.getTypes(), s2.getTypes()));

// After (correct - compares s1 to s2)
return Relation.get(CollectionUtils.containsAll(s1.getTypes(), s2.getTypes()));
```

### Issue
Fixes SkriptLang/Skript#8638

### Testing
The bug was identifiable from source inspection. The fix ensures the comparator correctly checks if `s1`'s types contain all of `s2`'s types, not both arguments being `s2`.
