### PR TITLE
Migrate and overhaul heal event and heal amount expression

### DIFF
--- a/src/main/java/ch/njol/skript/bukkitutil/HealthUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/HealthUtils.java
@@ -114,7 +114,7 @@ public class HealthUtils {
 			damage(damageable, -health);
 			return;
 		}
-		damageable.heal(health);
+		damageable.heal(health * 2);
 	}
 
 	public static double getDamage(EntityDamageEvent event) {

--- a/src/main/java/ch/njol/skript/bukkitutil/HealthUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/HealthUtils.java
@@ -114,7 +114,7 @@ public class HealthUtils {
 			damage(damageable, -health);
 			return;
 		}
-		setHealth(damageable, getHealth(damageable) + health);
+		damageable.heal(health);
 	}
 
 	public static double getDamage(EntityDamageEvent event) {

--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -39,7 +39,6 @@ import org.bukkit.event.enchantment.PrepareItemEnchantEvent;
 import org.bukkit.event.entity.*;
 import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
-import org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason;
 import org.bukkit.event.entity.EntityTransformEvent.TransformReason;
 import org.bukkit.event.hanging.HangingBreakByEntityEvent;
 import org.bukkit.event.hanging.HangingBreakEvent;
@@ -756,9 +755,6 @@ public final class BukkitEventValues {
 			.time(Time.FUTURE)
 			.build());
 		registry.register(EventValue.simple(InventoryMoveItemEvent.class, ItemStack.class, InventoryMoveItemEvent::getItem));
-
-		// EntityRegainHealthEvent
-		registry.register(EventValue.simple(EntityRegainHealthEvent.class, RegainReason.class, EntityRegainHealthEvent::getRegainReason));
 
 		// FurnaceExtractEvent
 		registry.register(EventValue.simple(FurnaceExtractEvent.class, Player.class, FurnaceExtractEvent::getPlayer));

--- a/src/main/java/org/skriptlang/skript/bukkit/entity/player/PlayerModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/entity/player/PlayerModule.java
@@ -37,7 +37,8 @@ public class PlayerModule extends HierarchicalAddonModule {
 			ExprPlayerListHeaderFooter::register,
 			ExprPlayerListName::register,
 			ExprPlayerListPriority::register,
-			ExprQuitMessage::register
+			ExprQuitMessage::register,
+			ExprHealAmount::register
 		);
 		if (Skript.classExists("io.papermc.paper.event.player.PlayerPickBlockEvent")) {
 			register(addon,

--- a/src/main/java/org/skriptlang/skript/bukkit/entity/player/PlayerModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/entity/player/PlayerModule.java
@@ -38,7 +38,8 @@ public class PlayerModule extends HierarchicalAddonModule {
 			ExprPlayerListName::register,
 			ExprPlayerListPriority::register,
 			ExprQuitMessage::register,
-			ExprHealAmount::register
+			ExprHealAmount::register,
+			ExprHealReason::register
 		);
 		if (Skript.classExists("io.papermc.paper.event.player.PlayerPickBlockEvent")) {
 			register(addon,

--- a/src/main/java/org/skriptlang/skript/bukkit/entity/player/PlayerModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/entity/player/PlayerModule.java
@@ -39,7 +39,8 @@ public class PlayerModule extends HierarchicalAddonModule {
 			ExprPlayerListPriority::register,
 			ExprQuitMessage::register,
 			ExprHealAmount::register,
-			ExprHealReason::register
+			ExprHealReason::register,
+			syntaxRegistry -> EvtHealing.register(syntaxRegistry, eventValueRegistry)
 		);
 		if (Skript.classExists("io.papermc.paper.event.player.PlayerPickBlockEvent")) {
 			register(addon,

--- a/src/main/java/org/skriptlang/skript/bukkit/entity/player/elements/events/EvtHealing.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/entity/player/elements/events/EvtHealing.java
@@ -32,7 +32,7 @@ public class EvtHealing extends SkriptEvent {
 					broadcast "%event-entity% was healed by %heal amount% hearts"
 				""")
 			.addExample("""
-				on player healing from regen:
+				on player healing from satiated:
 					send "You regenerated %heal amount% hearts!"
 				""")
 			.addExample("""

--- a/src/main/java/org/skriptlang/skript/bukkit/entity/player/elements/events/EvtHealing.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/entity/player/elements/events/EvtHealing.java
@@ -1,4 +1,4 @@
-package ch.njol.skript.events;
+package org.skriptlang.skript.bukkit.entity.player.elements.events;
 
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
@@ -6,25 +6,40 @@ import org.bukkit.event.entity.EntityRegainHealthEvent;
 import org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason;
 import org.jetbrains.annotations.Nullable;
 
-import ch.njol.skript.Skript;
 import ch.njol.skript.entity.EntityData;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptEvent;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
+import org.skriptlang.skript.bukkit.lang.eventvalue.EventValue;
+import org.skriptlang.skript.bukkit.lang.eventvalue.EventValueRegistry;
+import org.skriptlang.skript.bukkit.registration.BukkitSyntaxInfos;
+import org.skriptlang.skript.registration.SyntaxRegistry;
 
 public class EvtHealing extends SkriptEvent {
 
-	static {
-		Skript.registerEvent("Heal", EvtHealing.class, EntityRegainHealthEvent.class, "heal[ing] [of %-entitydatas%] [(from|due to|by) %-healreasons%]", "%entitydatas% heal[ing] [(from|due to|by) %-healreasons%]")
-				.description("Called when an entity is healed, e.g. by eating (players), being fed (pets), or by the effect of a potion of healing (overworld mobs) or harm (nether mobs).")
-				.examples(
-						"on heal:",
-						"on player healing from a regeneration potion:",
-						"on healing of a zombie, cow or a wither:",
-								"\theal reason is healing potion",
-								"\tcancel event"
-				)
-				.since("1.0, 2.9.0 (by reason)");
+	public static void register(SyntaxRegistry syntaxRegistry, EventValueRegistry registry) {
+		syntaxRegistry.register(BukkitSyntaxInfos.Event.KEY, BukkitSyntaxInfos.Event.builder(EvtHealing.class, "Healing")
+			.supplier(EvtHealing::new)
+			.addEvent(EntityRegainHealthEvent.class)
+			.addPattern("heal[ing] [of %-entitydatas%] [(from|due to|by) %-healreasons%]")
+			.addPattern("%entitydatas% heal[ing] [(from|due to|by) %-healreasons%]")
+			.addDescription("""
+				Called when an entity is healed, e.g. by eating (players), being fed (pets), or by the effect of a potion of healing (overworld mobs) or harm (nether mobs).
+				""")
+			.addExample("on heal")
+			.addExample("on player healing from a regeneration potion:")
+			.addExample("""
+				on healing of a zombie, cow or a wither:
+					heal reason is healing potion
+					cancel event
+				""")
+			.addSince("1.0, 2.9.0 (by reason)")
+			.build());
+
+		registry.register(EventValue.builder(EntityRegainHealthEvent.class, RegainReason.class)
+			.getter(EntityRegainHealthEvent::getRegainReason)
+			.patterns("healreason")
+			.build());
 	}
 
 	@Nullable
@@ -43,40 +58,45 @@ public class EvtHealing extends SkriptEvent {
 
 	@Override
 	public boolean check(Event event) {
-		if (!(event instanceof EntityRegainHealthEvent))
+		if (!(event instanceof EntityRegainHealthEvent healthEvent))
 			return false;
-		EntityRegainHealthEvent healthEvent = (EntityRegainHealthEvent) event;
+
 		if (entityDatas != null) {
 			Entity compare = healthEvent.getEntity();
 			boolean result = false;
+
 			for (EntityData<?> entityData : entityDatas.getAll()) {
 				if (entityData.isInstance(compare)) {
 					result = true;
 					break;
 				}
 			}
+
 			if (!result)
 				return false;
 		}
+
 		if (healReasons != null) {
 			RegainReason compare = healthEvent.getRegainReason();
 			boolean result = false;
+
 			for (RegainReason healReason : healReasons.getAll()) {
 				if (healReason == compare) {
 					result = true;
 					break;
 				}
 			}
-			if (!result)
-				return false;
+
+			return result;
 		}
+
 		return true;
 	}
 
 	@Override
 	public String toString(@Nullable Event event, boolean debug) {
 		return "heal" + (entityDatas != null ? " of " + entityDatas.toString(event, debug) : "") +
-				(healReasons != null ? " by " + healReasons.toString(event, debug) : "");
+			(healReasons != null ? " by " + healReasons.toString(event, debug) : "");
 	}
 
 }

--- a/src/main/java/org/skriptlang/skript/bukkit/entity/player/elements/events/EvtHealing.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/entity/player/elements/events/EvtHealing.java
@@ -38,10 +38,7 @@ public class EvtHealing extends SkriptEvent {
 			.addSince("2.9.0 (by reason)")
 			.build());
 
-		registry.register(EventValue.builder(EntityRegainHealthEvent.class, RegainReason.class)
-			.getter(EntityRegainHealthEvent::getRegainReason)
-			.patterns("healreason")
-			.build());
+		registry.register(EventValue.simple(EntityRegainHealthEvent.class, RegainReason.class, EntityRegainHealthEvent::getRegainReason));
 	}
 
 	@Nullable

--- a/src/main/java/org/skriptlang/skript/bukkit/entity/player/elements/events/EvtHealing.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/entity/player/elements/events/EvtHealing.java
@@ -33,7 +33,8 @@ public class EvtHealing extends SkriptEvent {
 					heal reason is healing potion
 					cancel event
 				""")
-			.addSince("1.0, 2.9.0 (by reason)")
+			.addSince("1.0")
+			.addSince("2.9.0 (by reason)")
 			.build());
 
 		registry.register(EventValue.builder(EntityRegainHealthEvent.class, RegainReason.class)

--- a/src/main/java/org/skriptlang/skript/bukkit/entity/player/elements/events/EvtHealing.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/entity/player/elements/events/EvtHealing.java
@@ -1,5 +1,6 @@
 package org.skriptlang.skript.bukkit.entity.player.elements.events;
 
+import ch.njol.skript.lang.SyntaxStringBuilder;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
 import org.bukkit.event.entity.EntityRegainHealthEvent;
@@ -96,8 +97,21 @@ public class EvtHealing extends SkriptEvent {
 
 	@Override
 	public String toString(@Nullable Event event, boolean debug) {
-		return "heal" + (entityDatas != null ? " of " + entityDatas.toString(event, debug) : "") +
-			(healReasons != null ? " by " + healReasons.toString(event, debug) : "");
+		SyntaxStringBuilder builder = new SyntaxStringBuilder(event, debug);
+
+		builder.append("heal");
+
+		if (entityDatas != null) {
+			builder.append("of");
+			builder.append(entityDatas);
+		}
+
+		if (healReasons != null) {
+			builder.append("by");
+			builder.append(healReasons);
+		}
+
+		return builder.toString();
 	}
 
 }

--- a/src/main/java/org/skriptlang/skript/bukkit/entity/player/elements/events/EvtHealing.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/entity/player/elements/events/EvtHealing.java
@@ -27,10 +27,16 @@ public class EvtHealing extends SkriptEvent {
 			.addDescription("""
 				Called when an entity is healed, e.g. by eating (players), being fed (pets), or by the effect of a potion of healing (overworld mobs) or harm (nether mobs).
 				""")
-			.addExample("on heal")
-			.addExample("on player healing from a regeneration potion:")
 			.addExample("""
-				on healing of a zombie, cow or a wither:
+				on heal:
+					broadcast "%event-entity% was healed by %heal amount% hearts"
+				""")
+			.addExample("""
+				on player healing from regen:
+					send "You regenerated %heal amount% hearts!"
+				""")
+			.addExample("""
+				on healing of a zombie, cow, or a wither:
 					heal reason is healing potion
 					cancel event
 				""")

--- a/src/main/java/org/skriptlang/skript/bukkit/entity/player/elements/expressions/ExprHealAmount.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/entity/player/elements/expressions/ExprHealAmount.java
@@ -1,5 +1,5 @@
 
-package ch.njol.skript.expressions;
+package org.skriptlang.skript.bukkit.entity.player.elements.expressions;
 
 import ch.njol.skript.lang.EventRestrictedSyntax;
 import org.bukkit.event.Event;
@@ -15,11 +15,12 @@ import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
+import org.skriptlang.skript.registration.SyntaxInfo;
+import org.skriptlang.skript.registration.SyntaxRegistry;
 
 @Name("Heal Amount")
 @Description("The amount of health healed in a <a href='/#heal'>heal event</a>.")
@@ -32,8 +33,12 @@ import ch.njol.util.coll.CollectionUtils;
 @Since("2.5.1")
 public class ExprHealAmount extends SimpleExpression<Double> implements EventRestrictedSyntax {
 
-	static {
-		Skript.registerExpression(ExprHealAmount.class, Double.class, ExpressionType.SIMPLE, "[the] heal[ing] amount");
+	public static void register(SyntaxRegistry syntaxRegistry) {
+		syntaxRegistry.register(SyntaxRegistry.EXPRESSION, SyntaxInfo.Expression.builder(ExprHealAmount.class, Double.class)
+			.supplier(ExprHealAmount::new)
+			.priority(SyntaxInfo.SIMPLE)
+			.addPattern("[the] heal[ing] amount")
+			.build());
 	}
 
 	private Kleenean delay;
@@ -49,46 +54,38 @@ public class ExprHealAmount extends SimpleExpression<Double> implements EventRes
 		return CollectionUtils.array(EntityRegainHealthEvent.class);
 	}
 
-	@Nullable
 	@Override
-	protected Double[] get(Event event) {
-		if (!(event instanceof EntityRegainHealthEvent))
+	protected Double @Nullable [] get(Event event) {
+		if (!(event instanceof EntityRegainHealthEvent healEvent))
 			return null;
-		return new Double[]{((EntityRegainHealthEvent) event).getAmount()};
+
+		return new Double[]{healEvent.getAmount() / 2};
 	}
 
-	@Nullable
 	@Override
-	public Class<?>[] acceptChange(ChangeMode mode) {
+	public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
 		if (delay != Kleenean.FALSE) {
 			Skript.error("The heal amount cannot be changed after the event has already passed");
 			return null;
 		}
+
 		if (mode == Changer.ChangeMode.REMOVE_ALL || mode == Changer.ChangeMode.RESET)
 			return null;
+
 		return CollectionUtils.array(Number.class);
 	}
 
 	@Override
-	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
-		if (!(event instanceof EntityRegainHealthEvent))
+	public void change(Event event, Object @Nullable [] delta, ChangeMode mode) {
+		if (!(event instanceof EntityRegainHealthEvent healEvent))
 			return;
 
-		EntityRegainHealthEvent healthEvent = (EntityRegainHealthEvent) event;
-		double value = delta == null ? 0 : ((Number) delta[0]).doubleValue();
+		double amount = delta == null ? 0 : ((Number) delta[0]).doubleValue() * 2;
+
 		switch (mode) {
-			case SET:
-			case DELETE:
-				healthEvent.setAmount(value);
-				break;
-			case ADD:
-				healthEvent.setAmount(healthEvent.getAmount() + value);
-				break;
-			case REMOVE:
-				healthEvent.setAmount(healthEvent.getAmount() - value);
-				break;
-			default:
-				break;
+			case SET, DELETE -> healEvent.setAmount(amount);
+			case ADD -> healEvent.setAmount(healEvent.getAmount() + amount);
+			case REMOVE -> healEvent.setAmount(healEvent.getAmount() - amount);
 		}
 	}
 

--- a/src/main/java/org/skriptlang/skript/bukkit/entity/player/elements/expressions/ExprHealReason.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/entity/player/elements/expressions/ExprHealReason.java
@@ -26,7 +26,6 @@ public class ExprHealReason extends EventValueExpression<RegainReason> {
 	public static void register(SyntaxRegistry syntaxRegistry) {
 		syntaxRegistry.register(SyntaxRegistry.EXPRESSION, SyntaxInfo.Expression.builder(ExprHealReason.class, RegainReason.class)
 			.supplier(ExprHealReason::new)
-			.priority(SyntaxInfo.SIMPLE)
 			.addPattern("(regen|health regain|heal[ing]) (reason|cause)")
 			.build());
 	}

--- a/src/main/java/org/skriptlang/skript/bukkit/entity/player/elements/expressions/ExprHealReason.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/entity/player/elements/expressions/ExprHealReason.java
@@ -1,4 +1,4 @@
-package ch.njol.skript.expressions;
+package org.skriptlang.skript.bukkit.entity.player.elements.expressions;
 
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Events;
@@ -6,9 +6,11 @@ import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.EventValueExpression;
-import ch.njol.skript.registrations.EventValues;
 
 import org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason;
+import org.skriptlang.skript.bukkit.lang.eventvalue.EventValue;
+import org.skriptlang.skript.registration.SyntaxInfo;
+import org.skriptlang.skript.registration.SyntaxRegistry;
 
 @Name("Heal Reason")
 @Description("The <a href='#healreason'>heal reason</a> of a <a href='#heal'>heal event</a>.")
@@ -21,8 +23,12 @@ import org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason;
 @Since("2.5")
 public class ExprHealReason extends EventValueExpression<RegainReason> {
 
-	static {
-		register(ExprHealReason.class, RegainReason.class, "(regen|health regain|heal[ing]) (reason|cause)");
+	public static void register(SyntaxRegistry syntaxRegistry) {
+		syntaxRegistry.register(SyntaxRegistry.EXPRESSION, SyntaxInfo.Expression.builder(ExprHealReason.class, RegainReason.class)
+			.supplier(ExprHealReason::new)
+			.priority(SyntaxInfo.SIMPLE)
+			.addPattern("(regen|health regain|heal[ing]) (reason|cause)")
+			.build());
 	}
 
 	public ExprHealReason() {
@@ -31,8 +37,9 @@ public class ExprHealReason extends EventValueExpression<RegainReason> {
 
 	@Override
 	public boolean setTime(int time) {
-		if (time == EventValues.TIME_FUTURE)
+		if (time == EventValue.Time.FUTURE.value())
 			return false;
+
 		return super.setTime(time);
 	}
 


### PR DESCRIPTION
### Problem
Currently, heal uses a utility that just set's their health to their current health + the heal amount
this does not call EntityRegainHealthEvent
Also, in the EntityRegainHealthEvent it doesn't take into account Skript using health (10 hearts) instead of hp (20hp), so heal-amount is hp and not hearts.
This is inconsistent with the rest of the code base.
Also, migrating the current system to the new module system.

Update HealUtils to use Damageable.heal instead of setHealth
The reason this was made in the first place is because Spigot has never and still doesn't have a Damageale.heal but now that Skript is paper only, this is appropriate


### Testing
currently, heal amount tested with
```
on heal:
    broadcast "hp: %player's health%"
    broadcast "initial heal amount: %heal amount%"
    add 1.5 to heal amount
    broadcast "add 1.5: %heal amount%"
    remove 3.2 from heal amount
    broadcast "remove 3.2: %heal amount%"
    set heal amount to heal amount * 0.75
    broadcast "set to 75%%: %heal amount%"
    broadcast "modified heal amount: %heal amount%"
    chance of 50%:
        delete heal amount
        broadcast "deleted heal amount: %heal amount%"
    wait 1 tick
    broadcast "hp after heal: %player's health%"
```
<img width="671" height="626" alt="image" src="https://github.com/user-attachments/assets/f53673c7-1d4d-41d4-90f7-191dce61c258" />

here's the current test for the heal event as well
<img width="760" height="391" alt="image" src="https://github.com/user-attachments/assets/b96b4db3-8fbf-4230-83b1-727659bc4aa2" />
```
command /heal:
    trigger:
        heal player by 0.5
        wait 1 tick
        heal player by 0.75
        wait 1 tick
        heal player by -3
        wait 1 tick
        heal player by 1
        wait 1 tick
        heal player by 1500.23
        wait 1 tick
        heal player by 100000000000000
        wait 1 tick
        heal player by -10000

on heal:
    broadcast "heal %entity% %heal amount%"

on damage:
    broadcast "damage %victim% %damage%"
```

migrated heal reason test
<img width="1010" height="765" alt="image" src="https://github.com/user-attachments/assets/c16f6df6-ab69-4782-b1de-6aeabf9199e7" />
```
on heal of player:
    broadcast "heal %player% %heal amount% %heal reason%"
```


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
