### PR TITLE
Fix StructureType comparator comparing s2 against itself

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/DefaultComparators.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultComparators.java
@@ -449,7 +449,7 @@ public class DefaultComparators {
 		Comparators.registerComparator(StructureType.class, StructureType.class, new Comparator<StructureType, StructureType>() {
 			@Override
 			public Relation compare(StructureType s1, StructureType s2) {
-				return Relation.get(CollectionUtils.containsAll(s2.getTypes(), s2.getTypes()));
+				return Relation.get(CollectionUtils.containsAll(s1.getTypes(), s2.getTypes()));
 			}
 
 			@Override


### PR DESCRIPTION
CollectionUtils.containsAll was called with s2.getTypes() for both
arguments, causing every tree type comparison to return EQUAL.
Changed the first argument to s1.getTypes().