### PR TITLE
Add explicit builder for default functions that do not return anything 

### DIFF
--- a/src/main/java/org/skriptlang/skript/common/function/DefaultFunction.java
+++ b/src/main/java/org/skriptlang/skript/common/function/DefaultFunction.java
@@ -6,6 +6,8 @@ import org.jetbrains.annotations.NotNull;
 import org.skriptlang.skript.addon.SkriptAddon;
 import org.skriptlang.skript.common.function.Parameter.Modifier;
 
+import java.util.function.Consumer;
+
 /**
  * A function that has been implemented in Java, instead of in Skript.
  * <p>
@@ -39,6 +41,7 @@ public sealed interface DefaultFunction<T>
 	/**
 	 * Creates a new builder for a function.
 	 *
+	 * @param source 	 The addon registering this function.
 	 * @param name       The name of the function.
 	 * @param returnType The type of the function.
 	 * @param <T>        The return type.
@@ -47,6 +50,18 @@ public sealed interface DefaultFunction<T>
 	@Contract("_, _, _ -> new")
 	static <T> @NotNull Builder<T> builder(@NotNull SkriptAddon source, @NotNull String name, @NotNull Class<T> returnType) {
 		return new DefaultFunctionImpl.BuilderImpl<>(source, name, returnType);
+	}
+
+	/**
+	 * Creates a new builder for a function which does not return anything.
+	 *
+	 * @param source 	 The addon registering this function.
+	 * @param name       The name of the function.
+	 * @return The builder for a function.
+	 */
+	@Contract("_, _ -> new")
+	static @NotNull VoidBuilder voidBuilder(@NotNull SkriptAddon source, @NotNull String name) {
+		return new DefaultFunctionImpl.VoidBuilderImpl(source, name);
 	}
 
 	/**
@@ -133,6 +148,86 @@ public sealed interface DefaultFunction<T>
 		 * @return The final function.
 		 */
 		DefaultFunction<T> build(@NotNull java.util.function.Function<FunctionArguments, T> execute);
+
+	}
+
+	/**
+	 * Represents a builder for {@link DefaultFunction DefaultFunctions} with no return value.
+	 */
+	interface VoidBuilder {
+
+		/**
+		 * Sets this function builder's {@link ch.njol.skript.util.Contract}.
+		 *
+		 * @param contract The contract.
+		 * @return This builder.
+		 */
+		@Contract("_ -> this")
+		VoidBuilder contract(@NotNull ch.njol.skript.util.Contract contract);
+
+		/**
+		 * Sets this function builder's description.
+		 *
+		 * @param description The description.
+		 * @return This builder.
+		 */
+		@Contract("_ -> this")
+		VoidBuilder description(@NotNull String @NotNull ... description);
+
+		/**
+		 * Sets this function builder's version history.
+		 *
+		 * @param since The version information.
+		 * @return This builder.
+		 */
+		@Contract("_ -> this")
+		VoidBuilder since(@NotNull String @NotNull ... since);
+
+		/**
+		 * Sets this function builder's examples.
+		 *
+		 * @param examples The examples.
+		 * @return This builder.
+		 */
+		@Contract("_ -> this")
+		VoidBuilder examples(@NotNull String @NotNull ... examples);
+
+		/**
+		 * Sets this function builder's keywords.
+		 *
+		 * @param keywords The keywords.
+		 * @return This builder.
+		 */
+		@Contract("_ -> this")
+		VoidBuilder keywords(@NotNull String @NotNull ... keywords);
+
+		/**
+		 * Sets this function builder's requires.
+		 *
+		 * @param requires The requirements.
+		 * @return This builder.
+		 */
+		@Contract("_ -> this")
+		VoidBuilder requires(@NotNull String @NotNull ... requires);
+
+		/**
+		 * Adds a parameter to this function builder.
+		 *
+		 * @param name      The parameter name.
+		 * @param type      The type of the parameter.
+		 * @param modifiers The {@link Modifier}s to apply to this parameter.
+		 * @return This builder.
+		 */
+		@Contract("_, _, _ -> this")
+		VoidBuilder parameter(@NotNull String name, @NotNull Class<?> type, Modifier @NotNull ... modifiers);
+
+		/**
+		 * Completes this builder with the code to execute on call of this function.
+		 *
+		 * @param execute The code to execute.
+		 * @return The final function.
+		 */
+		DefaultFunction<Void> build(@NotNull Consumer<FunctionArguments> execute);
 
 	}
 

--- a/src/main/java/org/skriptlang/skript/common/function/DefaultFunctionImpl.java
+++ b/src/main/java/org/skriptlang/skript/common/function/DefaultFunctionImpl.java
@@ -12,6 +12,7 @@ import org.skriptlang.skript.common.function.Parameter.Modifier.RangedModifier;
 
 import java.lang.reflect.Array;
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 final class DefaultFunctionImpl<T> extends ch.njol.skript.lang.function.Function<T> implements DefaultFunction<T> {
@@ -41,7 +42,6 @@ final class DefaultFunctionImpl<T> extends ch.njol.skript.lang.function.Function
 		Preconditions.checkNotNull(source, "source cannot be null");
 		Preconditions.checkNotNull(name, "name cannot be null");
 		Preconditions.checkNotNull(parameters, "parameters cannot be null");
-		Preconditions.checkNotNull(returnType, "return type cannot be null");
 		Preconditions.checkNotNull(execute, "execute cannot be null");
 
 		this.source = source;
@@ -277,15 +277,103 @@ final class DefaultFunctionImpl<T> extends ch.njol.skript.lang.function.Function
 					description, since, examples, keywords, requires);
 		}
 
-		/**
-		 * Checks whether the elements in a {@link String} array are null.
-		 *
-		 * @param strings The strings.
-		 */
-		private static void checkNotNull(@NotNull String[] strings, @NotNull String message) {
-			for (String string : strings) {
-				Preconditions.checkNotNull(string, message);
-			}
+	}
+
+	static class VoidBuilderImpl implements DefaultFunctionImpl.VoidBuilder {
+
+		private final SkriptAddon source;
+		private final String name;
+		private final SequencedMap<String, Parameter<?>> parameters = new LinkedHashMap<>();
+
+		private ch.njol.skript.util.Contract contract = null;
+
+		private String[] description;
+		private String[] since;
+		private String[] examples;
+		private String[] keywords;
+		private String[] requires;
+
+		VoidBuilderImpl(@NotNull SkriptAddon source, @NotNull String name) {
+			Preconditions.checkNotNull(source, "source cannot be null");
+			Preconditions.checkNotNull(name, "name cannot be null");
+
+			this.source = source;
+			this.name = name;
+		}
+
+		@Override
+		public VoidBuilder contract(@NotNull ch.njol.skript.util.Contract contract) {
+			Preconditions.checkNotNull(contract, "contract cannot be null");
+
+			this.contract = contract;
+			return this;
+		}
+
+		@Override
+		public VoidBuilder description(@NotNull String @NotNull ... description) {
+			Preconditions.checkNotNull(description, "description cannot be null");
+			checkNotNull(description, "description contents cannot be null");
+
+			this.description = description;
+			return this;
+		}
+
+		@Override
+		public VoidBuilder since(@NotNull String @NotNull ... since) {
+			Preconditions.checkNotNull(since, "since cannot be null");
+			checkNotNull(since, "since contents cannot be null");
+
+			this.since = since;
+			return this;
+		}
+
+		@Override
+		public VoidBuilder examples(@NotNull String @NotNull ... examples) {
+			Preconditions.checkNotNull(examples, "examples cannot be null");
+			checkNotNull(examples, "examples contents cannot be null");
+
+			this.examples = examples;
+			return this;
+		}
+
+		@Override
+		public VoidBuilder keywords(@NotNull String @NotNull ... keywords) {
+			Preconditions.checkNotNull(keywords, "keywords cannot be null");
+			checkNotNull(keywords, "keywords contents cannot be null");
+
+			this.keywords = keywords;
+			return this;
+		}
+
+		@Override
+		public VoidBuilder requires(@NotNull String @NotNull ... requires) {
+			Preconditions.checkNotNull(keywords, "requires cannot be null");
+			checkNotNull(keywords, "requires contents cannot be null");
+
+			this.requires = requires;
+			return this;
+		}
+
+		@Override
+		public VoidBuilder parameter(@NotNull String name, @NotNull Class<?> type, Parameter.Modifier @NotNull ... modifiers) {
+			Preconditions.checkNotNull(name, "name cannot be null");
+			Preconditions.checkNotNull(type, "type cannot be null");
+
+			parameters.put(name, new DefaultParameter<>(name, type, modifiers));
+			return this;
+		}
+
+		@Override
+		public DefaultFunction<Void> build(@NotNull Consumer<FunctionArguments> execute) {
+			Preconditions.checkNotNull(execute, "execute cannot be null");
+
+			return new DefaultFunctionImpl<>(source, name, parameters, null,
+					true, contract,
+					(args) -> {
+						execute.accept(args);
+						return null;
+					},
+					description, since, examples, keywords, requires);
 		}
 
 	}
@@ -310,5 +398,17 @@ final class DefaultFunctionImpl<T> extends ch.njol.skript.lang.function.Function
 			return toFormattedString();
 		}
 	}
+
+
+		/**
+		 * Checks whether the elements in a {@link String} array are null.
+		 *
+		 * @param strings The strings.
+		 */
+		private static void checkNotNull(@NotNull String[] strings, @NotNull String message) {
+			for (String string : strings) {
+				Preconditions.checkNotNull(string, message);
+			}
+		}
 
 }

--- a/src/main/java/org/skriptlang/skript/common/function/DefaultFunctionImpl.java
+++ b/src/main/java/org/skriptlang/skript/common/function/DefaultFunctionImpl.java
@@ -252,8 +252,8 @@ final class DefaultFunctionImpl<T> extends ch.njol.skript.lang.function.Function
 
 		@Override
 		public Builder<T> requires(@NotNull String @NotNull ... requires) {
-			Preconditions.checkNotNull(keywords, "requires cannot be null");
-			checkNotNull(keywords, "requires contents cannot be null");
+			Preconditions.checkNotNull(requires, "requires cannot be null");
+			checkNotNull(requires, "requires contents cannot be null");
 
 			this.requires = requires;
 			return this;
@@ -347,8 +347,8 @@ final class DefaultFunctionImpl<T> extends ch.njol.skript.lang.function.Function
 
 		@Override
 		public VoidBuilder requires(@NotNull String @NotNull ... requires) {
-			Preconditions.checkNotNull(keywords, "requires cannot be null");
-			checkNotNull(keywords, "requires contents cannot be null");
+			Preconditions.checkNotNull(requires, "requires cannot be null");
+			checkNotNull(requires, "requires contents cannot be null");
 
 			this.requires = requires;
 			return this;
@@ -381,10 +381,10 @@ final class DefaultFunctionImpl<T> extends ch.njol.skript.lang.function.Function
 	/**
 	 * A parameter for a {@link DefaultFunction}.
 	 *
-	 * @param name The name.
-	 * @param type The type's class.
+	 * @param name      The name.
+	 * @param type      The type's class.
 	 * @param modifiers The modifiers.
-	 * @param <T> The type.
+	 * @param <T>       The type.
 	 */
 	record DefaultParameter<T>(String name, Class<T> type, Set<Modifier> modifiers)
 			implements Parameter<T> {
@@ -400,15 +400,15 @@ final class DefaultFunctionImpl<T> extends ch.njol.skript.lang.function.Function
 	}
 
 
-		/**
-		 * Checks whether the elements in a {@link String} array are null.
-		 *
-		 * @param strings The strings.
-		 */
-		private static void checkNotNull(@NotNull String[] strings, @NotNull String message) {
-			for (String string : strings) {
-				Preconditions.checkNotNull(string, message);
-			}
+	/**
+	 * Checks whether the elements in a {@link String} array are null.
+	 *
+	 * @param strings The strings.
+	 */
+	private static void checkNotNull(@NotNull String[] strings, @NotNull String message) {
+		for (String string : strings) {
+			Preconditions.checkNotNull(string, message);
 		}
+	}
 
 }

--- a/src/test/java/ch/njol/skript/lang/function/FunctionRegistryTest.java
+++ b/src/test/java/ch/njol/skript/lang/function/FunctionRegistryTest.java
@@ -1,5 +1,6 @@
 package ch.njol.skript.lang.function;
 
+import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptAPIException;
 import ch.njol.skript.lang.function.FunctionRegistry.FunctionIdentifier;
 import ch.njol.skript.lang.function.FunctionRegistry.RetrievalResult;
@@ -9,6 +10,8 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
+import org.skriptlang.skript.common.function.DefaultFunction;
+import org.skriptlang.skript.common.function.DefaultFunctionTest;
 
 import static org.junit.Assert.*;
 
@@ -146,25 +149,15 @@ public class FunctionRegistryTest {
 		registry.remove(TEST_FUNCTION.getSignature());
 	}
 
-	private static final Function<Boolean> TEST_FUNCTION_B = new SimpleJavaFunction<>(FUNCTION_NAME,
-		new Parameter[]{
-			new Parameter<>("a", DefaultClasses.BOOLEAN, true, null)
-		}, DefaultClasses.BOOLEAN, true) {
-		@Override
-		public Boolean @Nullable [] executeSimple(Object[][] params) {
-			return new Boolean[]{true};
-		}
-	};
+	@SuppressWarnings("unchecked")
+	private static final Function<Void> TEST_FUNCTION_B = (Function<Void>) DefaultFunction.voidBuilder(Skript.instance(), FUNCTION_NAME)
+			.parameter("a", Boolean.class)
+			.build(args -> {});
 
-	private static final Function<Boolean> TEST_FUNCTION_N = new SimpleJavaFunction<>(FUNCTION_NAME,
-		new Parameter[]{
-			new Parameter<>("a", DefaultClasses.NUMBER, true, null)
-		}, DefaultClasses.BOOLEAN, true) {
-		@Override
-		public Boolean @Nullable [] executeSimple(Object[][] params) {
-			return new Boolean[]{true};
-		}
-	};
+	@SuppressWarnings("unchecked")
+	private static final Function<Void> TEST_FUNCTION_N = (Function<Void>) DefaultFunction.voidBuilder(Skript.instance(), FUNCTION_NAME)
+			.parameter("a", Number.class)
+			.build(args -> {});
 
 	@Test
 	public void testMultipleRegistrations() {
@@ -421,25 +414,15 @@ public class FunctionRegistryTest {
 		assertEquals(RetrievalResult.NOT_REGISTERED, registry.getSignature(null, FUNCTION_NAME).result());
 	}
 
-	private static final Function<Boolean> TEST_FUNCTION_P = new SimpleJavaFunction<>(FUNCTION_NAME,
-		new Parameter[]{
-			new Parameter<>("a", DefaultClasses.PLAYER, true, null)
-		}, DefaultClasses.BOOLEAN, true) {
-		@Override
-		public Boolean @Nullable [] executeSimple(Object[][] params) {
-			return new Boolean[]{true};
-		}
-	};
+	@SuppressWarnings("unchecked")
+	private static final Function<Void> TEST_FUNCTION_P = (Function<Void>) DefaultFunction.voidBuilder(Skript.instance(), FUNCTION_NAME)
+			.parameter("a", Player.class)
+			.build(args -> {});
 
-	private static final Function<Boolean> TEST_FUNCTION_OP = new SimpleJavaFunction<>(FUNCTION_NAME,
-			new Parameter[]{
-					new Parameter<>("a", DefaultClasses.OFFLINE_PLAYER, true, null)
-			}, DefaultClasses.BOOLEAN, true) {
-		@Override
-		public Boolean @Nullable [] executeSimple(Object[][] params) {
-			return new Boolean[]{true};
-		}
-	};
+	@SuppressWarnings("unchecked")
+	private static final Function<Void> TEST_FUNCTION_OP = (Function<Void>) DefaultFunction.voidBuilder(Skript.instance(), FUNCTION_NAME)
+			.parameter("a", OfflinePlayer.class)
+			.build(args -> {});
 
 	@Test
 	public void testGetExactSignature() {


### PR DESCRIPTION
### Problem
Previously, all default functions were expected to return a value. For default functions with side effects, this required returning a dummy value or `null` in the build method.


### Solution
Adds explicit support for functions that do not return anything by means of a `voidBuilder` method. This changes the final `build` method in the function build pipeline to take a Consumer instead of a Function, which removes the need for the developer to return a value. 


### Testing Completed
Updated FunctionRegistryTest to use void default functions.


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
