### PR TITLE
Fix simple SyntaxInfo return types

### DIFF
--- a/src/main/java/org/skriptlang/skript/bukkit/registration/BukkitSyntaxInfos.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/registration/BukkitSyntaxInfos.java
@@ -2,7 +2,6 @@ package org.skriptlang.skript.bukkit.registration;
 
 import ch.njol.skript.lang.SkriptEvent;
 import ch.njol.skript.lang.SkriptEvent.ListeningBehavior;
-import ch.njol.skript.lang.SyntaxElement;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.bukkit.registration.BukkitSyntaxInfosImpl.EventImpl;
@@ -43,7 +42,7 @@ public final class BukkitSyntaxInfos {
 		 * @return A syntax info representing {@code type}.
 		 */
 		@Contract("_, _, _, _, _ -> new")
-		static <E extends SkriptEvent> SyntaxInfo<E> simple(Class<E> eventClass, Supplier<E> instanceSupplier,
+		static <E extends SkriptEvent> Event<E> simple(Class<E> eventClass, Supplier<E> instanceSupplier,
 			String name, Class<? extends org.bukkit.event.Event> bukkitEventClass, String... patterns) {
 			return builder(eventClass, name)
 				.supplier(instanceSupplier)
@@ -187,7 +186,7 @@ public final class BukkitSyntaxInfos {
 			 * @return This builder.
 			 * @see Event#since()
 			 */
-			@Contract("_ -> this")
+			@Contract("-> this")
 			B clearSince();
 
 			/**

--- a/src/main/java/org/skriptlang/skript/registration/DefaultSyntaxInfos.java
+++ b/src/main/java/org/skriptlang/skript/registration/DefaultSyntaxInfos.java
@@ -31,7 +31,7 @@ public sealed interface DefaultSyntaxInfos permits SyntaxInfo {
 		 * @return A syntax info representing {@code type}.
 		 */
 		@Contract("_, _, _ , _-> new")
-		static <E extends ch.njol.skript.lang.Expression<R>, R> SyntaxInfo<E> simple(Class<E> expressionClass,
+		static <E extends ch.njol.skript.lang.Expression<R>, R> Expression<E, R> simple(Class<E> expressionClass,
 			Supplier<E> instanceSupplier, Class<R> returnType, String... patterns) {
 			return builder(expressionClass, returnType)
 				.supplier(instanceSupplier)
@@ -137,7 +137,7 @@ public sealed interface DefaultSyntaxInfos permits SyntaxInfo {
 		 * @return A syntax info representing {@code type}.
 		 */
 		@Contract("_, _, _ -> new")
-		static <E extends org.skriptlang.skript.lang.structure.Structure> SyntaxInfo<E> simple(Class<E> structureClass,
+		static <E extends org.skriptlang.skript.lang.structure.Structure> Structure<E> simple(Class<E> structureClass,
 			Supplier<E> instanceSupplier, String... patterns) {
 			return builder(structureClass)
 				.supplier(instanceSupplier)


### PR DESCRIPTION
### Problem
I used non-specific return types in https://github.com/SkriptLang/Skript/pull/8709.
My apologies for not being more thorough with my testing (checking my copy pasting 😞)

### Solution
Updated the return types to be specific for the implementations.


### Testing Completed
I actually manually verified the methods this time.


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
