### PR TITLE
Raw Name Entity Type Support

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprRawName.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprRawName.java
@@ -1,66 +1,70 @@
 package ch.njol.skript.expressions;
 
-import java.util.Arrays;
-import java.util.List;
-
-import org.bukkit.event.Event;
-import org.jetbrains.annotations.Nullable;
-
-import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.bukkitutil.EntityUtils;
+import ch.njol.skript.entity.EntityData;
+import ch.njol.skript.expressions.base.PropertyExpression;
+import org.bukkit.event.Event;
+
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Example;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
-import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Name("Raw Name")
-@Description("The raw Minecraft material name of the given item. Note that this is not guaranteed to give same results on all servers.")
+@Description("""
+	The raw Minecraft material name of the given item or entity type.
+	This expression may return multiple names for item types, but always returns a single name per entity data.
+	Note that this is not guaranteed to give same results on all servers.
+	""")
 @Example("raw name of tool of player")
-@Since("unknown (2.2)")
-public class ExprRawName extends SimpleExpression<String> {
+@Example("raw name of (type of event-entity)")
+@Since("unknown (2.2), entity types (INSERT VERSION)")
+public class ExprRawName extends PropertyExpression<Object, String> {
 	
 	static {
-		Skript.registerExpression(ExprRawName.class, String.class, ExpressionType.SIMPLE, "(raw|minecraft|vanilla) name[s] of %itemtypes%");
+		register(ExprRawName.class, String.class, "(raw|minecraft|vanilla) name[s]", "itemtypes/entitydatas");
 	}
-	
-	@SuppressWarnings("null")
-	private Expression<ItemType> types;
-	
-	@SuppressWarnings({"unchecked", "null"})
+
 	@Override
-	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
-		this.types = (Expression<ItemType>) exprs[0];
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		setExpr(expressions[0]);
 		return true;
 	}
-	
+
 	@Override
-	@Nullable
-	protected String[] get(final Event e) {
-		return Arrays.stream(types.getAll(e))
-				.map(ItemType::getRawNames)
-				.flatMap(List::stream)
-				.toArray(String[]::new);
+	protected String[] get(Event event, Object[] source) {
+		List<String> result = new ArrayList<>();
+		for (Object object : source) {
+			if (object instanceof ItemType itemType) {
+				result.addAll(itemType.getRawNames());
+			} else if (object instanceof EntityData<?> entityData) {
+				result.add(EntityUtils.toBukkitEntityType(entityData).getKey().asString());
+			}
+		}
+		return result.toArray(new String[0]);
 	}
-	
+
 	@Override
 	public boolean isSingle() {
-		return types.isSingle();
+		return getExpr().isSingle();
 	}
-	
+
 	@Override
 	public Class<? extends String> getReturnType() {
 		return String.class;
 	}
-	
-	@SuppressWarnings("null")
+
 	@Override
-	public String toString(final @Nullable Event e, final boolean debug) {
-		return "minecraft name of " + types.toString(e, debug);
+	public String toString(@Nullable Event event, boolean debug) {
+		return "raw name of " + getExpr().toString(event, debug);
 	}
-	
+
 }

--- a/src/test/skript/tests/syntaxes/expressions/ExprRawName.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprRawName.sk
@@ -7,3 +7,6 @@ test "raw name - item":
   assert vanilla name of stone is "minecraft:stone"
   assert vanilla name of oak planks is "minecraft:oak_planks"
   assert vanilla names of grass block and dirt are "minecraft:grass_block" and "minecraft:dirt"
+
+test "raw name - mixed":
+  assert vanilla names of stone, pig, grass block, cow are "minecraft:stone", "minecraft:pig", "minecraft:grass_block", "minecraft:cow"

--- a/src/test/skript/tests/syntaxes/expressions/ExprRawName.sk
+++ b/src/test/skript/tests/syntaxes/expressions/ExprRawName.sk
@@ -1,0 +1,9 @@
+test "raw name - entity":
+  assert vanilla name of cow is "minecraft:cow"
+  assert vanilla name of cave spider is "minecraft:cave_spider"
+  assert vanilla names of cow and pig are "minecraft:cow" and "minecraft:pig"
+
+test "raw name - item":
+  assert vanilla name of stone is "minecraft:stone"
+  assert vanilla name of oak planks is "minecraft:oak_planks"
+  assert vanilla names of grass block and dirt are "minecraft:grass_block" and "minecraft:dirt"


### PR DESCRIPTION
### Problem
Getting translate components for things that involve entity types requires the raw name of entity, but Skript doesn't support it


### Solution
Added support for EntityDatas in ExprRawName.sk, made ExprRawName a PropertyExpression


### Testing Completed
Added unit tests for single objects, single objects with spaces, plurals, and mixed plurals + in-game testing


### Supporting Information
<!--- Any related information, todos, breaking changes, or outstanding issues can be described here --->


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
