### PR TITLE
LocationClassInfo - fix null world error

### DIFF
--- a/src/main/java/org/skriptlang/skript/bukkit/types/LocationClassInfo.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/types/LocationClassInfo.java
@@ -126,13 +126,13 @@ public class LocationClassInfo extends ClassInfo<Location> {
 
 		@Override
 		public String toString(Location loc, int flags) {
-			String worldPart = loc.getWorld() == null ? "" : " in '" + loc.getWorld().getName() + "'"; // Safety: getWorld is marked as Nullable by spigot
+			String worldPart = loc.getWorld() == null ? "" : " in '" + loc.getWorld().getName() + "'"; // Safety: getWorld is marked as Nullable by Paper
 			return "x: " + Skript.toString(loc.getX()) + ", y: " + Skript.toString(loc.getY()) + ", z: " + Skript.toString(loc.getZ()) + ", yaw: " + Skript.toString(loc.getYaw()) + ", pitch: " + Skript.toString(loc.getPitch()) + worldPart;
 		}
 
 		@Override
 		public String toVariableNameString(Location loc) {
-			String worldPart = loc.getWorld() == null ? "" : loc.getWorld().getName() + ":"; // Safety: getWorld is marked as Nullable by spigot
+			String worldPart = loc.getWorld() == null ? "" : loc.getWorld().getName() + ":"; // Safety: getWorld is marked as Nullable by Paper
 			return worldPart + loc.getX() + "," + loc.getY() + "," + loc.getZ();
 		}
 

--- a/src/main/java/org/skriptlang/skript/bukkit/types/LocationClassInfo.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/types/LocationClassInfo.java
@@ -132,7 +132,8 @@ public class LocationClassInfo extends ClassInfo<Location> {
 
 		@Override
 		public String toVariableNameString(Location loc) {
-			return loc.getWorld().getName() + ":" + loc.getX() + "," + loc.getY() + "," + loc.getZ();
+			String worldPart = loc.getWorld() == null ? "" : loc.getWorld().getName() + ":"; // Safety: getWorld is marked as Nullable by spigot
+			return worldPart + loc.getX() + "," + loc.getY() + "," + loc.getZ();
 		}
 
 		@Override

--- a/src/test/skript/tests/bukkit/types/Location.sk
+++ b/src/test/skript/tests/bukkit/types/Location.sk
@@ -1,0 +1,24 @@
+test "Location ClassInfo":
+	set {_loc} to location(1,1,1, world("world"))
+	assert {_loc} is set with "Location variable should be set"
+
+	set {_string} to "%{_loc}%"
+	assert {_string} is set with "Location should be converted to string"
+	assert {_string} = "x: 1, y: 1, z: 1, yaw: 0, pitch: 0 in 'world'" with "Location should properly be converted to string"
+
+	set {_var::%{_loc}%} to 1
+	assert {_var::%{_loc}%} is set with "Location should be able to be used in a variable as an index"
+
+	delete {_loc}
+	delete {_string}
+
+	set {_loc} to location(1,1,1, {_null_world})
+	assert {_loc} is set with "Location variable should be set"
+
+	set {_string} to "%{_loc}%"
+	assert {_string} is set with "Location should be converted to string"
+	assert {_string} = "x: 1, y: 1, z: 1, yaw: 0, pitch: 0" with "Location should properly be converted to string"
+
+	set {_var::%{_loc}%} to 1
+	# Reference issue 8661
+	assert {_var::%{_loc}%} is set with "Location without a world should be able to be used in a variable as an index"


### PR DESCRIPTION
### Problem
ClassInfo for location `toVariableNameString` throws an error when the location is missing a world


### Solution
Do a world check before getting the world's name


### Testing Completed
Added a simple test for the classinfo to ensure toString/toVariableNameString properly world


### Supporting Information

---
**Completes:** #8661 
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
