### PR TITLE
Use MM formatting for ItemData stringification

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/ItemData.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemData.java
@@ -23,6 +23,7 @@ import org.bukkit.inventory.meta.MusicInstrumentMeta;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionEffect;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.bukkit.text.TextComponentParser;
 
 import java.io.IOException;
 import java.io.NotSerializableException;
@@ -242,8 +243,10 @@ public class ItemData implements Cloneable, YggdrasilExtendedSerializable {
 		StringBuilder builder = new StringBuilder(Aliases.getMaterialName(this, plural));
 		ItemMeta meta = stack != null ? stack.getItemMeta() : null;
 		if (meta != null && meta.hasDisplayName()) {
-			builder.append(" ").append(m_named).append(" ");
-			builder.append(meta.getDisplayName());
+			builder.append(" ")
+				.append(m_named)
+				.append(" ")
+				.append(TextComponentParser.instance().toString(meta.displayName()));
 		}
 		return builder.toString();
 	}


### PR DESCRIPTION
### Problem
When a Slot is converted to a string, such as `"%player's tool%"`, the result is a string containing legacy formatting rather than MiniMessage tags.


### Solution
Updates the ItemData#toString method to use the TextComponentParser to stringify the name component.


### Testing Completed
Manually verified in-game.

### Supporting Information
n/a

---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:**
- https://github.com/SkriptLang/Skript/issues/8642 (The cause of legacy formatting occurring)

**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
