### PR TITLE
Fix StructAliases ClassCastException & AliasesParser OOME

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/AliasesParser.java
+++ b/src/main/java/ch/njol/skript/aliases/AliasesParser.java
@@ -424,7 +424,7 @@ public class AliasesParser {
 		List<PatternSlot> slots = new ArrayList<>();
 		
 		// Compute variation slots
-		for (int i = 0; i < name.length();) {
+		for (int i = 0; i < name.length(); i += Character.charCount(name.codePointAt(i))) {
 			int c = name.codePointAt(i);
 			if (c == '{') { // Found variation name start
 				varStart = i;
@@ -444,16 +444,16 @@ public class AliasesParser {
 				VariationGroup vars = provider.getVariationGroup(varName);
 				if (vars == null) {
 					Skript.error(m_unknown_variation.toString(varName));
+					varStart = -1;
+					varEnd = i + 1;
 					continue;
 				}
 				slots.add(new VariationSlot(vars));
-				
+
 				// Variation name finished
 				varStart = -1;
 				varEnd = i + 1;
 			}
-			
-			i += Character.charCount(c);
 		}
 		
 		// Handle last non-variation slot
@@ -690,6 +690,10 @@ public class AliasesParser {
 	 * @return Name fixed.
 	 */
 	protected String fixName(String name) {
+		if (name.isEmpty()) {
+			return "";
+		}
+
 		/*
 		 * General logic:
 		 *

--- a/src/main/java/ch/njol/skript/structures/StructAliases.java
+++ b/src/main/java/ch/njol/skript/structures/StructAliases.java
@@ -37,7 +37,7 @@ public class StructAliases extends Structure {
 	public boolean init(Literal<?>[] args, int matchedPattern, ParseResult parseResult, @Nullable EntryContainer entryContainer) {
 		// noinspection ConstantConditions - entry container cannot be null as this structure is not simple
 		SectionNode node = entryContainer.getSource();
-		node.convertToEntries(0, "=");
+		node.convertToEntries(1, "=");
 
 		// Initialize and load script aliases
 		Script script = getParser().getCurrentScript();

--- a/src/test/skript/tests/regressions/5750-aliases-structure-classcastexception.sk
+++ b/src/test/skript/tests/regressions/5750-aliases-structure-classcastexception.sk
@@ -1,0 +1,9 @@
+parse:
+  results: {aliases structure class cast exception::*}
+  code:
+    aliases:
+      {my custom variation}:
+        abc = stone
+
+test "5750-aliases structure class cast exception":
+  assert {aliases structure class cast exception::*} isn't set

--- a/src/test/skript/tests/regressions/5871-aliases-structure-oome.sk
+++ b/src/test/skript/tests/regressions/5871-aliases-structure-oome.sk
@@ -1,0 +1,9 @@
+parse:
+  results: {aliases structure oome::*}
+  code:
+    aliases:
+      {null} = null
+
+test "5871-aliases structure oome":
+  assert {aliases structure oome::*} contains "Minecraft id null is not valid"
+  assert {aliases structure oome::*} contains "The variation {null} has not been defined before"


### PR DESCRIPTION
### Problem
```
aliases:
  {my custom variation}:
    night vision = - {"Potion": "minecraft:night_vision"}
```
This will throw a ClassCastException, because StructAliases only converts the root of the section to entries, not subsections

```
aliases:
  {null} = null
```
This will throw an OOME, because when the parser encounters an unknown variation, it throws an exception and moves onto the next loop. However, it skips the variable increment while doing so and causes an infinite loop

Fixing this caused a new bug where unknown variations would throw an OutOfRange exception in the fixName method

### Solution
In StructAliases, I made it so 1 subsection could be converted to entries, I don't think there is a case where you need more than 1

In AliasesParser, I added the variable increments before `continue`

In fixName, I added a simple check that checks if the string is empty and returns early


### Testing Completed
The code is above, after these fixes it properly prints the errors
<img width="653" height="206" alt="{A2704C8F-5B78-4B1D-825E-81C147E2D56B}" src="https://github.com/user-attachments/assets/adc2ce04-c618-4f01-9fb1-1a46f57b7b18" />



### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** #5871 #5750 
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
