### PR TITLE
Fix ExprNamed ArrayStoreException

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprNamed.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprNamed.java
@@ -68,16 +68,19 @@ public class ExprNamed extends PropertyExpression<Object, Object> {
 	@Override
 	protected Object[] get(Event event, Object[] source) {
 		Component name = this.name.getSingle(event);
-		if (name == null) {
-			return get(source, obj -> obj); // No name provided, do nothing
-		}
 		return get(source, object -> {
 			if (object instanceof InventoryType inventoryType) {
 				if (!inventoryType.isCreatable()) {
 					return null;
 				}
+				if (name == null) {
+					return Bukkit.createInventory(null, inventoryType);
+				}
 				return Bukkit.createInventory(null, inventoryType, name);
 			} else {
+				if (name == null) {
+					return object;
+				}
 				ItemType item = (ItemType) object;
 				item = item.clone();
 				ItemMeta meta = item.getItemMeta();

--- a/src/test/skript/tests/regressions/5923-inventory-name-array-store-exception.sk
+++ b/src/test/skript/tests/regressions/5923-inventory-name-array-store-exception.sk
@@ -1,0 +1,2 @@
+test "5923 inventory name array store exception":
+    set {_inv} to shulker box inventory named {_}


### PR DESCRIPTION
### Problem
`set {_inv} to shulker box inventory named {_}` throws an ArrayStoreException because it doesn't convert InventoryType to an Inventory


### Solution
In ExprNamed, if no name is given, create an inventory with no title instead


### Testing Completed
manual ingame test & regression test


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** #5923 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
