### PR TITLE
Proper toString for Simple Events

### DIFF
--- a/src/main/java/ch/njol/skript/lang/util/SimpleEvent.java
+++ b/src/main/java/ch/njol/skript/lang/util/SimpleEvent.java
@@ -9,12 +9,27 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * A very basic SkriptEvent which returns true for all events (i.e. all registered events).
- * 
- * @author Peter Güttinger
  */
 public class SimpleEvent extends SkriptEvent {
 
-	public SimpleEvent() {}
+	private final String toString;
+
+	/**
+	 * Creates a new SimpleEvent with the default toString of 'simple event'.
+	 * Prefer using {@link #SimpleEvent(String)} to provide a more descriptive toString.
+	 */
+	public SimpleEvent() {
+		this("simple event");
+	}
+
+	/**
+	 * Creates a new SimpleEvent with a custom toString.
+	 *
+	 * @param string the string to return in toString
+	 */
+	public SimpleEvent(String string) {
+		this.toString = string;
+	}
 
 	@Override
 	public boolean check(Event event) {
@@ -30,7 +45,7 @@ public class SimpleEvent extends SkriptEvent {
 
 	@Override
 	public String toString(@Nullable Event event, boolean debug) {
-		return "simple event";
+		return toString;
 	}
 
 }


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
Currently every simpleevent has the same toString: "simple event" unless they are merged into its own custom file seperate from SimpleEvents.java (e.g. EvtItem with its god awful `return "dispense/spawn/drop/craft/pickup/consume/break/despawn/merge/move/stonecutting"`) which is pretty messy + bad overhaul for errors or whatever else toString is used for. Imagine having an issue with item drop event just to get e.g. "event-example cannot be used in an on dispense/spawn/drop/craft/pickup/consume/break/despawn/merge/move/stonecutting bedrock event" its messy and not great
### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
Adds on to SimpleEvent which allows you to create a SimpleEvent("") so the usage would go something along in an event registry: `.supplier(() -> new SimpleEvent("my super cool event")` 
if no value is provided it will default to using 'simple event' for the toString

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
quicktest ran fine and no errors in intellij/conflicts so i'd say works

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->
small pr '-'

also credit to smurfy/sovde for the idea n code

---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
