### PR TITLE
Add Paper 26.2 testing environment

### DIFF
--- a/.github/workflows/java-25-builds.yml
+++ b/.github/workflows/java-25-builds.yml
@@ -15,7 +15,7 @@ jobs:
         with:
             environments: 26.1.2,26.2
             java_version: 25
-            parallel_jobs: 3
+            parallel_jobs: 1
 
     build:
         name: ${{ matrix.display }}

--- a/.github/workflows/java-25-builds.yml
+++ b/.github/workflows/java-25-builds.yml
@@ -13,7 +13,7 @@ jobs:
         if: "! contains(toJSON(github.event.commits.*.message), '[ci skip]')"
         uses: ./.github/workflows/parallelize-tests.yml
         with:
-            environments: 26.1.2, 26.2
+            environments: 26.1.2,26.2
             java_version: 25
             parallel_jobs: 3
 

--- a/.github/workflows/java-25-builds.yml
+++ b/.github/workflows/java-25-builds.yml
@@ -13,7 +13,7 @@ jobs:
         if: "! contains(toJSON(github.event.commits.*.message), '[ci skip]')"
         uses: ./.github/workflows/parallelize-tests.yml
         with:
-            environments: 26.1.2
+            environments: 26.1.2, 26.2
             java_version: 25
             parallel_jobs: 3
 

--- a/.github/workflows/junit-25-builds.yml
+++ b/.github/workflows/junit-25-builds.yml
@@ -15,7 +15,7 @@ jobs:
         with:
             environments: 26.1.2,26.2
             java_version: 25
-            parallel_jobs: 3
+            parallel_jobs: 1
 
     build:
         name: ${{ matrix.display }}

--- a/.github/workflows/junit-25-builds.yml
+++ b/.github/workflows/junit-25-builds.yml
@@ -13,7 +13,7 @@ jobs:
         if: "! contains(toJSON(github.event.commits.*.message), '[ci skip]')"
         uses: ./.github/workflows/parallelize-tests.yml
         with:
-            environments: 26.1.2, 26.2
+            environments: 26.1.2,26.2
             java_version: 25
             parallel_jobs: 3
 

--- a/.github/workflows/junit-25-builds.yml
+++ b/.github/workflows/junit-25-builds.yml
@@ -13,7 +13,7 @@ jobs:
         if: "! contains(toJSON(github.event.commits.*.message), '[ci skip]')"
         uses: ./.github/workflows/parallelize-tests.yml
         with:
-            environments: 26.1.2
+            environments: 26.1.2, 26.2
             java_version: 25
             parallel_jobs: 3
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 	shadow group: 'io.papermc', name: 'paperlib', version: '1.0.8'
 	shadow group: 'org.bstats', name: 'bstats-bukkit', version: '3.2.1'
 
-	implementation group: 'io.papermc.paper', name: 'paper-api', version: '26.1.2.build.+'
+	implementation group: 'io.papermc.paper', name: 'paper-api', version: '26.2.build.+'
 	implementation group: 'com.google.code.findbugs', name: 'findbugs', version: '3.0.1'
 
 	// bundled with Minecraft 1.19.4+ for display entity transforms

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ groupid=ch.njol
 name=skript
 version=2.15.3
 jarName=Skript.jar
-testEnv=java25/paper-26.1.2
+testEnv=java25/paper-26.2
 testEnvJavaVersion=25

--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -62,6 +62,7 @@ import org.bukkit.event.world.WorldEvent;
 import org.bukkit.inventory.*;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.potion.PotionType;
+import org.skriptlang.skript.bukkit.item.book.elements.expressions.ExprBookPages;
 import org.skriptlang.skript.bukkit.lang.eventvalue.EventValue;
 import org.skriptlang.skript.bukkit.lang.eventvalue.EventValue.Time;
 import org.skriptlang.skript.bukkit.lang.eventvalue.EventValueRegistry;
@@ -576,11 +577,11 @@ public final class BukkitEventValues {
 			return book;
 		}));
 		registry.register(EventValue.builder(PlayerEditBookEvent.class, Component[].class)
-			.getter(event -> event.getPreviousBookMeta().pages().toArray(new Component[0]))
+			.getter(event -> ExprBookPages.getPages(event.getPreviousBookMeta()).toArray(new Component[0]))
 			.time(Time.PAST)
 			.build());
 		registry.register(EventValue.simple(PlayerEditBookEvent.class, Component[].class, event ->
-			event.getNewBookMeta().pages().toArray(new Component[0])));
+			ExprBookPages.getPages(event.getNewBookMeta()).toArray(new Component[0])));
 		//ItemDespawnEvent
 		registry.register(EventValue.simple(ItemDespawnEvent.class, Item.class, ItemDespawnEvent::getEntity));
 		registry.register(EventValue.simple(ItemDespawnEvent.class, ItemStack.class, event -> event.getEntity().getItemStack()));

--- a/src/main/java/ch/njol/skript/entity/SimpleEntityData.java
+++ b/src/main/java/ch/njol/skript/entity/SimpleEntityData.java
@@ -255,6 +255,10 @@ public class SimpleEntityData extends EntityData<Entity> {
 			addSimpleEntity("parched", Parched.class);
 		}
 
+		if (Skript.isRunningMinecraft(26, 2)) {
+			addSimpleEntity("sulfur cube", SulfurCube.class);
+		}
+
 		// SuperTypes
 		addSuperEntity("human", HumanEntity.class);
 		addSuperEntity("damageable", Damageable.class);

--- a/src/main/java/org/skriptlang/skript/bukkit/item/book/elements/expressions/ExprBookPages.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/item/book/elements/expressions/ExprBookPages.java
@@ -13,6 +13,7 @@ import ch.njol.skript.lang.SyntaxStringBuilder;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
+import net.kyori.adventure.inventory.Book;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Material;
 import org.bukkit.event.Event;
@@ -39,6 +40,26 @@ import java.util.List;
 @Example("set page 1 of the player's held item to \"This page was written with Skript!\"")
 @Since("2.2-dev31, 2.7 (changers)")
 public class ExprBookPages extends SimpleExpression<Component> {
+
+	@SuppressWarnings("ConstantValue") // true on 26.1 and older
+	private static final boolean EXTENDS_ADVENTURE_BOOK = Book.class.isAssignableFrom(BookMeta.class);
+
+	public static List<Component> getPages(BookMeta bookMeta) {
+		if (EXTENDS_ADVENTURE_BOOK) {
+			//noinspection ConstantConditions
+			return ((Book) (Object) bookMeta).pages();
+		}
+		return bookMeta.pages();
+	}
+
+	public static void setPages(BookMeta bookMeta, List<Component> pages) {
+		if (EXTENDS_ADVENTURE_BOOK) {
+			//noinspection ConstantConditions, ResultOfMethodCallIgnored - modifies in place despite contract
+			((Book) (Object) bookMeta).pages(pages);
+		} else {
+			bookMeta.pages(pages);
+		}
+	}
 
 	public static void register(SyntaxRegistry syntaxRegistry) {
 		syntaxRegistry.register(SyntaxRegistry.EXPRESSION, SyntaxInfo.Expression.builder(ExprBookPages.class, Component.class)
@@ -77,7 +98,7 @@ public class ExprBookPages extends SimpleExpression<Component> {
 				return new Component[0];
 			}
 			if (isAllPages()) {
-				pages.addAll(bookMeta.pages());
+				pages.addAll(getPages(bookMeta));
 			} else {
 				Integer pageNumber = this.pageNumber.getSingle(event);
 				if (pageNumber == null) {
@@ -122,8 +143,7 @@ public class ExprBookPages extends SimpleExpression<Component> {
 
 			if (isAllPages()) {
 				switch (mode) {
-					case SET, DELETE, RESET -> //noinspection ResultOfMethodCallIgnored - modifies in place despite contract
-						bookMeta.pages(newPages);
+					case SET, DELETE, RESET -> setPages(bookMeta, newPages);
 					case ADD -> bookMeta.addPages(newPages.toArray(new Component[0]));
 					default -> throw new IllegalStateException();
 				}
@@ -131,10 +151,9 @@ public class ExprBookPages extends SimpleExpression<Component> {
 				switch (mode) {
 					case SET -> bookMeta.page(pageNumber, newPages.getFirst());
 					case DELETE -> {
-						List<Component> pages = new ArrayList<>(bookMeta.pages());
+						List<Component> pages = new ArrayList<>(getPages(bookMeta));
 						pages.remove(pageNumber);
-						//noinspection ResultOfMethodCallIgnored - modifies in place despite contract
-						bookMeta.pages(pages);
+						setPages(bookMeta, pages);
 					}
 					case RESET -> bookMeta.page(pageNumber, Component.empty());
 					default -> throw new IllegalStateException();

--- a/src/main/resources/lang/default.lang
+++ b/src/main/resources/lang/default.lang
@@ -286,6 +286,8 @@ biomes:
 	cherry_grove: cherry grove
 	# 1.21.3
 	pale_garden: pale garden
+	# 26.2
+	sulfur_caves: sulfur caves
 
 # -- Tree Types --
 tree types:
@@ -1626,6 +1628,11 @@ entities:
 		name: parched¦s
 		pattern: parched[plural:s]
 
+	# 26.2
+	sulfur cube:
+		name: sulfur cube¦s
+		pattern: sulfur cube[plural:s]
+
 	# SuperTypes
 	human:
 		name: human¦s
@@ -2096,6 +2103,12 @@ attribute types:
 	camera_distance: camera distance
 	waypoint_transmit_range: waypoint transmit range
 	waypoint_receive_range: waypoint receive range
+	# 26.2
+	bounciness: bounciness
+	friction_modifier: friction modifier
+	below_name_distance: below name distance, nameplate score visibility distance, name tag score visibility distance
+	air_drag_modifier: air drag modifier
+	name_tag_distance: name tag distance, nameplate visibility distance, name tag visibility distance
 
 # -- Environments --
 environments:
@@ -2285,6 +2298,25 @@ game effect:
 	trial_spawner_detect_player_ominous: ominous trial spawner detect player effect
 	trial_spawner_become_ominous: trial spawner become ominous effect
 	trial_spawner_spawn_item: trial spawner spawn item effect
+
+	# 26.2
+	dispenser_dispense: dispenser dispense effect
+	dispenser_fail: dispenser fail effect, dispenser fail to dispense effect, dispenser failure to dispense effect
+	dispenser_projectile_launch: dispenser projectile launch effect
+	record_stop: record stop effect, music disc stop effect
+	ender_dragon_shoot: ender dragon shoot effect, ender dragon shoots fireball effect
+	zombie_converted_to_villager: zombie converted to villager effect, zombie villager cured effect
+	wind_charge_shoot: wind charge shoot effect
+	sulfur_spike_land: sulfur spike land effect
+	smoke_shoot: smoke shoot effect, smoke eruption effect
+	destroy_block: destroy block effect, block destruction effect
+	ender_dragon_breath: ender dragon breath effect, ender dragon breathing effect
+	white_smoke_shoot: white smoke shoot effect, white smoke eruption effect
+	ender_dragon_growl: ender dragon growl effect, ender dragon growling effect
+	sculk_charge: sculk charge effect,
+	sculk_shriek: sculk shriek effect,
+	brush_block_complete: brush block complete effect, finish brushing block effect,
+	egg_crack: egg crack effect
 
 # -- Entity Effects --
 # all patterns should include the word 'effect' or 'animation'
@@ -2505,6 +2537,15 @@ particle:
 	white_smoke: white smoke particle¦s @a
 	witch: witch particle¦s @a
 
+	# 26.2
+	noxious_gas: noxious gas particle¦s @a, nausea gas particle¦s @a
+	noxious_gas_cloud: noxious gas cloud¦s @a, nausea gas cloud particle¦s @a
+	sulfur_cube_goo: sulfur cube goo particle¦s @a, sulfur cube jump particle¦s @a, sulfur cube jumping particle¦s @a
+	sulfur_bubbles: sulfur bubbles particle¦s @a, sulfur bubble column particle¦s @a
+	geyser: geyser particle¦s @a
+	geyser_base: geyser base particle¦s @a
+	geyser_plume: geyser plume particle¦s @a
+	geyser_poof: geyser poof particle¦s @a
 
 # -- Teleport Flags --
 teleport flags:
@@ -2769,6 +2810,8 @@ damage types:
 	wind_charge: wind charge
 	wither: wither
 	wither_skull: wither skull
+	# 26.2
+	sulfur_cube_hot: sulfur cube hot, hot sulfur cube, magma sulfur cube
 
 # -- Boolean --
 boolean:

--- a/src/test/skript/environments/java25/paper-26.2.json
+++ b/src/test/skript/environments/java25/paper-26.2.json
@@ -1,0 +1,17 @@
+{
+	"name": "paper-26.2",
+	"resources": [
+		{"source": "server.properties.generic", "target": "server.properties"}
+	],
+	"paperDownloads": [
+		{
+			"version": "26.2",
+			"target": "paperclip.jar"
+		}
+	],
+	"skriptTarget": "plugins/Skript.jar",
+	"commandLine": [
+		"-Dcom.mojang.eula.agree=true",
+		"-jar", "paperclip.jar", "--nogui"
+	]
+}


### PR DESCRIPTION
### Problem
Paper 26.2 has been out, and although not yet stable, we can start testing against it.

### Solution
Adds 26.2 testing environment as the latest.


### Testing Completed
Confirmed it ran via quickTest


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
