### PR TITLE
ExprGameMode Fix

### DIFF
--- a/src/main/java/org/skriptlang/skript/bukkit/entity/player/elements/expressions/ExprGameMode.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/entity/player/elements/expressions/ExprGameMode.java
@@ -38,7 +38,7 @@ public class ExprGameMode extends PropertyExpression<Player, GameMode> {
 			infoBuilder(
 				ExprGameMode.class,
 				GameMode.class,
-				"[the] game[ ]mode",
+				"game[ ]mode",
 				"players",
 				false
 			)


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
The pattern for ExprGameMode had `[the]` in it which was fine for the original pattern when it was using deprecated registry but once it was converted to a propertyexpr (which handles `the` for you) it allowed for wonky syntaxes such as `send player's the gamemode` or `send the the gamemode of player`)
<img width="925" height="273" alt="image" src="https://github.com/user-attachments/assets/322744cf-3407-4871-8c9b-18418f9c2edc" />


### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
Removes `[the]` from the pattern

### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
Manual testing + JUnitQuick + QuickTest all pass

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->
small pr '-'

---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
