### PR TITLE
Support `normalised vector`

### DIFF
--- a/src/main/java/ch/njol/skript/conditions/CondIsVectorNormalized.java
+++ b/src/main/java/ch/njol/skript/conditions/CondIsVectorNormalized.java
@@ -13,11 +13,12 @@ import org.bukkit.util.Vector;
 @Name("Is Normalized")
 @Description("Checks whether a vector is normalized i.e. length of 1")
 @Example("vector of player's location is normalized")
+@Example("vector in direction of player is normalised")
 @Since("2.5.1")
 public class CondIsVectorNormalized extends PropertyCondition<Vector> {
 	
 	static {
-		register(CondIsVectorNormalized.class, "normalized", "vectors");
+		register(CondIsVectorNormalized.class, "normali(s|z)ed", "vectors");
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprVectorNormalize.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprVectorNormalize.java
@@ -20,13 +20,14 @@ import ch.njol.skript.lang.simplification.SimplifiedLiteral;
 @Name("Vectors - Normalized")
 @Description("Returns the same vector but with length 1.")
 @Example("set {_v} to normalized {_v}")
+@Example("set {_v} to normalised {_u}")
 @Since("2.2-dev28")
 public class ExprVectorNormalize extends SimpleExpression<Vector> {
 
 	static {
 		Skript.registerExpression(ExprVectorNormalize.class, Vector.class, ExpressionType.COMBINED,
-				"normalize[d] %vector%",
-				"%vector% normalized");
+				"normali(z|s)e[d] %vector%",
+				"%vector% normali(z|s)ed");
 	}
 
 	@SuppressWarnings("null")

--- a/src/test/skript/tests/syntaxes/conditions/CondIsVectorNormalized.sk
+++ b/src/test/skript/tests/syntaxes/conditions/CondIsVectorNormalized.sk
@@ -1,4 +1,6 @@
 test "normalized vector":
 	assert vector(0,1,0) is normalized with "vector(0,1,0) not recognized as normal"
+	assert vector(0,1,0) is normalised with "vector(0,1,0) not recognized as normal"
 	assert vector(1,0,0) is normalized with "vector(1,0,0) not recognized as normal"
 	assert vector(1,2,3) is not normalized with "vector(1,2,3) recognized as normal"
+	assert normalised vector(0,2,0) is vector(0,1,0) with "vector(0,2,0) not normalized properly"


### PR DESCRIPTION
### Problem
Skript only supported the Americanised spelling of `normalized` rather than the international Commonwealth spelling (`normalised`).

### Solution
Added `normalised` as an option while keeping `normalized` internally (like how colours are Color internally). Also some tests to make sure it works.

### Testing Completed
Ran `quickTest` with the new tests to ensure `normalised` works.

### Supporting Information
I am personally fond of international spellings in all applicable situations, and if I were a Master of the Universe all software and humans would use international spelling, oxford commas, and ISO-8601 dates. To everyone else's delight I am not a Master of the Universe.

---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
