### PR TITLE
Improve event value cache

### DIFF
--- a/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/ConvertedEventValue.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/ConvertedEventValue.java
@@ -192,6 +192,11 @@ record ConvertedEventValue<SourceEvent extends Event, ConvertedEvent extends Eve
 	}
 
 	@Override
+	public boolean contextDependent() {
+		return source.contextDependent();
+	}
+
+	@Override
 	public boolean matches(EventValue<?, ?> eventValue) {
 		return matches(eventValue.eventClass(), eventValue.valueClass(), eventValue.patterns());
 	}

--- a/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValue.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValue.java
@@ -155,6 +155,14 @@ public sealed interface EventValue<E extends Event, V> permits EventValueImpl, C
 	@Contract(pure = true)
 	@Nullable String excludedErrorMessage();
 
+
+	/**
+	 *
+	 * @return
+	 */
+	@Contract(pure = true)
+	boolean contextDependent();
+
 	/**
 	 * Checks whether this event value matches the provided event value in terms of
 	 * event class, value class, and identifier patterns.
@@ -452,6 +460,20 @@ public sealed interface EventValue<E extends Event, V> permits EventValueImpl, C
 		 */
 		@Contract(value = "_ -> this", mutates = "this")
 		Builder<E, V> excludedErrorMessage(String excludedErrorMessage);
+
+		/**
+		 * Whether this event value's validation result depends on state outside of the event class
+		 * (e.g. configuration, server state, registry contents). When {@code true}, resolutions that
+		 * consider this event value are not cached by {@link EventValueRegistry}, ensuring the
+		 * validator is consulted on every lookup.
+		 * <p>
+		 * Defaults to {@code false}; only set this when an {@link Builder#eventValidator(Function)
+		 * event validator} is not pure for a given event class.
+		 *
+		 * @return {@code true} if resolutions involving this value should bypass the cache
+		 */
+		@Contract(value = " -> this", mutates = "this")
+		Builder<E, V> contextDependent();
 
 		/**
 		 * Builds the event value.

--- a/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValue.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValue.java
@@ -157,8 +157,15 @@ public sealed interface EventValue<E extends Event, V> permits EventValueImpl, C
 
 
 	/**
+	 * Whether this event value's validation result depends on state outside of the event class
+	 * (e.g. configuration, server state, registry contents). When {@code true}, resolutions that
+	 * consider this event value are not cached by {@link EventValueRegistry}, ensuring the
+	 * validator is consulted on every lookup.
+	 * <p>
+	 * Defaults to {@code false}; only set this when an {@link Builder#eventValidator(Function)
+	 * event validator} is not pure for a given event class.
 	 *
-	 * @return
+	 * @return {@code true} if resolutions involving this value should bypass the cache
 	 */
 	@Contract(pure = true)
 	boolean contextDependent();
@@ -462,15 +469,13 @@ public sealed interface EventValue<E extends Event, V> permits EventValueImpl, C
 		Builder<E, V> excludedErrorMessage(String excludedErrorMessage);
 
 		/**
-		 * Whether this event value's validation result depends on state outside of the event class
-		 * (e.g. configuration, server state, registry contents). When {@code true}, resolutions that
-		 * consider this event value are not cached by {@link EventValueRegistry}, ensuring the
-		 * validator is consulted on every lookup.
-		 * <p>
-		 * Defaults to {@code false}; only set this when an {@link Builder#eventValidator(Function)
-		 * event validator} is not pure for a given event class.
+		 * Marks this event value as context-dependent. Resolutions that consider this value will
+		 * not be cached, so the {@linkplain #eventValidator(Function) event validator} is
+		 * consulted on every lookup. Use this when the validator's answer for a given event
+		 * class may change at runtime (e.g. because it consults external state).
 		 *
-		 * @return {@code true} if resolutions involving this value should bypass the cache
+		 * @return this builder
+		 * @see EventValue#contextDependent()
 		 */
 		@Contract(value = " -> this", mutates = "this")
 		Builder<E, V> contextDependent();

--- a/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValueImpl.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValueImpl.java
@@ -36,6 +36,7 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 	private final Time time;
 	private final Collection<Class<? extends E>> excludedEvents;
 	private final @Nullable String excludedErrorMessage;
+	private final boolean contextDepenent;
 
 	private SkriptPattern[] compiledPatterns;
 
@@ -51,6 +52,7 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 		this.time = builder.time;
 		this.excludedEvents = builder.excludedEvents;
 		this.excludedErrorMessage = builder.excludedErrorMessage;
+		this.contextDepenent = builder.contextDependent;
 	}
 
 	@Override
@@ -154,6 +156,11 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 	}
 
 	@Override
+	public boolean contextDependent() {
+		return contextDepenent;
+	}
+
+	@Override
 	public boolean matches(EventValue<?, ?> eventValue) {
 		return matches(eventValue.eventClass(), eventValue.valueClass(), eventValue.patterns())
 			&& eventValue instanceof EventValueImpl<?,?> other
@@ -204,6 +211,7 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 		private Time time = Time.NOW;
 		private Collection<Class<? extends E>> excludedEvents = Collections.emptyList();
 		private @Nullable String excludedErrorMessage;
+		private boolean contextDependent = false;
 
 		BuilderImpl(Class<E> eventClass, Class<V> valueClass) {
 			this.eventClass = eventClass;
@@ -257,6 +265,12 @@ final class EventValueImpl<E extends Event, V> implements EventValue<E, V> {
 		@Override
 		public Builder<E, V> excludedErrorMessage(String excludedErrorMessage) {
 			this.excludedErrorMessage = excludedErrorMessage;
+			return this;
+		}
+
+		@Override
+		public Builder<E, V> contextDependent() {
+			this.contextDependent = true;
 			return this;
 		}
 

--- a/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValueRegistryImpl.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValueRegistryImpl.java
@@ -66,6 +66,12 @@ final class EventValueRegistryImpl implements EventValueRegistry {
 		return false;
 	}
 
+	private <E extends Event, V> void cache(Input<E, ?> input, Resolution<E, V> resolution, boolean contextDependent) {
+		if (contextDependent)
+			return;
+		eventValuesCache.put(input, resolution);
+	}
+
 	@Override
 	public <E extends Event, V> Resolution<E, V> resolve(Class<E> eventClass, String identifier) {
 		return resolve(eventClass, identifier, EventValue.Time.NOW);
@@ -96,14 +102,15 @@ final class EventValueRegistryImpl implements EventValueRegistry {
 			return resolution;
 
 		//noinspection unchecked
-		resolution = Resolver.<E, V>builder(eventClass)
+		var output = Resolver.<E, V>builder(eventClass)
 			.filter(ev -> ClassUtils.isRelatedTo(ev.eventClass(), eventClass) && ev.matchesInput(identifier))
 			.comparator(Resolver.EVENT_DISTANCE_COMPARATOR)
 			.mapper(ev -> (EventValue<E, V>) ev.getConverted(eventClass, ev.valueClass()))
 			.build().resolve(eventValues(time));
+		resolution = output.resolution();
 
 		if (resolution.successful()) {
-			eventValuesCache.put(input, resolution);
+			cache(input, resolution, output.contextDependent());
 			return resolution;
 		}
 
@@ -111,7 +118,7 @@ final class EventValueRegistryImpl implements EventValueRegistry {
 			return resolve(eventClass, identifier, EventValue.Time.NOW, flags);
 
 		resolution = Resolution.empty();
-		eventValuesCache.put(input, resolution);
+		cache(input, resolution, output.contextDependent());
 		return resolution;
 	}
 
@@ -144,31 +151,36 @@ final class EventValueRegistryImpl implements EventValueRegistry {
 		if (resolution != null)
 			return resolution;
 
-		resolution = resolveExact(eventClass, valueClass, time)
-			.anyOptional()
-			.map(eventValue -> Resolution.of(Collections.singletonList(eventValue)))
-			.orElse(Resolution.empty());
+		var output = Resolver.exact(eventClass, valueClass).resolve(eventValues(time));
+		resolution = output.resolution();
+
 		if (resolution.successful() || resolution.errored()) {
-			eventValuesCache.put(input, resolution);
+			cache(input, resolution, output.contextDependent());
 			return resolution;
 		}
 
-		resolution = resolveNearest(eventClass, valueClass, time);
+		output = resolveNearest(eventClass, valueClass, time);
+		resolution = output.resolution();
+
 		if (resolution.successful() || resolution.errored()) {
-			eventValuesCache.put(input, resolution);
+			cache(input, resolution, output.contextDependent());
 			return resolution;
 		}
 
 		if (flags.has(Flag.ALLOW_CONVERSION)) {
-			resolution = resolveWithDowncastConversion(eventClass, valueClass, time);
+			output = resolveWithDowncastConversion(eventClass, valueClass, time);
+			resolution = output.resolution();
+
 			if (resolution.successful() || resolution.errored()) {
-				eventValuesCache.put(input, resolution);
+				cache(input, resolution, output.contextDependent());
 				return resolution;
 			}
 
-			resolution = resolveWithConversion(eventClass, valueClass, time);
+			output = resolveWithConversion(eventClass, valueClass, time);
+			resolution = output.resolution();
+
 			if (resolution.successful() || resolution.errored()) {
-				eventValuesCache.put(input, resolution);
+				cache(input, resolution, output.contextDependent());
 				return resolution;
 			}
 		}
@@ -177,7 +189,6 @@ final class EventValueRegistryImpl implements EventValueRegistry {
 			return resolve(eventClass, valueClass, EventValue.Time.NOW, flags);
 
 		resolution = Resolution.empty();
-		eventValuesCache.put(input, resolution);
 		return resolution;
 	}
 
@@ -187,17 +198,13 @@ final class EventValueRegistryImpl implements EventValueRegistry {
 		Class<V> valueClass,
 		EventValue.Time time
 	) {
-		return Resolver.builder(eventClass, valueClass)
-			.filter(ev -> ev.eventClass().isAssignableFrom(eventClass) && ev.valueClass().equals(valueClass))
-			.comparator(Resolver.EVENT_DISTANCE_COMPARATOR)
-			.filterMatches()
-			.build().resolve(eventValues(time));
+		return Resolver.exact(eventClass, valueClass).resolve(eventValues(time)).resolution();
 	}
 
 	/**
 	 * Resolves to the nearest event and value class without conversion.
 	 */
-	private <E extends Event, V> Resolution<E, ? extends V> resolveNearest(
+	private <E extends Event, V> Resolver.Output<E, V> resolveNearest(
 		Class<E> eventClass,
 		Class<V> valueClass,
 		EventValue.Time time
@@ -214,7 +221,7 @@ final class EventValueRegistryImpl implements EventValueRegistry {
 	 * Resolves using downcast conversion when the desired value class is a supertype
 	 * of the registered value class.
 	 */
-	private <E extends Event, V> Resolution<E, V> resolveWithDowncastConversion(
+	private <E extends Event, V> Resolver.Output<E, V> resolveWithDowncastConversion(
 		Class<E> eventClass,
 		Class<V> valueClass,
 		EventValue.Time time
@@ -233,7 +240,7 @@ final class EventValueRegistryImpl implements EventValueRegistry {
 	/**
 	 * Resolves using {@link Converters} to convert value type when needed.
 	 */
-	private <E extends Event, V> Resolution<E, V> resolveWithConversion(
+	private <E extends Event, V> Resolver.Output<E, V> resolveWithConversion(
 		Class<E> eventClass,
 		Class<V> valueClass,
 		EventValue.Time time

--- a/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValueRegistryImpl.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValueRegistryImpl.java
@@ -109,7 +109,7 @@ final class EventValueRegistryImpl implements EventValueRegistry {
 			.build().resolve(eventValues(time));
 		resolution = output.resolution();
 
-		if (resolution.successful()) {
+		if (resolution.successful() || resolution.errored()) {
 			cache(input, resolution, output.contextDependent());
 			return resolution;
 		}

--- a/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/Resolver.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/lang/eventvalue/Resolver.java
@@ -74,21 +74,25 @@ class Resolver<E extends Event, V> {
 	 * Resolves the given list of {@link EventValue}s.
 	 *
 	 * @param eventValues The event values to resolve.
-	 * @return The resolution containing the best candidates.
+	 * @return The resolution containing the best candidates, along with a flag indicating
+	 * 	       whether any candidate considered was {@linkplain EventValue#contextDependent() context-dependent}.
 	 */
-	public EventValueRegistry.Resolution<E, V> resolve(List<EventValue<?, ?>> eventValues) {
+	public Output<E, V> resolve(List<EventValue<?, ?>> eventValues) {
 		List<EventValue<E, V>> best = new ArrayList<>();
 		EventValue<?, ?> bestMatch = null;
+		boolean contextDependent = false;
+
 		for (EventValue<?, ?> eventValue : eventValues) {
 			if (!filter.test(eventValue))
 				continue;
 
+			contextDependent |= eventValue.contextDependent();
 			switch (eventValue.validate(eventClass)) {
 				case INVALID -> {
 					continue;
 				}
 				case ABORT -> {
-					return EventValueRegistry.Resolution.error();
+					return new Output<>(EventValueRegistry.Resolution.error(), contextDependent);
 				}
 			}
 
@@ -109,9 +113,10 @@ class Resolver<E extends Event, V> {
 				best.add(converted);
 			}
 		}
+
 		if (valueClass != null && filterMatches)
-			return EventValueRegistry.Resolution.of(filterEventValues(valueClass, best));
-		return EventValueRegistry.Resolution.of(best);
+			return new Output<>(EventValueRegistry.Resolution.of(filterEventValues(valueClass, best)), contextDependent);
+		return new Output<>(EventValueRegistry.Resolution.of(best),  contextDependent);
 	}
 
 	/**
@@ -171,6 +176,14 @@ class Resolver<E extends Event, V> {
 	 */
 	static <E extends Event, V> Builder<E, V> builder(Class<E> eventClass, Class<V> valueClass) {
 		return new Builder<>(eventClass, valueClass);
+	}
+
+	static <E extends Event, V> Resolver<E, V> exact(Class<E> eventClass, Class<V> valueClass) {
+		return Resolver.builder(eventClass, valueClass)
+			.filter(ev -> ev.eventClass().isAssignableFrom(eventClass) && ev.valueClass().equals(valueClass))
+			.comparator(Resolver.EVENT_DISTANCE_COMPARATOR)
+			.filterMatches()
+			.build();
 	}
 
 	/**
@@ -308,5 +321,20 @@ class Resolver<E extends Event, V> {
 		Comparator<EventValue<?, ?>> create(Class<? extends Event> eventClass, Class<?> valueClass);
 
 	}
+
+	/**
+	 * The result of a {@link Resolver#resolve(List) resolve} call.
+	 *
+	 * @param resolution The resolution produced.
+	 * @param contextDependent Whether any candidate considered during resolution was
+	 *                         {@linkplain EventValue#contextDependent() context-dependent},
+	 *                         meaning the result must not be cached.
+	 * @param <E> The event type.
+	 * @param <V> The value type.
+	 */
+	record Output<E extends Event, V>(
+		EventValueRegistry.Resolution<E, V> resolution,
+		boolean contextDependent
+	) {}
 
 }

--- a/src/test/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValueRegistryTest.java
+++ b/src/test/java/org/skriptlang/skript/bukkit/lang/eventvalue/EventValueRegistryTest.java
@@ -1,0 +1,262 @@
+package org.skriptlang.skript.bukkit.lang.eventvalue;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Before;
+import org.junit.Test;
+import org.skriptlang.skript.lang.converter.Converters;
+
+import static org.junit.Assert.*;
+
+public class EventValueRegistryTest {
+
+	private EventValueRegistry registry;
+
+	@Before
+	public void setUp() {
+		registry = EventValueRegistry.empty(null);
+	}
+
+	private static class TestEvent extends Event {
+		@Override
+		public @NotNull HandlerList getHandlers() {
+			throw new UnsupportedOperationException();
+		}
+	}
+	private static class SubTestEvent extends TestEvent {}
+	private static class OtherEvent extends Event {
+		@Override
+		public @NotNull HandlerList getHandlers() {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	private static class TestValue {}
+	private static class SubTestValue extends TestValue {}
+	private static class OtherValue {}
+
+	@Test
+	public void testRegistration() {
+		EventValue<TestEvent, TestValue> ev = EventValue.builder(TestEvent.class, TestValue.class)
+				.patterns("test")
+				.getter(e -> new TestValue())
+				.build();
+
+		assertFalse(registry.isRegistered(ev));
+		registry.register(ev);
+		assertTrue(registry.isRegistered(ev));
+		assertTrue(registry.isRegistered(TestEvent.class, TestValue.class, EventValue.Time.NOW));
+
+		assertTrue(registry.elements().contains(ev));
+		assertTrue(registry.elements(EventValue.Time.NOW).contains(ev));
+		assertTrue(registry.elements(TestEvent.class).contains(ev));
+
+		assertTrue(registry.unregister(ev));
+		assertFalse(registry.isRegistered(ev));
+		assertFalse(registry.elements().contains(ev));
+	}
+
+	@Test
+	public void testResolveByIdentifier() {
+		EventValue<TestEvent, TestValue> ev = EventValue.builder(TestEvent.class, TestValue.class)
+				.patterns("test pattern")
+				.getter(e -> new TestValue())
+				.build();
+		registry.register(ev);
+
+		EventValueRegistry.Resolution<TestEvent, TestValue> res = registry.resolve(TestEvent.class, "test pattern");
+		assertTrue(res.successful());
+		assertEquals(ev, res.unique());
+
+		// Test sub-event
+		EventValueRegistry.Resolution<SubTestEvent, TestValue> subRes = registry.resolve(SubTestEvent.class, "test pattern");
+		assertTrue(subRes.successful());
+		// It should be a converted event value
+		assertEquals(ev.valueClass(), subRes.unique().valueClass());
+		assertEquals(TestEvent.class, subRes.unique().eventClass());
+
+		// Test non-matching identifier
+		assertFalse(registry.resolve(TestEvent.class, "wrong").successful());
+	}
+
+	@Test
+	public void testResolveByValueClass() {
+		EventValue<TestEvent, TestValue> ev = EventValue.builder(TestEvent.class, TestValue.class)
+				.getter(e -> new TestValue())
+				.build();
+		registry.register(ev);
+
+		EventValueRegistry.Resolution<TestEvent, ? extends TestValue> res = registry.resolve(TestEvent.class, TestValue.class);
+		assertTrue(res.successful());
+		assertEquals(ev, res.unique());
+
+		EventValueRegistry.Resolution<TestEvent, ? extends SubTestValue> subValueRes = registry.resolve(TestEvent.class, SubTestValue.class);
+		assertTrue(subValueRes.successful());
+	}
+
+	@Test
+	public void testCacheLogic() {
+		EventValue<TestEvent, TestValue> ev = EventValue.builder(TestEvent.class, TestValue.class)
+				.patterns("test")
+				.getter(e -> new TestValue())
+				.build();
+		registry.register(ev);
+
+		EventValueRegistry.Resolution<TestEvent, TestValue> res1 = registry.resolve(TestEvent.class, "test");
+		EventValueRegistry.Resolution<TestEvent, TestValue> res2 = registry.resolve(TestEvent.class, "test");
+
+		assertSame("Resolutions should be cached and return the same instance", res1, res2);
+
+		// Registering a new value should clear the cache
+		EventValue<OtherEvent, TestValue> ev2 = EventValue.builder(OtherEvent.class, TestValue.class)
+				.patterns("other")
+				.getter(e -> new TestValue())
+				.build();
+		registry.register(ev2);
+
+		EventValueRegistry.Resolution<TestEvent, TestValue> res3 = registry.resolve(TestEvent.class, "test");
+		assertNotSame("Cache should have been cleared", res1, res3);
+		assertEquals(res1, res3);
+	}
+
+	@Test
+	public void testContextDependentNotCached() {
+		EventValue<TestEvent, TestValue> ev = EventValue.builder(TestEvent.class, TestValue.class)
+				.patterns("test")
+				.getter(e -> new TestValue())
+				.contextDependent()
+				.build();
+		registry.register(ev);
+
+		EventValueRegistry.Resolution<TestEvent, TestValue> res1 = registry.resolve(TestEvent.class, "test");
+		EventValueRegistry.Resolution<TestEvent, TestValue> res2 = registry.resolve(TestEvent.class, "test");
+
+		assertNotSame("Context-dependent resolutions should not be cached", res1, res2);
+		assertEquals(res1, res2);
+	}
+
+	@Test
+	public void testUnmodifiableView() {
+		EventValue<TestEvent, TestValue> ev = EventValue.builder(TestEvent.class, TestValue.class)
+				.patterns("test")
+				.getter(e -> new TestValue())
+				.build();
+		registry.register(ev);
+
+		EventValueRegistry unmodifiable = registry.unmodifiableView();
+		assertTrue(unmodifiable.isRegistered(ev));
+
+		assertThrows(UnsupportedOperationException.class, () -> unmodifiable.register(ev));
+		assertThrows(UnsupportedOperationException.class, () -> unmodifiable.unregister(ev));
+	}
+
+	@Test
+	public void testTimeFallback() {
+		EventValue<TestEvent, TestValue> evPast = EventValue.builder(TestEvent.class, TestValue.class)
+				.patterns("test")
+				.time(EventValue.Time.PAST)
+				.getter(e -> new TestValue())
+				.build();
+		registry.register(evPast);
+
+		// Resolve past
+		assertTrue(registry.resolve(TestEvent.class, "test", EventValue.Time.PAST).successful());
+		// Resolve now (should fail)
+		assertFalse(registry.resolve(TestEvent.class, "test", EventValue.Time.NOW).successful());
+
+		EventValue<TestEvent, TestValue> evNow = EventValue.builder(TestEvent.class, TestValue.class)
+				.patterns("test")
+				.time(EventValue.Time.NOW)
+				.getter(e -> new TestValue())
+				.build();
+		registry.register(evNow);
+
+		// Resolve with fallback
+		EventValueRegistry.Resolution<TestEvent, TestValue> res = registry.resolve(
+				TestEvent.class, "test", EventValue.Time.FUTURE, EventValueRegistry.Flags.of(EventValueRegistry.Flag.FALLBACK_TO_DEFAULT_TIME_STATE));
+		assertTrue(res.successful());
+		assertEquals(evNow.valueClass(), res.unique().valueClass());
+		assertEquals(EventValue.Time.NOW, res.unique().time());
+	}
+
+	@Test
+	public void testResolveExact() {
+		EventValue<TestEvent, TestValue> ev = EventValue.builder(TestEvent.class, TestValue.class)
+				.getter(e -> new TestValue())
+				.build();
+		registry.register(ev);
+
+		assertTrue(registry.resolveExact(TestEvent.class, TestValue.class, EventValue.Time.NOW).successful());
+		assertTrue(registry.resolveExact(SubTestEvent.class, TestValue.class, EventValue.Time.NOW).successful());
+		assertFalse(registry.resolveExact(TestEvent.class, SubTestEvent.class, EventValue.Time.NOW).successful());
+	}
+
+	@Test
+	public void testAmbiguousResolution() {
+		EventValue<TestEvent, Integer> ev1 = EventValue.builder(TestEvent.class, Integer.class)
+				.patterns("test")
+				.getter(e -> 10)
+				.build();
+		EventValue<TestEvent, Double> ev2 = EventValue.builder(TestEvent.class, Double.class)
+				.patterns("test")
+				.getter(e -> 10.0)
+				.build();
+		registry.register(ev1);
+		registry.register(ev2);
+
+		EventValueRegistry.Resolution<TestEvent, ?> res = registry.resolve(TestEvent.class, "test");
+		assertTrue(res.successful());
+		assertTrue(res.multiple());
+		assertEquals(2, res.size());
+		assertNotNull(res.any());
+		assertTrue(res.anyOptional().isPresent());
+		assertThrows(IllegalStateException.class, res::unique);
+	}
+
+	@Test
+	public void testAbortValidation() {
+		EventValue<TestEvent, TestValue> ev = EventValue.builder(TestEvent.class, TestValue.class)
+				.patterns("test")
+				.eventValidator(event -> event.equals(SubTestEvent.class) ? EventValue.Validation.ABORT : EventValue.Validation.VALID)
+				.getter(e -> new TestValue())
+				.build();
+		registry.register(ev);
+
+		assertTrue(registry.resolve(TestEvent.class, "test").successful());
+		EventValueRegistry.Resolution<SubTestEvent, TestValue> res = registry.resolve(SubTestEvent.class, "test");
+		assertFalse(res.successful());
+		assertTrue(res.errored());
+	}
+
+	@Test
+	public void testDowncastConversion() {
+		EventValue<TestEvent, TestValue> ev = EventValue.builder(TestEvent.class, TestValue.class)
+				.getter(e -> new TestValue())
+				.build();
+		registry.register(ev);
+
+		// Resolve for SubTestValue (subtype of TestValue) should work with ALLOW_CONVERSION
+		EventValueRegistry.Resolution<TestEvent, ? extends SubTestValue> res = registry.resolve(TestEvent.class, SubTestValue.class, EventValue.Time.NOW,
+				EventValueRegistry.Flags.of(EventValueRegistry.Flag.ALLOW_CONVERSION));
+		assertTrue(res.successful());
+		assertEquals(SubTestValue.class, res.unique().valueClass());
+	}
+
+	@Test
+	public void testConverter() {
+		EventValue<TestEvent, TestValue> ev = EventValue.builder(TestEvent.class, TestValue.class)
+				.getter(e -> new TestValue())
+				.build();
+		registry.register(ev);
+
+		// Register a converter from TestValue to OtherValue
+		Converters.registerConverter(TestValue.class, OtherValue.class, from -> new OtherValue());
+
+		// Resolve for OtherValue should work with ALLOW_CONVERSION
+		EventValueRegistry.Resolution<TestEvent, ? extends OtherValue> res = registry.resolve(TestEvent.class, OtherValue.class, EventValue.Time.NOW,
+				EventValueRegistry.Flags.of(EventValueRegistry.Flag.ALLOW_CONVERSION));
+		assertTrue(res.successful());
+		assertEquals(OtherValue.class, res.unique().valueClass());
+	}
+}


### PR DESCRIPTION
### Problem
The event value registry doesn't take into account event validators when caching event value resolutions, this causes issues when an event value relies on external factors that are not constrained to just the event class. For example, skript-reflect's custom events register one skript event and rely on the identifier to figure out which custom event's logic to use. This causes Skript to wrongly cache event values as successful/failure and use the same cached result for all subsequent calls for that event value, no matter the custom event.


### Solution
Include an option to exclude an event value from being cached if it depends on external contexts.


### Testing Completed
EventValueRegistryTest.java


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** junie for writing most test cases <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
