### PR TITLE
Experiment Registry Compatibility Fix

### DIFF
--- a/src/main/java/org/skriptlang/skript/lang/experiment/ExperimentRegistry.java
+++ b/src/main/java/org/skriptlang/skript/lang/experiment/ExperimentRegistry.java
@@ -99,12 +99,28 @@ public class ExperimentRegistry implements Registry<Experiment>, ViewProvider<Ex
 	}
 
 	/**
+	 * @deprecated Use {@link #register(SkriptAddon, Experiment)}.
+	 */
+	@Deprecated(since = "INSERT VERSION", forRemoval = true)
+	public void register(ch.njol.skript.SkriptAddon addon, Experiment experiment) {
+		register((SkriptAddon) addon, experiment);
+	}
+
+	/**
 	 * @see #register(SkriptAddon, Experiment)
 	 */
 	public void registerAll(SkriptAddon addon, Experiment... experiments) {
 		for (Experiment experiment : experiments) {
 			this.register(addon, experiment);
 		}
+	}
+
+	/**
+	 * @deprecated Use {@link #registerAll(SkriptAddon, Experiment...)}.
+	 */
+	@Deprecated(since = "INSERT VERSION", forRemoval = true)
+	public void registerAll(ch.njol.skript.SkriptAddon addon, Experiment... experiments) {
+		registerAll((SkriptAddon) addon, experiments);
 	}
 
 	/**
@@ -123,6 +139,14 @@ public class ExperimentRegistry implements Registry<Experiment>, ViewProvider<Ex
 	}
 
 	/**
+	 * @deprecated Use {@link #unregister(SkriptAddon, Experiment)}.
+	 */
+	@Deprecated(since = "INSERT VERSION", forRemoval = true)
+	public void unregister(ch.njol.skript.SkriptAddon addon, Experiment experiment) {
+		unregister((SkriptAddon) addon, experiment);
+	}
+
+	/**
 	 * Creates (and registers) a new experimental feature flag, which will be available to scripts
 	 * with the {@code using %name%} structure.
 	 *
@@ -136,6 +160,14 @@ public class ExperimentRegistry implements Registry<Experiment>, ViewProvider<Ex
 		Experiment experiment = Experiment.constant(codeName, phase, patterns);
 		this.register(addon, experiment);
 		return experiment;
+	}
+
+	/**
+	 * @deprecated Use {@link #register(SkriptAddon, String, LifeCycle, String...)}.
+	 */
+	@Deprecated(since = "INSERT VERSION", forRemoval = true)
+	public Experiment register(ch.njol.skript.SkriptAddon addon, String codeName, LifeCycle phase, String... patterns) {
+		return register((SkriptAddon) addon, codeName, phase, patterns);
 	}
 
 	@Override


### PR DESCRIPTION
### Problem
In #8830, I forgot to include compatibility for methods that accepted a legacy SkriptAddon instance.
This causes addons using those methods (such as skript-gui) to fail to load.


### Solution
Adds deprecated compatibility methods for legacy SkriptAddon.


### Testing Completed
Manual in-game testing that an affected addon (skript-gui) loaded.


### Supporting Information
n/a


---
**Completes:** none <!-- Links to issues or discussions that should be completed when this PR is merged. -->
**Related:** none <!-- Links to issues or discussions with related information -->
**AI assistance:** none <!-- Was AI assistance used in the creation of this PR? If so, please specify the tool and extent of usage. -->
