### PR TITLE
Feature/damage abort event

### DIFF
--- a/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
@@ -1,7 +1,6 @@
 package org.skriptlang.skript.bukkit.block;
 
 import ch.njol.skript.lang.util.SimpleEvent;
-import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockDamageAbortEvent;
 import org.bukkit.inventory.ItemStack;
@@ -36,31 +35,25 @@ public class BlockModule extends HierarchicalAddonModule {
 		moduleRegistry(addon).register(BukkitSyntaxInfos.Event.KEY, BukkitSyntaxInfos.Event.builder(SimpleEvent.class, "Block Damage Abort")
 			.addEvent(BlockDamageAbortEvent.class)
 			.addPatterns(
-				"[player] (stop|abort[ing]) (damag(e|ing)|break(ing)) [a] block",
-				"block damage abort",
-				"block damage being aborted"
+				"[player] (interrupt|stop|abort[ing]) (damag(e|ing)|break(ing)) [a] block",
+				"block damage (interrupt|abort|stop)",
+				"block damage being (interrupted|aborted|stopped)"
 			)
 			.addDescription("Called when a player stops breaking a block.")
 			.addExample("""
-                on stop breaking block:
-                    send "Hey! You have to finish what you started!"
-                """)
+				on stop breaking block:
+					send "Hey! You have to finish what you started!" to player
+				""")
 			.addSince("INSERT VERSION")
 			.supplier(() -> new SimpleEvent("block damage abort"))
 			.build());
 
 		EventValueRegistry eventValueRegistry = addon.registry(EventValueRegistry.class);
-		eventValueRegistry.register(EventValue.builder(BlockDamageAbortEvent.class, Player.class)
-			.getter(BlockDamageAbortEvent::getPlayer)
-			.build());
 
-		eventValueRegistry.register(EventValue.builder(BlockDamageAbortEvent.class, Block.class)
-			.getter(BlockDamageAbortEvent::getBlock)
-			.build());
 
-		eventValueRegistry.register(EventValue.builder(BlockDamageAbortEvent.class, ItemStack.class)
-			.getter(BlockDamageAbortEvent::getItemInHand)
-			.build());
+		eventValueRegistry.register(EventValue.simple(BlockDamageAbortEvent.class, Player.class, BlockDamageAbortEvent::getPlayer));
+
+		eventValueRegistry.register(EventValue.simple(BlockDamageAbortEvent.class, ItemStack.class, BlockDamageAbortEvent::getItemInHand));
 	}
 
 	@Override
@@ -69,3 +62,4 @@ public class BlockModule extends HierarchicalAddonModule {
 	}
 
 }
+

--- a/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
@@ -35,13 +35,10 @@ public class BlockModule extends HierarchicalAddonModule {
 		// Register the event
 		moduleRegistry(addon).register(BukkitSyntaxInfos.Event.KEY, BukkitSyntaxInfos.Event.builder(SimpleEvent.class, "Block Damage Abort")
 			.addEvent(BlockDamageAbortEvent.class)
-			.addPatterns("[block] damage (abort|stop)")
-			.addPatterns("(stop|abort) [of] [block] damage")
-			.addPatterns("[block] (stop|abort) break[ing]")
-			.addPatterns("block (stop|abort) damag(e|ing)")
-			.addDescription("""
-                Called when a player stops breaking a block.
-                """)
+			.addPatterns("block damage (abort|stop)")
+			.addPatterns("(stop|abort) [of] block (break[ing]|damag(e|ing))")
+			.addPatterns("block (stop|abort) (break[ing]|damag(e|ing))")
+			.addDescription("Called when a player stops breaking a block.")
 			.addExample("""
                 on block stop breaking:
                     send "Hey! You have to finish what you started!"
@@ -55,6 +52,7 @@ public class BlockModule extends HierarchicalAddonModule {
 		eventValueRegistry.register(EventValue.builder(BlockDamageAbortEvent.class, Player.class)
 			.getter(BlockDamageAbortEvent::getPlayer)
 			.build());
+
 		eventValueRegistry.register(EventValue.builder(BlockDamageAbortEvent.class, Block.class)
 			.getter(BlockDamageAbortEvent::getBlock)
 			.build());

--- a/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
@@ -1,7 +1,6 @@
 package org.skriptlang.skript.bukkit.block;
 
 import ch.njol.skript.lang.util.SimpleEvent;
-import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockDamageAbortEvent;
 import org.bukkit.inventory.ItemStack;
@@ -50,15 +49,11 @@ public class BlockModule extends HierarchicalAddonModule {
 			.build());
 
 		EventValueRegistry eventValueRegistry = addon.registry(EventValueRegistry.class);
-		
-		eventValueRegistry.register(EventValue.builder(BlockDamageAbortEvent.class, Player.class)
-			.getter(BlockDamageAbortEvent::getPlayer)
-			.build());
 
 
-		eventValueRegistry.register(EventValue.builder(BlockDamageAbortEvent.class, ItemStack.class)
-			.getter(BlockDamageAbortEvent::getItemInHand)
-			.build());
+		eventValueRegistry.register(EventValue.simple(BlockDamageAbortEvent.class, Player.class, BlockDamageAbortEvent::getPlayer));
+
+		eventValueRegistry.register(EventValue.simple(BlockDamageAbortEvent.class, ItemStack.class, BlockDamageAbortEvent::getItemInHand));
 	}
 
 	@Override

--- a/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
@@ -35,7 +35,7 @@ public class BlockModule extends HierarchicalAddonModule {
 		moduleRegistry(addon).register(BukkitSyntaxInfos.Event.KEY, BukkitSyntaxInfos.Event.builder(SimpleEvent.class, "Block Damage Abort")
 			.addEvent(BlockDamageAbortEvent.class)
 			.addPatterns(
-				"[player] (interrupt|stop|abort[ing]) (damag(e|ing)|break(ing)) [a] block",
+				"[player] (stop[ping]|abort[ing]) (damag(e|ing)|break(ing)) [a] block",
 				"block (break|damage) (interrupt|stop|abort)",
 				"block (break|damage) being (interrupted|stopped|aborted)"
 			)
@@ -49,7 +49,6 @@ public class BlockModule extends HierarchicalAddonModule {
 			.build());
 
 		EventValueRegistry eventValueRegistry = addon.registry(EventValueRegistry.class);
-
 
 		eventValueRegistry.register(EventValue.simple(BlockDamageAbortEvent.class, Player.class, BlockDamageAbortEvent::getPlayer));
 

--- a/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
@@ -50,6 +50,7 @@ public class BlockModule extends HierarchicalAddonModule {
 			.build());
 
 		EventValueRegistry eventValueRegistry = addon.registry(EventValueRegistry.class);
+		
 		eventValueRegistry.register(EventValue.builder(BlockDamageAbortEvent.class, Player.class)
 			.getter(BlockDamageAbortEvent::getPlayer)
 			.build());

--- a/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
@@ -43,7 +43,7 @@ public class BlockModule extends HierarchicalAddonModule {
 			.addDescription("Called when a player stops breaking a block.")
 			.addExample("""
 				on stop breaking block:
-					send "Hey! You have to finish what you started!"
+					send "Hey! You have to finish what you started!" to player
 				""")
 			.addSince("INSERT VERSION")
 			.supplier(() -> new SimpleEvent("block damage abort"))

--- a/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
@@ -42,9 +42,9 @@ public class BlockModule extends HierarchicalAddonModule {
 			)
 			.addDescription("Called when a player stops breaking a block.")
 			.addExample("""
-                on stop breaking block:
-                    send "Hey! You have to finish what you started!"
-                """)
+				on stop breaking block:
+					send "Hey! You have to finish what you started!"
+				""")
 			.addSince("INSERT VERSION")
 			.supplier(() -> new SimpleEvent("block damage abort"))
 			.build());

--- a/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
@@ -35,7 +35,6 @@ public class BlockModule extends HierarchicalAddonModule {
 		// Register the event
 		moduleRegistry(addon).register(BukkitSyntaxInfos.Event.KEY, BukkitSyntaxInfos.Event.builder(SimpleEvent.class, "Block Damage Abort")
 			.addEvent(BlockDamageAbortEvent.class)
-			.addPatterns("block damage (abort|stop)")
 			.addPatterns("(stop|abort) [of] block (break[ing]|damag(e|ing))")
 			.addPatterns("block (stop|abort) (break[ing]|damag(e|ing))")
 			.addDescription("Called when a player stops breaking a block.")

--- a/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
@@ -4,6 +4,7 @@ import ch.njol.skript.lang.util.SimpleEvent;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockDamageAbortEvent;
+import org.bukkit.inventory.ItemStack;
 import org.skriptlang.skript.addon.AddonModule;
 import org.skriptlang.skript.addon.HierarchicalAddonModule;
 import org.skriptlang.skript.addon.SkriptAddon;
@@ -32,11 +33,11 @@ public class BlockModule extends HierarchicalAddonModule {
 	@Override
 	public void loadSelf(SkriptAddon addon) {
 
-		// Register the event
 		moduleRegistry(addon).register(BukkitSyntaxInfos.Event.KEY, BukkitSyntaxInfos.Event.builder(SimpleEvent.class, "Block Damage Abort")
 			.addEvent(BlockDamageAbortEvent.class)
-			.addPatterns("(stop|abort) [of] block (break[ing]|damag(e|ing))")
-			.addPatterns("block (stop|abort) (break[ing]|damag(e|ing))")
+			.addPatterns("[player] (stop|abort[ing]) (damag(e|ing)|break(ing)) [a] block")
+				.addPatterns("block damage abort")
+				.addPatterns("block damage being aborted")
 			.addDescription("Called when a player stops breaking a block.")
 			.addExample("""
                 on block stop breaking:
@@ -46,7 +47,6 @@ public class BlockModule extends HierarchicalAddonModule {
 			.supplier(() -> new SimpleEvent("block damage abort"))
 			.build());
 
-		// Register values for said event
 		EventValueRegistry eventValueRegistry = addon.registry(EventValueRegistry.class);
 		eventValueRegistry.register(EventValue.builder(BlockDamageAbortEvent.class, Player.class)
 			.getter(BlockDamageAbortEvent::getPlayer)
@@ -54,6 +54,10 @@ public class BlockModule extends HierarchicalAddonModule {
 
 		eventValueRegistry.register(EventValue.builder(BlockDamageAbortEvent.class, Block.class)
 			.getter(BlockDamageAbortEvent::getBlock)
+			.build());
+
+		eventValueRegistry.register(EventValue.builder(BlockDamageAbortEvent.class, ItemStack.class)
+			.getter(BlockDamageAbortEvent::getItemInHand)
 			.build());
 	}
 

--- a/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
@@ -35,12 +35,14 @@ public class BlockModule extends HierarchicalAddonModule {
 
 		moduleRegistry(addon).register(BukkitSyntaxInfos.Event.KEY, BukkitSyntaxInfos.Event.builder(SimpleEvent.class, "Block Damage Abort")
 			.addEvent(BlockDamageAbortEvent.class)
-			.addPatterns("[player] (stop|abort[ing]) (damag(e|ing)|break(ing)) [a] block")
-				.addPatterns("block damage abort")
-				.addPatterns("block damage being aborted")
+			.addPatterns(
+				"[player] (stop|abort[ing]) (damag(e|ing)|break(ing)) [a] block",
+				"block damage abort",
+				"block damage being aborted"
+			)
 			.addDescription("Called when a player stops breaking a block.")
 			.addExample("""
-                on block stop breaking:
+                on stop breaking block:
                     send "Hey! You have to finish what you started!"
                 """)
 			.addSince("INSERT VERSION")

--- a/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
@@ -35,9 +35,9 @@ public class BlockModule extends HierarchicalAddonModule {
 		moduleRegistry(addon).register(BukkitSyntaxInfos.Event.KEY, BukkitSyntaxInfos.Event.builder(SimpleEvent.class, "Block Damage Abort")
 			.addEvent(BlockDamageAbortEvent.class)
 			.addPatterns(
-				"[player] (stop|abort[ing]) (damag(e|ing)|break(ing)) [a] block",
-				"block damage abort",
-				"block damage being aborted"
+				"[player] (interrupt|stop|abort[ing]) (damag(e|ing)|break(ing)) [a] block",
+				"block (break|damage) (interrupt|stop|abort)",
+				"block (break|damage) being (interrupted|stopped|aborted)"
 			)
 			.addDescription("Called when a player stops breaking a block.")
 			.addExample("""

--- a/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
@@ -54,9 +54,6 @@ public class BlockModule extends HierarchicalAddonModule {
 			.getter(BlockDamageAbortEvent::getPlayer)
 			.build());
 
-		eventValueRegistry.register(EventValue.builder(BlockDamageAbortEvent.class, Block.class)
-			.getter(BlockDamageAbortEvent::getBlock)
-			.build());
 
 		eventValueRegistry.register(EventValue.builder(BlockDamageAbortEvent.class, ItemStack.class)
 			.getter(BlockDamageAbortEvent::getItemInHand)

--- a/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
+++ b/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java
@@ -1,10 +1,17 @@
 package org.skriptlang.skript.bukkit.block;
 
+import ch.njol.skript.lang.util.SimpleEvent;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockDamageAbortEvent;
 import org.skriptlang.skript.addon.AddonModule;
 import org.skriptlang.skript.addon.HierarchicalAddonModule;
 import org.skriptlang.skript.addon.SkriptAddon;
 import org.skriptlang.skript.bukkit.block.furnace.FurnaceModule;
 import org.skriptlang.skript.bukkit.block.sign.SignModule;
+import org.skriptlang.skript.bukkit.lang.eventvalue.EventValue;
+import org.skriptlang.skript.bukkit.lang.eventvalue.EventValueRegistry;
+import org.skriptlang.skript.bukkit.registration.BukkitSyntaxInfos;
 
 import java.util.List;
 
@@ -24,7 +31,33 @@ public class BlockModule extends HierarchicalAddonModule {
 
 	@Override
 	public void loadSelf(SkriptAddon addon) {
-		// intentionally left blank
+
+		// Register the event
+		moduleRegistry(addon).register(BukkitSyntaxInfos.Event.KEY, BukkitSyntaxInfos.Event.builder(SimpleEvent.class, "Block Damage Abort")
+			.addEvent(BlockDamageAbortEvent.class)
+			.addPatterns("[block] damage (abort|stop)")
+			.addPatterns("(stop|abort) [of] [block] damage")
+			.addPatterns("[block] (stop|abort) break[ing]")
+			.addPatterns("block (stop|abort) damag(e|ing)")
+			.addDescription("""
+                Called when a player stops breaking a block.
+                """)
+			.addExample("""
+                on block stop breaking:
+                    send "Hey! You have to finish what you started!"
+                """)
+			.addSince("INSERT VERSION")
+			.supplier(() -> new SimpleEvent("block damage abort"))
+			.build());
+
+		// Register values for said event
+		EventValueRegistry eventValueRegistry = addon.registry(EventValueRegistry.class);
+		eventValueRegistry.register(EventValue.builder(BlockDamageAbortEvent.class, Player.class)
+			.getter(BlockDamageAbortEvent::getPlayer)
+			.build());
+		eventValueRegistry.register(EventValue.builder(BlockDamageAbortEvent.class, Block.class)
+			.getter(BlockDamageAbortEvent::getBlock)
+			.build());
 	}
 
 	@Override


### PR DESCRIPTION
### Problem
<!--- Why is this PR necessary? What problems exist that needed solving?  --->
This PR aims to add the BlockDamageAbortEvent to skript to allow users to detect when a player stops breaking a block.

### Solution
<!--- Explain how your solution fixes the problem and summarize the major code changes.  --->
I added the event in the [BlockModule.java class](https://github.com/Pro2021CA/Skript/blob/feature/damage-abort-event/src/main/java/org/skriptlang/skript/bukkit/block/BlockModule.java) with the player and block as event values.


### Testing Completed
<!--- List test scripts/unit tests and any manual testing that was performed. If no test scripts or unit tests are present, explain why.  --->
It passed my manual testing and quickTests


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->

---
**Completes:** https://github.com/SkriptLang/Skript/issues/8752 <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
