### PR TITLE
Check if the plugin is enabled while loading hooks

### DIFF
--- a/src/main/java/ch/njol/skript/hooks/Hook.java
+++ b/src/main/java/ch/njol/skript/hooks/Hook.java
@@ -61,7 +61,7 @@ public abstract class Hook<P extends Plugin> {
 						clazz.getMethod("register", SyntaxRegistry.class).invoke(null, registry);
 					} catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
 						// noinspection ThrowableNotThrown
-						Skript.exception(e, "Error while loading a hook");
+						Skript.exception(e, "Error while loading a hook at " + clazz.getName());
 					}
 				}
 			})

--- a/src/main/java/ch/njol/skript/hooks/Hook.java
+++ b/src/main/java/ch/njol/skript/hooks/Hook.java
@@ -50,23 +50,7 @@ public abstract class Hook<P extends Plugin> {
 	}
 	
 	protected void loadClasses() throws IOException {
-		SyntaxRegistry registry = Skript.instance().syntaxRegistry();
-		ClassLoader.builder()
-			.basePackage(getClass().getPackage().getName())
-			.deep(true)
-			.initialize(true)
-			.forEachClass(clazz -> {
-				if (SyntaxElement.class.isAssignableFrom(clazz)) {
-					try {
-						clazz.getMethod("register", SyntaxRegistry.class).invoke(null, registry);
-					} catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-						// noinspection ThrowableNotThrown
-						Skript.exception(e, "Error while loading a hook at " + clazz.getName());
-					}
-				}
-			})
-			.build()
-			.loadClasses(Skript.class);
+		Skript.getAddonInstance().loadClasses(getClass().getPackage().getName());
 	}
 	
 	/**

--- a/src/main/java/ch/njol/skript/hooks/Hook.java
+++ b/src/main/java/ch/njol/skript/hooks/Hook.java
@@ -1,23 +1,24 @@
 package ch.njol.skript.hooks;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 
 import ch.njol.skript.doc.Documentation;
+import ch.njol.skript.lang.SyntaxElement;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.localization.ArgsMessage;
+import org.skriptlang.skript.registration.SyntaxRegistry;
+import org.skriptlang.skript.util.ClassLoader;
 
-/**
- * @author Peter Güttinger
- */
 public abstract class Hook<P extends Plugin> {
+
+	private final static ArgsMessage m_hooked = new ArgsMessage("hooks.hooked");
+	private final static ArgsMessage m_hook_error = new ArgsMessage("hooks.error");
 	
-	private final static ArgsMessage m_hooked = new ArgsMessage("hooks.hooked"),
-			m_hook_error = new ArgsMessage("hooks.error");
-	
-	public final P plugin;
+	protected final P plugin;
 	
 	public final P getPlugin() {
 		return plugin;
@@ -25,10 +26,10 @@ public abstract class Hook<P extends Plugin> {
 	
 	@SuppressWarnings("null")
 	public Hook() throws IOException {
-		@SuppressWarnings("unchecked")
-		final P p = (P) Bukkit.getPluginManager().getPlugin(getName());
-		plugin = p;
-		if (p == null) {
+		// noinspection unchecked
+		P plugin = (P) Bukkit.getPluginManager().getPlugin(getName());
+		this.plugin = plugin;
+		if (plugin == null || !plugin.isEnabled()) {
 			if (Documentation.canGenerateUnsafeDocs()) {
 				loadClasses();
 				if (Skript.logHigh())
@@ -38,20 +39,34 @@ public abstract class Hook<P extends Plugin> {
 		}
 
 		if (!init()) {
-			Skript.error(m_hook_error.toString(p.getName()));
+			Skript.error(m_hook_error.toString(plugin.getName()));
 			return;
 		}
 
 		loadClasses();
 
 		if (Skript.logHigh())
-			Skript.info(m_hooked.toString(p.getName()));
-
-		return;
+			Skript.info(m_hooked.toString(plugin.getName()));
 	}
 	
 	protected void loadClasses() throws IOException {
-		Skript.getAddonInstance().loadClasses("" + getClass().getPackage().getName());
+		SyntaxRegistry registry = Skript.instance().syntaxRegistry();
+		ClassLoader.builder()
+			.basePackage(getClass().getPackage().getName())
+			.deep(true)
+			.initialize(true)
+			.forEachClass(clazz -> {
+				if (SyntaxElement.class.isAssignableFrom(clazz)) {
+					try {
+						clazz.getMethod("register", SyntaxRegistry.class).invoke(null, registry);
+					} catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+						// noinspection ThrowableNotThrown
+						Skript.exception(e, "Error while loading a hook");
+					}
+				}
+			})
+			.build()
+			.loadClasses(Skript.class);
 	}
 	
 	/**


### PR DESCRIPTION
### Problem
When loading hooks, Skript checks if the plugin exists, but not if it's enabled. If the hooked plugin fails to enable, it completely bricks all script loading.

### Solution
Check if the plugin is enabled before loading the hook. The main change is around line 32. The rest is code cleanup.


### Testing Completed
Tested with an outdated WorldGuard jar before & after.
Made sure the syntaxes are still registered and work properly.


### Supporting Information
The issue could probably be reproduced with other hooks if their plugins fail to load.


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
