### PR TITLE
Fix Location.toVariableString() NPE

### DIFF
--- a/src/main/java/org/skriptlang/skript/bukkit/types/LocationClassInfo.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/types/LocationClassInfo.java
@@ -132,7 +132,8 @@ public class LocationClassInfo extends ClassInfo<Location> {
 
 		@Override
 		public String toVariableNameString(Location loc) {
-			return loc.getWorld().getName() + ":" + loc.getX() + "," + loc.getY() + "," + loc.getZ();
+			String worldName = loc.getWorld() == null ? "" : loc.getWorld().getName();
+			return worldName + ":" + loc.getX() + "," + loc.getY() + "," + loc.getZ();
 		}
 
 		@Override


### PR DESCRIPTION
### Problem
location.toVariableString() throws an NPE when the location's world is null


### Solution
Added a null check, which defaults to the world's name to "" just like toString()

### Testing Completed
```
on load:
  set {_l} to location(0,0,0,{_})
  set {_a::%{_l}%} to 1
```

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** #8661 
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
