### PR TITLE
Fix 'next loop-value' skipping iterations, breaking with delays

### DIFF
--- a/src/main/java/ch/njol/skript/sections/SecLoop.java
+++ b/src/main/java/ch/njol/skript/sections/SecLoop.java
@@ -79,13 +79,13 @@ public class SecLoop extends LoopSection {
 
 	protected @UnknownNullability Expression<?> expression;
 
-	private final transient Map<Event, Object> current = new WeakHashMap<>();
 	private final transient Map<Event, Iterator<?>> iteratorMap = new WeakHashMap<>();
 	private final transient Map<Event, Object> previous = new WeakHashMap<>();
+	private final transient Map<Event, Object> current = new WeakHashMap<>();
+	private final transient Map<Event, Object> next = new WeakHashMap<>();
 
 	protected @Nullable TriggerItem actualNext;
 	private boolean guaranteedToLoop;
-	private Object nextValue = null;
 	private boolean loopPeeking;
 	protected boolean iterableSingle;
 	protected boolean keyed;
@@ -156,6 +156,7 @@ public class SecLoop extends LoopSection {
 			}
 		}
 
+		Object nextValue = next.get(event);
 		if (iter == null || (!iter.hasNext() && nextValue == null)) {
 			exit(event);
 			debug(event, false);
@@ -164,7 +165,7 @@ public class SecLoop extends LoopSection {
 			previous.put(event, current.get(event));
 			if (nextValue != null) {
 				this.store(event, nextValue);
-				nextValue = null;
+				next.remove(event);
 			} else if (iter.hasNext()) {
 				this.store(event, iter.next());
 			}
@@ -194,12 +195,17 @@ public class SecLoop extends LoopSection {
 	public @Nullable Object getNext(Event event) {
 		if (!loopPeeking)
 			return null;
+		Object nextValue = next.get(event);
+		if (nextValue != null) {
+			return nextValue;
+		}
 		Iterator<?> iter = iteratorMap.get(event);
 		if (iter == null || !iter.hasNext())
 			return null;
 		if (iter instanceof PeekingIterator<?> peekingIterator)
 			return peekingIterator.peek();
 		nextValue = iter.next();
+		next.put(event, nextValue);
 		return nextValue;
 	}
 
@@ -236,10 +242,10 @@ public class SecLoop extends LoopSection {
 
 	@Override
 	public void exit(Event event) {
-		current.remove(event);
 		iteratorMap.remove(event);
 		previous.remove(event);
-		nextValue = null;
+		current.remove(event);
+		next.remove(event);
 		super.exit(event);
 	}
 

--- a/src/test/skript/tests/syntaxes/sections/SecLoop.sk
+++ b/src/test/skript/tests/syntaxes/sections/SecLoop.sk
@@ -1,0 +1,8 @@
+test "SecLoop":
+	# test next loop-value skipping iterations
+	set {_values::*} to 1, 2, and 3
+	loop {_values::*}:
+		set {_x} to the next loop-value
+		set {_x} to the next loop-value
+		add 1 to {_count}
+	assert {_count} is 3 with "did not run 3 times as expected when using next loop-value"


### PR DESCRIPTION
### Problem
As seen in #8658, `next loop-value` does not work properly with delays/simultaneous execution. It stores a single value for the syntax instance itself, rather than per event (even though this is already done for `previous` and `next`).
I also noticed that calling `next loop-value` multiple times will continue to fetch new values, resulting in iterations being skipped.


### Solution
- Uses an Event-Object map for tracking next values (as `previous` and `current` already do).
- Returns the already fetched `next` result for subsequent calls.


### Testing Completed
Tested skipping behavior with SecLoop.sk


### Supporting Information
There are a lot of maps being used here. We might consider some sort of middle layer data structure to hold the different values (as opposed to creating many maps).

---
**Completes:**
- Fixes #8658

**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
