### PR TITLE
EvtPlayerPickItemTest: Fix constructor resolution

### DIFF
--- a/src/test/java/org/skriptlang/skript/test/tests/syntaxes/events/EvtPlayerPickItemTest.java
+++ b/src/test/java/org/skriptlang/skript/test/tests/syntaxes/events/EvtPlayerPickItemTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 public class EvtPlayerPickItemTest extends SkriptJUnitTest {
 
 	private static final boolean SUPPORTS_PICK_EVENT = Skript.classExists("io.papermc.paper.event.player.PlayerPickBlockEvent");
+	private static final boolean SUPPORTS_PICKED_ITEM = Skript.isRunningMinecraft(26, 2);
 
 	private Player player;
 	private Pig pickedEntity;
@@ -50,8 +51,13 @@ public class EvtPlayerPickItemTest extends SkriptJUnitTest {
 		Event event = null;
 		try {
 			Class<?> eventClass = Class.forName("io.papermc.paper.event.player.PlayerPickBlockEvent");
-			event = (Event) eventClass.getConstructor(Player.class, Block.class, ItemStack.class, boolean.class, int.class, int.class)
+			if (SUPPORTS_PICKED_ITEM) {
+				event = (Event) eventClass.getConstructor(Player.class, Block.class, ItemStack.class, boolean.class, int.class, int.class)
 					.newInstance(player, pickedBlock, ItemStack.empty(), true, 0, 0);
+			} else {
+				event = (Event) eventClass.getConstructor(Player.class, Block.class, boolean.class, int.class, int.class)
+					.newInstance(player, pickedBlock, true, 0, 0);
+			}
 		} catch (Exception ignored) {}
 		return event;
 	}
@@ -60,8 +66,13 @@ public class EvtPlayerPickItemTest extends SkriptJUnitTest {
 		Event event = null;
 		try {
 			Class<?> eventClass = Class.forName("io.papermc.paper.event.player.PlayerPickEntityEvent");
-			event = (Event) eventClass.getConstructor(Player.class, Entity.class, ItemStack.class, boolean.class, int.class, int.class)
+			if (SUPPORTS_PICKED_ITEM) {
+				event = (Event) eventClass.getConstructor(Player.class, Entity.class, ItemStack.class, boolean.class, int.class, int.class)
 					.newInstance(player, pickedEntity, ItemStack.empty(), true, 0, 0);
+			} else {
+				event = (Event) eventClass.getConstructor(Player.class, Entity.class, boolean.class, int.class, int.class)
+					.newInstance(player, pickedEntity, true, 0, 0);
+			}
 		} catch (Exception ignored) {}
 		return event;
 	}

--- a/src/test/java/org/skriptlang/skript/test/tests/syntaxes/events/EvtPlayerPickItemTest.java
+++ b/src/test/java/org/skriptlang/skript/test/tests/syntaxes/events/EvtPlayerPickItemTest.java
@@ -10,6 +10,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Pig;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
+import org.bukkit.inventory.ItemStack;
 import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,7 +33,6 @@ public class EvtPlayerPickItemTest extends SkriptJUnitTest {
 	}
 
 	@Test
-	@SuppressWarnings("UnstableApiUsage")
 	public void test() {
 		if (!SUPPORTS_PICK_EVENT)
 			return;
@@ -50,8 +50,8 @@ public class EvtPlayerPickItemTest extends SkriptJUnitTest {
 		Event event = null;
 		try {
 			Class<?> eventClass = Class.forName("io.papermc.paper.event.player.PlayerPickBlockEvent");
-			event = (Event) eventClass.getConstructor(Player.class, Block.class, boolean.class, int.class, int.class)
-					.newInstance(player, pickedBlock, true, 0, 0);
+			event = (Event) eventClass.getConstructor(Player.class, Block.class, ItemStack.class, boolean.class, int.class, int.class)
+					.newInstance(player, pickedBlock, ItemStack.empty(), true, 0, 0);
 		} catch (Exception ignored) {}
 		return event;
 	}
@@ -60,8 +60,8 @@ public class EvtPlayerPickItemTest extends SkriptJUnitTest {
 		Event event = null;
 		try {
 			Class<?> eventClass = Class.forName("io.papermc.paper.event.player.PlayerPickEntityEvent");
-			event = (Event) eventClass.getConstructor(Player.class, Entity.class, boolean.class, int.class, int.class)
-					.newInstance(player, pickedEntity, true, 0, 0);
+			event = (Event) eventClass.getConstructor(Player.class, Entity.class, ItemStack.class, boolean.class, int.class, int.class)
+					.newInstance(player, pickedEntity, ItemStack.empty(), true, 0, 0);
 		} catch (Exception ignored) {}
 		return event;
 	}


### PR DESCRIPTION
### Problem
JUnit tests are failing as the constructor for this method was changed.
Event constructors are internal and thus subject to breaking changes without notice or deprecation.


### Solution
Updates the constructor resolution to include the ItemStack parameter.


### Testing Completed
JUnit tests now pass.

### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
