### PR TITLE
Add alternative Patterns constructor

### DIFF
--- a/src/main/java/ch/njol/skript/util/Patterns.java
+++ b/src/main/java/ch/njol/skript/util/Patterns.java
@@ -41,6 +41,23 @@ public class Patterns<T> {
 	}
 
 	/**
+	 * Creates a new {@link Patterns} with the provided paired inputs.
+	 * @param info Pattern-Value pairs, for example:
+	 * <code>
+	 * new Patterns("pattern1", value1, "pattern2", value2);
+	 * </code>
+	 */
+	public Patterns(Object... info) {
+		patterns = new String[info.length / 2];
+		types = new Object[info.length / 2];
+		for (int i = 0; i < info.length; i += 2) {
+			patterns[i / 2] = (String) info[i];
+			types[i / 2] = info[i + 1];
+			matchedPatterns.computeIfAbsent(info[i + 1], list -> new ArrayList<>()).add(i / 2);
+		}
+	}
+
+	/**
 	 * Returns an array of the registered patterns.
 	 * @return An {@link java.lang.reflect.Array} of {@link String}s.
 	 */

--- a/src/main/java/ch/njol/skript/util/Patterns.java
+++ b/src/main/java/ch/njol/skript/util/Patterns.java
@@ -51,9 +51,10 @@ public class Patterns<T> {
 		patterns = new String[info.length / 2];
 		types = new Object[info.length / 2];
 		for (int i = 0; i < info.length; i += 2) {
-			patterns[i / 2] = (String) info[i];
-			types[i / 2] = info[i + 1];
-			matchedPatterns.computeIfAbsent(info[i + 1], list -> new ArrayList<>()).add(i / 2);
+			int pattern = i / 2;
+			patterns[pattern] = (String) info[i];
+			types[pattern] = info[i + 1];
+			matchedPatterns.computeIfAbsent(info[i + 1], list -> new ArrayList<>()).add(pattern);
 		}
 	}
 


### PR DESCRIPTION
### Problem
Patterns creation is a bit bulky given the array arguments.


### Solution
I've added a simplified constructor that simply takes in a variable number of objects. The input is expected in the same format: `pattern1, value1, pattern2, value2, ...`

### Testing Completed
Tested on a few existing elements to verify functionality.

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->
n/a


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
