### PR TITLE
Add default function aliases

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/DefaultFunctions.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultFunctions.java
@@ -92,27 +92,20 @@ public class DefaultFunctions {
 			.examples("round(2.34) = 2", "round(2) = 2", "round(2.99) = 3", "round(2.5) = 3")
 			.since("2.2, 2.7 (decimal placement)"));
 
-		Functions.registerFunction(new SimpleJavaFunction<Long>("ceil", numberParam, DefaultClasses.LONG, true) {
-			@Override
-			public Long[] executeSimple(Object[][] params) {
-				if (params[0][0] instanceof Long)
-					return new Long[] {(Long) params[0][0]};
-				return new Long[] {Math2.ceil(((Number) params[0][0]).doubleValue())};
-			}
-		}.description("Rounds a number up, i.e. returns the closest integer larger than or equal to the argument.")
-			.examples("ceil(2.34) = 3", "ceil(2) = 2", "ceil(2.99) = 3")
-			.since("2.2"));
+		Functions.register(DefaultFunction.builder(skript, "ceil", Long.class)
+				.aliases("ceiling")
+				.description("Rounds a number up, i.e. returns the closest integer larger than or equal to the argument.")
+				.examples("ceiling(2.34) = 3", "ceiling(2) = 2", "ceiling(2.99) = 3")
+				.since("2.2")
+				.parameter("n", Number.class)
+				.build(args -> {
+					Number value = args.get("n");
 
-		Functions.registerFunction(new SimpleJavaFunction<Long>("ceiling", numberParam, DefaultClasses.LONG, true) {
-			@Override
-			public Long[] executeSimple(Object[][] params) {
-				if (params[0][0] instanceof Long)
-					return new Long[] {(Long) params[0][0]};
-				return new Long[] {Math2.ceil(((Number) params[0][0]).doubleValue())};
-			}
-		}.description("Alias of <a href='#ceil'>ceil</a>.")
-			.examples("ceiling(2.34) = 3", "ceiling(2) = 2", "ceiling(2.99) = 3")
-			.since("2.2"));
+					if (value instanceof Long l)
+						return l;
+
+					return Math2.ceil(value.doubleValue());
+				}));
 
 		Functions.registerFunction(new SimpleJavaFunction<Number>("abs", numberParam, DefaultClasses.NUMBER, true) {
 			@Override

--- a/src/main/java/ch/njol/skript/classes/data/DefaultFunctions.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultFunctions.java
@@ -95,7 +95,7 @@ public class DefaultFunctions {
 		Functions.register(DefaultFunction.builder(skript, "ceil", Long.class)
 				.aliases("ceiling")
 				.description("Rounds a number up, i.e. returns the closest integer larger than or equal to the argument.")
-				.examples("ceiling(2.34) = 3", "ceiling(2) = 2", "ceiling(2.99) = 3")
+				.examples("ceil(2.34) = 3", "ceil(2) = 2", "ceiling(2.99) = 3")
 				.since("2.2")
 				.parameter("n", Number.class)
 				.build(args -> {

--- a/src/main/java/ch/njol/skript/lang/function/FunctionRegistry.java
+++ b/src/main/java/ch/njol/skript/lang/function/FunctionRegistry.java
@@ -103,21 +103,21 @@ public final class FunctionRegistry implements Registry<Function<?>> {
 		}
 		Namespace ns = namespaces.computeIfAbsent(namespaceId, n -> new Namespace());
 
-		for (FunctionIdentifier identifier : FunctionIdentifier.of(signature)) {
-			// register
-			// since we are getting a set and then updating it,
-			// avoid race conditions by ensuring only one thread can access this namespace for this operation
-			synchronized (ns) {
+		// register
+		// since we are getting a set and then updating it,
+		// avoid race conditions by ensuring only one thread can access this namespace for this operation
+		synchronized (ns) {
+			for (FunctionIdentifier identifier : FunctionIdentifier.of(signature)) {
 				Set<FunctionIdentifier> identifiersWithName = ns.identifiers.computeIfAbsent(identifier.name, s -> new HashSet<>());
 				boolean exists = identifiersWithName.add(identifier);
 				if (!exists) {
 					alreadyRegisteredError(identifier.name, identifier, namespaceId);
 				}
-			}
 
-			Signature<?> existing = ns.signatures.putIfAbsent(identifier, signature);
-			if (existing != null) {
-				alreadyRegisteredError(identifier.name, identifier, namespaceId);
+				Signature<?> existing = ns.signatures.putIfAbsent(identifier, signature);
+				if (existing != null) {
+					alreadyRegisteredError(identifier.name, identifier, namespaceId);
+				}
 			}
 		}
 	}
@@ -584,18 +584,18 @@ public final class FunctionRegistry implements Registry<Function<?>> {
 	public void remove(@NotNull Signature<?> signature) {
 		Preconditions.checkNotNull(signature, "signature cannot be null");
 
+		Namespace namespace;
+		if (signature.isLocal()) {
+			namespace = namespaces.get(new NamespaceIdentifier(signature.namespace()));
+		} else {
+			namespace = namespaces.get(GLOBAL_NAMESPACE);
+		}
+
+		if (namespace == null) {
+			return;
+		}
+
 		for (FunctionIdentifier identifier : FunctionIdentifier.of(signature)) {
-			Namespace namespace;
-			if (signature.isLocal()) {
-				namespace = namespaces.get(new NamespaceIdentifier(signature.namespace()));
-			} else {
-				namespace = namespaces.get(GLOBAL_NAMESPACE);
-			}
-
-			if (namespace == null) {
-				return;
-			}
-
 			for (FunctionIdentifier other : namespace.identifiers.getOrDefault(identifier.name, Set.of())) {
 				if (!identifier.equals(other)) {
 					continue;

--- a/src/main/java/ch/njol/skript/lang/function/FunctionRegistry.java
+++ b/src/main/java/ch/njol/skript/lang/function/FunctionRegistry.java
@@ -101,24 +101,24 @@ public final class FunctionRegistry implements Registry<Function<?>> {
 		} else {
 			namespaceId = GLOBAL_NAMESPACE;
 		}
-
 		Namespace ns = namespaces.computeIfAbsent(namespaceId, n -> new Namespace());
-		FunctionIdentifier identifier = FunctionIdentifier.of(signature);
 
-		// register
-		// since we are getting a set and then updating it,
-		// avoid race conditions by ensuring only one thread can access this namespace for this operation
-		synchronized (ns) {
-			Set<FunctionIdentifier> identifiersWithName = ns.identifiers.computeIfAbsent(identifier.name, s -> new HashSet<>());
-			boolean exists = identifiersWithName.add(identifier);
-			if (!exists) {
-				alreadyRegisteredError(signature.getName(), identifier, namespaceId);
+		for (FunctionIdentifier identifier : FunctionIdentifier.of(signature)) {
+			// register
+			// since we are getting a set and then updating it,
+			// avoid race conditions by ensuring only one thread can access this namespace for this operation
+			synchronized (ns) {
+				Set<FunctionIdentifier> identifiersWithName = ns.identifiers.computeIfAbsent(identifier.name, s -> new HashSet<>());
+				boolean exists = identifiersWithName.add(identifier);
+				if (!exists) {
+					alreadyRegisteredError(identifier.name, identifier, namespaceId);
+				}
 			}
-		}
 
-		Signature<?> existing = ns.signatures.putIfAbsent(identifier, signature);
-		if (existing != null) {
-			alreadyRegisteredError(signature.getName(), identifier, namespaceId);
+			Signature<?> existing = ns.signatures.putIfAbsent(identifier, signature);
+			if (existing != null) {
+				alreadyRegisteredError(identifier.name, identifier, namespaceId);
+			}
 		}
 	}
 
@@ -163,16 +163,17 @@ public final class FunctionRegistry implements Registry<Function<?>> {
 			namespaceId = GLOBAL_NAMESPACE;
 		}
 
-		FunctionIdentifier identifier = FunctionIdentifier.of(function.getSignature());
-		if (!signatureExists(namespaceId, identifier)) {
-			register(namespace, function.getSignature());
-		}
+		for (FunctionIdentifier identifier : FunctionIdentifier.of(function.getSignature())) {
+			if (!signatureExists(namespaceId, identifier)) {
+				register(namespace, function.getSignature());
+			}
 
-		Namespace ns = namespaces.computeIfAbsent(namespaceId, n -> new Namespace());
+			Namespace ns = namespaces.computeIfAbsent(namespaceId, n -> new Namespace());
 
-		Function<?> existing = ns.functions.putIfAbsent(identifier, function);
-		if (existing != null) {
-			alreadyRegisteredError(name, identifier, namespaceId);
+			Function<?> existing = ns.functions.putIfAbsent(identifier, function);
+			if (existing != null) {
+				alreadyRegisteredError(identifier.name, identifier, namespaceId);
+			}
 		}
 	}
 
@@ -583,27 +584,26 @@ public final class FunctionRegistry implements Registry<Function<?>> {
 	public void remove(@NotNull Signature<?> signature) {
 		Preconditions.checkNotNull(signature, "signature cannot be null");
 
-		String name = signature.getName();
-		FunctionIdentifier identifier = FunctionIdentifier.of(signature);
-
-		Namespace namespace;
-		if (signature.isLocal()) {
-			namespace = namespaces.get(new NamespaceIdentifier(signature.namespace()));
-		} else {
-			namespace = namespaces.get(GLOBAL_NAMESPACE);
-		}
-
-		if (namespace == null) {
-			return;
-		}
-
-		for (FunctionIdentifier other : namespace.identifiers.getOrDefault(name, Set.of())) {
-			if (!identifier.equals(other)) {
-				continue;
+		for (FunctionIdentifier identifier : FunctionIdentifier.of(signature)) {
+			Namespace namespace;
+			if (signature.isLocal()) {
+				namespace = namespaces.get(new NamespaceIdentifier(signature.namespace()));
+			} else {
+				namespace = namespaces.get(GLOBAL_NAMESPACE);
 			}
 
-			removeUpdateMaps(namespace, other, name);
-			return;
+			if (namespace == null) {
+				return;
+			}
+
+			for (FunctionIdentifier other : namespace.identifiers.getOrDefault(identifier.name, Set.of())) {
+				if (!identifier.equals(other)) {
+					continue;
+				}
+
+				removeUpdateMaps(namespace, other, identifier.name);
+				return;
+			}
 		}
 	}
 
@@ -633,15 +633,6 @@ public final class FunctionRegistry implements Registry<Function<?>> {
 	 * An identifier for a function namespace.
 	 */
 	private record NamespaceIdentifier(@Nullable String name) {
-
-		/**
-		 * Returns whether this identifier is for local namespaces.
-		 *
-		 * @return Whether this identifier is for local namespaces.
-		 */
-		public boolean local() {
-			return name == null;
-		}
 
 	}
 
@@ -697,7 +688,7 @@ public final class FunctionRegistry implements Registry<Function<?>> {
 		 * @param signature The signature to get the identifier for.
 		 * @return The identifier for the signature.
 		 */
-		static FunctionIdentifier of(@NotNull Signature<?> signature) {
+		static Set<FunctionIdentifier> of(@NotNull Signature<?> signature) {
 			Preconditions.checkNotNull(signature, "signature cannot be null");
 
 			Parameter<?>[] signatureParams = signature.parameters().all();
@@ -712,9 +703,15 @@ public final class FunctionRegistry implements Registry<Function<?>> {
 
 				parameters[i] = param.type();
 			}
+			int minArgCount = parameters.length - optionalArgs;
 
-			return new FunctionIdentifier(signature.getName(), signature.isLocal(),
-				parameters.length - optionalArgs, parameters);
+			Set<FunctionIdentifier>	identifiers	= new HashSet<>();
+			identifiers.add(new FunctionIdentifier(signature.getName(), signature.isLocal(), minArgCount, parameters));
+			for (String alias : signature.aliases()) {
+				identifiers.add(new FunctionIdentifier(alias, signature.isLocal(), minArgCount, parameters));
+			}
+
+			return identifiers;
 		}
 
 		@Override

--- a/src/main/java/ch/njol/skript/lang/function/Functions.java
+++ b/src/main/java/ch/njol/skript/lang/function/Functions.java
@@ -66,11 +66,20 @@ public abstract class Functions {
 		if (!name.matches(functionNamePattern))
 			throw new SkriptAPIException("Invalid function name '%s'".formatted(name));
 
+		for (String s : function.signature().aliases()) {
+			if (!s.matches(functionNamePattern))
+				throw new SkriptAPIException("Invalid function name '%s'".formatted(name));
+		}
+
 		if (javaNamespace.getSignature(name) == null) {
 			javaNamespace.addSignature((Signature<?>) function.signature());
 			javaNamespace.addFunction((Function<?>) function);
 		}
+
 		globalFunctions.put(function.name(), javaNamespace);
+		for (String alias : function.signature().aliases()) {
+			globalFunctions.put(alias, javaNamespace);
+		}
 
 		FunctionRegistry.getRegistry().register(null, (Function<?>) function);
 

--- a/src/main/java/ch/njol/skript/lang/function/Signature.java
+++ b/src/main/java/ch/njol/skript/lang/function/Signature.java
@@ -10,6 +10,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 import org.skriptlang.skript.common.function.FunctionReference;
 import org.skriptlang.skript.common.function.Parameter.Modifier;
 import org.skriptlang.skript.common.function.Parameters;
@@ -67,6 +68,8 @@ public class Signature<T> implements org.skriptlang.skript.common.function.Signa
 	 * The class path for the origin of this signature.
 	 */
 	@Nullable String originClassPath;
+
+	private final Set<String> aliases = new HashSet<>();
 
 	static Class<?> getReturns(boolean single, Class<?> cls) {
 		if (single) {
@@ -130,6 +133,12 @@ public class Signature<T> implements org.skriptlang.skript.common.function.Signa
 		this(namespace, name, initParameters(parameters), returnType, false, contract);
 	}
 
+	public Signature(String namespace, String name, Set<String> aliases, Parameters parameters, Class<T> returnType, @Nullable Contract contract) {
+		this(namespace, name, parameters, returnType, false, contract);
+
+		this.aliases.addAll(aliases);
+	}
+
 	private static Parameters initParameters(org.skriptlang.skript.common.function.Parameter<?>[] params) {
 		SequencedMap<String, org.skriptlang.skript.common.function.Parameter<?>> map = new LinkedHashMap<>();
 		for (org.skriptlang.skript.common.function.Parameter<?> parameter : params) {
@@ -172,14 +181,16 @@ public class Signature<T> implements org.skriptlang.skript.common.function.Signa
 	}
 
 	@Override
+	public @Unmodifiable @NotNull Set<String> aliases() {
+		return Collections.unmodifiableSet(aliases);
+	}
+
+	@Override
 	public @Nullable Class<T> returnType() {
 		//noinspection unchecked
 		return (Class<T>) returns;
 	}
 
-	/**
-	 * @return A {@link SequencedMap} containing all parameters.
-	 */
 	@Override
 	public @NotNull Parameters parameters() {
 		return parameters;

--- a/src/main/java/ch/njol/skript/lang/function/Signature.java
+++ b/src/main/java/ch/njol/skript/lang/function/Signature.java
@@ -133,7 +133,7 @@ public class Signature<T> implements org.skriptlang.skript.common.function.Signa
 		this(namespace, name, initParameters(parameters), returnType, false, contract);
 	}
 
-	public Signature(String namespace, String name, Set<String> aliases, Parameters parameters, Class<T> returnType, @Nullable Contract contract) {
+	public Signature(String namespace, String name, Collection<String> aliases, Parameters parameters, Class<T> returnType, @Nullable Contract contract) {
 		this(namespace, name, parameters, returnType, false, contract);
 
 		this.aliases.addAll(aliases);
@@ -181,7 +181,7 @@ public class Signature<T> implements org.skriptlang.skript.common.function.Signa
 	}
 
 	@Override
-	public @Unmodifiable @NotNull Set<String> aliases() {
+	public @Unmodifiable @NotNull Collection<String> aliases() {
 		return Collections.unmodifiableSet(aliases);
 	}
 

--- a/src/main/java/org/skriptlang/skript/common/function/DefaultFunction.java
+++ b/src/main/java/org/skriptlang/skript/common/function/DefaultFunction.java
@@ -3,8 +3,11 @@ package org.skriptlang.skript.common.function;
 import ch.njol.skript.doc.Documentable;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Unmodifiable;
 import org.skriptlang.skript.addon.SkriptAddon;
 import org.skriptlang.skript.common.function.Parameter.Modifier;
+
+import java.util.Set;
 
 /**
  * A function that has been implemented in Java, instead of in Skript.
@@ -60,6 +63,13 @@ public sealed interface DefaultFunction<T>
 	 * @param <T> The return type of the function.
 	 */
 	interface Builder<T> {
+
+		/**
+		 * Sets this function builder's aliases.
+		 * @param aliases The aliases.
+		 * @return This builder.
+		 */
+		Builder<T> aliases(@NotNull String @NotNull ... aliases);
 
 		/**
 		 * Sets this function builder's {@link ch.njol.skript.util.Contract}.

--- a/src/main/java/org/skriptlang/skript/common/function/DefaultFunctionImpl.java
+++ b/src/main/java/org/skriptlang/skript/common/function/DefaultFunctionImpl.java
@@ -29,14 +29,15 @@ final class DefaultFunctionImpl<T> extends ch.njol.skript.lang.function.Function
 	DefaultFunctionImpl(
 			SkriptAddon source,
 			String name,
+			Set<String> aliases,
 			SequencedMap<String, Parameter<?>> parameters,
-			Class<T> returnType, boolean single,
+			Class<T> returnType,
 			@Nullable ch.njol.skript.util.Contract contract,
 			Function<FunctionArguments, T> execute,
 			String[] description, String[] since, String[] examples,
 			String[] keywords, String[] requires
 	) {
-		super(new Signature<>(null, name, parameters.values().toArray(new Parameter[0]), returnType, single, contract));
+		super(new Signature<>(null, name, aliases, new Parameters(parameters), returnType, contract));
 
 		Preconditions.checkNotNull(source, "source cannot be null");
 		Preconditions.checkNotNull(name, "name cannot be null");
@@ -187,6 +188,7 @@ final class DefaultFunctionImpl<T> extends ch.njol.skript.lang.function.Function
 		private final String name;
 		private final Class<T> returnType;
 		private final SequencedMap<String, Parameter<?>> parameters = new LinkedHashMap<>();
+		private final Set<String> aliases = new HashSet<>();
 
 		private ch.njol.skript.util.Contract contract = null;
 
@@ -204,6 +206,15 @@ final class DefaultFunctionImpl<T> extends ch.njol.skript.lang.function.Function
 			this.source = source;
 			this.name = name;
 			this.returnType = returnType;
+		}
+
+		@Override
+		public Builder<T> aliases(@NotNull String @NotNull ... aliases) {
+			Preconditions.checkNotNull(aliases, "aliases cannot be null");
+			checkNotNull(aliases, "aliases contents cannot be null");
+
+			this.aliases.addAll(Arrays.asList(aliases));
+			return this;
 		}
 
 		@Override
@@ -272,8 +283,8 @@ final class DefaultFunctionImpl<T> extends ch.njol.skript.lang.function.Function
 		public DefaultFunction<T> build(@NotNull Function<FunctionArguments, T> execute) {
 			Preconditions.checkNotNull(execute, "execute cannot be null");
 
-			return new DefaultFunctionImpl<>(source, name, parameters,
-					returnType, !returnType.isArray(), contract, execute,
+			return new DefaultFunctionImpl<>(source, name, aliases, parameters,
+					returnType, contract, execute,
 					description, since, examples, keywords, requires);
 		}
 

--- a/src/main/java/org/skriptlang/skript/common/function/DefaultFunctionImpl.java
+++ b/src/main/java/org/skriptlang/skript/common/function/DefaultFunctionImpl.java
@@ -29,7 +29,7 @@ final class DefaultFunctionImpl<T> extends ch.njol.skript.lang.function.Function
 	DefaultFunctionImpl(
 			SkriptAddon source,
 			String name,
-			Set<String> aliases,
+			Collection<String> aliases,
 			SequencedMap<String, Parameter<?>> parameters,
 			Class<T> returnType,
 			@Nullable ch.njol.skript.util.Contract contract,
@@ -188,7 +188,7 @@ final class DefaultFunctionImpl<T> extends ch.njol.skript.lang.function.Function
 		private final String name;
 		private final Class<T> returnType;
 		private final SequencedMap<String, Parameter<?>> parameters = new LinkedHashMap<>();
-		private final Set<String> aliases = new HashSet<>();
+		private final Collection<String> aliases = new HashSet<>();
 
 		private ch.njol.skript.util.Contract contract = null;
 

--- a/src/main/java/org/skriptlang/skript/common/function/Signature.java
+++ b/src/main/java/org/skriptlang/skript/common/function/Signature.java
@@ -7,9 +7,8 @@ import org.jetbrains.annotations.ApiStatus.NonExtendable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
-import org.jetbrains.annotations.UnmodifiableView;
 
-import java.util.Set;
+import java.util.Collection;
 
 /**
  * Represents a function signature.
@@ -25,7 +24,7 @@ public interface Signature<T> {
 	/**
 	 * @return All aliases for this implementation.
 	 */
-	@Unmodifiable @NotNull Set<String> aliases();
+	@Unmodifiable @NotNull Collection<String> aliases();
 
 	/**
 	 * @return The type of this parameter.

--- a/src/main/java/org/skriptlang/skript/common/function/Signature.java
+++ b/src/main/java/org/skriptlang/skript/common/function/Signature.java
@@ -33,7 +33,7 @@ public interface Signature<T> {
 	@Nullable Class<T> returnType();
 
 	/**
-	 * @return An unmodifiable view of all the parameters that this signature has.
+	 * @return An unmodifiable copy of all the parameters that this signature has.
 	 */
 	@Unmodifiable @NotNull Parameters parameters();
 

--- a/src/main/java/org/skriptlang/skript/common/function/Signature.java
+++ b/src/main/java/org/skriptlang/skript/common/function/Signature.java
@@ -6,7 +6,10 @@ import org.jetbrains.annotations.ApiStatus.Internal;
 import org.jetbrains.annotations.ApiStatus.NonExtendable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 import org.jetbrains.annotations.UnmodifiableView;
+
+import java.util.Set;
 
 /**
  * Represents a function signature.
@@ -20,6 +23,11 @@ import org.jetbrains.annotations.UnmodifiableView;
 public interface Signature<T> {
 
 	/**
+	 * @return All aliases for this implementation.
+	 */
+	@Unmodifiable @NotNull Set<String> aliases();
+
+	/**
 	 * @return The type of this parameter.
 	 */
 	@Nullable Class<T> returnType();
@@ -27,7 +35,7 @@ public interface Signature<T> {
 	/**
 	 * @return An unmodifiable view of all the parameters that this signature has.
 	 */
-	@UnmodifiableView @NotNull Parameters parameters();
+	@Unmodifiable @NotNull Parameters parameters();
 
 	/**
 	 * @return The contract of this signature.

--- a/src/test/java/ch/njol/skript/lang/function/FunctionRegistryTest.java
+++ b/src/test/java/ch/njol/skript/lang/function/FunctionRegistryTest.java
@@ -10,6 +10,8 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
 
+import java.util.Set;
+
 import static org.junit.Assert.*;
 
 public class FunctionRegistryTest {
@@ -369,8 +371,10 @@ public class FunctionRegistryTest {
 			}
 		};
 
-		FunctionIdentifier identifier = FunctionIdentifier.of(function.getSignature());
+		Set<FunctionIdentifier> identifiers = FunctionIdentifier.of(function.getSignature());
+		assertEquals(1, identifiers.size());
 
+		FunctionIdentifier identifier = identifiers.stream().findFirst().orElseThrow();
 		assertEquals(FUNCTION_NAME, identifier.name());
 		assertFalse(identifier.local());
 		assertEquals(1, identifier.minArgCount());
@@ -387,7 +391,7 @@ public class FunctionRegistryTest {
 			}
 		};
 
-		assertEquals(FunctionIdentifier.of(function2.getSignature()), identifier);
+		assertEquals(FunctionIdentifier.of(function2.getSignature()), identifiers);
 	}
 
 	// see https://github.com/SkriptLang/Skript/pull/8015

--- a/src/test/skript/tests/misc/function aliases.sk
+++ b/src/test/skript/tests/misc/function aliases.sk
@@ -1,0 +1,3 @@
+test "function aliases":
+    assert ceil(2.3) = 3
+    assert ceiling(2.3) = 3


### PR DESCRIPTION
### Problem
Functions with identical implementations previously had to be registered using separate registration calls, resulting in duplicate code.


### Solution
This PR adds support for aliases in function signatures. When building a DefaultFunction, the `aliases` method allows a developer to add additional aliases to an implementation. When this function is registered internally, a function identifier will be added for every alias (including the name) to the appropriate namespace.


### Testing Completed
Added integration test for `ceil` and `ceiling`.


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
