### PR TITLE
fix: correct online player count example in ExprHoverList

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprHoverList.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHoverList.java
@@ -1,4 +1,4 @@
-package ch.njol.skript.expressions;
+﻿package ch.njol.skript.expressions;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
@@ -35,7 +35,7 @@ import java.util.UUID;
 		clear the hover list
 		add "&aWelcome to the &6Minecraft &aserver!" to the hover list
 		add "" to the hover list # A blank line
-		add "&cThere are &6%online players count% &conline players!" to the hover list
+		add "&cThere are &6%online player count% &conline players!" to the hover list
 	""")
 @Since("2.3")
 @Events("server list ping")


### PR DESCRIPTION
## Summary

fix: correct online player count example in ExprHoverList

## Changes

- Example used %online players count% which is not a valid expression.
- Correct to %online player count% to match ExprOnlinePlayersCount.

Fixes #8848
