### PR TITLE
Fix plural item aliases

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/Aliases.java
+++ b/src/main/java/ch/njol/skript/aliases/Aliases.java
@@ -448,7 +448,8 @@ public abstract class Aliases {
 				// mod:an_item -> (mod's an item) | (an item from mod)
 				// minecraft:dirt -> dirt
 				if (NamespacedKey.MINECRAFT.equals(key.getNamespace())) {
-					parser.loadAlias(key.getKey().replace("_", " ") + "¦s", key.toString());
+					String name = key.getKey().replace("_", " ");
+					parser.loadAlias(name + (name.endsWith("s") ? "" : "¦s"), key.toString());
 				} else {
 					if (!modItemRegistered) modItemRegistered = true;
 					parser.loadAlias((key.getNamespace() + "'s " + key.getKey() + "¦s").replace("_", " "), key.toString());


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
Item aliases for items ending in 's' are semantically wrong in the plural: e.g. "Cobblestone Stairss" and "Ancient Debriss"

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
For generated aliases, check that the item name doesn't end with an 's' before adding the '¦s' plural marker.

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
Tested on paper-26.1.2-74 fresh server.
Manual testing via effect commands:
```
BEFORE
Executing 'send items of player's inventory'
64 oak stairss
64 spruce stairss
64 birch stairss
64 jungle stairss

AFTER
Executing 'send items in player's inventory'
64 oak stairs
64 spruce stairs
64 birch stairs
64 jungle stairs
```
and confirmed that other items are unaffected by the change.

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->
I would have just made an issue but I didn't want to waste your time so you get to waste your time reading this pr instead.

---
**Completes:**
- https://github.com/SkriptLang/Skript/issues/8311

**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
