### PR TITLE
Fix ExprBookPages changer

### DIFF
--- a/src/main/java/org/skriptlang/skript/bukkit/item/book/elements/expressions/ExprBookPages.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/item/book/elements/expressions/ExprBookPages.java
@@ -22,7 +22,7 @@ import org.skriptlang.skript.registration.SyntaxInfo;
 import org.skriptlang.skript.registration.SyntaxRegistry;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 
 @Name("Book Pages")
@@ -104,14 +104,17 @@ public class ExprBookPages extends SimpleExpression<Component> {
 
 	@Override
 	public void change(Event event, Object @Nullable [] delta, ChangeMode mode) {
-		int pageNumber = isAllPages() ? -1 : this.pageNumber.getOptionalSingle(event).orElse(-1);
-		List<Component> newPages = delta == null ? Collections.emptyList() : new ArrayList<>(delta.length);
+		int pageNumber = -1;
+		if (!isAllPages()) {
+			pageNumber = this.pageNumber.getOptionalSingle(event).orElse(-1);
+			if (pageNumber <= 0) {
+				return;
+			}
+		}
+		List<Component> newPages = delta == null ? List.of() : new ArrayList<>(delta.length);
 		if (delta != null) {
 			for (Object page : delta) {
 				newPages.add((Component) page);
-			}
-			if (pageNumber != -1 && newPages.isEmpty()) { // not setting this page to anything, exit early
-				return;
 			}
 		}
 
@@ -129,14 +132,29 @@ public class ExprBookPages extends SimpleExpression<Component> {
 				}
 			} else {
 				switch (mode) {
-					case SET -> bookMeta.page(pageNumber, newPages.getFirst());
+					case SET -> {
+						if (pageNumber > bookMeta.getPageCount()) {
+							Component[] pages = new Component[pageNumber - bookMeta.getPageCount()];
+							Arrays.fill(pages, Component.empty());
+							bookMeta.addPages(pages);
+						}
+						bookMeta.page(pageNumber, newPages.getFirst());
+					}
 					case DELETE -> {
+						if (pageNumber > bookMeta.getPageCount()) {
+							break;
+						}
 						List<Component> pages = new ArrayList<>(bookMeta.pages());
-						pages.remove(pageNumber);
+						pages.remove(pageNumber - 1);
 						//noinspection ResultOfMethodCallIgnored - modifies in place despite contract
 						bookMeta.pages(pages);
 					}
-					case RESET -> bookMeta.page(pageNumber, Component.empty());
+					case RESET -> {
+						if (pageNumber > bookMeta.getPageCount()) {
+							continue;
+						}
+						bookMeta.page(pageNumber, Component.empty());
+					}
 					default -> throw new IllegalStateException();
 				}
 			}

--- a/src/test/skript/tests/bukkit/item/book/ExprBookPages.sk
+++ b/src/test/skript/tests/bukkit/item/book/ExprBookPages.sk
@@ -1,0 +1,22 @@
+test "ExprBookPages":
+	set {_i} to a written book
+
+	# all pages
+	assert {_i}'s book pages are not set with "non-existent book pages failed"
+	set pages of {_i} to "&aPages testing" and "test 2"
+	assert size of {_i}'s book pages is 2 with "failed to match exact pages size"
+	assert page 2 of {_i} is "test 2" with "failed to compare page 2"
+	add "test 3" to the pages of {_i}
+	assert page 3 of {_i} is "test 3" with "failed to compare page 3"
+	clear pages of {_i}
+	assert {_i}'s book pages are not set with "non-existent book pages failed 2"
+
+	# specific pages
+	set page 3 of {_i} to "test 3"
+	assert page 3 of {_i} is "test 3" with "failed to set page 3"
+	assert size of {_i}'s book pages is 3 with "failed to add correct number of pages"
+	delete page 2 of {_i}
+	# page 3 becomes page 2
+	assert page 2 of {_i} is "test 3" with "failed to remove page 2"
+	reset page 2 of {_i}
+	assert page 2 of {_i} is "" with "failed to reset page 2"

--- a/src/test/skript/tests/syntaxes/expressions/ExprBookPages.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprBookPages.sk
@@ -1,6 +1,0 @@
-test "book pages":
-	set {_i} to a written book
-	assert {_i}'s book pages is not set with "non-existent book pages failed 2"
-	set pages of {_i} to "&aPages testing" and "test 2"
-	assert size of {_i}'s book pages is 2 with "failed to match exact pages size"
-	assert page 2 of {_i} is "test 2" with "failed to compare page 2"


### PR DESCRIPTION
### Problem
As described in #8751, the changers for book pages do not work as expected. They cause an error when attempting to modify a specific page that has not yet been set.


### Solution
Pages are 1-indexed, but care was not taken to ensure modified pages were already set. Additionally, specific page removal did not account for pages being 1-indexed.


### Testing Completed
I rewrote and expanded `ExprBookPages.sk` for full coverage


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:**
- closes #8751 

**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
