### PR TITLE
Fix multiline function examples in generated HTML

### DIFF
--- a/src/main/java/ch/njol/skript/doc/HTMLGenerator.java
+++ b/src/main/java/ch/njol/skript/doc/HTMLGenerator.java
@@ -570,12 +570,7 @@ public class HTMLGenerator extends DocumentationGenerator {
 
 	private @NotNull String addExamples(String desc, String @Nullable ... examples) {
 		if (examples != null) {
-			// sanitize
-			Documentation.escapeHTML(examples);
-			// replace newlines
-			for (int i = 0; i < examples.length; i++) {
-				examples[i] = examples[i].replace("\n", "<br>");
-			}
+			examples = formatExamplesForHTML(examples);
 		}
 
 		String mergedExamples = Joiner.on("<br>").join(getDefaultIfNullOrEmpty(examples, "Missing examples."));
@@ -844,7 +839,7 @@ public class HTMLGenerator extends DocumentationGenerator {
 
 		// Examples
 		String[] examples = getDefaultIfNullOrEmpty(typeExamples, "Missing examples.");
-		desc = desc.replace("${element.examples}", Joiner.on("\n<br>").join(Documentation.escapeHTML(examples)));
+		desc = desc.replace("${element.examples}", Joiner.on("\n<br>").join(formatExamplesForHTML(examples)));
 		desc = desc
 			.replace("${element.examples-safe}", Joiner.on("<br>").join(examples)
 				.replace("\\", "\\\\").replace("\"", "\\\"").replace("\t", "    "));
@@ -902,6 +897,14 @@ public class HTMLGenerator extends DocumentationGenerator {
 
 		assert desc != null;
 		return desc;
+	}
+
+	private static String[] formatExamplesForHTML(String[] examples) {
+		String[] escapedExamples = Documentation.escapeHTML(examples.clone());
+		for (int i = 0; i < escapedExamples.length; i++) {
+			escapedExamples[i] = escapedExamples[i].replace("\n", "<br>");
+		}
+		return escapedExamples;
 	}
 
 	@SuppressWarnings("null")

--- a/src/test/java/ch/njol/skript/doc/HTMLGeneratorTest.java
+++ b/src/test/java/ch/njol/skript/doc/HTMLGeneratorTest.java
@@ -1,0 +1,37 @@
+package ch.njol.skript.doc;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.function.Function;
+import org.junit.Test;
+import org.skriptlang.skript.common.function.DefaultFunction;
+
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+
+public class HTMLGeneratorTest {
+
+	@Test
+	public void formatsMultilineFunctionExamplesAsHtmlBreaks() throws Exception {
+		Path templateDir = Files.createTempDirectory("skript-html-generator");
+		try {
+			Files.writeString(templateDir.resolve("template.html"), "");
+			HTMLGenerator generator = new HTMLGenerator(templateDir.toFile(), templateDir.toFile());
+			DefaultFunction<String> function = DefaultFunction.builder(Skript.instance(), "test", String.class)
+				.examples("first <line>\nsecond line")
+				.build(args -> "result");
+
+			Method generateFunction = HTMLGenerator.class.getDeclaredMethod("generateFunction", String.class, Function.class);
+			generateFunction.setAccessible(true);
+			String generated = (String) generateFunction.invoke(generator, "${element.examples}", function);
+
+			assertEquals("first &lt;line&gt;<br>second line", generated);
+		} finally {
+			Files.deleteIfExists(templateDir.resolve("template.html"));
+			Files.deleteIfExists(templateDir);
+		}
+	}
+
+}


### PR DESCRIPTION
## Summary

- Convert newline characters in function documentation examples to `<br>` before inserting them into generated HTML.
- Keep HTML escaping intact and avoid mutating the source example array.
- Add a regression test covering HTML escaping and multiline function examples.

## Validation

- `./gradlew test --tests ch.njol.skript.doc.HTMLGeneratorTest --no-daemon` (compiles the test class; the repository intentionally excludes standard Gradle tests)
- `./gradlew JUnitQuick --no-daemon` (the new `HTMLGeneratorTest` was discovered and executed; the task is currently red because unrelated existing Paper 26.2 tests report 154 parsing/runtime failures)
- `git diff --check`

Resolves #8383.