### PR TITLE
Fix TestLogHandler Exception

### DIFF
--- a/src/main/java/ch/njol/skript/log/TestingLogHandler.java
+++ b/src/main/java/ch/njol/skript/log/TestingLogHandler.java
@@ -32,7 +32,7 @@ public class TestingLogHandler extends LogHandler {
 			String name = struct instanceof EvtTestCase test ? test.getTestName() : struct != null ? struct.getSyntaxTypeName() : null;
 			TestTracker.parsingStarted(name);
 
-			if (node != null) {
+			if (node != null && parser.isActive()) {
 				TestTracker.testFailed(entry.getMessage(), parser.getCurrentScript(), node.getLine());
 			} else {
 				TestTracker.testFailed(entry.getMessage());


### PR DESCRIPTION
### Problem
TestLogHandler would throw exceptions for indentation errors
`SkriptAPIException: This ParserInstance is not currently parsing/loading something!`


### Solution
Added a check to make sure the parser is active.


### Testing Completed
Manual testing on existing tests (before & after)


---
**Completes:** #8660 
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
