### PR TITLE
Add explicit location event values

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -347,10 +347,12 @@ public final class BukkitEventValues {
 		registry.register(EventValue.simple(PlayerPickupItemEvent.class, Item.class, PlayerPickupItemEvent::getItem));
 		registry.register(EventValue.simple(PlayerPickupItemEvent.class, ItemStack.class, event -> event.getItem().getItemStack()));
 		registry.register(EventValue.simple(PlayerPickupItemEvent.class, Entity.class, PlayerEvent::getPlayer));
+		registry.register(EventValue.simple(PlayerPickupItemEvent.class, Location.class, event -> event.getItem().getLocation()));
 		// EntityPickupItemEvent
 		registry.register(EventValue.simple(EntityPickupItemEvent.class, Entity.class, EntityPickupItemEvent::getEntity));
 		registry.register(EventValue.simple(EntityPickupItemEvent.class, Item.class, EntityPickupItemEvent::getItem));
 		registry.register(EventValue.simple(EntityPickupItemEvent.class, ItemType.class, event -> new ItemType(event.getItem().getItemStack())));
+		registry.register(EventValue.simple(EntityPickupItemEvent.class, Location.class, event -> event.getItem().getLocation()));
 		// PlayerItemConsumeEvent
 		registry.register(EventValue.builder(PlayerItemConsumeEvent.class, ItemStack.class)
 			.getter(PlayerItemConsumeEvent::getItem)


### PR DESCRIPTION
### Problem
`event-location` is not currently correctly resolved for the pickup events. This is likely a deeper issue with event value resolution, but this provides immediate relief.


### Solution
Adds dedicated location event values for the pick up events. I have decided to tie this to the location of the dropped item itself.


### Testing Completed
Manual in-game confirmation.


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:**
- Fixes #8637

**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
