### PR TITLE
RegistryClassInfo Housekeeping

### DIFF
--- a/src/main/java/ch/njol/skript/bukkitutil/BukkitUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/BukkitUtils.java
@@ -7,6 +7,7 @@ import ch.njol.skript.util.PaperUtils;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 
+import io.papermc.paper.registry.RegistryKey;
 import org.bukkit.Keyed;
 import org.bukkit.Registry;
 import org.bukkit.inventory.EquipmentSlot;
@@ -89,8 +90,25 @@ public class BukkitUtils {
 		String codeName,
 		String languageNode
 	) {
+		// validate class
 		if (!Skript.classExists(classPath))
 			return null;
+		Class<R> registryClass;
+		try {
+			//noinspection unchecked
+			registryClass = (Class<R>) Class.forName(classPath);
+		} catch (ClassNotFoundException e) {
+			Skript.debug("Could not retrieve the class with the path: '" + classPath + "'.");
+			throw new RuntimeException(e);
+		}
+
+		// first, try better RegistryKey
+		if (PaperUtils.registryExists(registryName)) {
+			RegistryKey<R> registryKey = PaperUtils.getBukkitRegistryKey(registryName);
+			return new RegistryClassInfo<>(registryClass, registryKey, codeName, languageNode);
+		}
+
+		// otherwise, standard Registry
 		Registry<R> registry = null;
 		if (BukkitUtils.registryExists(registryName)) {
 			try {
@@ -99,18 +117,8 @@ public class BukkitUtils {
 			} catch (NoSuchFieldException | IllegalAccessException e) {
 				throw new RuntimeException(e);
 			}
-		} else if (PaperUtils.registryExists(registryName)) {
-			registry = PaperUtils.getBukkitRegistry(registryName);
 		}
 		if (registry != null) {
-			Class<R> registryClass;
-			try {
-				//noinspection unchecked
-				registryClass = (Class<R>) Class.forName(classPath);
-			} catch (ClassNotFoundException e) {
-				Skript.debug("Could not retrieve the class with the path: '" + classPath + "'.");
-				throw new RuntimeException(e);
-			}
 			return new RegistryClassInfo<>(registryClass, registry, codeName, languageNode);
 		}
 		Skript.debug("There were no registries found for '" + registryName + "'.");

--- a/src/main/java/ch/njol/skript/classes/ClassInfo.java
+++ b/src/main/java/ch/njol/skript/classes/ClassInfo.java
@@ -133,7 +133,6 @@ public class ClassInfo<T> implements Debuggable {
 	 * @see SimpleLiteral
 	 */
 	public ClassInfo<T> defaultExpression(final DefaultExpression<T> defaultExpression) {
-		assert this.defaultExpression == null;
 		if (!defaultExpression.isDefault())
 			throw new IllegalArgumentException("defaultExpression.isDefault() must return true for the default expression of a class");
 		this.defaultExpression = defaultExpression;

--- a/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitClasses.java
@@ -11,6 +11,7 @@ import ch.njol.skript.lang.util.SimpleLiteral;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.util.BlockUtils;
 import ch.njol.yggdrasil.Fields;
+import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.world.MoonPhase;
 import net.kyori.adventure.text.Component;
 import org.bukkit.*;
@@ -326,7 +327,7 @@ public class BukkitClasses {
 				.since("2.0")
 				.changer(DefaultChangers.itemChanger));
 
-		Classes.registerClass(new RegistryClassInfo<>(Biome.class, Registry.BIOME, "biome", "biomes")
+		Classes.registerClass(new RegistryClassInfo<>(Biome.class, RegistryKey.BIOME, "biome", "biomes")
 				.user("biomes?")
 				.name("Biome")
 				.description("All possible biomes Minecraft uses to generate a world.",
@@ -600,7 +601,7 @@ public class BukkitClasses {
 					ExpressionPropertyHandler.of(GameRule::getName, String.class)
 				));
 
-		Classes.registerClass(new RegistryClassInfo<>(Attribute.class, Registry.ATTRIBUTE, "attributetype", "attribute types")
+		Classes.registerClass(new RegistryClassInfo<>(Attribute.class, RegistryKey.ATTRIBUTE, "attributetype", "attribute types")
 				.user("attribute ?types?")
 				.name("Attribute Type")
 				.description("Represents the type of an attribute. Note that this type does not contain any numerical values." +
@@ -659,14 +660,14 @@ public class BukkitClasses {
 				.description("Represents a change reason of an <a href='#experience cooldown change event'>experience cooldown change event</a>.")
 				.since("2.10"));
 
-		Classes.registerClass(new RegistryClassInfo<>(Villager.Type.class, Registry.VILLAGER_TYPE, "villagertype", "villager types")
+		Classes.registerClass(new RegistryClassInfo<>(Villager.Type.class, RegistryKey.VILLAGER_TYPE, "villagertype", "villager types")
 				.user("villager ?types?")
 				.name("Villager Type")
 				.description("Represents the different types of villagers. These are usually the biomes a villager can be from.")
 				.after("biome")
 				.since("2.10"));
 
-		Classes.registerClass(new RegistryClassInfo<>(Villager.Profession.class, Registry.VILLAGER_PROFESSION, "villagerprofession", "villager professions")
+		Classes.registerClass(new RegistryClassInfo<>(Villager.Profession.class, RegistryKey.VILLAGER_PROFESSION, "villagerprofession", "villager professions")
 				.user("villager ?professions?")
 				.name("Villager Profession")
 				.description("Represents the different professions of villagers.")
@@ -705,27 +706,7 @@ public class BukkitClasses {
 				.description("Represents a banner pattern.")
 				.since("2.10"));
 
-		ClassInfo<?> patternTypeInfo;
-		Registry<PatternType> patternRegistry = Bukkit.getRegistry(PatternType.class);
-		if (patternRegistry != null) {
-			patternTypeInfo = new RegistryClassInfo<>(PatternType.class, patternRegistry, "bannerpatterntype", "banner pattern types");
-		} else {
-			try {
-				Class<?> patternClass = Class.forName("org.bukkit.block.banner.PatternType");
-				if (patternClass.isEnum()) {
-					//noinspection unchecked,rawtypes
-					Class<? extends Enum> enumClass = (Class<? extends Enum>) patternClass;
-					//noinspection rawtypes,unchecked
-					patternTypeInfo = new EnumClassInfo<>(enumClass, "bannerpatterntype", "banner pattern types");
-				} else {
-					throw new IllegalStateException("PatternType is neither an enum nor a valid registry.");
-				}
-			} catch (ClassNotFoundException e) {
-				throw new RuntimeException(e);
-			}
-		}
-
-		Classes.registerClass(patternTypeInfo
+		Classes.registerClass(new RegistryClassInfo<>(PatternType.class, RegistryKey.BANNER_PATTERN, "bannerpatterntype", "banner pattern types")
 				.user("banner ?pattern ?types?")
 				.name("Banner Pattern Type")
 				.description("Represents the various banner patterns that can be applied to a banner.")

--- a/src/main/java/ch/njol/skript/classes/registry/RegistryClassInfo.java
+++ b/src/main/java/ch/njol/skript/classes/registry/RegistryClassInfo.java
@@ -3,10 +3,16 @@ package ch.njol.skript.classes.registry;
 import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.expressions.base.EventValueExpression;
 import ch.njol.skript.lang.DefaultExpression;
+import io.papermc.paper.registry.RegistryAccess;
+import io.papermc.paper.registry.RegistryKey;
 import org.bukkit.Keyed;
 import org.bukkit.Registry;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.Iterator;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * This class can be used for easily creating ClassInfos for {@link Registry}s.
@@ -16,12 +22,87 @@ import java.util.function.Consumer;
  */
 public class RegistryClassInfo<R extends Keyed> extends ClassInfo<R> {
 
+	private final @Nullable RegistryKey<R> registryKey;
+
+	/**
+	 * @param registryClass The registry class
+	 * @param registryKey The registry key
+	 * @param codeName The name used in patterns
+	 * @param languageNode The language node of the type
+	 */
+	public RegistryClassInfo(Class<R> registryClass, RegistryKey<R> registryKey, String codeName, String languageNode) {
+		this(registryClass, registryKey, RegistryAccess.registryAccess().getRegistry(registryKey), codeName,
+			languageNode, null, null);
+	}
+
+	/**
+	 * @param registryClass The registry class
+	 * @param registryKey The registry key
+	 * @param codeName The name used in patterns
+	 * @param languageNode The language node of the type
+	 * @param parseCallback A consumer to run on a successful parse.
+	 */
+	public RegistryClassInfo(Class<R> registryClass, RegistryKey<R> registryKey, String codeName, String languageNode,
+	                         Consumer<R> parseCallback) {
+		this(registryClass, registryKey, RegistryAccess.registryAccess().getRegistry(registryKey), codeName,
+			languageNode, null, parseCallback);
+	}
+
+	private RegistryClassInfo(Class<R> registryClass, @Nullable RegistryKey<R> registryKey, Registry<R> registry,
+							  String codeName, String languageNode, @Nullable DefaultExpression<R> defaultExpression,
+							  @Nullable Consumer<R> parseCallback) {
+		super(registryClass, codeName);
+
+		if (defaultExpression == null) {
+			defaultExpression = new EventValueExpression<>(registryClass);
+		}
+		if (parseCallback == null) {
+			parseCallback = ignored -> { };
+		}
+
+		this.registryKey = registryKey;
+		RegistryParser<R> registryParser = new RegistryParser<>(registry, languageNode, parseCallback);
+		usage(registryParser.getCombinedPatterns())
+			.supplier(registry::iterator)
+			.serializer(new RegistrySerializer<>(registry))
+			.defaultExpression(defaultExpression)
+			.parser(registryParser);
+	}
+
+	public @Nullable RegistryKey<R> registryKey() {
+		return registryKey;
+	}
+
+	@Override
+	public @NotNull RegistryParser<R> getParser() {
+		//noinspection ConstantConditions, unchecked
+		return (RegistryParser<R>) super.getParser();
+	}
+
+	@Override
+	public @NotNull RegistrySerializer<R> getSerializer() {
+		//noinspection ConstantConditions, unchecked
+		return (RegistrySerializer<R>) super.getSerializer();
+	}
+
+	@Override
+	public @NotNull Supplier<Iterator<R>> getSupplier() {
+		//noinspection ConstantConditions
+		return super.getSupplier();
+	}
+
+	/*
+	 * Legacy Constructors
+	 */
+
 	/**
 	 * @param registryClass The registry class
 	 * @param registry The registry
 	 * @param codeName The name used in patterns
 	 * @param languageNode The language node of the type
+	 * @deprecated Use {@link #RegistryClassInfo(Class, RegistryKey, String, String)}.
 	 */
+	@Deprecated(since = "INSERT VERSION", forRemoval = true)
 	public RegistryClassInfo(Class<R> registryClass, Registry<R> registry, String codeName, String languageNode) {
 		this(registryClass, registry, codeName, languageNode, new EventValueExpression<>(registryClass));
 	}
@@ -32,7 +113,9 @@ public class RegistryClassInfo<R extends Keyed> extends ClassInfo<R> {
 	 * @param codeName The name used in patterns
 	 * @param languageNode The language node of the type
 	 * @param parseCallback A consumer to run on a successful parse.
+	 * @deprecated Use {@link #RegistryClassInfo(Class, RegistryKey, String, String, Consumer)}.
 	 */
+	@Deprecated(since = "INSERT VERSION", forRemoval = true)
 	public RegistryClassInfo(Class<R> registryClass, Registry<R> registry, String codeName, String languageNode, Consumer<R> parseCallback) {
 		this(registryClass, registry, codeName, languageNode, new EventValueExpression<>(registryClass), parseCallback);
 	}
@@ -43,8 +126,11 @@ public class RegistryClassInfo<R extends Keyed> extends ClassInfo<R> {
 	 * @param codeName The name used in patterns
 	 * @param languageNode The language node of the type
 	 * @param defaultExpression The default expression of the type
+	 * @deprecated Use {@link #RegistryClassInfo(Class, RegistryKey, String, String)} with {@link #defaultExpression(DefaultExpression)}.
 	 */
-	public RegistryClassInfo(Class<R> registryClass, Registry<R> registry, String codeName, String languageNode, DefaultExpression<R> defaultExpression) {
+	@Deprecated(since = "INSERT VERSION", forRemoval = true)
+	public RegistryClassInfo(Class<R> registryClass, Registry<R> registry, String codeName, String languageNode,
+							 DefaultExpression<R> defaultExpression) {
 		this(registryClass, registry, codeName, languageNode, defaultExpression, ignored -> {});
 	}
 
@@ -55,15 +141,13 @@ public class RegistryClassInfo<R extends Keyed> extends ClassInfo<R> {
 	 * @param languageNode The language node of the type
 	 * @param defaultExpression The default expression of the type
 	 * @param parseCallback A consumer to run on a successful parse.
+	 * @deprecated Use {@link #RegistryClassInfo(Class, RegistryKey, String, String, Consumer)}
+	 *  with {@link #defaultExpression(DefaultExpression)}.
 	 */
-	public RegistryClassInfo(Class<R> registryClass, Registry<R> registry, String codeName, String languageNode, DefaultExpression<R> defaultExpression, Consumer<R> parseCallback) {
-		super(registryClass, codeName);
-		RegistryParser<R> registryParser = new RegistryParser<>(registry, languageNode, parseCallback);
-		usage(registryParser.getCombinedPatterns())
-			.supplier(registry::iterator)
-			.serializer(new RegistrySerializer<>(registry))
-			.defaultExpression(defaultExpression)
-			.parser(registryParser);
+	@Deprecated(since = "INSERT VERSION", forRemoval = true)
+	public RegistryClassInfo(Class<R> registryClass, Registry<R> registry, String codeName, String languageNode,
+							 DefaultExpression<R> defaultExpression, Consumer<R> parseCallback) {
+		this(registryClass, null, registry, codeName, languageNode, defaultExpression, parseCallback);
 	}
 
 	/**
@@ -89,7 +173,8 @@ public class RegistryClassInfo<R extends Keyed> extends ClassInfo<R> {
 	 * @deprecated {@code registerComparator} is no longer necessary.
 	 */
 	@Deprecated(since = "2.16", forRemoval = true)
-	public RegistryClassInfo(Class<R> registryClass, Registry<R> registry, String codeName, String languageNode, DefaultExpression<R> defaultExpression, boolean registerComparator) {
+	public RegistryClassInfo(Class<R> registryClass, Registry<R> registry, String codeName, String languageNode,
+							 DefaultExpression<R> defaultExpression, boolean registerComparator) {
 		this(registryClass, registry, codeName, languageNode, defaultExpression);
 	}
 

--- a/src/main/java/ch/njol/skript/entity/CatData.java
+++ b/src/main/java/ch/njol/skript/entity/CatData.java
@@ -1,15 +1,12 @@
 package ch.njol.skript.entity;
 
-import ch.njol.skript.bukkitutil.BukkitUtils;
-import ch.njol.skript.classes.ClassInfo;
-import ch.njol.skript.classes.EnumClassInfo;
 import ch.njol.skript.classes.registry.RegistryClassInfo;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.util.coll.CollectionUtils;
 import com.google.common.collect.Iterators;
-import org.bukkit.Registry;
+import io.papermc.paper.registry.RegistryKey;
 import org.bukkit.entity.Cat;
 import org.bukkit.entity.Cat.Type;
 import org.jetbrains.annotations.NotNull;
@@ -22,13 +19,7 @@ public class CatData extends EntityData<Cat> {
 	private static final Type[] TYPES;
 
 	static {
-		ClassInfo<Type> catTypeClassInfo;
-		if (BukkitUtils.registryExists("CAT_VARIANT")) {
-			catTypeClassInfo = new RegistryClassInfo<>(Cat.Type.class, Registry.CAT_VARIANT, "cattype", "cat types");
-		} else {
-			//noinspection unchecked, rawtypes - it is an enum on other versions
-			catTypeClassInfo = new EnumClassInfo<>((Class) Cat.Type.class, "cattype", "cat types");
-		}
+		var catTypeClassInfo = new RegistryClassInfo<>(Cat.Type.class, RegistryKey.CAT_VARIANT, "cattype", "cat types");
 		Classes.registerClass(catTypeClassInfo
 			.user("cat ?(type|race)s?")
 			.name("Cat Type")

--- a/src/main/java/ch/njol/skript/entity/ChickenData.java
+++ b/src/main/java/ch/njol/skript/entity/ChickenData.java
@@ -1,13 +1,12 @@
 package ch.njol.skript.entity;
 
-import ch.njol.skript.Skript;
-import ch.njol.skript.bukkitutil.BukkitUtils;
-import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.classes.registry.RegistryClassInfo;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.util.coll.CollectionUtils;
 import com.google.common.collect.Iterators;
+import io.papermc.paper.registry.RegistryKey;
 import org.bukkit.entity.Chicken;
 import org.bukkit.entity.Chicken.Variant;
 import org.jetbrains.annotations.NotNull;
@@ -17,21 +16,11 @@ import java.util.Objects;
 
 public class ChickenData extends EntityData<Chicken> {
 
-	private static final boolean VARIANTS_ENABLED;
-	private static final Object[] VARIANTS;
+	private static final Variant[] VARIANTS;
 
 	static {
-		ClassInfo<?> chickenVariantClassInfo = BukkitUtils.getRegistryClassInfo(
-			"org.bukkit.entity.Chicken$Variant",
-			"CHICKEN_VARIANT",
-			"chickenvariant",
-			"chicken variants"
-		);
-		if (chickenVariantClassInfo == null) {
-			// Registers a dummy/placeholder class to ensure working operation on MC versions that do not have 'Chicken.Variant' (1.21.4-)
-			chickenVariantClassInfo = new ClassInfo<>(ChickenVariantDummy.class,  "chickenvariant");
-		}
-		Classes.registerClass(chickenVariantClassInfo
+		var chickenVariantInfo = new RegistryClassInfo<>(Variant.class, RegistryKey.CHICKEN_VARIANT, "chickenvariant", "chicken variants");
+		Classes.registerClass(chickenVariantInfo
 			.user("chicken ?variants?")
 			.name("Chicken Variant")
 			.description("Represents the variant of a chicken entity.",
@@ -40,38 +29,31 @@ public class ChickenData extends EntityData<Chicken> {
 			.requiredPlugins("Minecraft 1.21.5+")
 			.documentationId("ChickenVariant")
 		);
+		VARIANTS = Iterators.toArray(chickenVariantInfo.getSupplier().get(), Variant.class);
 
 		register(ChickenData.class, "chicken", Chicken.class, "chicken");
-		if (Skript.classExists("org.bukkit.entity.Chicken$Variant")) {
-			VARIANTS_ENABLED = true;
-			VARIANTS = Iterators.toArray(Classes.getExactClassInfo(Chicken.Variant.class).getSupplier().get(), Chicken.Variant.class);
-		} else {
-			VARIANTS_ENABLED = false;
-			VARIANTS = null;
-		}
 	}
 
-	private @Nullable Object variant = null;
+	private @Nullable Variant variant = null;
 
 	public ChickenData() {}
 
-	// TODO: When safe, 'variant' should have the type changed to 'Chicken.Variant' when 1.21.6 is minimum supported version
-	public ChickenData(@Nullable Object variant) {
+	public ChickenData(@Nullable Variant variant) {
 		this.variant = variant;
 	}
 
 	@Override
 	protected boolean init(Literal<?>[] exprs, int matchedCodeName, int matchedPattern, ParseResult parseResult) {
-		if (VARIANTS_ENABLED && exprs[0] != null) {
+		if (exprs[0] != null) {
 			//noinspection unchecked
-			variant = ((Literal<Chicken.Variant>) exprs[0]).getSingle();
+			variant = ((Literal<Variant>) exprs[0]).getSingle();
 		}
 		return true;
 	}
 
 	@Override
 	protected boolean init(@Nullable Class<? extends Chicken> entityClass, @Nullable Chicken chicken) {
-		if (chicken != null && VARIANTS_ENABLED) {
+		if (chicken != null) {
 			variant = chicken.getVariant();
 		}
 		return true;
@@ -79,13 +61,11 @@ public class ChickenData extends EntityData<Chicken> {
 
 	@Override
 	public void set(Chicken chicken) {
-		if (VARIANTS_ENABLED) {
-			Variant variant = (Variant) this.variant;
-			if (variant == null)
-				variant = (Variant) CollectionUtils.getRandom(VARIANTS);
-			assert variant != null;
-			chicken.setVariant(variant);
-		}
+		Variant variant = this.variant;
+		if (variant == null)
+			variant = CollectionUtils.getRandom(VARIANTS);
+		assert variant != null;
+		chicken.setVariant(variant);
 	}
 
 	@Override
@@ -121,10 +101,5 @@ public class ChickenData extends EntityData<Chicken> {
 			return false;
 		return dataMatch(variant, other.variant);
 	}
-
-	/**
-	 * A dummy/placeholder class to ensure working operation on MC versions that do not have `Chicken.Variant`
-	 */
-	public static class ChickenVariantDummy {}
 
 }

--- a/src/main/java/ch/njol/skript/entity/CowData.java
+++ b/src/main/java/ch/njol/skript/entity/CowData.java
@@ -1,43 +1,26 @@
 package ch.njol.skript.entity;
 
-import ch.njol.skript.Skript;
-import ch.njol.skript.bukkitutil.BukkitUtils;
-import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.classes.registry.RegistryClassInfo;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.util.coll.CollectionUtils;
 import com.google.common.collect.Iterators;
+import io.papermc.paper.registry.RegistryKey;
 import org.bukkit.entity.Cow;
 import org.bukkit.entity.Cow.Variant;
-import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.Objects;
 
 public class CowData extends EntityData<Cow> {
 
-	private static final boolean VARIANTS_ENABLED;
 	private static final Object[] VARIANTS;
-	private static final Class<Cow> COW_CLASS;
-	private static final @Nullable Method getVariantMethod;
-	private static final @Nullable Method setVariantMethod;
 
 	static {
-		ClassInfo<?> cowVariantClassInfo = BukkitUtils.getRegistryClassInfo(
-			"org.bukkit.entity.Cow$Variant",
-			"COW_VARIANT",
-			"cowvariant",
-			"cow variants"
-		);
-		if (cowVariantClassInfo == null) {
-			// Registers a dummy/placeholder class to ensure working operation on MC versions that do not have 'Cow.Variant' (1.21.4-)
-			cowVariantClassInfo = new ClassInfo<>(CowVariantDummy.class, "cowvariant");
-		}
-		Classes.registerClass(cowVariantClassInfo
+		var cowVariantInfo = new RegistryClassInfo<>(Variant.class, RegistryKey.COW_VARIANT, "cowvariant", "cow variants");
+		Classes.registerClass(cowVariantInfo
 			.user("cow ?variants?")
 			.name("Cow Variant")
 			.description("Represents the variant of a cow entity.",
@@ -46,78 +29,53 @@ public class CowData extends EntityData<Cow> {
 			.requiredPlugins("Minecraft 1.21.5+")
 			.documentationId("CowVariant")
 		);
+		VARIANTS = Iterators.toArray(cowVariantInfo.getSupplier().get(), Variant.class);
 
-		Class<Cow> cowClass = null;
-
-		try {
-			//noinspection unchecked
-			cowClass = (Class<Cow>) Class.forName("org.bukkit.entity.Cow");
-		} catch (Exception ignored) {}
-
-		COW_CLASS = cowClass;
-		register(CowData.class, "cow", COW_CLASS, 0, "cow");
-		if (Skript.classExists("org.bukkit.entity.Cow$Variant")) {
-			VARIANTS_ENABLED = true;
-			VARIANTS = Iterators.toArray(Classes.getExactClassInfo(Cow.Variant.class).getSupplier().get(), Cow.Variant.class);
-			try {
-				getVariantMethod = COW_CLASS.getDeclaredMethod("getVariant");
-				setVariantMethod = COW_CLASS.getDeclaredMethod("setVariant", Cow.Variant.class);
-			} catch (Exception e) {
-				throw new RuntimeException("Could not retrieve get/set variant methods for Cow.", e);
-			}
-		} else {
-			VARIANTS_ENABLED = false;
-			VARIANTS = null;
-			getVariantMethod = null;
-			setVariantMethod = null;
-		}
+		register(CowData.class, "cow", Cow.class, 0, "cow");
 	}
 
-	private @Nullable Object variant = null;
+	private @Nullable Variant variant = null;
 
 	public CowData() {}
 
-	// TODO: When the api-version is 1.21.5, 'variant' should have the type changed to 'Cow.Variant' and reflection can be removed
-	public CowData(@Nullable Object variant) {
+	public CowData(@Nullable Variant variant) {
 		this.variant = variant;
 	}
 
 	@Override
 	protected boolean init(Literal<?>[] exprs, int matchedCodeName, int matchedPattern, ParseResult parseResult) {
-		if (VARIANTS_ENABLED && exprs[0] != null) {
+		if (exprs[0] != null) {
 			//noinspection unchecked
-			variant = ((Literal<Cow.Variant>) exprs[0]).getSingle();
+			variant = ((Literal<Variant>) exprs[0]).getSingle();
 		}
 		return true;
 	}
 
 	@Override
 	protected boolean init(@Nullable Class<? extends Cow> entityClass, @Nullable Cow cow) {
-		if (cow != null && VARIANTS_ENABLED) {
-			variant = getVariant(cow);
+		if (cow != null) {
+			variant = cow.getVariant();
 		}
 		return true;
 	}
 
 	@Override
 	public void set(Cow cow) {
-		if (VARIANTS_ENABLED) {
-			Variant variant = (Variant) this.variant;
-			if (variant == null)
-				variant = (Variant) CollectionUtils.getRandom(VARIANTS);
-			assert variant != null;
-			setVariant(cow, variant);
-		}
+		Variant variant = this.variant;
+		if (variant == null)
+			variant = (Variant) CollectionUtils.getRandom(VARIANTS);
+		assert variant != null;
+		cow.setVariant(variant);
 	}
 
 	@Override
 	protected boolean match(Cow cow) {
-		return variant == null || getVariant(cow) == variant;
+		return variant == null || cow.getVariant() == variant;
 	}
 
 	@Override
 	public Class<Cow> getType() {
-		return COW_CLASS;
+		return Cow.class;
 	}
 
 	@Override
@@ -143,53 +101,5 @@ public class CowData extends EntityData<Cow> {
 			return false;
 		return dataMatch(variant, other.variant);
 	}
-
-	/**
-	 * Due to the addition of 'AbstractCow' and 'api-version' being '1.19'
-	 * This helper method is required in order to set the {@link #variant} of the {@link Cow}
-	 * @param cow The {@link Cow} to set the variant
-	 */
-	public void setVariant(Cow cow) {
-		setVariant(cow, variant);
-	}
-
-	/**
-	 * Due to the addition of 'AbstractCow' and 'api-version' being '1.19'
-	 * This helper method is required in order to set the {@code object} of the {@link Cow}
-	 * @param cow The {@link Cow} to set the variant
-	 * @param object The 'Cow.Variant'
-	 */
-	public void setVariant(Cow cow, Object object) {
-		if (!VARIANTS_ENABLED || setVariantMethod == null)
-			return;
-		Entity entity = COW_CLASS.cast(cow);
-		try {
-			setVariantMethod.invoke(entity, (Cow.Variant) object);
-		} catch (IllegalAccessException | InvocationTargetException e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	/**
-	 * Due to the addition of 'AbstractCow' and 'api-version' being '1.19'
-	 * This helper method is required in order to get the 'Cow.Variant' of the {@link Cow}
-	 * @param cow The {@link Cow} to get the variant
-	 * @return The 'Cow.Variant'
-	 */
-	public @Nullable Object getVariant(Cow cow) {
-		if (!VARIANTS_ENABLED || getVariantMethod == null)
-			return null;
-		Entity entity = COW_CLASS.cast(cow);
-		try {
-			return getVariantMethod.invoke(entity);
-		} catch (IllegalAccessException | InvocationTargetException e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	/**
-	 * A dummy/placeholder class to ensure working operation on MC versions that do not have 'Cow.Variant'
-	 */
-	public static class CowVariantDummy {}
 
 }

--- a/src/main/java/ch/njol/skript/entity/FrogData.java
+++ b/src/main/java/ch/njol/skript/entity/FrogData.java
@@ -1,12 +1,13 @@
 package ch.njol.skript.entity;
 
-import ch.njol.skript.bukkitutil.BukkitUtils;
-import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.classes.registry.RegistryClassInfo;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.util.Patterns;
 import ch.njol.util.coll.CollectionUtils;
+import com.google.common.collect.Iterators;
+import io.papermc.paper.registry.RegistryKey;
 import org.bukkit.entity.Frog;
 import org.bukkit.entity.Frog.Variant;
 import org.jetbrains.annotations.NotNull;
@@ -26,16 +27,8 @@ public class FrogData extends EntityData<Frog> {
 	private static final Variant[] VARIANTS;
 
 	static {
-		EntityData.register(FrogData.class, "frog", Frog.class, 0, PATTERNS.getPatterns());
-		VARIANTS = new Variant[]{Variant.TEMPERATE, Variant.WARM, Variant.COLD};
-		ClassInfo<?> frogVariantClassInfo = BukkitUtils.getRegistryClassInfo(
-			"org.bukkit.entity.Frog$Variant",
-			"FROG_VARIANT",
-			"frogvariant",
-			"frog variants"
-		);
-		assert frogVariantClassInfo != null;
-		Classes.registerClass(frogVariantClassInfo
+		var frogVariantInfo = new RegistryClassInfo<>(Variant.class, RegistryKey.FROG_VARIANT, "frogvariant", "frog variants");
+		Classes.registerClass(frogVariantInfo
 			.user("frog ?variants?")
 			.name("Frog Variant")
 			.description("Represents the variant of a frog entity.",
@@ -43,6 +36,9 @@ public class FrogData extends EntityData<Frog> {
 			.since("2.13")
 			.documentationId("FrogVariant")
 		);
+		VARIANTS = Iterators.toArray(frogVariantInfo.getSupplier().get(), Variant.class);
+
+		EntityData.register(FrogData.class, "frog", Frog.class, 0, PATTERNS.getPatterns());
 	}
 
 	private @Nullable Variant variant = null;

--- a/src/main/java/ch/njol/skript/entity/PigData.java
+++ b/src/main/java/ch/njol/skript/entity/PigData.java
@@ -1,8 +1,6 @@
 package ch.njol.skript.entity;
 
-import ch.njol.skript.Skript;
-import ch.njol.skript.bukkitutil.BukkitUtils;
-import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.classes.registry.RegistryClassInfo;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.registrations.Classes;
@@ -10,7 +8,9 @@ import ch.njol.skript.util.Patterns;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import com.google.common.collect.Iterators;
+import io.papermc.paper.registry.RegistryKey;
 import org.bukkit.entity.Pig;
+import org.bukkit.entity.Pig.Variant;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -18,8 +18,7 @@ import java.util.Objects;
 
 public class PigData extends EntityData<Pig> {
 
-	private static final boolean VARIANTS_ENABLED;
-	private static final Object[] VARIANTS;
+	private static final Variant[] VARIANTS;
 	private static final Patterns<Kleenean> PATTERNS = new Patterns<>(new Object[][]{
 		{"pig", Kleenean.UNKNOWN},
 		{"saddled pig", Kleenean.TRUE},
@@ -27,17 +26,8 @@ public class PigData extends EntityData<Pig> {
 	});
 
 	static {
-		ClassInfo<?> pigVariantClassInfo = BukkitUtils.getRegistryClassInfo(
-			"org.bukkit.entity.Pig$Variant",
-			"PIG_VARIANT",
-			"pigvariant",
-			"pig variants"
-		);
-		if (pigVariantClassInfo == null) {
-			// Registers a dummy/placeholder class to ensure working operation on MC versions that do not have 'Pig.Variant' (1.21.4-)
-			pigVariantClassInfo = new ClassInfo<>(PigVariantDummy.class, "pigvariant");
-		}
-		Classes.registerClass(pigVariantClassInfo
+		var pigVariantInfo = new RegistryClassInfo<>(Variant.class, RegistryKey.PIG_VARIANT, "pigvariant", "pig variants");
+		Classes.registerClass(pigVariantInfo
 			.user("pig ?variants?")
 			.name("Pig Variant")
 			.description("Represents the variant of a pig entity.",
@@ -45,24 +35,17 @@ public class PigData extends EntityData<Pig> {
 			.since("2.12")
 			.requiredPlugins("Minecraft 1.21.5+")
 			.documentationId("PigVariant"));
+		VARIANTS = Iterators.toArray(pigVariantInfo.getSupplier().get(), Pig.Variant.class);
 
 		register(PigData.class, "pig", Pig.class, 0, PATTERNS.getPatterns());
-		if (Skript.classExists("org.bukkit.entity.Pig$Variant")) {
-			VARIANTS_ENABLED = true;
-			VARIANTS = Iterators.toArray(Classes.getExactClassInfo(Pig.Variant.class).getSupplier().get(), Pig.Variant.class);
-		} else {
-			VARIANTS_ENABLED = false;
-			VARIANTS = null;
-		}
 	}
 	
 	private Kleenean saddled = Kleenean.UNKNOWN;
-	private @Nullable Object variant = null;
+	private @Nullable Variant variant;
 
 	public PigData() {}
 
-	// TODO: When safe, 'variant' should have the type changed to 'Pig.Variant' when 1.21.5 is minimum supported version
-	public PigData(@Nullable Kleenean saddled, @Nullable Object variant) {
+	public PigData(@Nullable Kleenean saddled, @Nullable Variant variant) {
 		this.saddled = saddled != null ? saddled : Kleenean.UNKNOWN;
 		this.variant = variant;
 		super.codeNameIndex = PATTERNS.getMatchedPattern(this.saddled, 0).orElse(0);
@@ -71,7 +54,7 @@ public class PigData extends EntityData<Pig> {
 	@Override
 	protected boolean init(Literal<?>[] exprs, int matchedCodeName, int matchedPattern, ParseResult parseResult) {
 		saddled = PATTERNS.getInfo(matchedCodeName);
-		if (VARIANTS_ENABLED && exprs[0] != null) {
+		if (exprs[0] != null) {
 			//noinspection unchecked
 			variant = ((Literal<Pig.Variant>) exprs[0]).getSingle();
 		}
@@ -83,8 +66,7 @@ public class PigData extends EntityData<Pig> {
 		if (pig != null) {
 			saddled = Kleenean.get(pig.hasSaddle());
 			super.codeNameIndex = PATTERNS.getMatchedPattern(saddled, 0).orElse(0);
-			if (VARIANTS_ENABLED)
-				variant = pig.getVariant();
+			variant = pig.getVariant();
 		}
 		return true;
 	}
@@ -92,11 +74,9 @@ public class PigData extends EntityData<Pig> {
 	@Override
 	public void set(Pig pig) {
 		pig.setSaddle(saddled.isTrue());
-		if (VARIANTS_ENABLED) {
-			Object finalVariant = variant != null ? variant : CollectionUtils.getRandom(VARIANTS);
-			assert finalVariant != null;
-			pig.setVariant((Pig.Variant) finalVariant);
-		}
+		Variant finalVariant = variant != null ? variant : CollectionUtils.getRandom(VARIANTS);
+		assert finalVariant != null;
+		pig.setVariant(finalVariant);
 	}
 	
 	@Override
@@ -139,9 +119,4 @@ public class PigData extends EntityData<Pig> {
 		return variant == null || variant == other.variant;
 	}
 
-	/**
-	 * A dummy/placeholder class to ensure working operation on MC versions that do not have `Pig.Variant`
-	 */
-	public static class PigVariantDummy {}
-	
 }

--- a/src/main/java/ch/njol/skript/entity/WolfData.java
+++ b/src/main/java/ch/njol/skript/entity/WolfData.java
@@ -1,8 +1,6 @@
 package ch.njol.skript.entity;
 
-import ch.njol.skript.Skript;
-import ch.njol.skript.bukkitutil.BukkitUtils;
-import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.classes.registry.RegistryClassInfo;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.registrations.Classes;
@@ -11,8 +9,10 @@ import ch.njol.skript.util.Patterns;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import com.google.common.collect.Iterators;
+import io.papermc.paper.registry.RegistryKey;
 import org.bukkit.DyeColor;
 import org.bukkit.entity.Wolf;
+import org.bukkit.entity.Wolf.Variant;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -30,21 +30,11 @@ public class WolfData extends EntityData<Wolf> {
 		{"peaceful wolf", new WolfStates(Kleenean.FALSE, Kleenean.UNKNOWN)}
 	});
 
-	private static final boolean VARIANTS_ENABLED;
-	private static final Object[] VARIANTS;
+	private static final Variant[] VARIANTS;
 
 	static {
-		ClassInfo<?> wolfVariantClassInfo = BukkitUtils.getRegistryClassInfo(
-			"org.bukkit.entity.Wolf$Variant",
-			"WOLF_VARIANT",
-			"wolfvariant",
-			"wolf variants"
-		);
-		if (wolfVariantClassInfo == null) {
-			// Registers a dummy/placeholder class to ensure working operation on MC versions that do not have 'Wolf.Variant' (1.20.4-)
-			wolfVariantClassInfo = new ClassInfo<>(WolfVariantDummy.class, "wolfvariant");
-		}
-		Classes.registerClass(wolfVariantClassInfo
+		var wolfVariantInfo = new RegistryClassInfo<>(Variant.class, RegistryKey.WOLF_VARIANT, "wolfvariant", "wolf variants");
+		Classes.registerClass(wolfVariantInfo
 			.user("wolf ?variants?")
 			.name("Wolf Variant")
 			.description("Represents the variant of a wolf entity.",
@@ -52,18 +42,12 @@ public class WolfData extends EntityData<Wolf> {
 			.since("2.10")
 			.requiredPlugins("Minecraft 1.21+")
 			.documentationId("WolfVariant"));
+		VARIANTS = Iterators.toArray(wolfVariantInfo.getSupplier().get(), Variant.class);
 
 		EntityData.register(WolfData.class, "wolf", Wolf.class, 0, PATTERNS.getPatterns());
-		if (Skript.classExists("org.bukkit.entity.Wolf$Variant")) {
-			VARIANTS_ENABLED = true;
-			VARIANTS = Iterators.toArray(Classes.getExactClassInfo(Wolf.Variant.class).getSupplier().get(), Wolf.Variant.class);
-		} else {
-			VARIANTS_ENABLED = false;
-			VARIANTS = null;
-		}
 	}
 
-	private @Nullable Object variant = null;
+	private @Nullable Variant variant = null;
 	private @Nullable DyeColor collarColor = null;
 	private Kleenean isAngry = Kleenean.UNKNOWN;
 	private Kleenean isTamed = Kleenean.UNKNOWN;
@@ -94,9 +78,9 @@ public class WolfData extends EntityData<Wolf> {
 		assert state != null;
 		isAngry = state.angry;
 		isTamed = state.tamed;
-		if (exprs[0] != null && VARIANTS_ENABLED) {
+		if (exprs[0] != null) {
 			//noinspection unchecked
-			variant = ((Literal<Wolf.Variant>) exprs[0]).getSingle();
+			variant = ((Literal<Variant>) exprs[0]).getSingle();
 		}
 		if (exprs[1] != null) {
 			//noinspection unchecked
@@ -111,8 +95,7 @@ public class WolfData extends EntityData<Wolf> {
 			isAngry = Kleenean.get(wolf.isAngry());
 			isTamed = Kleenean.get(wolf.isTamed());
 			collarColor = wolf.getCollarColor();
-			if (VARIANTS_ENABLED)
-				variant = wolf.getVariant();
+			variant = wolf.getVariant();
 			super.codeNameIndex = PATTERNS.getMatchedPattern(new WolfStates(isAngry, isTamed), 0).orElse(0);
 		}
 		return true;
@@ -124,11 +107,9 @@ public class WolfData extends EntityData<Wolf> {
 		wolf.setTamed(isTamed.isTrue());
 		if (collarColor != null)
 			wolf.setCollarColor(collarColor);
-		if (VARIANTS_ENABLED) {
-			Object variantSet = variant != null ? variant : CollectionUtils.getRandom(VARIANTS);
-			assert variantSet != null;
-			wolf.setVariant((Wolf.Variant) variantSet);
-		}
+		Variant variantSet = variant != null ? variant : CollectionUtils.getRandom(VARIANTS);
+		assert variantSet != null;
+		wolf.setVariant(variantSet);
 	}
 
 	@Override
@@ -158,8 +139,7 @@ public class WolfData extends EntityData<Wolf> {
 		result = prime * result + isAngry.hashCode();
 		result = prime * result + isTamed.hashCode();
 		result = prime * result + Objects.hashCode(collarColor);
-		if (VARIANTS_ENABLED)
-			result = prime * result + Objects.hashCode(variant);
+		result = prime * result + Objects.hashCode(variant);
 		return result;
 	}
 
@@ -188,10 +168,5 @@ public class WolfData extends EntityData<Wolf> {
 			return false;
 		return dataMatch(variant, other.variant);
 	}
-
-	/**
-	 * A dummy/placeholder class to ensure working operation on MC versions that do not have `Wolf.Variant`
-	 */
-	public static class WolfVariantDummy {};
 
 }

--- a/src/main/java/ch/njol/skript/util/PaperUtils.java
+++ b/src/main/java/ch/njol/skript/util/PaperUtils.java
@@ -13,9 +13,9 @@ public class PaperUtils {
 	private static final boolean REGISTRY_KEY_EXISTS = Skript.classExists("io.papermc.paper.registry.RegistryKey");
 
 	/**
-	 * Check if a registry exists within {@link RegistryKey}
-	 * @param registry Registry to check for (Fully qualified name of registry)
-	 * @return True if registry exists else false
+	 * Check if a registry exists within {@link RegistryKey}.
+	 * @param registry Registry to check for.
+	 * @return True if registry exists else false.
 	 */
 	public static boolean registryExists(String registry) {
 		return REGISTRY_ACCESS_EXISTS
@@ -24,21 +24,34 @@ public class PaperUtils {
 	}
 
 	/**
-	 * Gets the Bukkit {@link Registry} from Paper's {@link RegistryKey}.
-	 * @param registry Registry to get (Fully qualified name of registry).
+	 * Gets a Paper {@link RegistryKey}.
+	 * @param registry Registry key to get.
 	 * @return The Bukkit {@link Registry} if registry exists else {@code null}.
 	 */
-	public static <T extends Keyed> @Nullable Registry<T> getBukkitRegistry(String registry) {
+	public static <T extends Keyed> @Nullable RegistryKey<T> getBukkitRegistryKey(String registry) {
 		if (!registryExists(registry))
 			return null;
-        RegistryKey registryKey;
+        RegistryKey<T> registryKey;
         try {
-			registryKey = (RegistryKey) RegistryKey.class.getField(registry).get(null);
+			//noinspection unchecked
+			registryKey = (RegistryKey<T>) RegistryKey.class.getField(registry).get(null);
         } catch (NoSuchFieldException | IllegalAccessException ignored) {
             return null;
         }
-		//noinspection unchecked
-		return (Registry<T>) RegistryAccess.registryAccess().getRegistry(registryKey);
+		return registryKey;
+	}
+
+	/**
+	 * Gets the Bukkit {@link Registry} from Paper's {@link RegistryKey}.
+	 * @param registry Registry to get.
+	 * @return The Bukkit {@link Registry} if registry exists else {@code null}.
+	 */
+	public static <T extends Keyed> @Nullable Registry<T> getBukkitRegistry(String registry) {
+		RegistryKey<T> registryKey = getBukkitRegistryKey(registry);
+		if (registryKey == null) {
+			return null;
+		}
+		return RegistryAccess.registryAccess().getRegistry(registryKey);
 	}
 
 }

--- a/src/main/java/org/skriptlang/skript/bukkit/damagesource/DamageSourceModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/damagesource/DamageSourceModule.java
@@ -43,7 +43,7 @@ public class DamageSourceModule extends HierarchicalAddonModule {
 		);
 
 		Classes.registerClass(
-			new RegistryClassInfo<>(DamageType.class, RegistryAccess.registryAccess().getRegistry(RegistryKey.DAMAGE_TYPE),
+			new RegistryClassInfo<>(DamageType.class, RegistryKey.DAMAGE_TYPE,
 									"damagetype", "damage types")
 			.user("damage ?types?")
 			.name("Damage Type")

--- a/src/main/java/org/skriptlang/skript/bukkit/enchantments/types/EnchantmentClassInfo.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/enchantments/types/EnchantmentClassInfo.java
@@ -1,7 +1,6 @@
 package org.skriptlang.skript.bukkit.enchantments.types;
 
 import ch.njol.skript.classes.registry.RegistryClassInfo;
-import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
 import org.bukkit.enchantments.Enchantment;
 import org.jetbrains.annotations.ApiStatus;
@@ -10,7 +9,7 @@ import org.jetbrains.annotations.ApiStatus;
 public class EnchantmentClassInfo extends RegistryClassInfo<Enchantment> {
 
 	public EnchantmentClassInfo() {
-		super(Enchantment.class, RegistryAccess.registryAccess().getRegistry(RegistryKey.ENCHANTMENT),
+		super(Enchantment.class, RegistryKey.ENCHANTMENT,
 			"enchantment", "enchantments");
 
 		user("enchantments?")

--- a/src/main/java/org/skriptlang/skript/bukkit/entity/entitydata/ZombieNautilusData.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/entity/entitydata/ZombieNautilusData.java
@@ -8,6 +8,7 @@ import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.variables.Variables;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
+import com.google.common.collect.Iterators;
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
 import org.bukkit.Registry;
@@ -26,14 +27,14 @@ public class ZombieNautilusData extends EntityData<ZombieNautilus> {
 		EntityData.register(ZombieNautilusData.class, "zombie nautilus", ZombieNautilus.class, 0, "zombie nautilus");
 		Variables.yggdrasil.registerSingleClass(Variant.class,  "ZombieNautilus.Variant");
 
-		Registry<@NotNull Variant> variantRegistry = RegistryAccess.registryAccess().getRegistry(RegistryKey.ZOMBIE_NAUTILUS_VARIANT);
-		VARIANTS = variantRegistry.stream().toArray(Variant[]::new);
-		Classes.registerClass(new RegistryClassInfo<>(Variant.class, variantRegistry, "zombienautilusvariant", "zombie nautilus variants")
+		var zombieNautilusVariantInfo = new RegistryClassInfo<>(Variant.class, RegistryKey.ZOMBIE_NAUTILUS_VARIANT, "zombienautilusvariant", "zombie nautilus variants");
+		Classes.registerClass(zombieNautilusVariantInfo
 			.user("zombie ?nautilus ?variants?")
 			.name("Zombie Nautilus Variant")
 			.description("Represents the variant of a zombie nautilus.")
 			.since("2.14")
 			.documentationId("ZombieNautilusVariant"));
+		VARIANTS = Iterators.toArray(zombieNautilusVariantInfo.getSupplier().get(), Variant.class);
 	}
 
 	private Kleenean isTamed = Kleenean.UNKNOWN;

--- a/src/main/java/org/skriptlang/skript/bukkit/potion/PotionModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/potion/PotionModule.java
@@ -1,19 +1,17 @@
 package org.skriptlang.skript.bukkit.potion;
 
 import ch.njol.skript.Skript;
-import ch.njol.skript.bukkitutil.BukkitUtils;
 import ch.njol.skript.classes.*;
 import ch.njol.skript.classes.registry.RegistryClassInfo;
 import ch.njol.skript.expressions.base.EventValueExpression;
 import ch.njol.skript.lang.ParseContext;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.yggdrasil.Fields;
-import org.bukkit.Registry;
+import io.papermc.paper.registry.RegistryKey;
 import org.bukkit.event.entity.EntityPotionEffectEvent;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.potion.PotionEffectTypeCategory;
-import org.jetbrains.annotations.NotNull;
 import org.skriptlang.skript.addon.AddonModule;
 import org.skriptlang.skript.addon.HierarchicalAddonModule;
 import org.skriptlang.skript.addon.SkriptAddon;
@@ -129,15 +127,7 @@ public class PotionModule extends HierarchicalAddonModule {
 				}
 			}));
 
-		Registry<@NotNull PotionEffectType> petRegistry;
-		if (BukkitUtils.registryExists("MOB_EFFECT")) { // Paper (1.21.4)
-			petRegistry = Registry.MOB_EFFECT;
-		} else if (BukkitUtils.registryExists("EFFECT")) { // Bukkit (1.20.3)
-			petRegistry = Registry.EFFECT;
-		} else {
-			throw new IllegalStateException("Potion effect registry does not exist");
-		}
-		Classes.registerClass(new RegistryClassInfo<>(PotionEffectType.class, petRegistry, "potioneffecttype", "potion effect types")
+		Classes.registerClass(new RegistryClassInfo<>(PotionEffectType.class, RegistryKey.MOB_EFFECT, "potioneffecttype", "potion effect types")
 			.user("potion ?effect ?types?")
 			.name("Potion Effect Type")
 			.description("A potion effect type, e.g. 'strength' or 'swiftness'.")

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -29,7 +29,7 @@ website: https://skriptlang.org
 main: ch.njol.skript.Skript
 
 version: @version@
-api-version: 1.21
+api-version: 1.21.5
 
 commands:
     skript:


### PR DESCRIPTION
### Problem
This PR addresses a few problems:
1. RegistryClassInfo only accepts Registry, whereas RegistryKey is now preferred. We can simplify usages with a constructor that accepts RegistryKey
2. Adding alternative constructors is pretty annoying due to all of the different combinations of parameters.

### Solution
I've removed the need for the defaultExpression constructor parameter by allowing `defaultExpression` to be used more than once on ClassInfo. Until we have a sane builder system, I think this will be fine.

I've deprecated the existing `Registry` based constructors in favor of others using `RegistryKey`. It is useful to store RegistryKey as well for future work (e.g. command arguments). For now, for compatibility, it is nullable. I don't believe there is a way to go from Registry->RegistryKey (someone please correct me if I am wrong).

Finally, I've overridden some of the ClassInfo methods to guarantee stronger contracts.

I've also updated all deprecated usages and cleaned up the unnecessary EntityData work.

### Testing Completed
Standard tests to confirm continued functionality.

### Supporting Information
This PR will not run on the 1.21.4 environment. I've updated the API version to 1.21.5 for the purposes of the other versions (below 1.21.5, the bytecode rewriter will rewrite Cow into AbstractCow, cause NSME for variant operations). This should be done separately in a proper PR after 2.16 is released.

---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
