### PR TITLE
Update used repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,10 +17,15 @@ configurations {
 allprojects {
 	repositories {
 		mavenCentral()
-		maven { url 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/' }
-		maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
-		maven { url 'https://repo.papermc.io/repository/maven-public/' }
-		maven { url 'https://ci.emc.gs/nexus/content/groups/aikar/' }
+		maven { // for Paper
+			url = 'https://repo.papermc.io/repository/maven-public/'
+		}
+		maven { // for WorldGuard
+			url = "https://maven.enginehub.org/repo/"
+		}
+		maven { // for Vault
+			url = 'https://jitpack.io'
+		}
 	}
 }
 
@@ -37,10 +42,11 @@ dependencies {
 	// Plugin hook libraries
 	implementation group: 'com.sk89q.worldguard', name: 'worldguard-legacy', version: '7.0.0-SNAPSHOT', {
 		exclude group: 'org.bukkit', module: 'bukkit'
-	}
-	implementation group: 'net.milkbowl.vault', name: 'Vault', version: '1.7.3', {
 		exclude group: 'org.bstats', module: 'bstats-bukkit'
+	}
+	implementation group: 'com.github.MilkBowl', name: 'VaultAPI', version: '1.7.1', {
 		exclude group: 'org.bukkit', module: 'bukkit'
+		exclude group: 'org.bstats', module: 'bstats-bukkit'
 	}
 
 	implementation fileTree(dir: 'lib', include: '*.jar')

--- a/src/main/java/ch/njol/skript/hooks/VaultHook.java
+++ b/src/main/java/ch/njol/skript/hooks/VaultHook.java
@@ -3,18 +3,18 @@ package ch.njol.skript.hooks;
 import java.io.IOException;
 
 import ch.njol.skript.doc.Documentation;
-import net.milkbowl.vault.Vault;
 import net.milkbowl.vault.chat.Chat;
 import net.milkbowl.vault.economy.Economy;
 import net.milkbowl.vault.permission.Permission;
 import org.bukkit.Bukkit;
 
 import ch.njol.skript.Skript;
+import org.bukkit.plugin.Plugin;
 
 /**
  * @author Peter Güttinger
  */
-public class VaultHook extends Hook<Vault> {
+public class VaultHook extends Hook<Plugin> {
 
 	public static final String NO_GROUP_SUPPORT = "The permissions plugin you are using does not support groups.";
 


### PR DESCRIPTION
### Problem
We are having build issues caused by using the old (and deprecated) oss index snapshot repository.
There also isn't really a need for us to be using it.

### Solution
Replaces the snapshot dependency in favor of the specific repositories recommended by the dependencies we were using it for: WorldGuard and Vault

It is recommended to reference VaultAPI over the plugin itself, so I have gone ahead and made that change. This affects the generic used for the VaultHook class, but that has no real effect.


### Testing Completed
I confirmed in game that the VaultHook is still working.


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
