### PR TITLE
Use 2 seconds as the default parse time warning threshold

### DIFF
--- a/src/main/resources/config.sk
+++ b/src/main/resources/config.sk
@@ -244,7 +244,7 @@ player name regex pattern: [a-zA-Z0-9_]{1,16}
 # A regex pattern that is used to match player names.
 # This can be used if you are using Geyser, where some usernames are prefixed by a certain character.
 
-long parse time warning threshold: 5 seconds
+long parse time warning threshold: 2 seconds
 # This setting determines how long a statement can take to parse before Skript produces a warning
 #   stating that the statement has taken a long time to parse.
 # A value of 0 seconds means that this warning should be disabled.

--- a/src/main/resources/config.sk
+++ b/src/main/resources/config.sk
@@ -244,7 +244,7 @@ player name regex pattern: [a-zA-Z0-9_]{1,16}
 # A regex pattern that is used to match player names.
 # This can be used if you are using Geyser, where some usernames are prefixed by a certain character.
 
-long parse time warning threshold: 0 seconds
+long parse time warning threshold: 5 seconds
 # This setting determines how long a statement can take to parse before Skript produces a warning
 #   stating that the statement has taken a long time to parse.
 # A value of 0 seconds means that this warning should be disabled.


### PR DESCRIPTION
### Problem
The `long parse time warning threshold` config option is disabled by default, meaning users with very complex lines get no indication that their script is problematic besides the server crashing or freezing for a long time when they attempt to load it.

### Solution
Use a ridiculously high default value that should never happen in well-behaving code instead of disabling the warning outright. 5 seconds to parse a single line is a definite indication that something is wrong with the script.

### Testing Completed
None

### Supporting Information
The previous rationale for disabling the warning is that users do not care if a line takes a long time to parse, and the warning does not help because it cannot interrupt parsing and leaves the user to fix the issue on their own: it was intended as a technical tool rather than a safeguard.

Judging from issues and Skript community help channels it seems that having the warning enabled by default would be beneficial to at least hint to the user that their code is too complex for the parser to handle.

---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
